### PR TITLE
fix #3818

### DIFF
--- a/cpp/open3d/geometry/Qhull.cpp
+++ b/cpp/open3d/geometry/Qhull.cpp
@@ -118,6 +118,7 @@ Qhull::ComputeDelaunayTetrahedralization(
     if (points.size() == 4) {
         delaunay_triangulation->vertices_ = points;
         delaunay_triangulation->tetras_.push_back(Vector4i(0, 1, 2, 3));
+        pt_map.insert(pt_map.end(), {0, 1, 2, 3});
         return std::make_tuple(delaunay_triangulation, pt_map);
     }
 


### PR DESCRIPTION
make sure ```pt_map``` has the same size as ```delaunay_triangulation->vertices_``` when cloud has only four points, see #3818 for details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3927)
<!-- Reviewable:end -->
