### PR TITLE
Refactor CUDAState()::GetInstance()

### DIFF
--- a/cpp/open3d/core/CUDAUtils.cpp
+++ b/cpp/open3d/core/CUDAUtils.cpp
@@ -40,8 +40,7 @@ namespace cuda {
 int DeviceCount() {
 #ifdef BUILD_CUDA_MODULE
     try {
-        std::shared_ptr<CUDAState> cuda_state = CUDAState::GetInstance();
-        return cuda_state->GetNumDevices();
+        return CUDAState::GetInstance().GetNumDevices();
     } catch (const std::runtime_error&) {  // GetInstance can throw
         return 0;
     }
@@ -203,8 +202,8 @@ CUDAScopedStream::~CUDAScopedStream() {
     cuda::SetStream(prev_stream_);
 }
 
-std::shared_ptr<CUDAState> CUDAState::GetInstance() {
-    static std::shared_ptr<CUDAState> instance{new CUDAState};
+CUDAState& CUDAState::GetInstance() {
+    static CUDAState instance;
     return instance;
 }
 

--- a/cpp/open3d/core/CUDAUtils.h
+++ b/cpp/open3d/core/CUDAUtils.h
@@ -196,7 +196,7 @@ private:
 /// https://github.com/pytorch/pytorch/blob/master/aten/src/THC/THCGeneral.cpp
 class CUDAState {
 public:
-    static std::shared_ptr<CUDAState> GetInstance();
+    static CUDAState& GetInstance();
 
     CUDAState(CUDAState const&) = delete;
     void operator=(CUDAState const&) = delete;

--- a/cpp/open3d/core/MemoryManagerCUDA.cpp
+++ b/cpp/open3d/core/MemoryManagerCUDA.cpp
@@ -103,8 +103,8 @@ void CUDAMemoryManager::Memcpy(void* dst_ptr,
             OPEN3D_CUDA_CHECK(cudaMemcpyAsync(dst_ptr, src_ptr, num_bytes,
                                               cudaMemcpyDeviceToDevice,
                                               cuda::GetStream()));
-        } else if (CUDAState::GetInstance()->IsP2PEnabled(src_device.GetID(),
-                                                          dst_device.GetID())) {
+        } else if (CUDAState::GetInstance().IsP2PEnabled(src_device.GetID(),
+                                                         dst_device.GetID())) {
             OPEN3D_CUDA_CHECK(cudaMemcpyPeerAsync(
                     dst_ptr, dst_device.GetID(), src_ptr, src_device.GetID(),
                     num_bytes, cuda::GetStream()));

--- a/cpp/open3d/core/kernel/ReductionCUDA.cu
+++ b/cpp/open3d/core/kernel/ReductionCUDA.cu
@@ -230,7 +230,7 @@ public:
                                 ? static_cast<int>(LastPow2(dim1))
                                 : MAX_NUM_THREADS;
         block_width_ =
-                std::min(dim0_pow2, CUDAState::GetInstance()->GetWarpSize());
+                std::min(dim0_pow2, CUDAState::GetInstance().GetWarpSize());
         block_height_ =
                 std::min(dim1_pow2, int(MAX_NUM_THREADS / block_width_));
         block_width_ =
@@ -305,7 +305,7 @@ public:
     int SharedMemorySize() const {
         if (!ShouldBlockYReduce() &&
             (!ShouldBlockXReduce() ||
-             block_width_ <= CUDAState::GetInstance()->GetWarpSize())) {
+             block_width_ <= CUDAState::GetInstance().GetWarpSize())) {
             return 0;
         }
         return element_size_bytes_ * num_threads_;
@@ -846,7 +846,7 @@ public:
             numerator_ = 1;
             denominator_ = 1;
         } else {
-            int device_id = CUDAState::GetInstance()->GetCurrentDeviceID();
+            int device_id = CUDAState::GetInstance().GetCurrentDeviceID();
             Device device(Device::DeviceType::CUDA, device_id);
             buffer_ = std::make_unique<Blob>(size, device);
             acc_ptr_ = (char*)buffer_->GetDataPtr();
@@ -972,7 +972,7 @@ private:
         void* buffer = nullptr;
         void* semaphores = nullptr;
         if (config.ShouldGlobalReduce()) {
-            int device_id = CUDAState::GetInstance()->GetCurrentDeviceID();
+            int device_id = CUDAState::GetInstance().GetCurrentDeviceID();
             Device device(Device::DeviceType::CUDA, device_id);
 
             buffer_blob =

--- a/cpp/tests/Main.cpp
+++ b/cpp/tests/Main.cpp
@@ -52,16 +52,15 @@ bool ShallDisableP2P(int argc, char** argv) {
 #endif
 
 int main(int argc, char** argv) {
-    open3d::utility::CPUInfo::GetInstance().Print();
+    using namespace open3d;
+    utility::CPUInfo::GetInstance().Print();
 #ifdef BUILD_CUDA_MODULE
     if (ShallDisableP2P(argc, argv)) {
-        std::shared_ptr<open3d::core::CUDAState> cuda_state =
-                open3d::core::CUDAState::GetInstance();
-        cuda_state->ForceDisableP2PForTesting();
-        open3d::utility::LogInfo("P2P device transfer has been disabled.");
+        core::CUDAState::GetInstance().ForceDisableP2PForTesting();
+        utility::LogInfo("P2P device transfer has been disabled.");
     }
 #endif
     testing::InitGoogleMock(&argc, argv);
-    open3d::utility::SetVerbosityLevel(open3d::utility::VerbosityLevel::Debug);
+    utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
     return RUN_ALL_TESTS();
 }

--- a/cpp/tests/core/CUDAUtils.cpp
+++ b/cpp/tests/core/CUDAUtils.cpp
@@ -37,13 +37,13 @@ namespace open3d {
 namespace tests {
 
 TEST(CUDAUtils, InitState) {
-    std::shared_ptr<core::CUDAState> cuda_state =
-            core::CUDAState::GetInstance();
-    utility::LogInfo("Number of CUDA devices: {}", cuda_state->GetNumDevices());
-    for (int i = 0; i < cuda_state->GetNumDevices(); ++i) {
-        for (int j = 0; j < cuda_state->GetNumDevices(); ++j) {
+    const int device_count = core::cuda::DeviceCount();
+    const core::CUDAState& cuda_state = core::CUDAState::GetInstance();
+    utility::LogInfo("Number of CUDA devices: {}", device_count);
+    for (int i = 0; i < device_count; ++i) {
+        for (int j = 0; j < device_count; ++j) {
             utility::LogInfo("P2PEnabled {}->{}: {}", i, j,
-                             cuda_state->GetP2PEnabled()[i][j]);
+                             cuda_state.GetP2PEnabled()[i][j]);
         }
     }
 }

--- a/cpp/tests/core/CoreTest.h
+++ b/cpp/tests/core/CoreTest.h
@@ -43,9 +43,8 @@ class PermuteDevices : public testing::TestWithParam<core::Device> {
 public:
     static std::vector<core::Device> TestCases() {
 #ifdef BUILD_CUDA_MODULE
-        std::shared_ptr<core::CUDAState> cuda_state =
-                core::CUDAState::GetInstance();
-        if (cuda_state->GetNumDevices() >= 1) {
+        const int device_count = core::cuda::DeviceCount();
+        if (device_count >= 1) {
             return {
                     core::Device("CPU:0"),
                     core::Device("CUDA:0"),
@@ -67,9 +66,8 @@ class PermuteDevicesWithFaiss : public testing::TestWithParam<core::Device> {
 public:
     static std::vector<core::Device> TestCases() {
 #if defined(BUILD_CUDA_MODULE) && defined(WITH_FAISS)
-        std::shared_ptr<core::CUDAState> cuda_state =
-                core::CUDAState::GetInstance();
-        if (cuda_state->GetNumDevices() >= 1) {
+        const int device_count = core::cuda::DeviceCount();
+        if (device_count >= 1) {
             return {
                     core::Device("CPU:0"),
                     core::Device("CUDA:0"),
@@ -92,9 +90,8 @@ class PermuteDevicePairs
 public:
     static std::vector<std::pair<core::Device, core::Device>> TestCases() {
 #ifdef BUILD_CUDA_MODULE
-        std::shared_ptr<core::CUDAState> cuda_state =
-                core::CUDAState::GetInstance();
-        if (cuda_state->GetNumDevices() > 1) {
+        const int device_count = core::cuda::DeviceCount();
+        if (device_count > 1) {
             // To test multiple CUDA devices, we only need to test CUDA 0 and 1.
             return {
                     {core::Device("CPU:0"), core::Device("CPU:0")},    // 0
@@ -107,7 +104,7 @@ public:
                     {core::Device("CUDA:1"), core::Device("CUDA:0")},  // 7
                     {core::Device("CUDA:1"), core::Device("CUDA:1")},  // 8
             };
-        } else if (cuda_state->GetNumDevices() == 1) {
+        } else if (device_count == 1) {
             return {
                     {core::Device("CPU:0"), core::Device("CPU:0")},
                     {core::Device("CPU:0"), core::Device("CUDA:0")},


### PR DESCRIPTION
Merge #3922 first.

- `CUDAState()` returns instance reference instead of shared ptr
- Rename `num_devices` to `device_count` to be consistent with CUDA API

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3925)
<!-- Reviewable:end -->
