### PR TITLE
fix doc for #1818

### DIFF
--- a/cpp/pybind/pipelines/registration/registration.cpp
+++ b/cpp/pybind/pipelines/registration/registration.cpp
@@ -536,17 +536,18 @@ must hold true for all edges.)");
 // Registration functions have similar arguments, sharing arg docstrings
 static const std::unordered_map<std::string, std::string>
         map_shared_argument_docstrings = {
-                {"checkers", "checkers"},
-                {"corres",
-                 "Checker class to check if two point clouds can be "
-                 "aligned. "
-                 "One of "
+                {"checkers",
+                 "Vector of Checker class to check if two point "
+                 "clouds can be aligned. One of "
                  "(``pipelines::registration::"
                  "CorrespondenceCheckerBasedOnEdgeLength``, "
                  "``pipelines::registration::"
                  "CorrespondenceCheckerBasedOnDistance``, "
                  "``pipelines::registration::"
                  "CorrespondenceCheckerBasedOnNormal``)"},
+                {"corres",
+                 "o3d.utility.Vector2iVector that stores indices of "
+                 "corresponding point or feature arrays."},
                 {"criteria", "Convergence criteria"},
                 {"estimation_method",
                  "Estimation method. One of "


### PR DESCRIPTION
Fix #1818.
Note now that the namespace has changed, we need to test with
`print(o3d.pipelines.registration.registration_ransac_based_on_correspondence.__doc__)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2214)
<!-- Reviewable:end -->
