### PR TITLE
Full CUDA static linking on Linux

### DIFF
--- a/3rdparty/faiss/faiss_build.cmake
+++ b/3rdparty/faiss/faiss_build.cmake
@@ -8,8 +8,8 @@ set(MKL_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/mkl_install)
 ExternalProject_Add(
     ext_faiss
     PREFIX faiss
-    URL https://github.com/isl-org/faiss/archive/28ef0e0fa5b99dabb371df9016a7df3e836a31f4.tar.gz # open3d_patch branch
-    URL_HASH SHA256=22d64aed0e6ee1ae60da2adf5746eb45802464f25965549cb47ce860bdb1f906
+    URL https://github.com/isl-org/faiss/archive/0493ff79e50dc4c5a55ebf0af4b7984d86f8227d.tar.gz # open3d_patch branch
+    URL_HASH SHA256=6550aa32ea28484ec774228b5cc7555c58304dd971bb5e5601999c351f20b9bd
     DOWNLOAD_DIR "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/faiss"
     UPDATE_COMMAND ""
     CMAKE_ARGS

--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -1251,7 +1251,7 @@ if (WITH_FAISS)
         INCLUDE_DIRS ${FAISS_INCLUDE_DIR}
         LIBRARIES    ${FAISS_LIBRARIES}
         LIB_DIR      ${FAISS_LIB_DIR}
-        DEPENDS      ext_faiss ${FAISS_EXTRA_DEPENDENCIES}
+        DEPENDS      ext_faiss
     )
     target_link_libraries(3rdparty_faiss INTERFACE ${CMAKE_DL_LIBS})
     list(APPEND Open3D_3RDPARTY_PRIVATE_TARGETS Open3D::3rdparty_faiss)

--- a/python/test/ml_ops/test_cublas.py
+++ b/python/test/ml_ops/test_cublas.py
@@ -1,0 +1,52 @@
+# ----------------------------------------------------------------------------
+# -                        Open3D: www.open3d.org                            -
+# ----------------------------------------------------------------------------
+# The MIT License (MIT)
+#
+# Copyright (c) 2018-2021 www.open3d.org
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ----------------------------------------------------------------------------
+
+import open3d as o3d
+import numpy as np
+import pytest
+import mltest
+
+# Skip all tests if the ml ops were not built
+pytestmark = mltest.default_marks
+
+
+@mltest.parametrize.ml_gpu_only
+def test_cublas_matmul(ml):
+    # This test checks if calling cublas functionality from open3d and the ml framework works.
+
+    rng = np.random.RandomState(123)
+
+    n = 20
+    arr = rng.rand(n, n).astype(np.float32)
+
+    # do matmul with open3d
+    A = o3d.core.Tensor.from_numpy(arr).cuda()
+    B = A @ A
+
+    # now use the ml framework cublas
+    C = mltest.run_op(ml, ml.device, True, ml.module.matmul, arr, arr)
+
+    np.testing.assert_allclose(B.cpu().numpy(), C)


### PR DESCRIPTION
The current release version of Python wheel for Linux depends on certain CUDA shared libraries. If the CUDA toolkit version does not match the one in `PATH`, all the CUDA functionalities will not work. 


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3817)
<!-- Reviewable:end -->