### PR TITLE
Add warnings to help debug CUDA / pybind issues

### DIFF
--- a/docs/getting_started.rst.in
+++ b/docs/getting_started.rst.in
@@ -140,11 +140,23 @@ Now, try importing Open3D.
 If this works, congratulations, now Open3D has been successfully installed!
 
 
+Troubleshooting:
+^^^^^^^^^^^^^^^^
+
+If you get an error when importing Open3D, enable detailed Python warnings to
+help troubleshoot the issue:
+
+.. code-block:: bash
+
+    python -W default -c "import open3d as o3d"
+
+
 Running Open3D tutorials
 ========================
 
 A complete set of Python tutorials and testing data will also be copied to
-demonstrate the usage of Open3D Python interface. See ``examples/python`` for all Python examples.
+demonstrate the usage of Open3D Python interface. See ``examples/python`` for
+all Python examples.
 
 .. note:: Open3D's Python tutorial utilizes some external packages: ``numpy``,
     ``matplotlib``, ``opencv-python``. OpenCV is only used for reconstruction


### PR DESCRIPTION
Warnings enabled (if cuda.pybind DSO not found):
```
$ python -W default -c "import open3d as o3d"
/Users/ssheorey/Documents/Open3D/Code/Open3D/build/lib/python_package/open3d/__init__.py:84: ImportWarning: Open3D was built with CUDA support, but Open3D CUDA Python binding library not found! Falling back to the CPU Python binding library.
  warnings.warn(
Using external Open3D-ML in /Users/ssheorey/Documents/Open3D/Code/Open3D-ML/
```
Warnings disabled:
```
$ python -c "import open3d as o3d"
Using external Open3D-ML in /Users/ssheorey/Documents/Open3D/Code/Open3D-ML/
```

See: https://github.com/isl-org/Open3D/issues/3827#issuecomment-898672575

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3918)
<!-- Reviewable:end -->
