### PR TITLE
removing unnecessary lines

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,15 +93,6 @@ if (Open3D_USE_OPENMP)
 	endif()
 endif()
 
-# Check Python
-find_package (PythonLibs)
-find_package (PythonInterp)
-if (NOT PYTHONLIBS_FOUND OR NOT PYTHONINTERP_FOUND)
-  message(STATUS "Disable Open3D Python binding since Python is not installed.")
-  set(Open3D_BUILD_PYTHON_BINDING OFF)
-  set(Open3D_BUILD_PYTHON_BINDING_TESTS OFF)
-endif (NOT PYTHONLIBS_FOUND OR NOT PYTHONINTERP_FOUND)
-
 message(STATUS "Open3D_BUILD_LIBREALSENSE=${Open3D_BUILD_LIBREALSENSE}")
 message(STATUS "Open3D_BUILD_PYTHON_BINDING=${Open3D_BUILD_PYTHON_BINDING}")
 message(STATUS "Open3D_BUILD_PYTHON_BINDING_TESTS=${Open3D_BUILD_PYTHON_BINDING_TESTS}")


### PR DESCRIPTION
This fix address #66.  The problem was following cmake commands
```
find_package (PythonLibs)
find_package (PythonInterp)
```
They distracts naming conventions for compiling python binding. Therefore, it generates `py3d` instead of `py3d.so` in Unix and MacOSX.

The deleted line was intended for detecting python, but it turns out to be not necessary. Let's consider following scenario.
1) `Open3D_BUILD_PYTHON_BINDING` flag is on by default. 
2) An user who does not have Python will encounter cmake configuration error. 
3) User then can decide not to build pybind by turning this flag OFF.

Therefore, it is reasonable to delete these cmake scripts.