### PR TITLE
fix for EstimateNormals.cpp

### DIFF
--- a/src/Core/Geometry/EstimateNormals.cpp
+++ b/src/Core/Geometry/EstimateNormals.cpp
@@ -147,6 +147,8 @@ bool EstimateNormals(PointCloud &cloud,
 				normal *= -1.0;
 			}
 			cloud.normals_[i] = normal;
+		} else {
+			cloud.normals_[i] = Eigen::Vector3d(0.0, 0.0, 1.0);
 		}
 	}
 	


### PR DESCRIPTION
This simple fix handles #102. There are exceptional cases that random and unnormalized values are assigned to normal vector.