### PR TITLE
Add lambda to TestOpenMP

### DIFF
--- a/src/Python/Core/py3d_odometry.cpp
+++ b/src/Python/Core/py3d_odometry.cpp
@@ -76,7 +76,8 @@ void pybind_odometry(py::module &m)
 		.def_readwrite("min_depth", &OdometryOption::min_depth_)
 		.def_readwrite("max_depth", &OdometryOption::max_depth_)
 		.def("__repr__", [](const OdometryOption &c) {
-		int num_pyramid_level = c.iteration_number_per_pyramid_level_.size();
+		int num_pyramid_level = 
+				(int)c.iteration_number_per_pyramid_level_.size();
 		std::string str_iteration_number_per_pyramid_level_ = "[ ";
 		for (int i = 0; i < num_pyramid_level; i++) 
 			str_iteration_number_per_pyramid_level_ += 


### PR DESCRIPTION
See discussion in #52 

I read a lot of posts and found this:
https://stackoverflow.com/questions/17363003/why-use-stdbind-over-lambdas-in-c14

In general, Lambdas should always be used instead of ``std::bind``. The reason is that most compilers will more likely treat lambdas inline and apply optimization. While in some cases, ``std::bind`` causes an expensive function call.

Speed-wise, the latest benchmark results on windows:
lambdas = inline function call > ``std::bind`` > direct operation
On Ubuntu:
direct operation > inline function call >= lambdas > ``std::bind``
Though the difference between the first three are small.

I think we are ready to move on to wrap the function in Eigen.h/cpp, and use Lambdas as parameters.