### PR TITLE
Add StdAllocator and apply to stdgpu backend

### DIFF
--- a/3rdparty/stdgpu/stdgpu.cmake
+++ b/3rdparty/stdgpu/stdgpu.cmake
@@ -7,8 +7,8 @@ include(ExternalProject)
 ExternalProject_Add(
     ext_stdgpu
     PREFIX stdgpu
-    URL https://github.com/stotko/stdgpu/archive/6005da976fe97c035909da6ea64cd7420949002a.tar.gz
-    URL_HASH SHA256=fe173abe4b91d1b0197590ccb67da5bf80e1ba538955b872a52f8db46ea051e1
+    URL https://github.com/stotko/stdgpu/archive/e10f6f3ccc9902d693af4380c3bcd188ec34a2e6.tar.gz
+    URL_HASH SHA256=7bb2733b099f7cedc86d2aee7830d128ac1222cfafa34cbaa4e818483c0a93f6
     DOWNLOAD_DIR "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/stdgpu"
     UPDATE_COMMAND ""
     CMAKE_ARGS

--- a/cpp/benchmarks/core/Hashmap.cpp
+++ b/cpp/benchmarks/core/Hashmap.cpp
@@ -220,6 +220,55 @@ void HashClearInt(benchmark::State& state,
     }
 }
 
+void HashRehashInt(benchmark::State& state,
+                   int capacity,
+                   int duplicate_factor,
+                   const Device& device,
+                   const HashmapBackend& backend) {
+    int slots = std::max(1, capacity / duplicate_factor);
+    HashData<int, int> data(capacity, slots);
+
+    Tensor keys(data.keys_, {capacity}, core::Int32, device);
+    Tensor values(data.vals_, {capacity}, core::Int32, device);
+
+    Hashmap hashmap_warmup(capacity, core::Int32, core::Int32, {1}, {1}, device,
+                           backend);
+    Tensor addrs, masks;
+    hashmap_warmup.Insert(keys, values, addrs, masks);
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        Hashmap hashmap(capacity, core::Int32, core::Int32, {1}, {1}, device,
+                        backend);
+        Tensor addrs, masks;
+
+        hashmap.Insert(keys, values, addrs, masks);
+
+        int64_t s = hashmap.Size();
+        if (s != slots) {
+            utility::LogError(
+                    "Error returning hashmap size, expected {}, but got {}.",
+                    slots, s);
+        }
+
+        cuda::Synchronize(device);
+        state.ResumeTiming();
+
+        hashmap.Rehash(2 * capacity);
+
+        cuda::Synchronize(device);
+        state.PauseTiming();
+
+        s = hashmap.Size();
+        if (s != slots) {
+            utility::LogError(
+                    "Error returning hashmap size, expected {}, but got {}.",
+                    slots, s);
+        }
+        state.ResumeTiming();
+    }
+}
+
 class Int3 {
 public:
     Int3() : x_(0), y_(0), z_(0){};
@@ -396,6 +445,58 @@ void HashClearInt3(benchmark::State& state,
     }
 }
 
