### PR TITLE
Fix undefined names: docstr and VisibleDeprecationWarning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Master
 
 * Python 3.9 support. Tensorflow bump 2.4.1 -> 2.5.0. PyTorch bump 1.7.1 -> 1.8.1 (LTS)
+* Fix undefined names: docstr and VisibleDeprecationWarning (PR #3844)
 
 ## 0.13
 

--- a/cpp/pybind/generate_torch_ops_wrapper.py
+++ b/cpp/pybind/generate_torch_ops_wrapper.py
@@ -54,7 +54,7 @@ def parse_schema_from_docstring(docstring):
     open3d::my_function(int a, Tensor b, Tensor c) -> Tensor d
     open3d::my_function(int a, Tensor b, str c='bla') -> Tensor d
     """
-    m = re.search('with schema: open3d::(.*)$', docstr)
+    m = re.search('with schema: open3d::(.*)$', docstring)
     fn_signature = m.group(1)
     m = re.match('^(.*)\((.*)\) -> (.*)', fn_signature)
     fn_name, arguments, returns = m.group(1), m.group(2), m.group(3)

--- a/python/test/core/test_core.py
+++ b/python/test/core/test_core.py
@@ -209,7 +209,7 @@ def test_tensor_constructor(dtype, device):
         import warnings
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore",
-                                    category=VisibleDeprecationWarning)
+                                    category=np.VisibleDeprecationWarning)
             o3_t = o3c.Tensor(li_t, dtype, device)
 
     # Automatic casting


### PR DESCRIPTION
$ `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
```
./Open3D/cpp/pybind/generate_torch_ops_wrapper.py:57:49: F821 undefined name 'docstr'
    m = re.search('with schema: open3d::(.*)$', docstr)
                                                ^
./Open3D/python/test/core/test_core.py:212:46: F821 undefined name 'VisibleDeprecationWarning'
                                    category=VisibleDeprecationWarning)
                                             ^
2     F821 undefined name 'docstr'
2
```
https://github.com/numpy/numpy/blob/main/numpy/_globals.py#L44 change made in #3421

@stotko Your review please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3844)
<!-- Reviewable:end -->
