### PR TITLE
Remove USE_SYSTEM_GOOGLETEST option

### DIFF
--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -1010,37 +1010,19 @@ list(APPEND Open3D_3RDPARTY_PRIVATE_TARGETS Open3D::3rdparty_poisson)
 
 # Googletest
 if (BUILD_UNIT_TESTS)
-    if(USE_SYSTEM_GOOGLETEST)
-        find_path(gtest_INCLUDE_DIRS gtest/gtest.h)
-        find_library(gtest_LIBRARY gtest)
-        find_path(gmock_INCLUDE_DIRS gmock/gmock.h)
-        find_library(gmock_LIBRARY gmock)
-        if(gtest_INCLUDE_DIRS AND gtest_LIBRARY AND gmock_INCLUDE_DIRS AND gmock_LIBRARY)
-            message(STATUS "Using installed googletest")
-            add_library(3rdparty_googletest INTERFACE)
-            target_include_directories(3rdparty_googletest INTERFACE ${gtest_INCLUDE_DIRS} ${gmock_INCLUDE_DIRS})
-            target_link_libraries(3rdparty_googletest INTERFACE ${gtest_LIBRARY} ${gmock_LIBRARY})
-            add_library(Open3D::3rdparty_googletest ALIAS 3rdparty_googletest)
-        else()
-            message(STATUS "Unable to find installed googletest")
-            set(USE_SYSTEM_GOOGLETEST OFF)
-        endif()
-    endif()
-    if(NOT USE_SYSTEM_GOOGLETEST)
-        include(${Open3D_3RDPARTY_DIR}/googletest/googletest.cmake)
-        open3d_build_3rdparty_library(3rdparty_googletest DIRECTORY ${GOOGLETEST_SOURCE_DIR}
-            SOURCES
-                googletest/src/gtest-all.cc
-                googlemock/src/gmock-all.cc
-            INCLUDE_DIRS
-                googletest/include/
-                googletest/
-                googlemock/include/
-                googlemock/
-            DEPENDS
-                ext_googletest
-        )
-    endif()
+    include(${Open3D_3RDPARTY_DIR}/googletest/googletest.cmake)
+    open3d_build_3rdparty_library(3rdparty_googletest DIRECTORY ${GOOGLETEST_SOURCE_DIR}
+        SOURCES
+            googletest/src/gtest-all.cc
+            googlemock/src/gmock-all.cc
+        INCLUDE_DIRS
+            googletest/include/
+            googletest/
+            googlemock/include/
+            googlemock/
+        DEPENDS
+            ext_googletest
+    )
 endif()
 
 # Google benchmark

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,6 @@ option(USE_SYSTEM_EIGEN3          "Use system pre-installed eigen3"          OFF
 option(USE_SYSTEM_FMT             "Use system pre-installed fmt"             OFF)
 option(USE_SYSTEM_GLEW            "Use system pre-installed glew"            OFF)
 option(USE_SYSTEM_GLFW            "Use system pre-installed glfw"            OFF)
-option(USE_SYSTEM_GOOGLETEST      "Use system pre-installed googletest"      OFF)
 option(USE_SYSTEM_IMGUI           "Use system pre-installed imgui"           OFF)
 option(USE_SYSTEM_JPEG            "Use system pre-installed jpeg"            OFF)
 option(USE_SYSTEM_LIBLZF          "Use system pre-installed liblzf"          OFF)
@@ -756,7 +755,6 @@ set(3RDPARTY_DEPENDENCIES
     fmt
     GLEW
     GLFW
-    googletest
     imgui
     ippicv
     JPEG


### PR DESCRIPTION
Preinstalled versions of `googletest` only work with setting the option `GLIBCXX_USE_CXX11_ABI` to `ON`. However, the default is `OFF` and Tensorflow and PyTorch also rely on that different setting. Since `googletest` is only used in our unit tests (which are not installed) and not by the Open3D library itself, building it from source does not affect packaging for repository maintainers or other use cases.

Fixes #3785 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3808)
<!-- Reviewable:end -->