+void HashRehashInt3(benchmark::State& state,
+                    int capacity,
+                    int duplicate_factor,
+                    const Device& device,
+                    const HashmapBackend& backend) {
+    int slots = std::max(1, capacity / duplicate_factor);
+    HashData<Int3, int> data(capacity, slots);
+
+    std::vector<int> keys_Int3;
+    keys_Int3.assign(reinterpret_cast<int*>(data.keys_.data()),
+                     reinterpret_cast<int*>(data.keys_.data()) + 3 * capacity);
+    Tensor keys(keys_Int3, {capacity, 3}, core::Int32, device);
+    Tensor values(data.vals_, {capacity}, core::Int32, device);
+
+    Hashmap hashmap_warmup(capacity, core::Int32, core::Int32, {3}, {1}, device,
+                           backend);
+    Tensor addrs, masks;
+    hashmap_warmup.Insert(keys, values, addrs, masks);
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        Hashmap hashmap(capacity, core::Int32, core::Int32, {3}, {1}, device,
+                        backend);
+        Tensor addrs, masks;
+
+        hashmap.Insert(keys, values, addrs, masks);
+
+        int64_t s = hashmap.Size();
+        if (s != slots) {
+            utility::LogError(
+                    "Error returning hashmap size, expected {}, but got {}.",
+                    slots, s);
+        }
+
+        cuda::Synchronize(device);
+        state.ResumeTiming();
+
+        hashmap.Rehash(2 * capacity);
+
+        cuda::Synchronize(device);
+        state.PauseTiming();
+
+        s = hashmap.Size();
+        if (s != slots) {
+            utility::LogError(
+                    "Error returning hashmap size, expected {}, but got {}.",
+                    slots, s);
+        }
+        state.ResumeTiming();
+    }
+}
+
 // Note: to enable large scale insertion (> 1M entries), change
 // default_max_load_factor() in stdgpu from 1.0 to 1.2~1.4.
 #define ENUM_BM_CAPACITY(FN, FACTOR, DEVICE, BACKEND)                          \
@@ -441,6 +542,8 @@ ENUM_BM_BACKEND(HashFindInt)
 ENUM_BM_BACKEND(HashFindInt3)
 ENUM_BM_BACKEND(HashClearInt)
 ENUM_BM_BACKEND(HashClearInt3)
+ENUM_BM_BACKEND(HashRehashInt)
+ENUM_BM_BACKEND(HashRehashInt3)
 
 }  // namespace core
 }  // namespace open3d

--- a/cpp/open3d/core/Device.h
+++ b/cpp/open3d/core/Device.h
@@ -42,9 +42,7 @@ public:
     enum class DeviceType { CPU = 0, CUDA = 1 };
 
     /// Default constructor.
-    Device() : device_type_(DeviceType::CPU), device_id_(0) {
-        AssertCPUDeviceIDIsZero();
-    }
+    Device() = default;
 
     /// Constructor with device specified.
     Device(DeviceType device_type, int device_id)
@@ -130,8 +128,8 @@ protected:
     }
 
 protected:
-    DeviceType device_type_;
-    int device_id_;
+    DeviceType device_type_ = DeviceType::CPU;
+    int device_id_ = 0;
 };
 
 const Device HOST = Device("CPU:0");

--- a/cpp/open3d/core/StdAllocator.h
+++ b/cpp/open3d/core/StdAllocator.h
@@ -1,0 +1,99 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include "open3d/core/Device.h"
+#include "open3d/core/MemoryManager.h"
+
+namespace open3d {
+namespace core {
+
+/// Class satisfying the Allocator requirements defined by the C++ standard.
+/// This bridge makes the MemoryManager interface accessible to all classes
+/// and containers that use the standard Allocator interface.
+///
+/// This is particularly useful to allocate (potentially cached) GPU memory
+/// or different types of memory depending on the provided device.
+template <typename T>
+class StdAllocator {
+public:
+    /// T.
+    using value_type = T;
+
+    /// Default constructor.
+    StdAllocator() = default;
+
+    /// Constructor from device.
+    explicit StdAllocator(const Device& device) : device_(device) {}
+
+    /// Default copy constructor.
+    StdAllocator(const StdAllocator&) = default;
+
+    /// Default copy assignment operator.
+    StdAllocator& operator=(const StdAllocator&) = default;
+
+    /// Default move constructor.
+    StdAllocator(StdAllocator&&) = default;
+
+    /// Default move assignment operator.
+    StdAllocator& operator=(StdAllocator&&) = default;
+
+    /// Rebind copy constructor.
+    template <typename U>
+    StdAllocator(const StdAllocator<U>& other) : device_(other.device_) {}
+
+    /// Allocates memory of size \p n.
+    T* allocate(std::size_t n) {
+        return static_cast<T*>(MemoryManager::Malloc(n * sizeof(T), device_));
+    }
+
+    /// Deallocates memory from pointer \p p of size \p n .
+    void deallocate(T* p, std::size_t n) { MemoryManager::Free(p, device_); }
+
+    /// Returns true if the instances are equal, false otherwise.
+    bool operator==(const StdAllocator& other) const {
+        return device_ == other.device_;
+    }
+
+    /// Returns true if the instances are not equal, false otherwise.
+    bool operator!=(const StdAllocator& other) const {
+        return !operator==(other);
+    }
+
+    /// Returns the device on which memory is allocated.
+    Device GetDevice() const { return device_; }
+
+private:
+    // Allow access in rebind constructor.
+    template <typename T2>
+    friend class StdAllocator;
+
+    Device device_;
+};
+
+}  // namespace core
+}  // namespace open3d

