### PR TITLE
Revert ccache -M 1G for ARM docker build

### DIFF
--- a/.github/workflows/Dockerfile.openblas
+++ b/.github/workflows/Dockerfile.openblas
@@ -88,7 +88,6 @@ RUN CCACHE_DIR=$(ccache -p | grep cache_dir | grep -oE "[^ ]+$") \
  && cd ${CCACHE_DIR_PARENT} \
  && wget https://storage.googleapis.com/open3d-ci-cache/${CCACHE_TAR_NAME}.tar.gz \
  && tar -xf ${CCACHE_TAR_NAME}.tar.gz \
- && ccache -M 1G \
  && ccache -s
 ENV PATH=/usr/lib/ccache:${PATH}
 


### PR DESCRIPTION
Also updated the Google cloud cache `open3d-arm64-ci-ccache.tar.gz` manually.
The new limit is ccache's default 5G limit.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3904)
<!-- Reviewable:end -->
