### PR TITLE
ReadPointCloud default parameter changed

### DIFF
--- a/cpp/open3d/io/PointCloudIO.h
+++ b/cpp/open3d/io/PointCloudIO.h
@@ -47,8 +47,8 @@ struct ReadPointCloudOption {
             // Attention: when you update the defaults, update the docstrings in
             // pybind/io/class_io.cpp
             std::string format = "auto",
-            bool remove_nan_points = true,
-            bool remove_infinite_points = true,
+            bool remove_nan_points = false,
+            bool remove_infinite_points = false,
             bool print_progress = false,
             std::function<bool(double)> update_progress = {})
         : format(format),

--- a/cpp/pybind/io/class_io.cpp
+++ b/cpp/pybind/io/class_io.cpp
@@ -189,8 +189,8 @@ void pybind_class_io(py::module &m_io) {
                 return pcd;
             },
             "Function to read PointCloud from file", "filename"_a,
-            "format"_a = "auto", "remove_nan_points"_a = true,
-            "remove_infinite_points"_a = true, "print_progress"_a = false);
+            "format"_a = "auto", "remove_nan_points"_a = false,
+            "remove_infinite_points"_a = false, "print_progress"_a = false);
     docstring::FunctionDocInject(m_io, "read_point_cloud",
                                  map_shared_argument_docstrings);
 


### PR DESCRIPTION
- Changed default parameter for `ReadPointCloud` to set `remove_nan_points` and `remove_inf_points` as false (as they are not supported in tensor pipeline yet). 
- This also changes the default for legacy.

Discussion:
- ReadParamOptions might be complicated, may we replace it directly with bool?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3879)
<!-- Reviewable:end -->
