### PR TITLE
t write_point_cloud pybind default param set to write binary

### DIFF
--- a/cpp/pybind/t/io/class_io.cpp
+++ b/cpp/pybind/t/io/class_io.cpp
@@ -115,7 +115,7 @@ void pybind_class_io(py::module &m_io) {
                         {write_ascii, compressed, print_progress});
             },
             "Function to write PointCloud with tensor attributes to file.",
-            "filename"_a, "pointcloud"_a, "write_ascii"_a = true,
+            "filename"_a, "pointcloud"_a, "write_ascii"_a = false,
             "compressed"_a = false, "print_progress"_a = false);
     docstring::FunctionDocInject(m_io, "write_point_cloud",
                                  map_shared_argument_docstrings);


### PR DESCRIPTION
Loading time are different when the file is saved as ASCII v/s BIN. [Similar results were observed when opened with MeshLab].

|             | points     | file size | Loading Time [ASCII] | Loading Time [BIN] |
| ----------- | ---------- | --------- | -------------------- | -------------------- |
| bedroom.ply | 20,061,457 | 450 MB      | 28,129 ms            | 5,300 ms             |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3816)
<!-- Reviewable:end -->
