### PR TITLE
Add support for gold linker + LTO

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -69,6 +69,7 @@ jobs:
       - name: Install dependencies
         run: |
           ./util/install_deps_ubuntu.sh assume-yes
+          sudo apt-get install binutils-gold    # Optional faster linking
           wget https://github.com/intel-isl/open3d_downloads/releases/download/ccache/ccache
           chmod +x ccache
           sudo mv ccache /usr/local/bin

--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -168,8 +168,12 @@ set(ExternalProject_CMAKE_ARGS
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
     -DCMAKE_POLICY_DEFAULT_CMP0091:STRING=NEW
     -DCMAKE_MSVC_RUNTIME_LIBRARY:STRING=${CMAKE_MSVC_RUNTIME_LIBRARY}
-    -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-    )
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON)
+if(IPO_AVAILABLE)
+    list(APPEND ExternalProject_CMAKE_ARGS
+    -DCMAKE_POLICY_DEFAULT_CMP0069:STRING=NEW
+    -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=TRUE)
+endif()
 # Keep 3rd party symbols hidden from Open3D user code. Do not use if 3rd party
 # libraries throw exceptions that escape Open3D.
 set(ExternalProject_CMAKE_ARGS_hidden

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,13 +80,17 @@ option(BUILD_PYTORCH_OPS          "Build ops for PyTorch"                    OFF
 option(BUNDLE_OPEN3D_ML           "Includes the Open3D-ML repo in the wheel" OFF)
 
 # Release build options
-option(DEVELOPER_BUILD      "Add +commit_hash to the project version number" ON )
+option(DEVELOPER_BUILD      "Add +commit_hash to the project version number"  ON)
 if (NOT DEVELOPER_BUILD)
     if (NOT BUILD_COMMON_CUDA_ARCHS)
         set(BUILD_COMMON_CUDA_ARCHS ON CACHE BOOL "Build for common CUDA GPUs (for release)" FORCE)
         message(WARNING "Setting BUILD_COMMON_CUDA_ARCHS=ON since DEVELOPER_BUILD is OFF.")
     endif()
 endif()
+# TODO: Set to OFF by default. Takes a while.
+cmake_dependent_option(
+    OPEN3D_ENABLE_LTO           "Enable LTO / IPO. ON for Production builds." ON
+    "DEVELOPER_BUILD"                                                         ON)
 
 # Default build type on single-config generators.
 # For multi-config generators (e.g. Visual Studio), CMAKE_CONFIGURATION_TYPES
@@ -380,6 +384,18 @@ add_link_options(
     "$<$<COMPILE_LANGUAGE:CXX>:${HARDENING_LDFLAGS}>"
     )
 
+# Link Time Optimization
+if (OPEN3D_ENABLE_LTO)
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT IPO_AVAILABLE)
+    if (IPO_AVAILABLE AND CMAKE_BUILD_TYPE STREQUAL Release)
+        message("IPO (LTO) is available. Enabling for Release builds.")
+    endif ()
+else ()
+    set(IPO_AVAILABLE FALSE)
+endif()
+
+
 # Build CUDA module by default if CUDA is available
 if(BUILD_CUDA_MODULE)
     find_package(CUDAToolkit REQUIRED)
@@ -451,7 +467,22 @@ if(BUILD_CUDA_MODULE)
 endif ()
 
 # OS specific settings
-if(WIN32)
+if (UNIX AND NOT APPLE)
+# Faster linking with gold linker on Linux.
+    set(USE_LINKER gold CACHE STRING "Linker: bfd (GNU default), gold (Open3D default)")
+    set_property(CACHE USE_LINKER PROPERTY STRINGS bfd gold)
+    if(USE_LINKER STREQUAL gold)
+        execute_process(COMMAND ${CMAKE_C_COMPILER} -fuse-ld=${USE_LINKER}
+            -Wl,--version RESULT_VARIABLE USE_LINKER_OK OUTPUT_QUIET ERROR_QUIET)
+        if (USE_LINKER_OK EQUAL 0)
+            add_link_options(-fuse-ld=${USE_LINKER})
+        else()
+            message(STATUS "Linker ${USE_LINKER} not available. Falling back "
+            "to default GNU linker.")
+            set(USE_LINKER bfd CACHE STRING "Linker: bfd (GNU default), gold (Open3D default)" FORCE)
+        endif()
+    endif()
+elseif (WIN32)
     # Windows defaults to hidden symbol visibility, override that
     # TODO: It would be better to explictly export symbols.
     #       Then, we could use -fvisibility=hidden for Linux as well
@@ -632,6 +663,11 @@ function(open3d_set_global_properties target)
                 $<$<PLATFORM_ID:Darwin>:-x> $<TARGET_FILE:${target}>
                 COMMAND_EXPAND_LISTS)
         endif()
+    endif()
+
+    if(IPO_AVAILABLE)   # Enable LTO for Release builds
+        set_target_properties(${target} PROPERTIES INTERPROCEDURAL_OPTIMIZATION
+            $<IF:$<CONFIG:Release>,TRUE,FALSE>)
     endif()
 
 endfunction()

--- a/util/docker/open3d-gpu/scripts/env-setup.sh
+++ b/util/docker/open3d-gpu/scripts/env-setup.sh
@@ -10,7 +10,7 @@ SUDO=${SUDO:=sudo}
 UBUNTU_VERSION=${UBUNTU_VERSION:="$(lsb_release -cs)"} # Empty in macOS
 
 $SUDO apt-get update
-$SUDO apt-get --yes install git software-properties-common
+$SUDO apt-get --yes install git software-properties-common binutils-gold
 echo "Installing Python3 and setting as default python"
 $SUDO apt-get --yes --no-install-recommends install python3 python3-pip \
     python3-setuptools python3-venv


### PR DESCRIPTION
Gold is enabled by default since it is faster (multithreaded linking). Gold also has a more mature LTO support. (compared to the GCC default linker bfd).

Add support for LTO. Enable by default for production builds.
Option for dev builds. Default is ON for testing, but will be set to OFF later since LTO increases build time.

Gold + LTO build total time: 9min42s
BFD + LTO build total time: 11min11s

Without LTO, Gold is 2-3 times faster for linking.

LLD is slightly faster than gold, but gives link errors when used as a drop in replacement.

ld.gold: (pybind + tests): 1m26s

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3673)
<!-- Reviewable:end -->
