### PR TITLE
Fix crash when visualizing single point Point Cloud

### DIFF
--- a/cpp/open3d/visualization/rendering/filament/FilamentScene.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentScene.cpp
@@ -337,14 +337,12 @@ bool FilamentScene::AddGeometry(const std::string& object_name,
     }
 
     // Build Filament buffers
-    auto geometry_buffer_builder = GeometryBuffersBuilder::GetBuilder(geometry);
-    if (!geometry_buffer_builder) {
+    auto buffer_builder = GeometryBuffersBuilder::GetBuilder(geometry);
+    if (!buffer_builder) {
         utility::LogWarning("Geometry type {} is not supported yet!",
                             static_cast<size_t>(geometry.GetGeometryType()));
         return false;
     }
-
-    auto buffer_builder = GeometryBuffersBuilder::GetBuilder(geometry);
     if (!downsampled_name.empty()) {
         buffer_builder->SetDownsampleThreshold(downsample_threshold);
     }

--- a/cpp/open3d/visualization/rendering/filament/PointCloudBuffers.cpp
+++ b/cpp/open3d/visualization/rendering/filament/PointCloudBuffers.cpp
@@ -283,14 +283,21 @@ GeometryBuffersBuilder::Buffers PointCloudBuffersBuilder::ConstructBuffers() {
 
 filament::Box PointCloudBuffersBuilder::ComputeAABB() {
     const auto geometry_aabb = geometry_.GetAxisAlignedBoundingBox();
-
-    const filament::math::float3 min(geometry_aabb.min_bound_.x(),
-                                     geometry_aabb.min_bound_.y(),
-                                     geometry_aabb.min_bound_.z());
-    const filament::math::float3 max(geometry_aabb.max_bound_.x(),
-                                     geometry_aabb.max_bound_.y(),
-                                     geometry_aabb.max_bound_.z());
-
+    filament::math::float3 min(geometry_aabb.min_bound_.x(),
+                               geometry_aabb.min_bound_.y(),
+                               geometry_aabb.min_bound_.z());
+    filament::math::float3 max(geometry_aabb.max_bound_.x(),
+                               geometry_aabb.max_bound_.y(),
+                               geometry_aabb.max_bound_.z());
+    // Filament chokes on empty bounding boxes so don't allow it
+    if (geometry_aabb.IsEmpty()) {
+        min.x -= 0.1f;
+        min.y -= 0.1f;
+        min.z -= 0.1f;
+        max.x += 0.1f;
+        max.y += 0.1f;
+        max.z += 0.1f;
+    }
     Box aabb;
     aabb.set(min, max);
 


### PR DESCRIPTION
This can be tested with Open3DViewer viewer using the attached file which consists of a single point. It is a PLY file. Change the extension to `.ply`.
[test_one_point.txt](https://github.com/isl-org/Open3D/files/7050965/test_one_point.txt)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3979)
<!-- Reviewable:end -->
