### PR TITLE
Faster TensorCPU KNN Search.

### DIFF
--- a/cpp/open3d/core/nns/NanoFlannIndex.cpp
+++ b/cpp/open3d/core/nns/NanoFlannIndex.cpp
@@ -82,52 +82,39 @@ std::pair<Tensor, Tensor> NanoFlannIndex::SearchKnn(const Tensor &query_points,
                 "[NanoFlannIndex::SearchKnn] knn should be larger than 0.");
     }
 
-    int64_t num_query_points = query_points.GetShape()[0];
-    Dtype dtype = GetDtype();
+    const int64_t num_neighbors = std::min(
+            static_cast<int64_t>(GetDatasetSize()), static_cast<int64_t>(knn));
+    const int64_t num_query_points = query_points.GetShape()[0];
+    const Dtype dtype = GetDtype();
 
-    Tensor indices;
-    Tensor distances;
+    Tensor indices = Tensor::Empty({num_query_points, num_neighbors},
+                                   Dtype::FromType<index_t>());
+    Tensor distances = Tensor::Empty({num_query_points, num_neighbors}, dtype);
+
     DISPATCH_FLOAT_DTYPE_TO_TEMPLATE(dtype, [&]() {
-        Tensor batch_indices = Tensor::Full({num_query_points, knn}, -1,
-                                            Dtype::FromType<index_t>());
-        Tensor batch_distances =
-                Tensor::Full({num_query_points, knn}, -1, dtype);
+        const core::Tensor query_contiguous = query_points.Contiguous();
+        const scalar_t *query_ptr = query_contiguous.GetDataPtr<scalar_t>();
+        const int query_dim = GetDimension();
+
+        index_t *indices_ptr = indices.GetDataPtr<index_t>();
+        scalar_t *distances_ptr = distances.GetDataPtr<scalar_t>();
 
         auto holder =
                 static_cast<NanoFlannIndexHolder<L2, scalar_t, index_t> *>(
                         holder_.get());
 
         // Parallel search.
-        tbb::parallel_for(
-                tbb::blocked_range<size_t>(0, num_query_points),
-                [&](const tbb::blocked_range<size_t> &r) {
-                    for (size_t i = r.begin(); i != r.end(); ++i) {
-                        auto single_indices =
-                                batch_indices[i].GetDataPtr<index_t>();
-                        auto single_distances =
-                                batch_distances[i].GetDataPtr<scalar_t>();
-
-                        // search
-                        holder->index_->knnSearch(
-                                query_points[i].GetDataPtr<scalar_t>(),
-                                (size_t)knn, single_indices, single_distances);
-                    }
-                });
-        // Check if the number of neighbors are same.
-        Tensor check_valid = batch_indices.Ge(0)
-                                     .To(Dtype::FromType<index_t>())
-                                     .Sum({-1}, false);
-        int64_t num_neighbors = check_valid[0].Item<index_t>();
-        if (check_valid.Ne(num_neighbors).Any()) {
-            utility::LogError(
-                    "[NanoFlannIndex::SearchKnn] The number of neighbors are "
-                    "different. Something went wrong.");
-        }
-        // Slice non-zero items.
-        indices = batch_indices.Slice(1, 0, num_neighbors)
-                          .View({num_query_points, num_neighbors});
-        distances = batch_distances.Slice(1, 0, num_neighbors)
-                            .View({num_query_points, num_neighbors});
+        tbb::parallel_for(tbb::blocked_range<size_t>(0, num_query_points),
+                          [&](const tbb::blocked_range<size_t> &r) {
+                              for (size_t i = r.begin(); i != r.end(); ++i) {
+                                  // search
+                                  holder->index_->knnSearch(
+                                          query_ptr + query_dim * i,
+                                          (size_t)num_neighbors,
+                                          indices_ptr + num_neighbors * i,
+                                          distances_ptr + num_neighbors * i);
+                              }
+                          });
     });
     return std::make_pair(indices, distances);
 };


### PR DESCRIPTION
Changes:
- Assuming `num_neighbors = min(dataset_size, knn)`, removed checks. 
- Replaced `Filled tensor of {-1} of shape {num_query_points, knn}` with `Empty tensor of shape {num_query_points, num_neighbors}`.
----
Effect on performance of `estimate_noramls`:

```
------------------------------------------------------------------------------------------------
Benchmark                                                      Before             After   
------------------------------------------------------------------------------------------------
EstimateNormals/CPU F32 KNN[0.02 | 30]                      51.8 ms         23.4 ms          
EstimateNormals/CPU F64 KNN[0.02 | 30]                      54.6 ms         24.1 ms          
LegacyEstimateNormals/Legacy KNN[0.02 | 30]                 27.4 ms         27.4 ms
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3945)
<!-- Reviewable:end -->
