### PR TITLE
Allow serialization of partial data

### DIFF
--- a/cpp/open3d/io/rpc/MessageUtils.cpp
+++ b/cpp/open3d/io/rpc/MessageUtils.cpp
@@ -155,43 +155,54 @@ std::shared_ptr<t::geometry::Geometry> MeshDataToGeometry(
     if (mesh_data.CheckMessage(errstr)) {
         if (mesh_data.O3DTypeIsTriangleMesh() ||
             mesh_data.faces.CheckNonEmpty()) {
-            if (mesh_data.faces.CheckShape({-1, 3}, errstr)) {
-                auto mesh = std::make_shared<t::geometry::TriangleMesh>();
+            auto mesh = std::make_shared<t::geometry::TriangleMesh>();
+            if (mesh_data.vertices.CheckNonEmpty()) {
                 mesh->SetVertexPositions(ArrayToTensor(mesh_data.vertices));
-                for (auto item : mesh_data.vertex_attributes) {
-                    mesh->SetVertexAttr(item.first, ArrayToTensor(item.second));
-                }
-                mesh->SetTriangleIndices(ArrayToTensor(mesh_data.faces));
-                for (auto item : mesh_data.face_attributes) {
-                    mesh->SetTriangleAttr(item.first,
-                                          ArrayToTensor(item.second));
-                }
-                return mesh;
-            } else {
-                LogWarning("MeshDataToGeometry: Invalid shape for faces, {}",
-                           errstr);
             }
+            for (auto item : mesh_data.vertex_attributes) {
+                mesh->SetVertexAttr(item.first, ArrayToTensor(item.second));
+            }
+            if (mesh_data.faces.CheckNonEmpty()) {
+                if (mesh_data.faces.CheckShape({-1, 3}, errstr)) {
+                    mesh->SetTriangleIndices(ArrayToTensor(mesh_data.faces));
+                } else {
+                    LogWarning(
+                            "MeshDataToGeometry: Invalid shape for faces, {}",
+                            errstr);
+                }
+            }
+            for (auto item : mesh_data.face_attributes) {
+                mesh->SetTriangleAttr(item.first, ArrayToTensor(item.second));
+            }
+            return mesh;
         } else if (mesh_data.O3DTypeIsLineSet() ||
                    mesh_data.lines.CheckNonEmpty()) {
-            if (mesh_data.lines.CheckShape({-1, 2}, errstr)) {
-                auto ls = std::make_shared<t::geometry::LineSet>();
+            auto ls = std::make_shared<t::geometry::LineSet>();
+            if (mesh_data.vertices.CheckNonEmpty()) {
                 ls->SetPointPositions(ArrayToTensor(mesh_data.vertices));
-                for (auto item : mesh_data.vertex_attributes) {
-                    ls->SetPointAttr(item.first, ArrayToTensor(item.second));
-                }
-                ls->SetLineIndices(ArrayToTensor(mesh_data.lines));
-                for (auto item : mesh_data.line_attributes) {
-                    ls->SetLineAttr(item.first, ArrayToTensor(item.second));
-                }
-                return ls;
-            } else {
-                LogWarning("MeshDataToGeometry: Invalid shape for lines, {}",
-                           errstr);
             }
+            for (auto item : mesh_data.vertex_attributes) {
+                ls->SetPointAttr(item.first, ArrayToTensor(item.second));
+            }
+            if (mesh_data.lines.CheckNonEmpty()) {
+                if (mesh_data.lines.CheckShape({-1, 2}, errstr)) {
+                    ls->SetLineIndices(ArrayToTensor(mesh_data.lines));
+                } else {
+                    LogWarning(
+                            "MeshDataToGeometry: Invalid shape for lines, {}",
+                            errstr);
+                }
+            }
+            for (auto item : mesh_data.line_attributes) {
+                ls->SetLineAttr(item.first, ArrayToTensor(item.second));
+            }
+            return ls;
         } else if (mesh_data.O3DTypeIsPointCloud() ||
                    mesh_data.vertices.CheckNonEmpty()) {
             auto pcd = std::make_shared<t::geometry::PointCloud>();
-            pcd->SetPointPositions(ArrayToTensor(mesh_data.vertices));
+            if (mesh_data.vertices.CheckNonEmpty()) {
+                pcd->SetPointPositions(ArrayToTensor(mesh_data.vertices));
+            }
             for (auto item : mesh_data.vertex_attributes) {
                 pcd->SetPointAttr(item.first, ArrayToTensor(item.second));
             }
@@ -267,7 +278,7 @@ messages::MeshData GeometryToMeshData(const t::geometry::LineSet& ls) {
         LogError("GeometryToMeshData: LineSet has no points!");
     }
 
-    // triangles
+    // lines
     auto line_attributes = ls.GetLineAttr();
     mesh_data.line_attributes = TensorMapToArrayMap(line_attributes);
     if (mesh_data.line_attributes.count("indices")) {

--- a/cpp/open3d/io/rpc/Messages.h
+++ b/cpp/open3d/io/rpc/Messages.h
@@ -318,6 +318,7 @@ struct MeshData {
     bool O3DTypeIsTriangleMesh() const { return o3d_type == "TriangleMesh"; }
 
     bool CheckVertices(std::string& errstr) const {
+        if (vertices.shape.empty()) return true;
         std::string tmp = "invalid vertices array:";
         bool status = vertices.CheckNonEmpty(tmp) &&
                       vertices.CheckShape({-1, 3}, tmp);
@@ -378,8 +379,8 @@ struct MeshData {
 
     bool CheckMessage(std::string& errstr) const {
         std::string tmp = "invalid mesh_data message:";
-        bool status = CheckO3DType(errstr) && CheckVertices(errstr) &&
-                      CheckFaces(errstr);
+        bool status =
+                CheckO3DType(tmp) && CheckVertices(tmp) && CheckFaces(tmp);
         if (!status) errstr += tmp;
         return status;
     }

--- a/cpp/open3d/io/rpc/RemoteFunctions.h
+++ b/cpp/open3d/io/rpc/RemoteFunctions.h
@@ -87,7 +87,6 @@ bool SetTriangleMesh(const geometry::TriangleMesh& mesh,
                              std::shared_ptr<ConnectionBase>());
 
 /// Function for sending general mesh data.
-/// \param vertices    Tensor with vertices of shape [N,3]
 ///
 /// \param path               Path descriptor defining a location in the scene
 /// tree. E.g., 'mygroup/mypoints'.
@@ -95,6 +94,8 @@ bool SetTriangleMesh(const geometry::TriangleMesh& mesh,
 /// \param time               The time point associated with the object.
 ///
 /// \param layer              The layer for this object.
+///
+/// \param vertices           Tensor with vertices of shape [N,3]
 ///
 /// \param vertex_attributes  Map with Tensors storing vertex attributes. The
 /// first dim of each attribute must match the number of vertices.
@@ -119,13 +120,20 @@ bool SetTriangleMesh(const geometry::TriangleMesh& mesh,
 ///
 /// \param textures           Map of Tensors for storing textures.
 ///
-/// \param connection  The connection object used for sending the data.
-///                    If nullptr a default connection object will be used.
+/// \param o3d_type           The type of the geometry. This is one of
+/// "PointCloud", "LineSet", "TriangleMesh". This argument should be specified
+/// for partial data that has no primary key data, e.g., a triangle mesh without
+/// vertices but with other attribute tensors.
 ///
-bool SetMeshData(const core::Tensor& vertices,
-                 const std::string& path = "",
+/// \param connection         The connection object used for sending the data.
+///                           If nullptr a default connection object will be
+///                           used.
+///
+bool SetMeshData(const std::string& path = "",
                  int time = 0,
                  const std::string& layer = "",
+                 const core::Tensor& vertices = core::Tensor({0},
+                                                             core::Float32),
                  const std::map<std::string, core::Tensor>& vertex_attributes =
                          std::map<std::string, core::Tensor>(),
                  const core::Tensor& faces = core::Tensor({0}, core::Int32),
@@ -136,6 +144,7 @@ bool SetMeshData(const core::Tensor& vertices,
                          std::map<std::string, core::Tensor>(),
                  const std::map<std::string, core::Tensor>& textures =
                          std::map<std::string, core::Tensor>(),
+                 const std::string& o3d_type = std::string(),
                  std::shared_ptr<ConnectionBase> connection =
                          std::shared_ptr<ConnectionBase>());
 

--- a/cpp/pybind/io/rpc.cpp
+++ b/cpp/pybind/io/rpc.cpp
@@ -127,23 +127,24 @@ A connection writing to a memory buffer.
                      "the connection."},
             });
 
-    m.def("set_mesh_data", &rpc::SetMeshData, "vertices"_a, "path"_a = "",
-          "time"_a = 0, "layer"_a = "",
+    m.def("set_mesh_data", &rpc::SetMeshData, "path"_a = "", "time"_a = 0,
+          "layer"_a = "", "vertices"_a = core::Tensor({0}, core::Float32),
           "vertex_attributes"_a = std::map<std::string, core::Tensor>(),
           "faces"_a = core::Tensor({0}, core::Int32),
           "face_attributes"_a = std::map<std::string, core::Tensor>(),
           "lines"_a = core::Tensor({0}, core::Int32),
           "line_attributes"_a = std::map<std::string, core::Tensor>(),
           "textures"_a = std::map<std::string, core::Tensor>(),
+          "o3d_type"_a = std::string(),
           "connection"_a = std::shared_ptr<rpc::ConnectionBase>(),
           "Sends a set_mesh_data message.");
     docstring::FunctionDocInject(
             m, "set_mesh_data",
             {
-                    {"vertices", "Tensor defining the vertices."},
                     {"path", "A path descriptor, e.g., 'mygroup/points'."},
                     {"time", "The time associated with this data."},
                     {"layer", "The layer associated with this data."},
+                    {"vertices", "Tensor defining the vertices."},
                     {"vertex_attributes",
                      "dict of Tensors with vertex attributes."},
                     {"faces", "Tensor defining the faces with vertex indices."},
@@ -153,6 +154,12 @@ A connection writing to a memory buffer.
                     {"line_attributes",
                      "dict of Tensors with line attributes."},
                     {"textures", "dict of Tensors with textures."},
+                    {"o3d_type", R"doc(The type of the geometry. This is one of 
+"PointCloud", "LineSet", "TriangleMesh".
+This argument should be specified for partial
+data that has no primary key data, e.g., a triangle
+mesh without vertices but with other attribute
+tensors.)doc"},
                     {"connection",
                      "A Connection object. Use None to automatically create "
                      "the connection."},

--- a/python/test/io/rpc/test_serialization.py
+++ b/python/test/io/rpc/test_serialization.py
@@ -81,7 +81,7 @@ def test_set_mesh_data_deserialization():
                         size=lines.shape[:1] + (2,)).astype(rng.choice(dtypes)),
     }
 
-    path, time, geom = set_mesh_data_to_geometry(verts,
+    path, time, geom = set_mesh_data_to_geometry(vertices=verts,
                                                  vertex_attributes=vert_attrs,
                                                  path="pcd",
                                                  time=123)
@@ -92,7 +92,7 @@ def test_set_mesh_data_deserialization():
     for k, v in vert_attrs.items():
         np.testing.assert_equal(geom.point[k].numpy(), v)
 
-    path, time, geom = set_mesh_data_to_geometry(verts,
+    path, time, geom = set_mesh_data_to_geometry(vertices=verts,
                                                  faces=tris,
                                                  vertex_attributes=vert_attrs,
                                                  face_attributes=tri_attrs,
@@ -108,7 +108,7 @@ def test_set_mesh_data_deserialization():
     for k, v in tri_attrs.items():
         np.testing.assert_equal(geom.triangle[k].numpy(), v)
 
-    path, time, geom = set_mesh_data_to_geometry(verts,
+    path, time, geom = set_mesh_data_to_geometry(vertices=verts,
                                                  lines=lines,
                                                  vertex_attributes=vert_attrs,
                                                  line_attributes=line_attrs,
@@ -123,3 +123,51 @@ def test_set_mesh_data_deserialization():
         np.testing.assert_equal(geom.point[k].numpy(), v)
     for k, v in line_attrs.items():
         np.testing.assert_equal(geom.line[k].numpy(), v)
+
+    #
+    # Test partial data
+    #
+    path, time, geom = set_mesh_data_to_geometry(vertex_attributes=vert_attrs,
+                                                 path="pcd",
+                                                 time=123,
+                                                 o3d_type="PointCloud")
+    assert path == "pcd"
+    assert time == 123
+    assert isinstance(geom, o3d.t.geometry.PointCloud)
+    for k, v in vert_attrs.items():
+        np.testing.assert_equal(geom.point[k].numpy(), v)
+
+    path, time, geom = set_mesh_data_to_geometry(vertex_attributes=vert_attrs,
+                                                 face_attributes=tri_attrs,
+                                                 path="trimesh",
+                                                 time=123,
+                                                 o3d_type="TriangleMesh")
+    assert path == "trimesh"
+    assert time == 123
+    assert isinstance(geom, o3d.t.geometry.TriangleMesh)
+    for k, v in vert_attrs.items():
+        np.testing.assert_equal(geom.vertex[k].numpy(), v)
+    for k, v in tri_attrs.items():
+        np.testing.assert_equal(geom.triangle[k].numpy(), v)
+
+    path, time, geom = set_mesh_data_to_geometry(vertex_attributes=vert_attrs,
+                                                 line_attributes=line_attrs,
+                                                 path="lines",
+                                                 time=123,
+                                                 o3d_type="LineSet")
+    assert path == "lines"
+    assert time == 123
+    assert isinstance(geom, o3d.t.geometry.LineSet)
+    for k, v in vert_attrs.items():
+        np.testing.assert_equal(geom.point[k].numpy(), v)
+    for k, v in line_attrs.items():
+        np.testing.assert_equal(geom.line[k].numpy(), v)
+
+    # Without o3d_type and no primary key data the returned object is None
+    path, time, geom = set_mesh_data_to_geometry(vertex_attributes=vert_attrs,
+                                                 path="unknown",
+                                                 time=123,
+                                                 o3d_type="")
+    assert path == "unknown"
+    assert time == 123
+    assert geom is None


### PR DESCRIPTION
This PR relaxes some of the sanity checks for the serialization/deserialization to allow geometries that have no primary data like vertices or face indices.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3963)
<!-- Reviewable:end -->
