### PR TITLE
Remove SmallArray<T, N> class

### DIFF
--- a/cpp/open3d/core/Indexer.h
+++ b/cpp/open3d/core/Indexer.h
@@ -34,6 +34,7 @@
 #include "open3d/core/SizeVector.h"
 #include "open3d/core/Tensor.h"
 #include "open3d/utility/Logging.h"
+#include "open3d/utility/MiniVec.h"
 
 namespace open3d {
 namespace core {
@@ -52,19 +53,6 @@ static constexpr int64_t MAX_INPUTS = 10;
 // Maximum number of outputs of an op. This number can be increased when
 // necessary.
 static constexpr int64_t MAX_OUTPUTS = 2;
-
-// Fixed-size array type usable from host and device.
-template <typename T, int size>
-struct alignas(16) SmallArray {
-    T data_[size];
-
-    OPEN3D_HOST_DEVICE T operator[](int i) const { return data_[i]; }
-    OPEN3D_HOST_DEVICE T& operator[](int i) { return data_[i]; }
-
-    SmallArray() = default;
-    SmallArray(const SmallArray&) = default;
-    SmallArray& operator=(const SmallArray&) = default;
-};
 
 template <int NARGS, typename index_t = uint32_t>
 struct OffsetCalculator {
@@ -88,9 +76,9 @@ struct OffsetCalculator {
         }
     }
 
-    OPEN3D_HOST_DEVICE SmallArray<index_t, NARGS> get(
+    OPEN3D_HOST_DEVICE utility::MiniVec<index_t, NARGS> get(
             index_t linear_idx) const {
-        SmallArray<index_t, NARGS> offsets;
+        utility::MiniVec<index_t, NARGS> offsets;
 #if defined(__CUDA_ARCH__)
 #pragma unroll
 #endif

--- a/cpp/open3d/core/kernel/ReductionCUDA.cu
+++ b/cpp/open3d/core/kernel/ReductionCUDA.cu
@@ -597,7 +597,7 @@ public:
         // unroll that exposes instruction level parallelism.
         while (idx < config_.num_inputs_per_output_) {
             // load input
-            SmallArray<scalar_t, vt0> values;
+            utility::MiniVec<scalar_t, vt0> values;
             if (input_calc_.dims_ == 1) {
                 StridedIterate<vt0>(
                         [&](index_t i, index_t idx) {


### PR DESCRIPTION
`MiniVec<T, N>` is a strict superset of `SmallArray<T, N>` and can be used instead. Thus, remove the latter and replace any usages by the former.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3949)
<!-- Reviewable:end -->
