### PR TITLE
Default Constructor for Tensor PointCloud and TriangleMesh Pybind

### DIFF
--- a/cpp/open3d/t/geometry/LineSet.cpp
+++ b/cpp/open3d/t/geometry/LineSet.cpp
@@ -90,9 +90,9 @@ std::string LineSet::ToString() const {
     } else {
         for (const auto &keyval : point_attr_) {
             if (keyval.first == "positions") continue;
-            str += fmt::format(" {} ({}, {}),", keyval.first,
+            str += fmt::format(" {} (dtype = {}, shape = {}),", keyval.first,
                                keyval.second.GetDtype().ToString(),
-                               keyval.second.GetShape(1));
+                               keyval.second.GetShape().ToString());
         }
         str[str.size() - 1] = '.';
     }
@@ -108,9 +108,9 @@ std::string LineSet::ToString() const {
     } else {
         for (const auto &keyval : line_attr_) {
             if (keyval.first == "indices") continue;
-            str += fmt::format(" {} ({}, {}),", keyval.first,
+            str += fmt::format(" {} (dtype = {}, shape = {}),", keyval.first,
                                keyval.second.GetDtype().ToString(),
-                               keyval.second.GetShape(1));
+                               keyval.second.GetShape().ToString());
         }
         str[str.size() - 1] = '.';
     }

--- a/cpp/open3d/t/geometry/PointCloud.cpp
+++ b/cpp/open3d/t/geometry/PointCloud.cpp
@@ -74,14 +74,14 @@ std::string PointCloud::ToString() const {
         return fmt::format("PointCloud on {} [0 points ()] Attributes: None.",
                            GetDevice().ToString());
     auto str = fmt::format("PointCloud on {} [{} points ({})] Attributes:",
-                           GetDevice().ToString(), GetPoints().GetShape(0),
+                           GetDevice().ToString(), GetPoints().GetLength(),
                            GetPoints().GetDtype().ToString());
     if (point_attr_.size() == 1) return str + " None.";
     for (const auto &keyval : point_attr_) {
         if (keyval.first != "points") {
             str += fmt::format(" {} ({}, {}),", keyval.first,
                                keyval.second.GetDtype().ToString(),
-                               keyval.second.GetShape(1));
+                               keyval.second.GetLength());
         }
     }
     str[str.size() - 1] = '.';

