### PR TITLE
Revert "Throw proper error for invalid CUDA device id. (#3890)"

### DIFF
--- a/cpp/open3d/core/CUDAUtils.cpp
+++ b/cpp/open3d/core/CUDAUtils.cpp
@@ -88,41 +88,6 @@ void Synchronize(const Device& device) {
 #endif
 }
 
-void AssertCUDADeviceAvailable(int device_id) {
-#ifdef BUILD_CUDA_MODULE
-    if (cuda::DeviceCount() == 0) {
-        utility::LogError(
-                "Invalid device 'CUDA:{}'. -DBUILD_CUDA_MODULE=ON, but no "
-                "CUDA device available.",
-                device_id);
-    } else if (cuda::DeviceCount() == 1 && device_id != 0) {
-        utility::LogError(
-                "Invalid CUDA Device 'CUDA:{}'. Device ID expected to "
-                "be 0, but got {}.",
-                device_id, device_id);
-    } else if (device_id < 0 || device_id >= cuda::DeviceCount()) {
-        utility::LogError(
-                "Invalid CUDA Device 'CUDA:{}'. Device ID expected to "
-                "be between 0 to {}, but got {}.",
-                device_id, cuda::DeviceCount() - 1, device_id);
-    }
-#else
-    utility::LogError(
-            "-DBUILD_CUDA_MODULE=OFF. Please build with -DBUILD_CUDA_MODULE=ON "
-            "to use CUDA device.");
-#endif
-}
-
-void AssertCUDADeviceAvailable(const Device& device) {
-    if (device.GetType() == Device::DeviceType::CUDA) {
-        AssertCUDADeviceAvailable(device.GetID());
-    } else {
-        utility::LogError(
-                "Expected device-type to be CUDA, but got device '{}'",
-                device.ToString());
-    }
-}
-
 #ifdef BUILD_CUDA_MODULE
 int GetDevice() {
     int device;
@@ -131,7 +96,6 @@ int GetDevice() {
 }
 
 static void SetDevice(int device_id) {
-    AssertCUDADeviceAvailable(device_id);
     OPEN3D_CUDA_CHECK(cudaSetDevice(device_id));
 }
 

--- a/cpp/open3d/core/CUDAUtils.h
+++ b/cpp/open3d/core/CUDAUtils.h
@@ -254,16 +254,6 @@ void Synchronize();
 /// \param device The device to be synchronized.
 void Synchronize(const Device& device);
 
-/// Checks if the CUDA device-ID is available and throws error if not. The CUDA
-/// device-ID must be between 0 to device count - 1.
-/// \param device_id The cuda device id to be checked.
-void AssertCUDADeviceAvailable(int device_id);
-
-/// Checks if the CUDA device-ID is available and throws error if not. The CUDA
-/// device-ID must be between 0 to device count - 1.
-/// \param device The device to be checked.
-void AssertCUDADeviceAvailable(const Device& device);
-
 #ifdef BUILD_CUDA_MODULE
 
 int GetDevice();

--- a/cpp/tests/core/Tensor.cpp
+++ b/cpp/tests/core/Tensor.cpp
@@ -359,8 +359,10 @@ TEST_P(TensorPermuteDevicePairs, ToDevice) {
 
     EXPECT_ANY_THROW(src_t.To(core::Device("CPU:1")));
 
-    EXPECT_ANY_THROW(src_t.To(core::Device("CUDA:-1")));
-    EXPECT_ANY_THROW(src_t.To(core::Device("CUDA:100000")));
+    // TODO: CUDA exceptions are not captured by EXPECT_ANY_THROW. Detect
+    // invalid device and throw an exception at an earlier stage.
+    // EXPECT_ANY_THROW(src_t.To(core::Device("CUDA:-1")));
+    // EXPECT_ANY_THROW(src_t.To(core::Device("CUDA:100000")));
 }
 
 TEST_P(TensorPermuteDevicePairs, CopyBroadcast) {


### PR DESCRIPTION
Master build failing since #3890. Testing again without #3890.

This reverts commit 617b96ff3f2ca48b073dbb02943c92b678102261.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3907)
<!-- Reviewable:end -->