--- a/cpp/open3d/core/hashmap/CUDA/StdGPUHashmap.h
+++ b/cpp/open3d/core/hashmap/CUDA/StdGPUHashmap.h
@@ -26,22 +26,108 @@
 
 #pragma once
 
-#include <stdgpu/iterator.h>  // device_begin, device_end
-#include <stdgpu/memory.h>    // createDeviceArray, destroyDeviceArray
-#include <stdgpu/platform.h>  // STDGPU_HOST_DEVICE
-#include <thrust/for_each.h>
+#include <stdgpu/memory.h>
 #include <thrust/transform.h>
 
-#include <limits>
-#include <stdgpu/unordered_map.cuh>  // stdgpu::unordered_map
-#include <unordered_map>
+#include <stdgpu/unordered_map.cuh>
+#include <type_traits>
 
-#include "open3d/core/ParallelFor.h"
+#include "open3d/core/CUDAUtils.h"
+#include "open3d/core/StdAllocator.h"
 #include "open3d/core/hashmap/CUDA/CUDAHashmapBufferAccessor.h"
 #include "open3d/core/hashmap/DeviceHashmap.h"
 
 namespace open3d {
 namespace core {
+
+/// Class satisfying the Allocator requirements defined by the C++ standard.
+/// This bridge makes the MemoryManager interface accessible to all classes
+/// and containers in stdgpu that use the standard Allocator interface.
+///
+/// This allows to allocate (potentially cached) GPU memory in stdgpu.
+template <typename T>
+class StdGPUAllocator {
+public:
+    /// T.
+    using value_type = T;
+
+    /// Default constructor.
+    StdGPUAllocator() = default;
+
+    /// Constructor from device.
+    explicit StdGPUAllocator(const Device& device) : std_allocator_(device) {}
+
+    /// Default copy constructor.
+    StdGPUAllocator(const StdGPUAllocator&) = default;
+
+    /// Default copy assignment operator.
+    StdGPUAllocator& operator=(const StdGPUAllocator&) = default;
+
+    /// Default move constructor.
+    StdGPUAllocator(StdGPUAllocator&&) = default;
+
+    /// Default move assignment operator.
+    StdGPUAllocator& operator=(StdGPUAllocator&&) = default;
+
+    /// Rebind copy constructor.
+    template <typename U>
+    StdGPUAllocator(const StdGPUAllocator<U>& other)
+        : std_allocator_(other.std_allocator_) {}
+
+    /// Allocates memory of size \p n.
+    T* allocate(std::size_t n) {
+        if (GetDevice().GetType() != Device::DeviceType::CUDA) {
+            utility::LogError("Unsupported device.");
+        }
+
+        T* p = std_allocator_.allocate(n);
+        stdgpu::register_memory(p, n, stdgpu::dynamic_memory_type::device);
+        return p;
+    }
+
+    /// Deallocates memory from pointer \p p of size \p n .
+    void deallocate(T* p, std::size_t n) {
+        if (GetDevice().GetType() != Device::DeviceType::CUDA) {
+            utility::LogError("Unsupported device.");
+        }
+
+        stdgpu::deregister_memory(p, n, stdgpu::dynamic_memory_type::device);
+        std_allocator_.deallocate(p, n);
+    }
+
+    /// Returns true if the instances are equal, false otherwise.
+    bool operator==(const StdGPUAllocator& other) {
+        return std_allocator_ == other.std_allocator_;
+    }
+
+    /// Returns true if the instances are not equal, false otherwise.
+    bool operator!=(const StdGPUAllocator& other) { return !operator==(other); }
+
+    /// Returns the device on which memory is allocated.
+    Device GetDevice() const { return std_allocator_.GetDevice(); }
+
+private:
+    // Allow access in rebind constructor.
+    template <typename T2>
+    friend class StdGPUAllocator;
+
+    StdAllocator<T> std_allocator_;
+};
+
+// These typedefs must be defined outside of StdGPUHashmap to make them
+// accessible in raw CUDA kernels.
+template <typename Key>
+using InternalStdGPUHashmapAllocator =
+        StdGPUAllocator<thrust::pair<const Key, addr_t>>;
+
+template <typename Key, typename Hash>
+using InternalStdGPUHashmap =
+        stdgpu::unordered_map<Key,
+                              addr_t,
+                              Hash,
+                              stdgpu::equal_to<Key>,
+                              InternalStdGPUHashmapAllocator<Key>>;
+
 template <typename Key, typename Hash>
 class StdGPUHashmap : public DeviceHashmap {
 public:
@@ -83,12 +169,12 @@ public:
     std::vector<int64_t> BucketSizes() const override;
     float LoadFactor() const override;
 
-    stdgpu::unordered_map<Key, addr_t, Hash> GetImpl() const { return impl_; }
+    InternalStdGPUHashmap<Key, Hash> GetImpl() const { return impl_; }
 
 protected:
     // Use reference, since the structure itself is implicitly handled as a
     // pointer directly by stdgpu.
-    stdgpu::unordered_map<Key, addr_t, Hash> impl_;
+    InternalStdGPUHashmap<Key, Hash> impl_;
 
     CUDAHashmapBufferAccessor buffer_accessor_;
 
@@ -150,7 +236,7 @@ void StdGPUHashmap<Key, Hash>::Activate(const void* input_keys,
 
 // Need an explicit kernel for non-const access to map
 template <typename Key, typename Hash>
-__global__ void STDGPUFindKernel(stdgpu::unordered_map<Key, addr_t, Hash> map,
+__global__ void STDGPUFindKernel(InternalStdGPUHashmap<Key, Hash> map,
                                  CUDAHashmapBufferAccessor buffer_accessor,
                                  const Key* input_keys,
                                  addr_t* output_addrs,
@@ -177,12 +263,12 @@ void StdGPUHashmap<Key, Hash>::Find(const void* input_keys,
     STDGPUFindKernel<<<blocks, threads, 0, core::cuda::GetStream()>>>(
             impl_, buffer_accessor_, static_cast<const Key*>(input_keys),
             output_addrs, output_masks, count);
-    cuda::Synchronize();
+    cuda::Synchronize(this->device_);
 }
 
 // Need an explicit kernel for non-const access to map
 template <typename Key, typename Hash>
-__global__ void STDGPUEraseKernel(stdgpu::unordered_map<Key, addr_t, Hash> map,
+__global__ void STDGPUEraseKernel(InternalStdGPUHashmap<Key, Hash> map,
                                   CUDAHashmapBufferAccessor buffer_accessor,
                                   const Key* input_keys,
                                   addr_t* output_addrs,
@@ -219,7 +305,7 @@ void StdGPUHashmap<Key, Hash>::Erase(const void* input_keys,
     STDGPUEraseKernel<<<blocks, threads, 0, core::cuda::GetStream()>>>(
             impl_, buffer_accessor_, static_cast<const Key*>(input_keys),
             output_addrs, output_masks, count);
-    cuda::Synchronize();
+    cuda::Synchronize(this->device_);
 }
 
 template <typename Key>
@@ -297,7 +383,7 @@ float StdGPUHashmap<Key, Hash>::LoadFactor() const {
 
 // Need an explicit kernel for non-const access to map
 template <typename Key, typename Hash>
-__global__ void STDGPUInsertKernel(stdgpu::unordered_map<Key, addr_t, Hash> map,
+__global__ void STDGPUInsertKernel(InternalStdGPUHashmap<Key, Hash> map,
                                    CUDAHashmapBufferAccessor buffer_accessor,
                                    const Key* input_keys,
                                    const void* input_values,
@@ -357,7 +443,7 @@ void StdGPUHashmap<Key, Hash>::InsertImpl(const void* input_keys,
             impl_, buffer_accessor_, static_cast<const Key*>(input_keys),
             input_values, this->dsize_value_, output_addrs, output_masks,
             count);
-    cuda::Synchronize();
+    cuda::Synchronize(this->device_);
 }
 
 template <typename Key, typename Hash>
@@ -376,11 +462,16 @@ void StdGPUHashmap<Key, Hash>::Allocate(int64_t capacity) {
                            this->buffer_->GetHeap());
     buffer_accessor_.Reset(this->device_);
 
-    CachedMemoryManager::ReleaseCache(this->device_);
+    // stdgpu initializes on the default stream. Set the current stream to
+    // ensure correct behavior.
+    {
+        CUDAScopedStream scoped_stream(cuda::GetDefaultStream());
 
-    impl_ = stdgpu::unordered_map<Key, addr_t, Hash>::createDeviceObject(
-            this->capacity_);
-    cuda::Synchronize();
+        impl_ = InternalStdGPUHashmap<Key, Hash>::createDeviceObject(
+                this->capacity_,
+                InternalStdGPUHashmapAllocator<Key>(this->device_));
+        cuda::Synchronize(this->device_);
+    }
 }
 
 template <typename Key, typename Hash>
@@ -389,7 +480,13 @@ void StdGPUHashmap<Key, Hash>::Free() {
 
     buffer_accessor_.HostFree(this->device_);
 
-    stdgpu::unordered_map<Key, addr_t, Hash>::destroyDeviceObject(impl_);
+    // stdgpu initializes on the default stream. Set the current stream to
+    // ensure correct behavior.
+    {
+        CUDAScopedStream scoped_stream(cuda::GetDefaultStream());
+
+        InternalStdGPUHashmap<Key, Hash>::destroyDeviceObject(impl_);
+    }
 }
 }  // namespace core
 }  // namespace open3d


### PR DESCRIPTION
#### Highlights:

- Add `StdAllocator` as conforming `Allocator` interface for containers.
- Add `StdGPUAllocator` which is based on `StdAllocator` and includes additional device checks as well as memory register functionality required by `stdgpu`.
- Change custom default constructor of `Device` to automatically generated one. This implicitly "adds" `OPEN3D_HOST_DEVICE` for CUDA code and is required for `StdGPUAllocator`.
- Add `Rehash` benchmark.

#### Benchmark summary on Intel i7-10750H + NVIDIA RTX 2070 MAX-Q with 8 GB VRAM:

- `Insert`: 7% slower on very small sizes, 10-47% faster for large sizes.
- `Erase`: 7% slower on very small sizes, 10-45% faster for large sizes.
- `Find`: Identical performance.
- `Clear`: 15% slower on very small sizes, 40-50% faster for large sizes.
- `Rehash`: 10-12% faster on very small sizes, 34-67% faster for large sizes.
- `VoxelDownSample`: 15-23% faster across all sampling sizes.

(Exact numbers skipped to avoid cluttering of this summary.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3804)
<!-- Reviewable:end -->
