### PR TITLE
Deterministic registration

### DIFF
--- a/cpp/open3d/pipelines/registration/FastGlobalRegistration.cpp
+++ b/cpp/open3d/pipelines/registration/FastGlobalRegistration.cpp
@@ -30,6 +30,7 @@
 #include "open3d/geometry/PointCloud.h"
 #include "open3d/pipelines/registration/Feature.h"
 #include "open3d/pipelines/registration/Registration.h"
+#include "open3d/utility/Helper.h"
 #include "open3d/utility/Logging.h"
 
 namespace open3d {
@@ -124,13 +125,12 @@ static std::vector<std::pair<int, int>> AdvancedMatching(
     int ncorr = static_cast<int>(corres_cross.size());
     int number_of_trial = ncorr * 100;
 
-    std::mt19937 generator(option.seed_);
-    std::uniform_int_distribution<int> distribution(0, ncorr - 1);
+    utility::UniformRandInt dist_gen(0, ncorr - 1, option.seed_);
     std::vector<std::pair<int, int>> corres_tuple;
     for (i = 0; i < number_of_trial; i++) {
-        rand0 = distribution(generator);
-        rand1 = distribution(generator);
-        rand2 = distribution(generator);
+        rand0 = dist_gen();
+        rand1 = dist_gen();
+        rand2 = dist_gen();
         idi0 = corres_cross[rand0].first;
         idj0 = corres_cross[rand0].second;
         idi1 = corres_cross[rand1].first;

--- a/cpp/open3d/pipelines/registration/FastGlobalRegistration.cpp
+++ b/cpp/open3d/pipelines/registration/FastGlobalRegistration.cpp
@@ -127,12 +127,12 @@ static std::vector<std::pair<int, int>> AdvancedMatching(
 
     unsigned int seed_val = option.seed_.has_value() ? option.seed_.value()
                                                      : std::random_device{}();
-    utility::UniformRandInt dist_gen(0, ncorr - 1, seed_val);
+    utility::UniformRandIntGenerator rand_generator(0, ncorr - 1, seed_val);
     std::vector<std::pair<int, int>> corres_tuple;
     for (i = 0; i < number_of_trial; i++) {
-        rand0 = dist_gen();
-        rand1 = dist_gen();
-        rand2 = dist_gen();
+        rand0 = rand_generator();
+        rand1 = rand_generator();
+        rand2 = rand_generator();
         idi0 = corres_cross[rand0].first;
         idj0 = corres_cross[rand0].second;
         idi1 = corres_cross[rand1].first;

--- a/cpp/open3d/pipelines/registration/FastGlobalRegistration.cpp
+++ b/cpp/open3d/pipelines/registration/FastGlobalRegistration.cpp
@@ -125,7 +125,9 @@ static std::vector<std::pair<int, int>> AdvancedMatching(
     int ncorr = static_cast<int>(corres_cross.size());
     int number_of_trial = ncorr * 100;
 
-    utility::UniformRandInt dist_gen(0, ncorr - 1, option.seed_);
+    unsigned int seed_val = option.seed_.has_value() ? option.seed_.value()
+                                                     : std::random_device{}();
+    utility::UniformRandInt dist_gen(0, ncorr - 1, seed_val);
     std::vector<std::pair<int, int>> corres_tuple;
     for (i = 0; i < number_of_trial; i++) {
         rand0 = dist_gen();

--- a/cpp/open3d/pipelines/registration/FastGlobalRegistration.cpp
+++ b/cpp/open3d/pipelines/registration/FastGlobalRegistration.cpp
@@ -30,7 +30,6 @@
 #include "open3d/geometry/PointCloud.h"
 #include "open3d/pipelines/registration/Feature.h"
 #include "open3d/pipelines/registration/Registration.h"
-#include "open3d/utility/Helper.h"
 #include "open3d/utility/Logging.h"
 
 namespace open3d {
@@ -115,7 +114,7 @@ static std::vector<std::pair<int, int>> AdvancedMatching(
             }
         }
     }
-    utility::LogDebug("points are remained : %d", (int)corres_cross.size());
+    utility::LogDebug("points are remained : {:d}", (int)corres_cross.size());
 
     // STEP 3) TUPLE CONSTRAINT
     utility::LogDebug("\t[tuple constraint] ");
@@ -125,11 +124,13 @@ static std::vector<std::pair<int, int>> AdvancedMatching(
     int ncorr = static_cast<int>(corres_cross.size());
     int number_of_trial = ncorr * 100;
 
+    std::mt19937 generator(option.seed_);
+    std::uniform_int_distribution<int> distribution(0, ncorr - 1);
     std::vector<std::pair<int, int>> corres_tuple;
     for (i = 0; i < number_of_trial; i++) {
-        rand0 = utility::UniformRandInt(0, ncorr - 1);
-        rand1 = utility::UniformRandInt(0, ncorr - 1);
-        rand2 = utility::UniformRandInt(0, ncorr - 1);
+        rand0 = distribution(generator);
+        rand1 = distribution(generator);
+        rand2 = distribution(generator);
         idi0 = corres_cross[rand0].first;
         idj0 = corres_cross[rand0].second;
         idi1 = corres_cross[rand1].first;

--- a/cpp/open3d/pipelines/registration/FastGlobalRegistration.h
+++ b/cpp/open3d/pipelines/registration/FastGlobalRegistration.h
@@ -32,6 +32,8 @@
 #include <tuple>
 #include <vector>
 
+#include "open3d/utility/Optional.h"
+
 namespace open3d {
 
 namespace geometry {
@@ -63,14 +65,15 @@ public:
     /// \param tuple_scale Similarity measure used for tuples of feature points.
     /// \param maximum_tuple_count Maximum numer of tuples.
     /// \param seed Random seed.
-    FastGlobalRegistrationOption(double division_factor = 1.4,
-                                 bool use_absolute_scale = false,
-                                 bool decrease_mu = true,
-                                 double maximum_correspondence_distance = 0.025,
-                                 int iteration_number = 64,
-                                 double tuple_scale = 0.95,
-                                 int maximum_tuple_count = 1000,
-                                 unsigned int seed = std::random_device{}())
+    FastGlobalRegistrationOption(
+            double division_factor = 1.4,
+            bool use_absolute_scale = false,
+            bool decrease_mu = true,
+            double maximum_correspondence_distance = 0.025,
+            int iteration_number = 64,
+            double tuple_scale = 0.95,
+            int maximum_tuple_count = 1000,
+            utility::optional<unsigned int> seed = utility::nullopt)
         : division_factor_(division_factor),
           use_absolute_scale_(use_absolute_scale),
           decrease_mu_(decrease_mu),
@@ -100,7 +103,7 @@ public:
     /// Maximum number of tuples..
     int maximum_tuple_count_;
     /// Random seed
-    unsigned int seed_;
+    utility::optional<unsigned int> seed_;
 };
 
 RegistrationResult FastGlobalRegistration(

--- a/cpp/open3d/pipelines/registration/FastGlobalRegistration.h
+++ b/cpp/open3d/pipelines/registration/FastGlobalRegistration.h
@@ -28,6 +28,7 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+#include <random>
 #include <tuple>
 #include <vector>
 
@@ -61,20 +62,23 @@ public:
     /// \param iteration_number Maximum number of iterations.
     /// \param tuple_scale Similarity measure used for tuples of feature points.
     /// \param maximum_tuple_count Maximum numer of tuples.
+    /// \param seed Random seed.
     FastGlobalRegistrationOption(double division_factor = 1.4,
                                  bool use_absolute_scale = false,
                                  bool decrease_mu = true,
                                  double maximum_correspondence_distance = 0.025,
                                  int iteration_number = 64,
                                  double tuple_scale = 0.95,
-                                 int maximum_tuple_count = 1000)
+                                 int maximum_tuple_count = 1000,
+                                 unsigned int seed = std::random_device{}())
         : division_factor_(division_factor),
           use_absolute_scale_(use_absolute_scale),
           decrease_mu_(decrease_mu),
           maximum_correspondence_distance_(maximum_correspondence_distance),
           iteration_number_(iteration_number),
           tuple_scale_(tuple_scale),
-          maximum_tuple_count_(maximum_tuple_count) {}
+          maximum_tuple_count_(maximum_tuple_count),
+          seed_(seed) {}
     ~FastGlobalRegistrationOption() {}
 
 public:
@@ -95,6 +99,8 @@ public:
     double tuple_scale_;
     /// Maximum number of tuples..
     int maximum_tuple_count_;
+    /// Random seed
+    unsigned int seed_;
 };
 
 RegistrationResult FastGlobalRegistration(

--- a/cpp/open3d/pipelines/registration/FastGlobalRegistration.h
+++ b/cpp/open3d/pipelines/registration/FastGlobalRegistration.h
@@ -28,7 +28,6 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
-#include <random>
 #include <tuple>
 #include <vector>
 

--- a/cpp/open3d/pipelines/registration/Registration.cpp
+++ b/cpp/open3d/pipelines/registration/Registration.cpp
@@ -29,7 +29,6 @@
 #include "open3d/geometry/KDTreeFlann.h"
 #include "open3d/geometry/PointCloud.h"
 #include "open3d/pipelines/registration/Feature.h"
-#include "open3d/utility/Helper.h"
 #include "open3d/utility/Logging.h"
 #include "open3d/utility/Parallel.h"
 
@@ -206,7 +205,8 @@ RegistrationResult RegistrationRANSACBasedOnCorrespondence(
         const std::vector<std::reference_wrapper<const CorrespondenceChecker>>
                 &checkers /* = {}*/,
         const RANSACConvergenceCriteria &criteria
-        /* = RANSACConvergenceCriteria()*/) {
+        /* = RANSACConvergenceCriteria()*/,
+        utility::optional<unsigned int> seed /* = utility::nullopt*/) {
     if (ransac_n < 3 || (int)corres.size() < ransac_n ||
         max_correspondence_distance <= 0.0) {
         return RegistrationResult();
@@ -220,13 +220,16 @@ RegistrationResult RegistrationRANSACBasedOnCorrespondence(
         CorrespondenceSet ransac_corres(ransac_n);
         RegistrationResult best_result_local;
         int exit_itr_local = criteria.max_iteration_;
+        std::mt19937 generator(
+            seed.has_value() ? seed.value() : std::random_device{}());
+        std::uniform_int_distribution<int> distribution(
+            0, static_cast<int>(corres.size()) - 1);
 
 #pragma omp for nowait
         for (int itr = 0; itr < criteria.max_iteration_; itr++) {
             if (itr < exit_itr_local) {
                 for (int j = 0; j < ransac_n; j++) {
-                    ransac_corres[j] = corres[utility::UniformRandInt(
-                            0, static_cast<int>(corres.size()) - 1)];
+                    ransac_corres[j] = corres[distribution(generator)];
                 }
 
                 Eigen::Matrix4d transformation =
@@ -294,7 +297,8 @@ RegistrationResult RegistrationRANSACBasedOnFeatureMatching(
         const std::vector<std::reference_wrapper<const CorrespondenceChecker>>
                 &checkers /* = {}*/,
         const RANSACConvergenceCriteria &criteria
-        /* = RANSACConvergenceCriteria()*/) {
+        /* = RANSACConvergenceCriteria()*/,
+        utility::optional<unsigned int> seed /* = utility::nullopt*/) {
     if (ransac_n < 3 || max_correspondence_distance <= 0.0) {
         return RegistrationResult();
     }
@@ -346,7 +350,7 @@ RegistrationResult RegistrationRANSACBasedOnFeatureMatching(
                               corres_mutual.size());
             return RegistrationRANSACBasedOnCorrespondence(
                     source, target, corres_mutual, max_correspondence_distance,
-                    estimation, ransac_n, checkers, criteria);
+                    estimation, ransac_n, checkers, criteria, seed);
         }
         utility::LogDebug(
                 "Too few correspondences after mutual filter, fall back to "
@@ -355,7 +359,7 @@ RegistrationResult RegistrationRANSACBasedOnFeatureMatching(
 
     return RegistrationRANSACBasedOnCorrespondence(
             source, target, corres_ij, max_correspondence_distance, estimation,
-            ransac_n, checkers, criteria);
+            ransac_n, checkers, criteria, seed);
 }
 
 Eigen::Matrix6d GetInformationMatrixFromPointClouds(

--- a/cpp/open3d/pipelines/registration/Registration.cpp
+++ b/cpp/open3d/pipelines/registration/Registration.cpp
@@ -29,6 +29,7 @@
 #include "open3d/geometry/KDTreeFlann.h"
 #include "open3d/geometry/PointCloud.h"
 #include "open3d/pipelines/registration/Feature.h"
+#include "open3d/utility/Helper.h"
 #include "open3d/utility/Logging.h"
 #include "open3d/utility/Parallel.h"
 
@@ -220,16 +221,16 @@ RegistrationResult RegistrationRANSACBasedOnCorrespondence(
         CorrespondenceSet ransac_corres(ransac_n);
         RegistrationResult best_result_local;
         int exit_itr_local = criteria.max_iteration_;
-        std::mt19937 generator(
-            seed.has_value() ? seed.value() : std::random_device{}());
-        std::uniform_int_distribution<int> distribution(
-            0, static_cast<int>(corres.size()) - 1);
+        unsigned int seed_val =
+                seed.has_value() ? seed.value() : std::random_device{}();
+        utility::UniformRandInt dist_gen(0, static_cast<int>(corres.size()) - 1,
+                                         seed_val);
 
 #pragma omp for nowait
         for (int itr = 0; itr < criteria.max_iteration_; itr++) {
             if (itr < exit_itr_local) {
                 for (int j = 0; j < ransac_n; j++) {
-                    ransac_corres[j] = corres[distribution(generator)];
+                    ransac_corres[j] = corres[dist_gen()];
                 }
 
                 Eigen::Matrix4d transformation =

--- a/cpp/open3d/pipelines/registration/Registration.cpp
+++ b/cpp/open3d/pipelines/registration/Registration.cpp
@@ -223,14 +223,14 @@ RegistrationResult RegistrationRANSACBasedOnCorrespondence(
         int exit_itr_local = criteria.max_iteration_;
         unsigned int seed_val =
                 seed.has_value() ? seed.value() : std::random_device{}();
-        utility::UniformRandInt dist_gen(0, static_cast<int>(corres.size()) - 1,
-                                         seed_val);
+        utility::UniformRandIntGenerator rand_generator(
+                0, static_cast<int>(corres.size()) - 1, seed_val);
 
 #pragma omp for nowait
         for (int itr = 0; itr < criteria.max_iteration_; itr++) {
             if (itr < exit_itr_local) {
                 for (int j = 0; j < ransac_n; j++) {
-                    ransac_corres[j] = corres[dist_gen()];
+                    ransac_corres[j] = corres[rand_generator()];
                 }
 
                 Eigen::Matrix4d transformation =

--- a/cpp/open3d/pipelines/registration/Registration.h
+++ b/cpp/open3d/pipelines/registration/Registration.h
@@ -27,12 +27,14 @@
 #pragma once
 
 #include <Eigen/Core>
+#include <random>
 #include <tuple>
 #include <vector>
 
 #include "open3d/pipelines/registration/CorrespondenceChecker.h"
 #include "open3d/pipelines/registration/TransformationEstimation.h"
 #include "open3d/utility/Eigen.h"
+#include "open3d/utility/Optional.h"
 
 namespace open3d {
 
@@ -185,6 +187,7 @@ RegistrationResult RegistrationICP(
 /// \param ransac_n Fit ransac with `ransac_n` correspondences.
 /// \param checkers Correspondence checker.
 /// \param criteria Convergence criteria.
+/// \param seed Random seed.
 RegistrationResult RegistrationRANSACBasedOnCorrespondence(
         const geometry::PointCloud &source,
         const geometry::PointCloud &target,
@@ -195,8 +198,8 @@ RegistrationResult RegistrationRANSACBasedOnCorrespondence(
         int ransac_n = 3,
         const std::vector<std::reference_wrapper<const CorrespondenceChecker>>
                 &checkers = {},
-        const RANSACConvergenceCriteria &criteria =
-                RANSACConvergenceCriteria());
+        const RANSACConvergenceCriteria &criteria = RANSACConvergenceCriteria(),
+        utility::optional<unsigned int> seed = utility::nullopt);
 
 /// \brief Function for global RANSAC registration based on feature matching.
 ///
@@ -211,6 +214,7 @@ RegistrationResult RegistrationRANSACBasedOnCorrespondence(
 /// \param ransac_n Fit ransac with `ransac_n` correspondences.
 /// \param checkers Correspondence checker.
 /// \param criteria Convergence criteria.
+/// \param seed Random seed.
 RegistrationResult RegistrationRANSACBasedOnFeatureMatching(
         const geometry::PointCloud &source,
         const geometry::PointCloud &target,
@@ -223,8 +227,8 @@ RegistrationResult RegistrationRANSACBasedOnFeatureMatching(
         int ransac_n = 3,
         const std::vector<std::reference_wrapper<const CorrespondenceChecker>>
                 &checkers = {},
-        const RANSACConvergenceCriteria &criteria =
-                RANSACConvergenceCriteria());
+        const RANSACConvergenceCriteria &criteria = RANSACConvergenceCriteria(),
+        utility::optional<unsigned int> seed = utility::nullopt);
 
 /// \param source The source point cloud.
 /// \param target The target point cloud.

--- a/cpp/open3d/pipelines/registration/Registration.h
+++ b/cpp/open3d/pipelines/registration/Registration.h
@@ -27,7 +27,6 @@
 #pragma once
 
 #include <Eigen/Core>
-#include <random>
 #include <tuple>
 #include <vector>
 

--- a/cpp/open3d/utility/Helper.cpp
+++ b/cpp/open3d/utility/Helper.cpp
@@ -30,7 +30,6 @@
 
 #include <algorithm>
 #include <cctype>
-#include <random>
 #include <unordered_set>
 
 #ifdef _WIN32
@@ -114,12 +113,6 @@ void Sleep(int milliseconds) {
 #else
     usleep(milliseconds * 1000);
 #endif  // _WIN32
-}
-
-int UniformRandInt(const int min, const int max) {
-    static thread_local std::mt19937 generator(std::random_device{}());
-    std::uniform_int_distribution<int> distribution(min, max);
-    return distribution(generator);
 }
 
 std::string GetCurrentTimeStamp() {

--- a/cpp/open3d/utility/Helper.h
+++ b/cpp/open3d/utility/Helper.h
@@ -143,15 +143,16 @@ inline int DivUp(int x, int y) {
     return tmp.quot + (tmp.rem != 0 ? 1 : 0);
 }
 
-/// \class UniformRandInt
+/// \class UniformRandIntGenerator
 ///
 /// \brief Draw pseudo-random integers bounded by min and max (inclusive)
 /// from a uniform distribution
-class UniformRandInt {
+class UniformRandIntGenerator {
 public:
-    UniformRandInt(const int min,
-                   const int max,
-                   std::mt19937::result_type seed = std::random_device{}())
+    UniformRandIntGenerator(
+            const int min,
+            const int max,
+            std::mt19937::result_type seed = std::random_device{}())
         : distribution_(min, max), generator_(seed) {}
     int operator()() { return distribution_(generator_); }
 

--- a/cpp/open3d/utility/Helper.h
+++ b/cpp/open3d/utility/Helper.h
@@ -29,6 +29,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <functional>
+#include <random>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -142,30 +143,22 @@ inline int DivUp(int x, int y) {
     return tmp.quot + (tmp.rem != 0 ? 1 : 0);
 }
 
-/// Thread-safe function returning a pseudo-random integer.
-/// The integer is drawn from a uniform distribution bounded by min and max
-/// (inclusive)
-int UniformRandInt(const int min, const int max);
+/// \class UniformRandInt
+///
+/// \brief Draw pseudo-random integers bounded by min and max (inclusive)
+/// from a uniform distribution
+class UniformRandInt {
+public:
+    UniformRandInt(const int min,
+                   const int max,
+                   std::mt19937::result_type seed = std::random_device{}())
+        : distribution_(min, max), generator_(seed) {}
+    int operator()() { return distribution_(generator_); }
 
-/// Uniformly distributed binary-friendly floating point number in [0, 1).
-///
-/// Binary-friendly means that the random number can be represented by floating
-/// point with a few bits of mantissa. The binary-friendliness is useful for
-/// unit testing since it reduces the chances of numerical errors.
-///
-/// E.g.
-/// - 0.9 is not representable by floating point accurately, the actual value
-///   stored in a float32 is 0.89999997615814208984375...
-/// - 0.875 = 0.5 + 0.25 + 0.125, is binary-friendly.
-///
-/// \param power The possible random numbers are: n * 1 / (2 ^ power),
-///              where n = 0, 1, 2, ..., (2 ^ power - 1).
-template <typename T>
-T UniformRandFloatBinaryFriendly(unsigned int power = 5) {
-    double p = std::pow(2, power);
-    int n = UniformRandInt(0, p - 1);
-    return static_cast<T>(1. / p * n);
-}
+protected:
+    std::uniform_int_distribution<int> distribution_;
+    std::mt19937 generator_;
+};
 
 /// Returns current time stamp.
 std::string GetCurrentTimeStamp();

--- a/cpp/pybind/pipelines/registration/registration.cpp
+++ b/cpp/pybind/pipelines/registration/registration.cpp
@@ -469,19 +469,10 @@ must hold true for all edges.)");
                              int iteration_number, double tuple_scale,
                              int maximum_tuple_count,
                              utility::optional<unsigned int> seed) {
-                     if (!seed.has_value()) {
-                         return new FastGlobalRegistrationOption(
-                                 division_factor, use_absolute_scale,
-                                 decrease_mu, maximum_correspondence_distance,
-                                 iteration_number, tuple_scale,
-                                 maximum_tuple_count);
-                     } else {
-                         return new FastGlobalRegistrationOption(
-                                 division_factor, use_absolute_scale,
-                                 decrease_mu, maximum_correspondence_distance,
-                                 iteration_number, tuple_scale,
-                                 maximum_tuple_count, seed.value());
-                     }
+                     return new FastGlobalRegistrationOption(
+                             division_factor, use_absolute_scale, decrease_mu,
+                             maximum_correspondence_distance, iteration_number,
+                             tuple_scale, maximum_tuple_count, seed);
                  }),
                  "division_factor"_a = 1.4, "use_absolute_scale"_a = false,
                  "decrease_mu"_a = false,
@@ -531,7 +522,9 @@ must hold true for all edges.)");
                         "\nseed={}", c.division_factor_, c.use_absolute_scale_,
                         c.decrease_mu_, c.maximum_correspondence_distance_,
                         c.iteration_number_, c.tuple_scale_,
-                        c.maximum_tuple_count_, c.seed_);
+                        c.maximum_tuple_count_,
+                        c.seed_.has_value() ? std::to_string(c.seed_.value())
+                                            : "None");
             });
 
     // open3d.registration.RegistrationResult

--- a/cpp/pybind/pipelines/registration/registration.cpp
+++ b/cpp/pybind/pipelines/registration/registration.cpp
@@ -611,6 +611,7 @@ static const std::unordered_map<std::string, std::string>
                  "source point's correspondence is itself."},
                 {"option", "Registration option"},
                 {"ransac_n", "Fit ransac with ``ransac_n`` correspondences"},
+                {"seed", "Random seed."},
                 {"source_feature", "Source point cloud feature."},
                 {"source", "The source point cloud."},
                 {"target_feature", "Target point cloud feature."},
@@ -667,7 +668,8 @@ void pybind_registration_methods(py::module &m) {
           "ransac_n"_a = 3,
           "checkers"_a = std::vector<
                   std::reference_wrapper<const CorrespondenceChecker>>(),
-          "criteria"_a = RANSACConvergenceCriteria(100000, 0.999));
+          "criteria"_a = RANSACConvergenceCriteria(100000, 0.999),
+          "seed"_a = py::none());
     docstring::FunctionDocInject(m,
                                  "registration_ransac_based_on_correspondence",
                                  map_shared_argument_docstrings);
@@ -682,7 +684,8 @@ void pybind_registration_methods(py::module &m) {
           "ransac_n"_a = 3,
           "checkers"_a = std::vector<
                   std::reference_wrapper<const CorrespondenceChecker>>(),
-          "criteria"_a = RANSACConvergenceCriteria(100000, 0.999));
+          "criteria"_a = RANSACConvergenceCriteria(100000, 0.999),
+          "seed"_a = py::none());
     docstring::FunctionDocInject(
             m, "registration_ransac_based_on_feature_matching",
             map_shared_argument_docstrings);

--- a/cpp/pybind/pipelines/registration/registration.cpp
+++ b/cpp/pybind/pipelines/registration/registration.cpp
@@ -467,17 +467,27 @@ must hold true for all edges.)");
                              bool decrease_mu,
                              double maximum_correspondence_distance,
                              int iteration_number, double tuple_scale,
-                             int maximum_tuple_count) {
-                     return new FastGlobalRegistrationOption(
-                             division_factor, use_absolute_scale, decrease_mu,
-                             maximum_correspondence_distance, iteration_number,
-                             tuple_scale, maximum_tuple_count);
+                             int maximum_tuple_count,
+                             utility::optional<unsigned int> seed) {
+                     if (!seed.has_value()) {
+                         return new FastGlobalRegistrationOption(
+                                 division_factor, use_absolute_scale,
+                                 decrease_mu, maximum_correspondence_distance,
+                                 iteration_number, tuple_scale,
+                                 maximum_tuple_count);
+                     } else {
+                         return new FastGlobalRegistrationOption(
+                                 division_factor, use_absolute_scale,
+                                 decrease_mu, maximum_correspondence_distance,
+                                 iteration_number, tuple_scale,
+                                 maximum_tuple_count, seed.value());
+                     }
                  }),
                  "division_factor"_a = 1.4, "use_absolute_scale"_a = false,
                  "decrease_mu"_a = false,
                  "maximum_correspondence_distance"_a = 0.025,
                  "iteration_number"_a = 64, "tuple_scale"_a = 0.95,
-                 "maximum_tuple_count"_a = 1000)
+                 "maximum_tuple_count"_a = 1000, "seed"_a = py::none())
             .def_readwrite(
                     "division_factor",
                     &FastGlobalRegistrationOption::division_factor_,
@@ -505,6 +515,8 @@ must hold true for all edges.)");
             .def_readwrite("maximum_tuple_count",
                            &FastGlobalRegistrationOption::maximum_tuple_count_,
                            "float: Maximum tuple numbers.")
+            .def_readwrite("seed", &FastGlobalRegistrationOption::seed_,
+                           "unsigned int: Random seed.")
             .def("__repr__", [](const FastGlobalRegistrationOption &c) {
                 return fmt::format(
                         ""
@@ -516,10 +528,10 @@ must hold true for all edges.)");
                         "\niteration_number={}"
                         "\ntuple_scale={}"
                         "\nmaximum_tuple_count={}",
-                        c.division_factor_, c.use_absolute_scale_,
+                        "\nseed={}", c.division_factor_, c.use_absolute_scale_,
                         c.decrease_mu_, c.maximum_correspondence_distance_,
                         c.iteration_number_, c.tuple_scale_,
-                        c.maximum_tuple_count_);
+                        c.maximum_tuple_count_, c.seed_);
             });
 
     // open3d.registration.RegistrationResult

--- a/cpp/tests/core/Tensor.cpp
+++ b/cpp/tests/core/Tensor.cpp
@@ -1752,8 +1752,9 @@ TEST_P(TensorPermuteDevices, ReduceSumLargeArray) {
     std::vector<int64_t> sizes = TensorSizes::TestCases();
     int64_t max_size = *std::max_element(sizes.begin(), sizes.end());
     std::vector<int> vals(max_size);
+    utility::UniformRandInt dist_gen(0, 3);
     std::transform(vals.begin(), vals.end(), vals.begin(),
-                   [](int x) -> int { return utility::UniformRandInt(0, 3); });
+                   [&dist_gen](int x) -> int { return dist_gen(); });
 
     for (int64_t size : sizes) {
         int ref_result = std::accumulate(vals.begin(), vals.begin() + size, 0,

--- a/cpp/tests/core/Tensor.cpp
+++ b/cpp/tests/core/Tensor.cpp
@@ -1752,9 +1752,9 @@ TEST_P(TensorPermuteDevices, ReduceSumLargeArray) {
     std::vector<int64_t> sizes = TensorSizes::TestCases();
     int64_t max_size = *std::max_element(sizes.begin(), sizes.end());
     std::vector<int> vals(max_size);
-    utility::UniformRandInt dist_gen(0, 3);
-    std::transform(vals.begin(), vals.end(), vals.begin(),
-                   [&dist_gen](int x) -> int { return dist_gen(); });
+    std::transform(vals.begin(), vals.end(), vals.begin(), [](int x) -> int {
+        return utility::UniformRandIntGenerator(0, 3)();
+    });
 
     for (int64_t size : sizes) {
         int ref_result = std::accumulate(vals.begin(), vals.begin() + size, 0,

--- a/cpp/tests/utility/Helper.cpp
+++ b/cpp/tests/utility/Helper.cpp
@@ -24,12 +24,42 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
+#include "open3d/utility/Helper.h"
+
 #include "tests/UnitTest.h"
 
 namespace open3d {
 namespace tests {
 
-TEST(Helper, DISABLED_SplitString) { NotImplemented(); }
+TEST(Helper, UniformRandIntGeneratorWithFixedSeed) {
+    std::array<int, 1024> values;
+    utility::UniformRandIntGenerator rand_generator(0, 9, 42);
+    for (auto it = values.begin(); it != values.end(); ++it)
+        *it = rand_generator();
+
+    for (int i = 0; i < 10; i++) {
+        std::array<int, 1024> new_values;
+        utility::UniformRandIntGenerator new_rand_generator(0, 9, 42);
+        for (auto it = new_values.begin(); it != new_values.end(); ++it)
+            *it = new_rand_generator();
+        EXPECT_TRUE(values == new_values);
+    }
+}
+
+TEST(Helper, UniformRandIntGeneratorWithRandomSeed) {
+    std::array<int, 1024> values;
+    utility::UniformRandIntGenerator rand_generator(0, 9);
+    for (auto it = values.begin(); it != values.end(); ++it)
+        *it = rand_generator();
+
+    for (int i = 0; i < 10; i++) {
+        std::array<int, 1024> new_values;
+        utility::UniformRandIntGenerator new_rand_generator(0, 9);
+        for (auto it = new_values.begin(); it != new_values.end(); ++it)
+            *it = new_rand_generator();
+        EXPECT_FALSE(values == new_values);
+    }
+}
 
 }  // namespace tests
 }  // namespace open3d


### PR DESCRIPTION
This PR addresses https://github.com/intel-isl/Open3D/issues/1263 for allowing deterministic registration:
- Adds a `seed` optional parameter to `RegistrationRANSACBasedOnCorrespondence` and `RegistrationRANSACBasedOnFeatureMatching`
- Adds a `seed` member to `FastGlobalRegistrationOption`
- Replaces the `UniformRandInt` function with a callable class that accepts an optional seed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3737)
<!-- Reviewable:end -->
