### PR TITLE
Simplify header target usage

### DIFF
--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -16,15 +16,16 @@ set(Open3D_3RDPARTY_EXTERNAL_MODULES)
 set(Open3D_3RDPARTY_PUBLIC_TARGETS)
 
 # HEADER_TARGETS
-# CMake targets we use in our public interface, but as a special case we do not
-# need to link against the library. This simplifies dependencies where we merely
-# expose declared data types from other libraries in our public headers, so it
-# would be overkill to require all library users to link against that dependency.
+# CMake targets we use in our public interface, but as a special case we only
+# need to link privately against the library. This simplifies dependencies
+# where we merely expose declared data types from other libraries in our
+# public headers, so it would be overkill to require all library users to link
+# against that dependency.
 set(Open3D_3RDPARTY_HEADER_TARGETS)
 
 # PRIVATE_TARGETS
 # CMake targets for dependencies which are not exposed in the public API. This
-# will probably include HEADER_TARGETS, but also anything else we use internally.
+# will include anything else we use internally.
 set(Open3D_3RDPARTY_PRIVATE_TARGETS)
 
 find_package(PkgConfig QUIET)
@@ -596,7 +597,6 @@ if(NOT USE_SYSTEM_GLEW)
     endif()
 endif()
 list(APPEND Open3D_3RDPARTY_HEADER_TARGETS Open3D::3rdparty_glew)
-list(APPEND Open3D_3RDPARTY_PRIVATE_TARGETS Open3D::3rdparty_glew)
 
 # GLFW
 if(USE_SYSTEM_GLFW)
@@ -655,7 +655,6 @@ if(TARGET Open3D::3rdparty_x11)
     target_link_libraries(3rdparty_glfw INTERFACE Open3D::3rdparty_x11)
 endif()
 list(APPEND Open3D_3RDPARTY_HEADER_TARGETS Open3D::3rdparty_glfw)
-list(APPEND Open3D_3RDPARTY_PRIVATE_TARGETS Open3D::3rdparty_glfw)
 
 # TurboJPEG
 if(USE_SYSTEM_JPEG AND BUILD_AZURE_KINECT)
@@ -1190,7 +1189,6 @@ if(BUILD_GUI)
         target_link_options(3rdparty_filament INTERFACE "-fobjc-link-runtime")
     endif()
     list(APPEND Open3D_3RDPARTY_HEADER_TARGETS Open3D::3rdparty_filament)
-    list(APPEND Open3D_3RDPARTY_PRIVATE_TARGETS Open3D::3rdparty_filament)
 endif()
 
 # RPC interface

--- a/cmake/Open3DLink3rdpartyLibraries.cmake
+++ b/cmake/Open3DLink3rdpartyLibraries.cmake
@@ -24,5 +24,7 @@ function(open3d_link_3rdparty_libraries target)
             message(WARNING "Skipping non-existent header dependency ${dep}")
         endif()
     endforeach()
+    # Link header dependencies privately.
+    target_link_libraries(${target} PRIVATE ${Open3D_3RDPARTY_HEADER_TARGETS})
 
 endfunction()


### PR DESCRIPTION
Header targets are defined as dependencies used in *public headers* but *linked privately*. The latter step is currently implemented by also treating them also as private targets. Instead we should automatically link them privately and do not add them to the list of private targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3937)
<!-- Reviewable:end -->
