### PR TITLE
Fix typo of online-processing.py

### DIFF
--- a/examples/python/gui/online-processing.py
+++ b/examples/python/gui/online-processing.py
@@ -174,7 +174,7 @@ class PipelineModel:
                 log.warning(f"No valid depth data in frame {frame_id})")
                 continue
 
-            n_pts += self.pcd_frame.point['points'].shape[0]
+            n_pts += self.pcd_frame.point['positions'].shape[0]
             if frame_id % 60 == 0 and frame_id > 0:
                 t0, t1 = t1, time.perf_counter()
                 log.debug(f"\nframe_id = {frame_id}, \t {(t1-t0)*1000./60:0.2f}"
@@ -376,7 +376,7 @@ class PipelineView:
         if not self.flag_gui_init:
             # Set dummy point cloud to allocate graphics memory
             dummy_pcd = o3d.t.geometry.PointCloud({
-                'points':
+                'positions':
                     o3d.core.Tensor.zeros((self.max_pcd_vertices, 3),
                                           o3d.core.Dtype.Float32),
                 'colors':


### PR DESCRIPTION
TensorMap doesn't have "points" key. It has "positions".
https://github.com/isl-org/Open3D/blob/4f70ff19da8f65380a3835c10cbadb1a01c1b80e/cpp/open3d/t/geometry/TensorMap.h#L43

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3969)
<!-- Reviewable:end -->