--- a/cpp/open3d/t/geometry/PointCloud.cpp
+++ b/cpp/open3d/t/geometry/PointCloud.cpp
@@ -81,9 +81,9 @@ std::string PointCloud::ToString() const {
     if (point_attr_.size() == 1) return str + " None.";
     for (const auto &keyval : point_attr_) {
         if (keyval.first != "positions") {
-            str += fmt::format(" {} ({}, {}),", keyval.first,
+            str += fmt::format(" {} (dtype = {}, shape = {}),", keyval.first,
                                keyval.second.GetDtype().ToString(),
-                               keyval.second.GetLength());
+                               keyval.second.GetShape().ToString());
         }
     }
     str[str.size() - 1] = '.';

--- a/cpp/open3d/t/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/t/geometry/TriangleMesh.cpp
@@ -75,29 +75,31 @@ std::string TriangleMesh::ToString() const {
             GetTriangleIndices().GetLength(),
             GetTriangleIndices().GetDtype().ToString());
 
-    std::string vertices_attr_str = "\nVertices Attributes: ";
+    std::string vertices_attr_str = "\nVertices Attributes:";
     if (vertex_attr_.size() == 1) {
         vertices_attr_str += " None.";
     } else {
         for (const auto &kv : vertex_attr_) {
             if (kv.first != "positions") {
-                vertices_attr_str += fmt::format(
-                        " {} ({}, {}),", kv.first,
-                        kv.second.GetDtype().ToString(), kv.second.GetLength());
+                vertices_attr_str +=
+                        fmt::format(" {} (dtype = {}, shape = {}),", kv.first,
+                                    kv.second.GetDtype().ToString(),
+                                    kv.second.GetShape().ToString());
             }
         }
         vertices_attr_str[vertices_attr_str.size() - 1] = '.';
     }
 
-    std::string triangles_attr_str = "\nTriangles Attributes: ";
+    std::string triangles_attr_str = "\nTriangles Attributes:";
     if (triangle_attr_.size() == 1) {
         triangles_attr_str += " None.";
     } else {
         for (const auto &kv : triangle_attr_) {
             if (kv.first != "indices") {
-                triangles_attr_str += fmt::format(
-                        " {} ({}, {}),", kv.first,
-                        kv.second.GetDtype().ToString(), kv.second.GetLength());
+                triangles_attr_str +=
+                        fmt::format(" {} (dtype = {}, shape = {}),", kv.first,
+                                    kv.second.GetDtype().ToString(),
+                                    kv.second.GetShape().ToString());
             }
         }
         triangles_attr_str[triangles_attr_str.size() - 1] = '.';

--- a/cpp/open3d/t/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/t/geometry/TriangleMesh.cpp
@@ -62,6 +62,49 @@ TriangleMesh::TriangleMesh(const core::Tensor &vertices,
     SetTriangles(triangles);
 }
 
+std::string TriangleMesh::ToString() const {
+    if (vertex_attr_.size() == 0 || triangle_attr_.size() == 0)
+        return fmt::format("TriangleMesh on {} [{} vertices and {} triangles].",
+                           GetDevice().ToString(), vertex_attr_.size(),
+                           triangle_attr_.size());
+
+    auto str = fmt::format(
+            "TriangleMesh on {} [{} vertices ({}) and {} triangles ({})].",
+            GetDevice().ToString(), GetVertices().GetLength(),
+            GetVertices().GetDtype().ToString(), GetTriangles().GetLength(),
+            GetTriangles().GetDtype().ToString());
+
+    std::string vertices_attr_str = "\n Vertices Attributes: ";
+    if (vertex_attr_.size() == 1) {
+        vertices_attr_str += " None.";
+    } else {
+        for (const auto &kv : vertex_attr_) {
+            if (kv.first != "vertices") {
+                vertices_attr_str += fmt::format(
+                        " {} ({}, {}),", kv.first,
+                        kv.second.GetDtype().ToString(), kv.second.GetLength());
+            }
+        }
+        vertices_attr_str[vertices_attr_str.size() - 1] = '.';
+    }
+
+    std::string triangles_attr_str = "\n Triangles Attributes: ";
+    if (triangle_attr_.size() == 1) {
+        triangles_attr_str += " None.";
+    } else {
+        for (const auto &kv : triangle_attr_) {
+            if (kv.first != "vertices") {
+                triangles_attr_str += fmt::format(
+                        " {} ({}, {}),", kv.first,
+                        kv.second.GetDtype().ToString(), kv.second.GetLength());
+            }
+        }
+        triangles_attr_str[triangles_attr_str.size() - 1] = '.';
+    }
+
+    return str + vertices_attr_str + triangles_attr_str;
+}
+
 TriangleMesh &TriangleMesh::Transform(const core::Tensor &transformation) {
     kernel::transform::TransformPoints(transformation, GetVertices());
     if (HasVertexNormals()) {

--- a/cpp/open3d/t/geometry/TriangleMesh.h
+++ b/cpp/open3d/t/geometry/TriangleMesh.h
@@ -127,6 +127,9 @@ public:
     virtual ~TriangleMesh() override {}
 
 public:
+    /// \brief Text description.
+    std::string ToString() const;
+
     /// Transfer the triangle mesh to a specified device.
     /// \param device The targeted device to convert to.
     /// \param copy If true, a new triangle mesh is always created; if false,

--- a/cpp/pybind/t/geometry/pointcloud.cpp
+++ b/cpp/pybind/t/geometry/pointcloud.cpp
@@ -65,7 +65,9 @@ void pybind_pointcloud(py::module& m) {
                        "A pointcloud contains a set of 3D points.");
 
     // Constructors.
-    pointcloud.def(py::init<const core::Device&>(), "device"_a)
+    pointcloud
+            .def(py::init<const core::Device&>(),
+                 "device"_a = core::Device("CPU:0"))
             .def(py::init<const core::Tensor&>(), "points"_a)
             .def(py::init<const std::unordered_map<std::string,
                                                    core::Tensor>&>(),

--- a/cpp/pybind/t/geometry/trianglemesh.cpp
+++ b/cpp/pybind/t/geometry/trianglemesh.cpp
@@ -43,9 +43,12 @@ void pybind_trianglemesh(py::module& m) {
                     "A triangle mesh contains a set of 3d vertices and faces.");
 
     // Constructors.
-    triangle_mesh.def(py::init<const core::Device&>(), "device"_a)
+    triangle_mesh
+            .def(py::init<const core::Device&>(),
+                 "device"_a = core::Device("CPU:0"))
             .def(py::init<const core::Tensor&, const core::Tensor&>(),
-                 "vertices"_a, "triangles"_a);
+                 "vertices"_a, "triangles"_a)
+            .def("__repr__", &TriangleMesh::ToString);
 
     // Triangle mesh's attributes: vertices, vertex_colors, vertex_normals, etc.
     // def_property_readonly is sufficient, since the returned TensorMap can

--- a/cpp/tests/t/geometry/LineSet.cpp
+++ b/cpp/tests/t/geometry/LineSet.cpp
@@ -131,11 +131,14 @@ TEST_P(LineSetPermuteDevices, Getters) {
 
     // ToString
     std::string text = "LineSet on " + device.ToString() +
-                       "\n[2 points (Float32)] Attributes: labels (Float32, 3)."
+                       "\n[2 points (Float32)] Attributes: labels (dtype = "
+                       "Float32, shape = {2, 3})."
                        "\n[2 lines (Int64)] Attributes: ";
     EXPECT_THAT(lineset.ToString(),  // Compiler dependent output
-                AnyOf(text + "labels (Float32, 3), colors (Float32, 3).",
-                      text + "colors (Float32, 3), labels (Float32, 3)."));
+                AnyOf(text + "labels (dtype = Float32, shape = {2, 3}), colors "
+                             "(dtype = Float32, shape = {2, 3}).",
+                      text + "colors (dtype = Float32, shape = {2, 3}), labels "
+                             "(dtype = Float32, shape = {2, 3})."));
 }
 
 TEST_P(LineSetPermuteDevices, Setters) {

--- a/cpp/tests/t/geometry/PointCloud.cpp
+++ b/cpp/tests/t/geometry/PointCloud.cpp
@@ -342,8 +342,10 @@ TEST_P(PointCloudPermuteDevices, Getters) {
     std::string text = "PointCloud on " + device.ToString() +
                        " [2 points (Float32)] Attributes: ";
     EXPECT_THAT(pcd.ToString(),  // Compiler dependent output
-                AnyOf(text + "colors (Float32, 3), labels (Float32, 3).",
-                      text + "labels (Float32, 3), colors (Float32, 3)."));
+                AnyOf(text + "colors (dtype = Float32, shape = {2, 3}), labels "
+                             "(dtype = Float32, shape = {2, 3}).",
+                      text + "labels (dtype = Float32, shape = (2, 3)), colors "
+                             "(dtype = Float32, shape = {2, 3})."));
 }
 
 TEST_P(PointCloudPermuteDevices, Setters) {

--- a/cpp/tests/t/geometry/TriangleMesh.cpp
+++ b/cpp/tests/t/geometry/TriangleMesh.cpp
@@ -126,17 +126,33 @@ TEST_P(TriangleMeshPermuteDevices, Getters) {
                     (void)tl);
     EXPECT_NO_THROW(const core::Tensor& tl = mesh.GetTriangleAttr("labels");
                     (void)tl);
+}
 
-    // ToString Test.
-    // ToString may print the attributes in any order. In order to reduce
-    // complexity of the test, keeping only one attribute per tensor-map.
-    mesh.RemoveVertexAttr("labels");
-    mesh.RemoveTriangleAttr("labels");
+TEST_P(TriangleMeshPermuteDevices, ToString) {
+    core::Device device = GetParam();
 
-    std::string text = "TriangleMesh on " + device.ToString() +
-                       " [2 vertices (Float32) and 2 triangles (Int64)]."
-                       "\nVertices Attributes:  colors (Float32, 2)."
-                       "\nTriangles Attributes:  normals (Float32, 2).";
+    core::Tensor vertices = core::Tensor::Ones({2, 3}, core::Float32, device);
+    core::Tensor vertex_colors =
+            core::Tensor::Ones({2, 3}, core::Float32, device) * 2;
+    core::Tensor vertex_labels =
+            core::Tensor::Ones({2, 3}, core::Float32, device) * 3;
+
+    core::Tensor triangles = core::Tensor::Ones({2, 3}, core::Int64, device);
+    core::Tensor triangle_normals =
+            core::Tensor::Ones({2, 3}, core::Float32, device) * 2;
+    core::Tensor triangle_labels =
+            core::Tensor::Ones({2, 3}, core::Float32, device) * 3;
+
+    t::geometry::TriangleMesh mesh(vertices, triangles);
+    mesh.SetVertexColors(vertex_colors);
+    mesh.SetTriangleNormals(triangle_normals);
+
+    std::string text =
+            "TriangleMesh on " + device.ToString() +
+            " [2 vertices (Float32) and 2 triangles (Int64)]."
+            "\nVertices Attributes: colors (dtype = Float32, shape = {2, 3})."
+            "\nTriangles Attributes: normals (dtype = Float32, shape = {2, "
+            "3}).";
 
     EXPECT_STREQ(mesh.ToString().c_str(), text.c_str());
 
@@ -146,8 +162,8 @@ TEST_P(TriangleMeshPermuteDevices, Getters) {
     // Mesh with only primary attributes.
     std::string text_2 = "TriangleMesh on " + device.ToString() +
                          " [2 vertices (Float32) and 2 triangles (Int64)]."
-                         "\nVertices Attributes:  None."
-                         "\nTriangles Attributes:  None.";
+                         "\nVertices Attributes: None."
+                         "\nTriangles Attributes: None.";
 
     EXPECT_STREQ(mesh.ToString().c_str(), text_2.c_str());
 


### PR DESCRIPTION
- Default constructor for `Tensor` `PointCloud` and `TriangleMesh` `Pybind`.
- `TriangleMesh::ToString()`

Updated `ToString()` for pointcloud and lineset:
Previously for a `custom` attribute of `shape (4, 3, 2)` and type `Float32`, ToString for `pointcloud` and `lineset` printed: 
`Attribute: custom (Float32, 3)`, now it prints `Attribute: custom (dtype = Float32, shape = {4, 3, 2})`, which might be more clear.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3880)
<!-- Reviewable:end -->
