### PR TITLE
Make docs archive available after wheels are ready.

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -99,7 +99,7 @@ jobs:
           if-no-files-found: error
 
       - name: Deploy docs
-        # if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         run: |
           # Compress and upload the docs, only for master branch
           docs_out_dir="docs/_out" # Docs in ${docs_out_dir}/html

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -99,12 +99,13 @@ jobs:
           if-no-files-found: error
 
       - name: Deploy docs
-        if: ${{ github.ref == 'refs/heads/master' }}
+        # if: ${{ github.ref == 'refs/heads/master' }}
         run: |
           # Compress and upload the docs, only for master branch
           docs_out_dir="docs/_out" # Docs in ${docs_out_dir}/html
           tar_file="${{ github.sha }}.tar.gz"
           rm -rf ${tar_file}
           tar -C ${docs_out_dir} -czvf ${tar_file} html
-          gsutil cp ${tar_file} gs://open3d-docs/${tar_file}
-          echo "Download the docs at: https://storage.googleapis.com/open3d-docs/${tar_file}"
+          gsutil cp ${tar_file} gs://open3d-docs/wait_for_wheels_${tar_file}
+          echo "Docs archive uploaded to:"
+          echo "https://storage.googleapis.com/open3d-docs/wait_for_wheels_${tar_file}"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -212,7 +212,7 @@ jobs:
   ready-docs:
     name: Ready docs archive
     runs-on: ubuntu-18.04
-    # if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.ref == 'refs/heads/master' }}
     needs: [build-wheel]
     steps:
       - name: GCloud CLI setup

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -209,6 +209,27 @@ jobs:
           gsutil cp build/lib/python_package/conda_package/linux-64/${{ env.CONDA_PKG_NAME }} gs://open3d-releases-master/conda_package/linux-64/
           echo "Download conda package at: https://storage.googleapis.com/open3d-releases-master/conda_package/linux-64/${{ env.CONDA_PKG_NAME }}"
 
+  ready-docs:
+    name: Ready docs archive
+    runs-on: ubuntu-18.04
+    # if: ${{ github.ref == 'refs/heads/master' }}
+    needs: [build-wheel]
+    steps:
+      - name: GCloud CLI setup
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          version: ${{ env.GCE_CLI_GHA_VERSION }}
+          service_account_key: ${{ secrets.GCE_SA_KEY_GPU_CI }}
+          project_id: ${{ secrets.GCE_DOCS_PROJECT }}
+          export_default_credentials: true
+
+      - name: Rename documentation archive
+        run: |
+          docs_tar_file="${{ github.sha }}.tar.gz"
+          gsutil mv gs://open3d-docs/wait_for_wheels_${docs_tar_file} gs://open3d-docs/${docs_tar_file}
+          echo "All development wheels available. Documentation archive is ready for deployment:"
+          echo "https://storage.googleapis.com/open3d-docs/${docs_tar_file}"
+
   test-wheel:
     name: Test wheel
     runs-on: ubuntu-18.04


### PR DESCRIPTION
Upload docs archive with a prefix initially.
Rename to correct name after Ubuntu wheels are uploaded.
Ubuntu wheels take the longest to build (on master).
~~Upload enabled on all branches for testing.~~ Only master

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3919)
<!-- Reviewable:end -->
