### PR TITLE
Minimize cached CUDA state

### DIFF
--- a/cpp/open3d/core/CUDAUtils.cpp
+++ b/cpp/open3d/core/CUDAUtils.cpp
@@ -40,8 +40,14 @@ namespace cuda {
 int DeviceCount() {
 #ifdef BUILD_CUDA_MODULE
     try {
-        return CUDAState::GetInstance().GetNumDevices();
-    } catch (const std::runtime_error&) {  // GetInstance can throw
+        int num_devices;
+        OPEN3D_CUDA_CHECK(cudaGetDeviceCount(&num_devices));
+        return num_devices;
+
+    }
+    // This function is also used to detect CUDA support in our Python code.
+    // Thus, catch any errors if no GPU is available.
+    catch (const std::runtime_error&) {
         return 0;
     }
 #else
@@ -72,8 +78,7 @@ void ReleaseCache() {
 void Synchronize() {
 #ifdef BUILD_CUDA_MODULE
     for (int i = 0; i < DeviceCount(); ++i) {
-        CUDAScopedDevice scoped_device(Device("CUDA", i));
-        OPEN3D_CUDA_CHECK(cudaDeviceSynchronize());
+        Synchronize(Device(Device::DeviceType::CUDA, i));
     }
 #endif
 }
@@ -151,6 +156,8 @@ public:
 
 private:
     CUDAStream() = default;
+    CUDAStream(const CUDAStream&) = delete;
+    CUDAStream& operator=(const CUDAStream&) = delete;
 
     cudaStream_t stream_ = Default();
 };
@@ -175,7 +182,9 @@ CUDAScopedDevice::CUDAScopedDevice(int device_id)
 }
 
 CUDAScopedDevice::CUDAScopedDevice(const Device& device)
-    : CUDAScopedDevice(device.GetID()) {}
+    : CUDAScopedDevice(device.GetID()) {
+    cuda::AssertCUDADeviceAvailable(device);
+}
 
 CUDAScopedDevice::~CUDAScopedDevice() { cuda::SetDevice(prev_device_id_); }
 
@@ -207,37 +216,21 @@ CUDAState& CUDAState::GetInstance() {
     return instance;
 }
 
-bool CUDAState::IsP2PEnabled(int src_id, int tar_id) {
-    if (src_id < 0 || src_id >= num_devices_) {
-        utility::LogError("Device id {} is out of bound of total {} devices.",
-                          src_id, num_devices_);
-    }
-    if (tar_id < 0 || tar_id >= num_devices_) {
-        utility::LogError("Device id {} is out of bound of total {} devices.",
-                          tar_id, num_devices_);
-    }
+bool CUDAState::IsP2PEnabled(int src_id, int tar_id) const {
+    cuda::AssertCUDADeviceAvailable(src_id);
+    cuda::AssertCUDADeviceAvailable(tar_id);
     return p2p_enabled_[src_id][tar_id];
 }
 
-bool CUDAState::IsP2PEnabled(const Device& src, const Device& tar) {
+bool CUDAState::IsP2PEnabled(const Device& src, const Device& tar) const {
+    cuda::AssertCUDADeviceAvailable(src);
+    cuda::AssertCUDADeviceAvailable(tar);
     return p2p_enabled_[src.GetID()][tar.GetID()];
 }
 
-std::vector<std::vector<bool>> CUDAState::GetP2PEnabled() const {
-    return p2p_enabled_;
-}
-
-int CUDAState::GetNumDevices() const { return num_devices_; }
-
-int CUDAState::GetWarpSize() const { return warp_sizes_[GetCurrentDeviceID()]; }
-
-int CUDAState::GetCurrentDeviceID() const { return cuda::GetDevice(); }
-
-/// Disable P2P device transfer by marking p2p_enabled_ to `false`, in order
-/// to run non-p2p tests on a p2p-capable machine.
 void CUDAState::ForceDisableP2PForTesting() {
-    for (int src_id = 0; src_id < num_devices_; ++src_id) {
-        for (int tar_id = 0; tar_id < num_devices_; ++tar_id) {
+    for (int src_id = 0; src_id < cuda::DeviceCount(); ++src_id) {
+        for (int tar_id = 0; tar_id < cuda::DeviceCount(); ++tar_id) {
             if (src_id != tar_id && p2p_enabled_[src_id][tar_id]) {
                 p2p_enabled_[src_id][tar_id] = false;
             }
@@ -246,22 +239,16 @@ void CUDAState::ForceDisableP2PForTesting() {
 }
 
 CUDAState::CUDAState() {
-    OPEN3D_CUDA_CHECK(cudaGetDeviceCount(&num_devices_));
-
     // Check and enable all possible peer to peer access.
     p2p_enabled_ = std::vector<std::vector<bool>>(
-            num_devices_, std::vector<bool>(num_devices_, false));
+            cuda::DeviceCount(), std::vector<bool>(cuda::DeviceCount(), false));
 
-    for (int src_id = 0; src_id < num_devices_; ++src_id) {
-        for (int tar_id = 0; tar_id < num_devices_; ++tar_id) {
+    for (int src_id = 0; src_id < cuda::DeviceCount(); ++src_id) {
+        for (int tar_id = 0; tar_id < cuda::DeviceCount(); ++tar_id) {
             if (src_id == tar_id) {
                 p2p_enabled_[src_id][tar_id] = true;
             } else {
-                // Avoid CUDAScopedDevice() or SetDevice() here as they
-                // introduce circular dependencies. See:
-                // https://github.com/isl-org/Open3D/pull/3922.
-                int prev_id = cuda::GetDevice();
-                OPEN3D_CUDA_CHECK(cudaSetDevice(src_id));
+                CUDAScopedDevice scoped_device(src_id);
 
                 // Check access.
                 int can_access = 0;
@@ -272,7 +259,7 @@ CUDAState::CUDAState() {
                     p2p_enabled_[src_id][tar_id] = true;
                     cudaError_t err = cudaDeviceEnablePeerAccess(tar_id, 0);
                     if (err == cudaErrorPeerAccessAlreadyEnabled) {
-                        // Ignore error since p2p is already enabled.
+                        // Ignore error since P2P is already enabled.
                         cudaGetLastError();
                     } else {
                         OPEN3D_CUDA_CHECK(err);
@@ -280,31 +267,22 @@ CUDAState::CUDAState() {
                 } else {
                     p2p_enabled_[src_id][tar_id] = false;
                 }
-
-                OPEN3D_CUDA_CHECK(cudaSetDevice(prev_id));
             }
         }
-    }
-
-    // Cache warp sizes
-    warp_sizes_.resize(num_devices_);
-    for (int device_id = 0; device_id < num_devices_; ++device_id) {
-        cudaDeviceProp device_prop;
-        OPEN3D_CUDA_CHECK(cudaGetDeviceProperties(&device_prop, device_id));
-        warp_sizes_[device_id] = device_prop.warpSize;
     }
 }
 
 int GetCUDACurrentDeviceTextureAlignment() {
-    int value = 0;
-    cudaError_t err = cudaDeviceGetAttribute(
-            &value, cudaDevAttrTextureAlignment, cuda::GetDevice());
-    if (err != cudaSuccess) {
-        utility::LogError(
-                "GetCUDACurrentDeviceTextureAlignment(): "
-                "cudaDeviceGetAttribute failed with {}",
-                cudaGetErrorString(err));
-    }
+    int value;
+    OPEN3D_CUDA_CHECK(cudaDeviceGetAttribute(
+            &value, cudaDevAttrTextureAlignment, cuda::GetDevice()));
+    return value;
+}
+
+int GetCUDACurrentWarpSize() {
+    int value;
+    OPEN3D_CUDA_CHECK(cudaDeviceGetAttribute(&value, cudaDevAttrWarpSize,
+                                             cuda::GetDevice()));
     return value;
 }
 

--- a/cpp/open3d/core/CUDAUtils.h
+++ b/cpp/open3d/core/CUDAUtils.h
@@ -182,7 +182,7 @@ private:
 /// CUDAState is a lazy-evaluated singleton class that initializes and stores
 /// the states of CUDA devices.
 ///
-/// Currently is stores total number of devices and peer-to-peer availability.
+/// Currently is stores the peer-to-peer availability.
 ///
 /// In the future, it can also be used to store
 /// - Device allocators
@@ -191,40 +191,34 @@ private:
 /// - ...
 ///
 /// Ref:
-/// https://stackoverflow.com/a/1008289/1255535
-/// https://stackoverflow.com/a/40337728/1255535
 /// https://github.com/pytorch/pytorch/blob/master/aten/src/THC/THCGeneral.cpp
 class CUDAState {
 public:
     static CUDAState& GetInstance();
 
-    CUDAState(CUDAState const&) = delete;
-    void operator=(CUDAState const&) = delete;
+    CUDAState(const CUDAState&) = delete;
+    CUDAState& operator=(const CUDAState&) = delete;
 
-    bool IsP2PEnabled(int src_id, int tar_id);
+    /// Returns true if peer-to-peer is available from the CUDA device-ID
+    /// \p src_id to \p tar_id.
+    bool IsP2PEnabled(int src_id, int tar_id) const;
 
-    bool IsP2PEnabled(const Device& src, const Device& tar);
+    /// Returns true if peer-to-peer is available from the CUDA device
+    /// \p src to \p tar.
+    bool IsP2PEnabled(const Device& src, const Device& tar) const;
 
-    std::vector<std::vector<bool>> GetP2PEnabled() const;
-
-    int GetNumDevices() const;
-
-    int GetWarpSize() const;
-
-    int GetCurrentDeviceID() const;
-
-    /// Disable P2P device transfer by marking p2p_enabled_ to `false`, in order
-    /// to run non-p2p tests on a p2p-capable machine.
+    /// Disables P2P device transfer between all devices, in order to run
+    /// non-P2P tests on a P2P-capable machine.
     void ForceDisableP2PForTesting();
 
 private:
     CUDAState();
 
-private:
-    int num_devices_ = 0;
-    std::vector<int> warp_sizes_;
     std::vector<std::vector<bool>> p2p_enabled_;
 };
+
+/// Returns the size of a warp for the current device.
+int GetCUDACurrentWarpSize();
 
 /// Returns the texture alignment in bytes for the current device.
 int GetCUDACurrentDeviceTextureAlignment();

--- a/cpp/open3d/core/CUDAUtils.h
+++ b/cpp/open3d/core/CUDAUtils.h
@@ -182,7 +182,7 @@ private:
 /// CUDAState is a lazy-evaluated singleton class that initializes and stores
 /// the states of CUDA devices.
 ///
-/// Currently is stores the peer-to-peer availability.
+/// Currently it stores the peer-to-peer availability.
 ///
 /// In the future, it can also be used to store
 /// - Device allocators

--- a/cpp/open3d/core/kernel/ReductionCUDA.cu
+++ b/cpp/open3d/core/kernel/ReductionCUDA.cu
@@ -229,8 +229,7 @@ public:
         int dim1_pow2 = dim1 < MAX_NUM_THREADS
                                 ? static_cast<int>(LastPow2(dim1))
                                 : MAX_NUM_THREADS;
-        block_width_ =
-                std::min(dim0_pow2, CUDAState::GetInstance().GetWarpSize());
+        block_width_ = std::min(dim0_pow2, GetCUDACurrentWarpSize());
         block_height_ =
                 std::min(dim1_pow2, int(MAX_NUM_THREADS / block_width_));
         block_width_ =
@@ -305,7 +304,7 @@ public:
     int SharedMemorySize() const {
         if (!ShouldBlockYReduce() &&
             (!ShouldBlockXReduce() ||
-             block_width_ <= CUDAState::GetInstance().GetWarpSize())) {
+             block_width_ <= GetCUDACurrentWarpSize())) {
             return 0;
         }
         return element_size_bytes_ * num_threads_;
@@ -846,8 +845,7 @@ public:
             numerator_ = 1;
             denominator_ = 1;
         } else {
-            int device_id = CUDAState::GetInstance().GetCurrentDeviceID();
-            Device device(Device::DeviceType::CUDA, device_id);
+            Device device(Device::DeviceType::CUDA, cuda::GetDevice());
             buffer_ = std::make_unique<Blob>(size, device);
             acc_ptr_ = (char*)buffer_->GetDataPtr();
             numerator_ = acc_t_size;
@@ -972,8 +970,7 @@ private:
         void* buffer = nullptr;
         void* semaphores = nullptr;
         if (config.ShouldGlobalReduce()) {
-            int device_id = CUDAState::GetInstance().GetCurrentDeviceID();
-            Device device(Device::DeviceType::CUDA, device_id);
+            Device device(Device::DeviceType::CUDA, cuda::GetDevice());
 
             buffer_blob =
                     std::make_unique<Blob>(config.GlobalMemorySize(), device);

--- a/cpp/tests/core/CUDAUtils.cpp
+++ b/cpp/tests/core/CUDAUtils.cpp
@@ -43,7 +43,7 @@ TEST(CUDAUtils, InitState) {
     for (int i = 0; i < device_count; ++i) {
         for (int j = 0; j < device_count; ++j) {
             utility::LogInfo("P2PEnabled {}->{}: {}", i, j,
-                             cuda_state.GetP2PEnabled()[i][j]);
+                             cuda_state.IsP2PEnabled(i, j));
         }
     }
 }


### PR DESCRIPTION
Changes:
- Move `GetNumDevices()` to standalone `DeviceCount()`.
- Move `GetWarpSize()` to standalone `GetCUDACurrentWarpSize()`.
- Remove superfluous `GetCurrentDeviceID()`.
- Re-enable `CUDAScopedDevice` usage in `CUDAState` constructor.
- Minor fixes for const correctness, copy constructors in singletons, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3946)
<!-- Reviewable:end -->
