### PR TITLE
Refactor HashMap and backends

### DIFF
--- a/cpp/benchmarks/core/HashMap.cpp
+++ b/cpp/benchmarks/core/HashMap.cpp
@@ -220,11 +220,11 @@ void HashClearInt(benchmark::State& state,
     }
 }
 
-void HashRehashInt(benchmark::State& state,
-                   int capacity,
-                   int duplicate_factor,
-                   const Device& device,
-                   const HashBackendType& backend) {
+void HashReserveInt(benchmark::State& state,
+                    int capacity,
+                    int duplicate_factor,
+                    const Device& device,
+                    const HashBackendType& backend) {
     int slots = std::max(1, capacity / duplicate_factor);
     HashData<int, int> data(capacity, slots);
 
@@ -254,7 +254,7 @@ void HashRehashInt(benchmark::State& state,
         cuda::Synchronize(device);
         state.ResumeTiming();
 
-        hashmap.Rehash(2 * capacity);
+        hashmap.Reserve(2 * capacity);
 
         cuda::Synchronize(device);
         state.PauseTiming();
@@ -445,11 +445,11 @@ void HashClearInt3(benchmark::State& state,
     }
 }
 
-void HashRehashInt3(benchmark::State& state,
-                    int capacity,
-                    int duplicate_factor,
-                    const Device& device,
-                    const HashBackendType& backend) {
+void HashReserveInt3(benchmark::State& state,
+                     int capacity,
+                     int duplicate_factor,
+                     const Device& device,
+                     const HashBackendType& backend) {
     int slots = std::max(1, capacity / duplicate_factor);
     HashData<Int3, int> data(capacity, slots);
 
@@ -482,7 +482,7 @@ void HashRehashInt3(benchmark::State& state,
         cuda::Synchronize(device);
         state.ResumeTiming();
 
-        hashmap.Rehash(2 * capacity);
+        hashmap.Reserve(2 * capacity);
 
         cuda::Synchronize(device);
         state.PauseTiming();
@@ -542,8 +542,8 @@ ENUM_BM_BACKEND(HashFindInt)
 ENUM_BM_BACKEND(HashFindInt3)
 ENUM_BM_BACKEND(HashClearInt)
 ENUM_BM_BACKEND(HashClearInt3)
-ENUM_BM_BACKEND(HashRehashInt)
-ENUM_BM_BACKEND(HashRehashInt3)
+ENUM_BM_BACKEND(HashReserveInt)
+ENUM_BM_BACKEND(HashReserveInt3)
 
 }  // namespace core
 }  // namespace open3d

--- a/cpp/open3d/core/hashmap/CPU/CreateCPUHashBackend.cpp
+++ b/cpp/open3d/core/hashmap/CPU/CreateCPUHashBackend.cpp
@@ -59,8 +59,9 @@ std::shared_ptr<DeviceHashBackend> CreateCPUHashBackend(
 
     std::shared_ptr<DeviceHashBackend> device_hashmap_ptr;
     DISPATCH_DTYPE_AND_DIM_TO_TEMPLATE(key_dtype, dim, [&] {
-        device_hashmap_ptr = std::make_shared<TBBHashBackend<key_t, hash_t>>(
-                init_capacity, key_dsize, value_dsizes, device);
+        device_hashmap_ptr =
+                std::make_shared<TBBHashBackend<key_t, hash_t, eq_t>>(
+                        init_capacity, key_dsize, value_dsizes, device);
     });
     return device_hashmap_ptr;
 }

--- a/cpp/open3d/core/hashmap/CPU/TBBHashBackend.h
+++ b/cpp/open3d/core/hashmap/CPU/TBBHashBackend.h
@@ -196,7 +196,6 @@ void TBBHashBackend<Key, Hash, Eq>::Insert(
 
     size_t n_values = value_dsizes_.size();
 
-    bool assign = (input_values_soa.size() == n_values);
     if (input_values_soa.size() != n_values && input_values_soa.size() != 0) {
         utility::LogWarning(
                 "Input values mismatch with actual stored values, fall back to "
@@ -226,14 +225,10 @@ void TBBHashBackend<Key, Hash, Eq>::Insert(
                 uint8_t* dst_value = static_cast<uint8_t*>(
                         buffer_accessor_->GetValuePtr(buf_index, j));
 
-                if (assign) {
-                    const uint8_t* src_value =
-                            static_cast<const uint8_t*>(input_values_soa[j]) +
-                            this->value_dsizes_[j] * i;
-                    std::memcpy(dst_value, src_value, this->value_dsizes_[j]);
-                } else {
-                    std::memset(dst_value, 0, this->value_dsizes_[j]);
-                }
+                const uint8_t* src_value =
+                        static_cast<const uint8_t*>(input_values_soa[j]) +
+                        this->value_dsizes_[j] * i;
+                std::memcpy(dst_value, src_value, this->value_dsizes_[j]);
             }
 
             // Update from dummy 0

--- a/cpp/open3d/core/hashmap/CPU/TBBHashBackend.h
+++ b/cpp/open3d/core/hashmap/CPU/TBBHashBackend.h
@@ -94,7 +94,8 @@ protected:
                     bool* output_masks,
                     int64_t count);
 
-    void Allocate(int64_t capacity);
+    void Allocate(int64_t capacity, int64_t bucket_count) override;
+    void Free() override{};
 };
 
 template <typename Key, typename Hash, typename Eq>
@@ -104,7 +105,7 @@ TBBHashBackend<Key, Hash, Eq>::TBBHashBackend(
         const std::vector<int64_t>& value_dsizes,
         const Device& device)
     : DeviceHashBackend(init_capacity, key_dsize, value_dsizes, device) {
-    Allocate(init_capacity);
+    Allocate(init_capacity, 0);
 }
 
 template <typename Key, typename Hash, typename Eq>
@@ -228,7 +229,7 @@ void TBBHashBackend<Key, Hash, Eq>::Rehash(int64_t buckets) {
     int64_t new_capacity =
             int64_t(std::ceil(buckets * avg_capacity_per_bucket));
 
-    Allocate(new_capacity);
+    Allocate(new_capacity, 0);
 
     if (count > 0) {
         Tensor output_buf_indices({count}, core::Int32, this->device_);
@@ -328,7 +329,8 @@ void TBBHashBackend<Key, Hash, Eq>::InsertImpl(
 }
 
 template <typename Key, typename Hash, typename Eq>
-void TBBHashBackend<Key, Hash, Eq>::Allocate(int64_t capacity) {
+void TBBHashBackend<Key, Hash, Eq>::Allocate(int64_t capacity,
+                                             int64_t bucket_count) {
     this->capacity_ = capacity;
 
     this->buffer_ = std::make_shared<HashBackendBuffer>(

--- a/cpp/open3d/core/hashmap/CPU/TBBHashBackend.h
+++ b/cpp/open3d/core/hashmap/CPU/TBBHashBackend.h
@@ -194,13 +194,7 @@ void TBBHashBackend<Key, Hash, Eq>::Insert(
         int64_t count) {
     const Key* input_keys_templated = static_cast<const Key*>(input_keys);
 
-    size_t n_values = value_dsizes_.size();
-
-    if (input_values_soa.size() != n_values && input_values_soa.size() != 0) {
-        utility::LogWarning(
-                "Input values mismatch with actual stored values, fall back to "
-                "activate/reset instead of insertion.");
-    }
+    size_t n_values = input_values_soa.size();
 
 #pragma omp parallel for num_threads(utility::EstimateMaxThreads())
     for (int64_t i = 0; i < count; ++i) {

--- a/cpp/open3d/core/hashmap/CPU/TBBHashBackend.h
+++ b/cpp/open3d/core/hashmap/CPU/TBBHashBackend.h
@@ -46,7 +46,7 @@ public:
                    const Device& device);
     ~TBBHashBackend();
 
-    void Rehash(int64_t buckets) override;
+    void Reserve(int64_t capacity) override;
 
     void Insert(const void* input_keys,
                 const std::vector<const void*>& input_values_soa,
@@ -161,8 +161,8 @@ void TBBHashBackend<Key, Hash, Eq>::Clear() {
 }
 
 template <typename Key, typename Hash, typename Eq>
-void TBBHashBackend<Key, Hash, Eq>::Rehash(int64_t buckets) {
-    impl_->rehash(buckets);
+void TBBHashBackend<Key, Hash, Eq>::Reserve(int64_t capacity) {
+    impl_->rehash(std::ceil(capacity / impl_->max_load_factor()));
 }
 
 template <typename Key, typename Hash, typename Eq>

--- a/cpp/open3d/core/hashmap/CPU/TBBHashBackend.h
+++ b/cpp/open3d/core/hashmap/CPU/TBBHashBackend.h
@@ -77,7 +77,7 @@ public:
         return impl_;
     }
 
-    void Allocate(int64_t capacity, int64_t bucket_count) override;
+    void Allocate(int64_t capacity) override;
     void Free() override{};
 
 protected:
@@ -94,7 +94,7 @@ TBBHashBackend<Key, Hash, Eq>::TBBHashBackend(
         const std::vector<int64_t>& value_dsizes,
         const Device& device)
     : DeviceHashBackend(init_capacity, key_dsize, value_dsizes, device) {
-    Allocate(init_capacity, 0);
+    Allocate(init_capacity);
 }
 
 template <typename Key, typename Hash, typename Eq>
@@ -236,8 +236,7 @@ void TBBHashBackend<Key, Hash, Eq>::Insert(
 }
 
 template <typename Key, typename Hash, typename Eq>
-void TBBHashBackend<Key, Hash, Eq>::Allocate(int64_t capacity,
-                                             int64_t bucket_count) {
+void TBBHashBackend<Key, Hash, Eq>::Allocate(int64_t capacity) {
     this->capacity_ = capacity;
 
     this->buffer_ = std::make_shared<HashBackendBuffer>(

--- a/cpp/open3d/core/hashmap/CUDA/CreateCUDAHashBackend.cu
+++ b/cpp/open3d/core/hashmap/CUDA/CreateCUDAHashBackend.cu
@@ -64,13 +64,13 @@ std::shared_ptr<DeviceHashBackend> CreateCUDAHashBackend(
         backend == HashBackendType::StdGPU) {
         DISPATCH_DTYPE_AND_DIM_TO_TEMPLATE(key_dtype, dim, [&] {
             device_hashmap_ptr =
-                    std::make_shared<StdGPUHashBackend<key_t, hash_t>>(
+              std::make_shared<StdGPUHashBackend<key_t, hash_t, eq_t>>(
                             init_capacity, key_dsize, value_dsizes, device);
         });
     } else {  // if (backend == HashBackendType::Slab) {
         DISPATCH_DTYPE_AND_DIM_TO_TEMPLATE(key_dtype, dim, [&] {
             device_hashmap_ptr =
-                    std::make_shared<SlabHashBackend<key_t, hash_t>>(
+              std::make_shared<SlabHashBackend<key_t, hash_t, eq_t>>(
                             init_capacity, key_dsize, value_dsizes, device);
         });
     }

--- a/cpp/open3d/core/hashmap/CUDA/CreateCUDAHashBackend.cu
+++ b/cpp/open3d/core/hashmap/CUDA/CreateCUDAHashBackend.cu
@@ -64,13 +64,13 @@ std::shared_ptr<DeviceHashBackend> CreateCUDAHashBackend(
         backend == HashBackendType::StdGPU) {
         DISPATCH_DTYPE_AND_DIM_TO_TEMPLATE(key_dtype, dim, [&] {
             device_hashmap_ptr =
-              std::make_shared<StdGPUHashBackend<key_t, hash_t, eq_t>>(
+                    std::make_shared<StdGPUHashBackend<key_t, hash_t, eq_t>>(
                             init_capacity, key_dsize, value_dsizes, device);
         });
     } else {  // if (backend == HashBackendType::Slab) {
         DISPATCH_DTYPE_AND_DIM_TO_TEMPLATE(key_dtype, dim, [&] {
             device_hashmap_ptr =
-              std::make_shared<SlabHashBackend<key_t, hash_t, eq_t>>(
+                    std::make_shared<SlabHashBackend<key_t, hash_t, eq_t>>(
                             init_capacity, key_dsize, value_dsizes, device);
         });
     }

--- a/cpp/open3d/core/hashmap/CUDA/SlabHashBackend.h
+++ b/cpp/open3d/core/hashmap/CUDA/SlabHashBackend.h
@@ -34,7 +34,7 @@
 
 namespace open3d {
 namespace core {
-template <typename Key, typename Hash>
+template <typename Key, typename Hash, typename Eq>
 class SlabHashBackend : public DeviceHashBackend {
 public:
     SlabHashBackend(int64_t init_capacity,
@@ -74,12 +74,12 @@ public:
     std::vector<int64_t> BucketSizes() const override;
     float LoadFactor() const override;
 
-    SlabHashBackendImpl<Key, Hash> GetImpl() { return impl_; }
+    SlabHashBackendImpl<Key, Hash, Eq> GetImpl() { return impl_; }
 
 protected:
     /// The struct is directly passed to kernels by value, so cannot be a
     /// shared pointer.
-    SlabHashBackendImpl<Key, Hash> impl_;
+    SlabHashBackendImpl<Key, Hash, Eq> impl_;
 
     CUDAHashBackendBufferAccessor buffer_accessor_;
     std::shared_ptr<SlabNodeManager> node_mgr_;
@@ -98,8 +98,8 @@ protected:
     int64_t bucket_count_;
 };
 
-template <typename Key, typename Hash>
-SlabHashBackend<Key, Hash>::SlabHashBackend(
+template <typename Key, typename Hash, typename Eq>
+SlabHashBackend<Key, Hash, Eq>::SlabHashBackend(
         int64_t init_capacity,
         int64_t key_dsize,
         const std::vector<int64_t>& value_dsizes,
@@ -109,13 +109,13 @@ SlabHashBackend<Key, Hash>::SlabHashBackend(
     Allocate(init_buckets, init_capacity);
 }
 
-template <typename Key, typename Hash>
-SlabHashBackend<Key, Hash>::~SlabHashBackend() {
+template <typename Key, typename Hash, typename Eq>
+SlabHashBackend<Key, Hash, Eq>::~SlabHashBackend() {
     Free();
 }
 
-template <typename Key, typename Hash>
-void SlabHashBackend<Key, Hash>::Rehash(int64_t buckets) {
+template <typename Key, typename Hash, typename Eq>
+void SlabHashBackend<Key, Hash, Eq>::Rehash(int64_t buckets) {
     int64_t count = Size();
 
     Tensor active_keys;
@@ -158,8 +158,8 @@ void SlabHashBackend<Key, Hash>::Rehash(int64_t buckets) {
     }
 }
 
-template <typename Key, typename Hash>
-void SlabHashBackend<Key, Hash>::Insert(
+template <typename Key, typename Hash, typename Eq>
+void SlabHashBackend<Key, Hash, Eq>::Insert(
         const void* input_keys,
         const std::vector<const void*>& input_values_soa,
         buf_index_t* output_buf_indices,
@@ -179,20 +179,20 @@ void SlabHashBackend<Key, Hash>::Insert(
                count);
 }
 
-template <typename Key, typename Hash>
-void SlabHashBackend<Key, Hash>::Activate(const void* input_keys,
-                                          buf_index_t* output_buf_indices,
-                                          bool* output_masks,
-                                          int64_t count) {
+template <typename Key, typename Hash, typename Eq>
+void SlabHashBackend<Key, Hash, Eq>::Activate(const void* input_keys,
+                                              buf_index_t* output_buf_indices,
+                                              bool* output_masks,
+                                              int64_t count) {
     std::vector<const void*> null_values;
     Insert(input_keys, null_values, output_buf_indices, output_masks, count);
 }
 
-template <typename Key, typename Hash>
-void SlabHashBackend<Key, Hash>::Find(const void* input_keys,
-                                      buf_index_t* output_buf_indices,
-                                      bool* output_masks,
-                                      int64_t count) {
+template <typename Key, typename Hash, typename Eq>
+void SlabHashBackend<Key, Hash, Eq>::Find(const void* input_keys,
+                                          buf_index_t* output_buf_indices,
+                                          bool* output_masks,
+                                          int64_t count) {
     if (count == 0) return;
 
     OPEN3D_CUDA_CHECK(cudaMemset(output_masks, 0, sizeof(bool) * count));
@@ -207,10 +207,10 @@ void SlabHashBackend<Key, Hash>::Find(const void* input_keys,
     OPEN3D_CUDA_CHECK(cudaGetLastError());
 }
 
-template <typename Key, typename Hash>
-void SlabHashBackend<Key, Hash>::Erase(const void* input_keys,
-                                       bool* output_masks,
-                                       int64_t count) {
+template <typename Key, typename Hash, typename Eq>
+void SlabHashBackend<Key, Hash, Eq>::Erase(const void* input_keys,
+                                           bool* output_masks,
+                                           int64_t count) {
     if (count == 0) return;
 
     OPEN3D_CUDA_CHECK(cudaMemset(output_masks, 0, sizeof(bool) * count));
@@ -233,8 +233,8 @@ void SlabHashBackend<Key, Hash>::Erase(const void* input_keys,
     MemoryManager::Free(buf_indices, this->device_);
 }
 
-template <typename Key, typename Hash>
-int64_t SlabHashBackend<Key, Hash>::GetActiveIndices(
+template <typename Key, typename Hash, typename Eq>
+int64_t SlabHashBackend<Key, Hash, Eq>::GetActiveIndices(
         buf_index_t* output_buf_indices) {
     uint32_t* count = static_cast<uint32_t*>(
             MemoryManager::Malloc(sizeof(uint32_t), this->device_));
@@ -259,8 +259,8 @@ int64_t SlabHashBackend<Key, Hash>::GetActiveIndices(
     return static_cast<int64_t>(ret);
 }
 
-template <typename Key, typename Hash>
-void SlabHashBackend<Key, Hash>::Clear() {
+template <typename Key, typename Hash, typename Eq>
+void SlabHashBackend<Key, Hash, Eq>::Clear() {
     // Clear the heap
     this->buffer_->ResetHeap();
 
@@ -274,18 +274,18 @@ void SlabHashBackend<Key, Hash>::Clear() {
     node_mgr_->Reset();
 }
 
-template <typename Key, typename Hash>
-int64_t SlabHashBackend<Key, Hash>::Size() const {
+template <typename Key, typename Hash, typename Eq>
+int64_t SlabHashBackend<Key, Hash, Eq>::Size() const {
     return this->buffer_->GetHeapTopIndex();
 }
 
-template <typename Key, typename Hash>
-int64_t SlabHashBackend<Key, Hash>::GetBucketCount() const {
+template <typename Key, typename Hash, typename Eq>
+int64_t SlabHashBackend<Key, Hash, Eq>::GetBucketCount() const {
     return bucket_count_;
 }
 
-template <typename Key, typename Hash>
-std::vector<int64_t> SlabHashBackend<Key, Hash>::BucketSizes() const {
+template <typename Key, typename Hash, typename Eq>
+std::vector<int64_t> SlabHashBackend<Key, Hash, Eq>::BucketSizes() const {
     thrust::device_vector<int64_t> elems_per_bucket(impl_.bucket_count_);
     thrust::fill(elems_per_bucket.begin(), elems_per_bucket.end(), 0);
 
@@ -304,13 +304,13 @@ std::vector<int64_t> SlabHashBackend<Key, Hash>::BucketSizes() const {
     return result;
 }
 
-template <typename Key, typename Hash>
-float SlabHashBackend<Key, Hash>::LoadFactor() const {
+template <typename Key, typename Hash, typename Eq>
+float SlabHashBackend<Key, Hash, Eq>::LoadFactor() const {
     return float(Size()) / float(this->bucket_count_);
 }
 
-template <typename Key, typename Hash>
-void SlabHashBackend<Key, Hash>::InsertImpl(
+template <typename Key, typename Hash, typename Eq>
+void SlabHashBackend<Key, Hash, Eq>::InsertImpl(
         const void* input_keys,
         const std::vector<const void*>& input_values_soa,
         buf_index_t* output_buf_indices,
@@ -350,9 +350,9 @@ void SlabHashBackend<Key, Hash>::InsertImpl(
     OPEN3D_CUDA_CHECK(cudaGetLastError());
 }
 
-template <typename Key, typename Hash>
-void SlabHashBackend<Key, Hash>::Allocate(int64_t bucket_count,
-                                          int64_t capacity) {
+template <typename Key, typename Hash, typename Eq>
+void SlabHashBackend<Key, Hash, Eq>::Allocate(int64_t bucket_count,
+                                              int64_t capacity) {
     this->bucket_count_ = bucket_count;
     this->capacity_ = capacity;
 
@@ -376,8 +376,8 @@ void SlabHashBackend<Key, Hash>::Allocate(int64_t bucket_count,
     impl_.Setup(this->bucket_count_, node_mgr_->impl_, buffer_accessor_);
 }
 
-template <typename Key, typename Hash>
-void SlabHashBackend<Key, Hash>::Free() {
+template <typename Key, typename Hash, typename Eq>
+void SlabHashBackend<Key, Hash, Eq>::Free() {
     buffer_accessor_.Shutdown(this->device_);
     MemoryManager::Free(impl_.bucket_list_head_, this->device_);
 }

--- a/cpp/open3d/core/hashmap/CUDA/SlabHashBackend.h
+++ b/cpp/open3d/core/hashmap/CUDA/SlabHashBackend.h
@@ -252,11 +252,8 @@ void SlabHashBackend<Key, Hash, Eq>::Insert(
 
     thrust::device_vector<const void*> input_values_soa_device(
             input_values_soa.begin(), input_values_soa.end());
-    int64_t n_values =
-            input_values_soa.size() == impl_.buffer_accessor_.n_values_
-                    ? impl_.buffer_accessor_.n_values_
-                    : 0;
-    // https://stackoverflow.com/a/37998941
+
+    int64_t n_values = input_values_soa.size();
     const void* const* ptr_input_values_soa =
             thrust::raw_pointer_cast(input_values_soa_device.data());
     DISPATCH_DIVISOR_SIZE_TO_BLOCK_T(

--- a/cpp/open3d/core/hashmap/CUDA/SlabHashBackend.h
+++ b/cpp/open3d/core/hashmap/CUDA/SlabHashBackend.h
@@ -45,7 +45,7 @@ public:
 
     ~SlabHashBackend();
 
-    void Rehash(int64_t buckets) override;
+    void Reserve(int64_t capacity) override;
 
     void Insert(const void* input_keys,
                 const std::vector<const void*>& input_values_soa,
@@ -102,7 +102,7 @@ SlabHashBackend<Key, Hash, Eq>::~SlabHashBackend() {
 }
 
 template <typename Key, typename Hash, typename Eq>
-void SlabHashBackend<Key, Hash, Eq>::Rehash(int64_t buckets) {}
+void SlabHashBackend<Key, Hash, Eq>::Reserve(int64_t capacity) {}
 
 template <typename Key, typename Hash, typename Eq>
 void SlabHashBackend<Key, Hash, Eq>::Find(const void* input_keys,

--- a/cpp/open3d/core/hashmap/CUDA/SlabHashBackend.h
+++ b/cpp/open3d/core/hashmap/CUDA/SlabHashBackend.h
@@ -72,7 +72,7 @@ public:
 
     SlabHashBackendImpl<Key, Hash, Eq> GetImpl() { return impl_; }
 
-    void Allocate(int64_t capacity, int64_t bucket_count) override;
+    void Allocate(int64_t capacity) override;
     void Free() override;
 
 protected:
@@ -93,8 +93,7 @@ SlabHashBackend<Key, Hash, Eq>::SlabHashBackend(
         const std::vector<int64_t>& value_dsizes,
         const Device& device)
     : DeviceHashBackend(init_capacity, key_dsize, value_dsizes, device) {
-    int64_t init_buckets = init_capacity * 2;
-    Allocate(init_capacity, init_buckets);
+    Allocate(init_capacity);
 }
 
 template <typename Key, typename Hash, typename Eq>
@@ -269,9 +268,8 @@ void SlabHashBackend<Key, Hash, Eq>::Insert(
 }
 
 template <typename Key, typename Hash, typename Eq>
-void SlabHashBackend<Key, Hash, Eq>::Allocate(int64_t capacity,
-                                              int64_t bucket_count) {
-    this->bucket_count_ = bucket_count;
+void SlabHashBackend<Key, Hash, Eq>::Allocate(int64_t capacity) {
+    this->bucket_count_ = capacity * 2;
     this->capacity_ = capacity;
 
     // Allocate buffer for key values.

--- a/cpp/open3d/core/hashmap/CUDA/SlabHashBackendImpl.h
+++ b/cpp/open3d/core/hashmap/CUDA/SlabHashBackendImpl.h
@@ -60,7 +60,7 @@ namespace core {
 // They are equivalent, but we differentiate them in the implementation to
 // emphasize the differences.
 
-template <typename Key, typename Hash>
+template <typename Key, typename Hash, typename Eq>
 class SlabHashBackendImpl {
 public:
     SlabHashBackendImpl();
@@ -127,6 +127,7 @@ public:
 
 public:
     Hash hash_fn_;
+    Eq eq_fn_;
     int64_t bucket_count_;
 
     Slab* bucket_list_head_;
@@ -138,63 +139,63 @@ public:
 };
 
 /// Kernels
-template <typename Key, typename Hash>
-__global__ void InsertKernelPass0(SlabHashBackendImpl<Key, Hash> impl,
+template <typename Key, typename Hash, typename Eq>
+__global__ void InsertKernelPass0(SlabHashBackendImpl<Key, Hash, Eq> impl,
                                   const void* input_keys,
                                   buf_index_t* output_buf_indices,
                                   int heap_counter_prev,
                                   int64_t count);
 
-template <typename Key, typename Hash>
-__global__ void InsertKernelPass1(SlabHashBackendImpl<Key, Hash> impl,
+template <typename Key, typename Hash, typename Eq>
+__global__ void InsertKernelPass1(SlabHashBackendImpl<Key, Hash, Eq> impl,
                                   const void* input_keys,
                                   buf_index_t* output_buf_indices,
                                   bool* output_masks,
                                   int64_t count);
 
-template <typename Key, typename Hash>
-__global__ void InsertKernelPass2(SlabHashBackendImpl<Key, Hash> impl,
+template <typename Key, typename Hash, typename Eq>
+__global__ void InsertKernelPass2(SlabHashBackendImpl<Key, Hash, Eq> impl,
                                   const void* const* input_values_soa,
                                   buf_index_t* output_buf_indices,
                                   bool* output_masks,
                                   int64_t count,
                                   int64_t n_values);
 
-template <typename Key, typename Hash>
-__global__ void FindKernel(SlabHashBackendImpl<Key, Hash> impl,
+template <typename Key, typename Hash, typename Eq>
+__global__ void FindKernel(SlabHashBackendImpl<Key, Hash, Eq> impl,
                            const void* input_keys,
                            buf_index_t* output_buf_indices,
                            bool* output_masks,
                            int64_t count);
 
-template <typename Key, typename Hash>
-__global__ void EraseKernelPass0(SlabHashBackendImpl<Key, Hash> impl,
+template <typename Key, typename Hash, typename Eq>
+__global__ void EraseKernelPass0(SlabHashBackendImpl<Key, Hash, Eq> impl,
                                  const void* input_keys,
                                  buf_index_t* output_buf_indices,
                                  bool* output_masks,
                                  int64_t count);
 
-template <typename Key, typename Hash>
-__global__ void EraseKernelPass1(SlabHashBackendImpl<Key, Hash> impl,
+template <typename Key, typename Hash, typename Eq>
+__global__ void EraseKernelPass1(SlabHashBackendImpl<Key, Hash, Eq> impl,
                                  buf_index_t* output_buf_indices,
                                  bool* output_masks,
                                  int64_t count);
 
-template <typename Key, typename Hash>
-__global__ void GetActiveIndicesKernel(SlabHashBackendImpl<Key, Hash> impl,
+template <typename Key, typename Hash, typename Eq>
+__global__ void GetActiveIndicesKernel(SlabHashBackendImpl<Key, Hash, Eq> impl,
                                        buf_index_t* output_buf_indices,
                                        uint32_t* output_count);
 
-template <typename Key, typename Hash>
-__global__ void CountElemsPerBucketKernel(SlabHashBackendImpl<Key, Hash> impl,
-                                          int64_t* bucket_elem_counts);
+template <typename Key, typename Hash, typename Eq>
+__global__ void CountElemsPerBucketKernel(
+        SlabHashBackendImpl<Key, Hash, Eq> impl, int64_t* bucket_elem_counts);
 
-template <typename Key, typename Hash>
-SlabHashBackendImpl<Key, Hash>::SlabHashBackendImpl()
+template <typename Key, typename Hash, typename Eq>
+SlabHashBackendImpl<Key, Hash, Eq>::SlabHashBackendImpl()
     : bucket_count_(0), bucket_list_head_(nullptr) {}
 
-template <typename Key, typename Hash>
-void SlabHashBackendImpl<Key, Hash>::Setup(
+template <typename Key, typename Hash, typename Eq>
+void SlabHashBackendImpl<Key, Hash, Eq>::Setup(
         int64_t init_buckets,
         const SlabNodeManagerImpl& allocator_impl,
         const CUDAHashBackendBufferAccessor& buffer_accessor) {
@@ -203,12 +204,13 @@ void SlabHashBackendImpl<Key, Hash>::Setup(
     buffer_accessor_ = buffer_accessor;
 }
 
-template <typename Key, typename Hash>
-__device__ bool SlabHashBackendImpl<Key, Hash>::Insert(bool lane_active,
-                                                       uint32_t lane_id,
-                                                       uint32_t bucket_id,
-                                                       const Key& key,
-                                                       buf_index_t buf_index) {
+template <typename Key, typename Hash, typename Eq>
+__device__ bool SlabHashBackendImpl<Key, Hash, Eq>::Insert(
+        bool lane_active,
+        uint32_t lane_id,
+        uint32_t bucket_id,
+        const Key& key,
+        buf_index_t buf_index) {
     uint32_t work_queue = 0;
     uint32_t prev_work_queue = 0;
     uint32_t slab_ptr = kHeadSlabAddr;
@@ -307,8 +309,8 @@ __device__ bool SlabHashBackendImpl<Key, Hash>::Insert(bool lane_active,
     return mask;
 }
 
-template <typename Key, typename Hash>
-__device__ Pair<buf_index_t, bool> SlabHashBackendImpl<Key, Hash>::Find(
+template <typename Key, typename Hash, typename Eq>
+__device__ Pair<buf_index_t, bool> SlabHashBackendImpl<Key, Hash, Eq>::Find(
         bool lane_active,
         uint32_t lane_id,
         uint32_t bucket_id,
@@ -374,8 +376,8 @@ __device__ Pair<buf_index_t, bool> SlabHashBackendImpl<Key, Hash>::Find(
     return make_pair(buf_index, mask);
 }
 
-template <typename Key, typename Hash>
-__device__ Pair<buf_index_t, bool> SlabHashBackendImpl<Key, Hash>::Erase(
+template <typename Key, typename Hash, typename Eq>
+__device__ Pair<buf_index_t, bool> SlabHashBackendImpl<Key, Hash, Eq>::Erase(
         bool lane_active,
         uint32_t lane_id,
         uint32_t bucket_id,
@@ -435,10 +437,9 @@ __device__ Pair<buf_index_t, bool> SlabHashBackendImpl<Key, Hash>::Erase(
     return make_pair(buf_index, mask);
 }
 
-template <typename Key, typename Hash>
-__device__ void SlabHashBackendImpl<Key, Hash>::WarpSyncKey(const Key& key,
-                                                            uint32_t lane_id,
-                                                            Key& ret_key) {
+template <typename Key, typename Hash, typename Eq>
+__device__ void SlabHashBackendImpl<Key, Hash, Eq>::WarpSyncKey(
+        const Key& key, uint32_t lane_id, Key& ret_key) {
     auto dst_key_ptr = reinterpret_cast<int*>(&ret_key);
     auto src_key_ptr = reinterpret_cast<const int*>(&key);
     for (int i = 0; i < key_size_in_int_; ++i) {
@@ -447,8 +448,8 @@ __device__ void SlabHashBackendImpl<Key, Hash>::WarpSyncKey(const Key& key,
     }
 }
 
-template <typename Key, typename Hash>
-__device__ int32_t SlabHashBackendImpl<Key, Hash>::WarpFindKey(
+template <typename Key, typename Hash, typename Eq>
+__device__ int32_t SlabHashBackendImpl<Key, Hash, Eq>::WarpFindKey(
         const Key& key, uint32_t lane_id, uint32_t slab_entry) {
     bool is_lane_found =
             // Select key lanes.
@@ -457,38 +458,39 @@ __device__ int32_t SlabHashBackendImpl<Key, Hash>::WarpFindKey(
             && (slab_entry != kEmptyNodeAddr)
             // Find keys in buffer. Now slab_entry is interpreted as buf_index.
             &&
-            (*static_cast<Key*>(buffer_accessor_.GetKeyPtr(slab_entry)) == key);
+            eq_fn_(*static_cast<Key*>(buffer_accessor_.GetKeyPtr(slab_entry)),
+                   key);
 
     return __ffs(__ballot_sync(kNodePtrLanesMask, is_lane_found)) - 1;
 }
 
-template <typename Key, typename Hash>
+template <typename Key, typename Hash, typename Eq>
 __device__ int32_t
-SlabHashBackendImpl<Key, Hash>::WarpFindEmpty(uint32_t slab_entry) {
+SlabHashBackendImpl<Key, Hash, Eq>::WarpFindEmpty(uint32_t slab_entry) {
     bool is_lane_empty = (slab_entry == kEmptyNodeAddr);
     return __ffs(__ballot_sync(kNodePtrLanesMask, is_lane_empty)) - 1;
 }
 
-template <typename Key, typename Hash>
+template <typename Key, typename Hash, typename Eq>
 __device__ int64_t
-SlabHashBackendImpl<Key, Hash>::ComputeBucket(const Key& key) const {
+SlabHashBackendImpl<Key, Hash, Eq>::ComputeBucket(const Key& key) const {
     return hash_fn_(key) % bucket_count_;
 }
 
-template <typename Key, typename Hash>
+template <typename Key, typename Hash, typename Eq>
 __device__ uint32_t
-SlabHashBackendImpl<Key, Hash>::AllocateSlab(uint32_t lane_id) {
+SlabHashBackendImpl<Key, Hash, Eq>::AllocateSlab(uint32_t lane_id) {
     return node_mgr_impl_.WarpAllocate(lane_id);
 }
 
-template <typename Key, typename Hash>
-__device__ __forceinline__ void SlabHashBackendImpl<Key, Hash>::FreeSlab(
+template <typename Key, typename Hash, typename Eq>
+__device__ __forceinline__ void SlabHashBackendImpl<Key, Hash, Eq>::FreeSlab(
         uint32_t slab_ptr) {
     node_mgr_impl_.FreeUntouched(slab_ptr);
 }
 
-template <typename Key, typename Hash>
-__global__ void InsertKernelPass0(SlabHashBackendImpl<Key, Hash> impl,
+template <typename Key, typename Hash, typename Eq>
+__global__ void InsertKernelPass0(SlabHashBackendImpl<Key, Hash, Eq> impl,
                                   const void* input_keys,
                                   buf_index_t* output_buf_indices,
                                   int heap_counter_prev,
@@ -506,8 +508,8 @@ __global__ void InsertKernelPass0(SlabHashBackendImpl<Key, Hash> impl,
     }
 }
 
-template <typename Key, typename Hash>
-__global__ void InsertKernelPass1(SlabHashBackendImpl<Key, Hash> impl,
+template <typename Key, typename Hash, typename Eq>
+__global__ void InsertKernelPass1(SlabHashBackendImpl<Key, Hash, Eq> impl,
                                   const void* input_keys,
                                   buf_index_t* output_buf_indices,
                                   bool* output_masks,
@@ -543,8 +545,8 @@ __global__ void InsertKernelPass1(SlabHashBackendImpl<Key, Hash> impl,
     }
 }
 
-template <typename Key, typename Hash>
-__global__ void InsertKernelPass2(SlabHashBackendImpl<Key, Hash> impl,
+template <typename Key, typename Hash, typename Eq>
+__global__ void InsertKernelPass2(SlabHashBackendImpl<Key, Hash, Eq> impl,
                                   const void* const* input_values_soa,
                                   buf_index_t* output_buf_indices,
                                   bool* output_masks,
@@ -573,8 +575,8 @@ __global__ void InsertKernelPass2(SlabHashBackendImpl<Key, Hash> impl,
     }
 }
 
-template <typename Key, typename Hash>
-__global__ void FindKernel(SlabHashBackendImpl<Key, Hash> impl,
+template <typename Key, typename Hash, typename Eq>
+__global__ void FindKernel(SlabHashBackendImpl<Key, Hash, Eq> impl,
                            const void* input_keys,
                            buf_index_t* output_buf_indices,
                            bool* output_masks,
@@ -612,8 +614,8 @@ __global__ void FindKernel(SlabHashBackendImpl<Key, Hash> impl,
     }
 }
 
-template <typename Key, typename Hash>
-__global__ void EraseKernelPass0(SlabHashBackendImpl<Key, Hash> impl,
+template <typename Key, typename Hash, typename Eq>
+__global__ void EraseKernelPass0(SlabHashBackendImpl<Key, Hash, Eq> impl,
                                  const void* input_keys,
                                  buf_index_t* output_buf_indices,
                                  bool* output_masks,
@@ -647,8 +649,8 @@ __global__ void EraseKernelPass0(SlabHashBackendImpl<Key, Hash> impl,
     }
 }
 
-template <typename Key, typename Hash>
-__global__ void EraseKernelPass1(SlabHashBackendImpl<Key, Hash> impl,
+template <typename Key, typename Hash, typename Eq>
+__global__ void EraseKernelPass1(SlabHashBackendImpl<Key, Hash, Eq> impl,
                                  buf_index_t* output_buf_indices,
                                  bool* output_masks,
                                  int64_t count) {
@@ -658,8 +660,8 @@ __global__ void EraseKernelPass1(SlabHashBackendImpl<Key, Hash> impl,
     }
 }
 
-template <typename Key, typename Hash>
-__global__ void GetActiveIndicesKernel(SlabHashBackendImpl<Key, Hash> impl,
+template <typename Key, typename Hash, typename Eq>
+__global__ void GetActiveIndicesKernel(SlabHashBackendImpl<Key, Hash, Eq> impl,
                                        buf_index_t* output_buf_indices,
                                        uint32_t* output_count) {
     uint32_t tid = threadIdx.x + blockIdx.x * blockDim.x;
@@ -698,9 +700,9 @@ __global__ void GetActiveIndicesKernel(SlabHashBackendImpl<Key, Hash> impl,
     }
 }
 
-template <typename Key, typename Hash>
-__global__ void CountElemsPerBucketKernel(SlabHashBackendImpl<Key, Hash> impl,
-                                          int64_t* bucket_elem_counts) {
+template <typename Key, typename Hash, typename Eq>
+__global__ void CountElemsPerBucketKernel(
+        SlabHashBackendImpl<Key, Hash, Eq> impl, int64_t* bucket_elem_counts) {
     uint32_t tid = threadIdx.x + blockIdx.x * blockDim.x;
     uint32_t lane_id = threadIdx.x & 0x1F;
 

--- a/cpp/open3d/core/hashmap/CUDA/StdGPUHashBackend.h
+++ b/cpp/open3d/core/hashmap/CUDA/StdGPUHashBackend.h
@@ -168,7 +168,7 @@ public:
 
     InternalStdGPUHashBackend<Key, Hash, Eq> GetImpl() const { return impl_; }
 
-    void Allocate(int64_t capacity, int64_t bucket_count);
+    void Allocate(int64_t capacity);
     void Free();
 
 protected:
@@ -186,7 +186,7 @@ StdGPUHashBackend<Key, Hash, Eq>::StdGPUHashBackend(
         const std::vector<int64_t>& value_dsizes,
         const Device& device)
     : DeviceHashBackend(init_capacity, key_dsize, value_dsizes, device) {
-    Allocate(init_capacity, 0);
+    Allocate(init_capacity);
 }
 
 template <typename Key, typename Hash, typename Eq>
@@ -401,8 +401,7 @@ void StdGPUHashBackend<Key, Hash, Eq>::Insert(
 }
 
 template <typename Key, typename Hash, typename Eq>
-void StdGPUHashBackend<Key, Hash, Eq>::Allocate(int64_t capacity,
-                                                int64_t bucket_count) {
+void StdGPUHashBackend<Key, Hash, Eq>::Allocate(int64_t capacity) {
     this->capacity_ = capacity;
 
     // Allocate buffer for key values.

--- a/cpp/open3d/core/hashmap/CUDA/StdGPUHashBackend.h
+++ b/cpp/open3d/core/hashmap/CUDA/StdGPUHashBackend.h
@@ -383,11 +383,8 @@ void StdGPUHashBackend<Key, Hash, Eq>::Insert(
 
     thrust::device_vector<const void*> input_values_soa_device(
             input_values_soa.begin(), input_values_soa.end());
-    int64_t n_values = input_values_soa.size() == buffer_accessor_.n_values_
-                               ? buffer_accessor_.n_values_
-                               : 0;
 
-    // https://stackoverflow.com/a/37998941
+    int64_t n_values = input_values_soa.size();
     const void* const* ptr_input_values_soa =
             thrust::raw_pointer_cast(input_values_soa_device.data());
 

--- a/cpp/open3d/core/hashmap/CUDA/StdGPUHashBackend.h
+++ b/cpp/open3d/core/hashmap/CUDA/StdGPUHashBackend.h
@@ -139,7 +139,7 @@ public:
                       const Device& device);
     ~StdGPUHashBackend();
 
-    void Rehash(int64_t buckets) override;
+    void Reserve(int64_t capacity) override;
 
     void Insert(const void* input_keys,
                 const std::vector<const void*>& input_values_soa,
@@ -300,7 +300,7 @@ void StdGPUHashBackend<Key, Hash, Eq>::Clear() {
 }
 
 template <typename Key, typename Hash, typename Eq>
-void StdGPUHashBackend<Key, Hash, Eq>::Rehash(int64_t buckets) {}
+void StdGPUHashBackend<Key, Hash, Eq>::Reserve(int64_t capacity) {}
 
 template <typename Key, typename Hash, typename Eq>
 int64_t StdGPUHashBackend<Key, Hash, Eq>::GetBucketCount() const {

--- a/cpp/open3d/core/hashmap/CUDA/StdGPUHashBackend.h
+++ b/cpp/open3d/core/hashmap/CUDA/StdGPUHashBackend.h
@@ -463,7 +463,7 @@ void StdGPUHashBackend<Key, Hash, Eq>::InsertImpl(
     int64_t n_values = input_values_soa.size() == buffer_accessor_.n_values_
                                ? buffer_accessor_.n_values_
                                : 0;
-    // std::cout << "n_values = " << n_values << "\n";
+
     // https://stackoverflow.com/a/37998941
     const void* const* ptr_input_values_soa =
             thrust::raw_pointer_cast(input_values_soa_device.data());

--- a/cpp/open3d/core/hashmap/DeviceHashBackend.h
+++ b/cpp/open3d/core/hashmap/DeviceHashBackend.h
@@ -48,13 +48,13 @@ public:
           device_(device) {}
     virtual ~DeviceHashBackend() {}
 
-    /// Rehash expects a lot of extra memory space at runtime,
+    /// Reserve expects a lot of extra memory space at runtime,
     /// since it consists of
     /// 1) dumping all key value pairs to a buffer
     /// 2) creating a new hash table
     /// 3) parallel inserting dumped key value pairs
     /// 4) deallocating old hash table
-    virtual void Rehash(int64_t buckets) = 0;
+    virtual void Reserve(int64_t capacity) = 0;
 
     /// Parallel insert contiguous arrays of keys and values.
     virtual void Insert(const void* input_keys,

--- a/cpp/open3d/core/hashmap/DeviceHashBackend.h
+++ b/cpp/open3d/core/hashmap/DeviceHashBackend.h
@@ -115,6 +115,10 @@ public:
     /// Get the i-th value buffer that store an actual value array.
     Tensor GetValueBuffer(size_t i = 0) { return buffer_->GetValueBuffer(i); }
 
+protected:
+    virtual void Allocate(int64_t capacity, int64_t bucket_count) = 0;
+    virtual void Free() = 0;
+
 public:
     int64_t capacity_;
 

--- a/cpp/open3d/core/hashmap/DeviceHashBackend.h
+++ b/cpp/open3d/core/hashmap/DeviceHashBackend.h
@@ -107,7 +107,7 @@ public:
     /// Get the i-th value buffer that store an actual value array.
     Tensor GetValueBuffer(size_t i = 0) { return buffer_->GetValueBuffer(i); }
 
-    virtual void Allocate(int64_t capacity, int64_t bucket_count) = 0;
+    virtual void Allocate(int64_t capacity) = 0;
     virtual void Free() = 0;
 
 public:

--- a/cpp/open3d/core/hashmap/DeviceHashBackend.h
+++ b/cpp/open3d/core/hashmap/DeviceHashBackend.h
@@ -63,14 +63,6 @@ public:
                         bool* output_masks,
                         int64_t count) = 0;
 
-    /// Parallel activate contiguous arrays of keys without copying values.
-    /// Specifically useful for large value elements (e.g., a tensor), where we
-    /// can do in-place management after activation.
-    virtual void Activate(const void* input_keys,
-                          buf_index_t* output_buf_indices,
-                          bool* output_masks,
-                          int64_t count) = 0;
-
     /// Parallel find a contiguous array of keys.
     virtual void Find(const void* input_keys,
                       buf_index_t* output_buf_indices,
@@ -115,7 +107,6 @@ public:
     /// Get the i-th value buffer that store an actual value array.
     Tensor GetValueBuffer(size_t i = 0) { return buffer_->GetValueBuffer(i); }
 
-protected:
     virtual void Allocate(int64_t capacity, int64_t bucket_count) = 0;
     virtual void Free() = 0;
 

--- a/cpp/open3d/core/hashmap/Dispatch.h
+++ b/cpp/open3d/core/hashmap/Dispatch.h
@@ -99,12 +99,6 @@
 namespace open3d {
 namespace utility {
 
-#ifndef __CUDACC__
-using int4 = MiniVec<int, 4>;
-using int3 = MiniVec<int, 3>;
-using int2 = MiniVec<int, 2>;
-#endif
-
 template <typename T, int N>
 struct MiniVecHash {
 public:

--- a/cpp/open3d/core/hashmap/Dispatch.h
+++ b/cpp/open3d/core/hashmap/Dispatch.h
@@ -73,6 +73,10 @@
         }                                                                    \
     }()
 
+#ifdef __CUDACC__
+// Reinterpret hash maps' void* value arrays as CUDA primitive types arrays, to
+// avoid slow memcpy or byte-by-byte copy in kernels.
+// Not used in the CPU version since memcpy is relatively fast on CPU.
 #define DISPATCH_DIVISOR_SIZE_TO_BLOCK_T(DIVISOR, ...) \
     [&] {                                              \
         if (DIVISOR == 16) {                           \
@@ -95,6 +99,7 @@
             return __VA_ARGS__();                      \
         }                                              \
     }()
+#endif
 
 namespace open3d {
 namespace utility {

--- a/cpp/open3d/core/hashmap/Dispatch.h
+++ b/cpp/open3d/core/hashmap/Dispatch.h
@@ -28,36 +28,43 @@
 
 #include "open3d/core/Dtype.h"
 #include "open3d/utility/Logging.h"
+#include "open3d/utility/MiniVec.h"
 
 // TODO: dispatch more combinations.
 #define DISPATCH_DTYPE_AND_DIM_TO_TEMPLATE(DTYPE, DIM, ...)                  \
     [&] {                                                                    \
         if (DTYPE == open3d::core::Int32) {                                  \
             if (DIM == 1) {                                                  \
-                using key_t = Block<int, 1>;                                 \
-                using hash_t = BlockHash<int, 1>;                            \
+                using key_t = utility::MiniVec<int, 1>;                      \
+                using hash_t = utility::MiniVecHash<int, 1>;                 \
+                using eq_t = utility::MiniVecEq<int, 1>;                     \
                 return __VA_ARGS__();                                        \
             } else if (DIM == 2) {                                           \
-                using key_t = Block<int, 2>;                                 \
-                using hash_t = BlockHash<int, 2>;                            \
+                using key_t = utility::MiniVec<int, 2>;                      \
+                using hash_t = utility::MiniVecHash<int, 2>;                 \
+                using eq_t = utility::MiniVecEq<int, 2>;                     \
                 return __VA_ARGS__();                                        \
             } else if (DIM == 3) {                                           \
-                using key_t = Block<int, 3>;                                 \
-                using hash_t = BlockHash<int, 3>;                            \
+                using key_t = utility::MiniVec<int, 3>;                      \
+                using hash_t = utility::MiniVecHash<int, 3>;                 \
+                using eq_t = utility::MiniVecEq<int, 3>;                     \
                 return __VA_ARGS__();                                        \
             }                                                                \
         } else if (DTYPE == open3d::core::Int64) {                           \
             if (DIM == 1) {                                                  \
-                using key_t = Block<int64_t, 1>;                             \
-                using hash_t = BlockHash<int64_t, 1>;                        \
+                using key_t = utility::MiniVec<int64_t, 1>;                  \
+                using hash_t = utility::MiniVecHash<int64_t, 1>;             \
+                using eq_t = utility::MiniVecEq<int64_t, 1>;                 \
                 return __VA_ARGS__();                                        \
             } else if (DIM == 2) {                                           \
-                using key_t = Block<int64_t, 2>;                             \
-                using hash_t = BlockHash<int64_t, 2>;                        \
+                using key_t = utility::MiniVec<int64_t, 2>;                  \
+                using hash_t = utility::MiniVecHash<int64_t, 2>;             \
+                using eq_t = utility::MiniVecEq<int64_t, 2>;                 \
                 return __VA_ARGS__();                                        \
             } else if (DIM == 3) {                                           \
-                using key_t = Block<int64_t, 3>;                             \
-                using hash_t = BlockHash<int64_t, 3>;                        \
+                using key_t = utility::MiniVec<int64_t, 3>;                  \
+                using hash_t = utility::MiniVecHash<int64_t, 3>;             \
+                using eq_t = utility::MiniVecEq<int64_t, 3>;                 \
                 return __VA_ARGS__();                                        \
             }                                                                \
         } else {                                                             \
@@ -67,65 +74,39 @@
     }()
 
 namespace open3d {
-namespace core {
-template <typename T, size_t N>
-class Block {
+namespace utility {
+
+template <typename T, int N>
+struct MiniVecHash {
 public:
-    Block() = default;
-
-    OPEN3D_HOST_DEVICE Block(const Block<T, N>& other) {
-#if defined(__CUDA_ARCH__)
-#pragma unroll
-#endif
-        for (size_t i = 0; i < N; ++i) {
-            data_[i] = other.data_[i];
-        }
-    }
-
-    OPEN3D_HOST_DEVICE Block<T, N>& operator=(const Block<T, N>& other) {
-#if defined(__CUDA_ARCH__)
-#pragma unroll
-#endif
-        for (size_t i = 0; i < N; ++i) {
-            data_[i] = other.data_[i];
-        }
-
-        return *this;
-    }
-
-    OPEN3D_HOST_DEVICE bool operator==(const Block<T, N>& other) const {
-        bool is_eq = true;
-#if defined(__CUDA_ARCH__)
-#pragma unroll
-#endif
-        for (size_t i = 0; i < N; ++i) {
-            is_eq = is_eq && (data_[i] == other.data_[i]);
-        }
-        return is_eq;
-    }
-
-    OPEN3D_HOST_DEVICE T Get(size_t i) const { return data_[i]; }
-    OPEN3D_HOST_DEVICE void Set(size_t i, const T& value) { data_[i] = value; }
-
-private:
-    T data_[N];
-};
-
-template <typename T, size_t N>
-struct BlockHash {
-public:
-    OPEN3D_HOST_DEVICE uint64_t operator()(const Block<T, N>& key) const {
+    OPEN3D_HOST_DEVICE uint64_t operator()(const MiniVec<T, N>& key) const {
         uint64_t hash = UINT64_C(14695981039346656037);
 #if defined(__CUDA_ARCH__)
 #pragma unroll
 #endif
-        for (size_t i = 0; i < N; ++i) {
-            hash ^= static_cast<uint64_t>(key.Get(i));
+        for (int i = 0; i < N; ++i) {
+            hash ^= static_cast<uint64_t>(key[i]);
             hash *= UINT64_C(1099511628211);
         }
         return hash;
     }
 };
 
-}  // namespace core
+template <typename T, int N>
+struct MiniVecEq {
+public:
+    OPEN3D_HOST_DEVICE bool operator()(const MiniVec<T, N>& lhs,
+                                       const MiniVec<T, N>& rhs) const {
+        bool is_equal = true;
+#if defined(__CUDA_ARCH__)
+#pragma unroll
+#endif
+        for (int i = 0; i < N; ++i) {
+            is_equal = is_equal && (lhs[i] == rhs[i]);
+        }
+        return is_equal;
+    }
+};
+
+}  // namespace utility
 }  // namespace open3d

--- a/cpp/open3d/core/hashmap/Dispatch.h
+++ b/cpp/open3d/core/hashmap/Dispatch.h
@@ -73,8 +73,37 @@
         }                                                                    \
     }()
 
+#define DISPATCH_DIVISOR_SIZE_TO_BLOCK_T(DIVISOR, ...) \
+    [&] {                                              \
+        if (DIVISOR == 16) {                           \
+            using block_t = int4;                      \
+            return __VA_ARGS__();                      \
+        } else if (DIVISOR == 12) {                    \
+            using block_t = int3;                      \
+            return __VA_ARGS__();                      \
+        } else if (DIVISOR == 8) {                     \
+            using block_t = int2;                      \
+            return __VA_ARGS__();                      \
+        } else if (DIVISOR == 4) {                     \
+            using block_t = int;                       \
+            return __VA_ARGS__();                      \
+        } else if (DIVISOR == 2) {                     \
+            using block_t = int16_t;                   \
+            return __VA_ARGS__();                      \
+        } else {                                       \
+            using block_t = uint8_t;                   \
+            return __VA_ARGS__();                      \
+        }                                              \
+    }()
+
 namespace open3d {
 namespace utility {
+
+#ifndef __CUDACC__
+using int4 = MiniVec<int, 4>;
+using int3 = MiniVec<int, 3>;
+using int2 = MiniVec<int, 2>;
+#endif
 
 template <typename T, int N>
 struct MiniVecHash {

--- a/cpp/open3d/core/hashmap/HashBackendBuffer.cpp
+++ b/cpp/open3d/core/hashmap/HashBackendBuffer.cpp
@@ -34,6 +34,23 @@ HashBackendBuffer::HashBackendBuffer(int64_t capacity,
                                      int64_t key_dsize,
                                      std::vector<int64_t> value_dsizes,
                                      const Device &device) {
+    // First compute common bytesize divisor for fast copying values.
+    const std::vector<int64_t> kDivisors = {16, 12, 8, 4, 2, 1};
+
+    for (const auto &divisor : kDivisors) {
+        bool valid = true;
+        blocks_per_element_.clear();
+        for (size_t i = 0; i < value_dsizes.size(); ++i) {
+            int64_t bytesize = value_dsizes[i];
+            valid = valid && (bytesize % divisor == 0);
+            blocks_per_element_.push_back(bytesize / divisor);
+        }
+        if (valid) {
+            common_block_size_ = divisor;
+            break;
+        }
+    }
+
     heap_ = Tensor({capacity}, core::UInt32, device);
 
     key_buffer_ = Tensor({capacity},

--- a/cpp/open3d/core/hashmap/HashBackendBuffer.cpp
+++ b/cpp/open3d/core/hashmap/HashBackendBuffer.cpp
@@ -104,6 +104,14 @@ std::vector<int64_t> HashBackendBuffer::GetValueDsizes() const {
     return value_dsizes;
 }
 
+int64_t HashBackendBuffer::GetCommonBlockSize() const {
+    return common_block_size_;
+}
+
+std::vector<int64_t> HashBackendBuffer::GetValueBlocksPerElement() const {
+    return blocks_per_element_;
+}
+
 Tensor HashBackendBuffer::GetIndexHeap() const { return heap_; }
 
 HashBackendBuffer::HeapTop &HashBackendBuffer::GetHeapTop() {

--- a/cpp/open3d/core/hashmap/HashBackendBuffer.h
+++ b/cpp/open3d/core/hashmap/HashBackendBuffer.h
@@ -114,6 +114,9 @@ protected:
 
     Tensor key_buffer_;
     std::vector<Tensor> value_buffers_;
+
+    int64_t common_block_size_;
+    std::vector<int64_t> blocks_per_element_;
 };
 }  // namespace core
 }  // namespace open3d

--- a/cpp/open3d/core/hashmap/HashBackendBuffer.h
+++ b/cpp/open3d/core/hashmap/HashBackendBuffer.h
@@ -89,6 +89,12 @@ public:
     /// Return value's data sizes in bytes.
     std::vector<int64_t> GetValueDsizes() const;
 
+    /// Get the common block size divisor of all values types.
+    int64_t GetCommonBlockSize() const;
+
+    /// Return value's data sizes in the unit of common block size divisor.
+    std::vector<int64_t> GetValueBlocksPerElement() const;
+
     /// Return the index heap tensor.
     Tensor GetIndexHeap() const;
 

--- a/cpp/open3d/core/hashmap/HashMap.cpp
+++ b/cpp/open3d/core/hashmap/HashMap.cpp
@@ -64,7 +64,37 @@ HashMap::HashMap(int64_t init_capacity,
 }
 
 void HashMap::Rehash(int64_t buckets) {
-    return device_hashmap_->Rehash(buckets);
+    int64_t count = Size();
+
+    Tensor active_keys;
+    std::vector<Tensor> active_values;
+
+    if (count > 0) {
+        Tensor active_buf_indices = GetActiveIndices();
+        Tensor active_indices = active_buf_indices.To(core::Int64);
+
+        active_keys = GetKeyTensor().IndexGet({active_indices});
+        auto value_buffers = GetValueTensors();
+        for (auto& value_buffer : value_buffers) {
+            active_values.emplace_back(value_buffer.IndexGet({active_indices}));
+        }
+    }
+
+    float avg_capacity_per_bucket =
+            float(GetCapacity()) / float(GetBucketCount());
+    device_hashmap_->Free();
+    device_hashmap_->Allocate(
+            std::max(int64_t(std::ceil(buckets * avg_capacity_per_bucket)),
+                     active_keys.GetLength()),
+            buckets);
+
+    if (count > 0) {
+        Tensor output_buf_indices, output_masks;
+        InsertImpl(active_keys, active_values, output_buf_indices,
+                   output_masks);
+    }
+
+    device_hashmap_->Rehash(buckets);
 }
 
 std::pair<Tensor, Tensor> HashMap::Insert(const Tensor& input_keys,
@@ -108,10 +138,13 @@ Tensor HashMap::GetActiveIndices() const {
 void HashMap::InsertImpl(const Tensor& input_keys,
                          const std::vector<Tensor>& input_values_soa,
                          Tensor& output_buf_indices,
-                         Tensor& output_masks) {
-    CheckKeyValueLengthCompatibility(input_keys, input_values_soa);
+                         Tensor& output_masks,
+                         bool is_activate_op) {
     CheckKeyCompatibility(input_keys);
-    CheckValueCompatibility(input_values_soa);
+    if (!is_activate_op) {
+        CheckKeyValueLengthCompatibility(input_keys, input_values_soa);
+        CheckValueCompatibility(input_values_soa);
+    }
 
     int64_t length = input_keys.GetLength();
     PrepareIndicesOutput(output_buf_indices, length);
@@ -132,30 +165,48 @@ void HashMap::Insert(const Tensor& input_keys,
                      const Tensor& input_values,
                      Tensor& output_buf_indices,
                      Tensor& output_masks) {
-    InsertImpl(input_keys, {input_values}, output_buf_indices, output_masks);
+    Insert(input_keys, std::vector<Tensor>{input_values}, output_buf_indices,
+           output_masks);
 }
 
 void HashMap::Insert(const Tensor& input_keys,
                      const std::vector<Tensor>& input_values_soa,
                      Tensor& output_buf_indices,
                      Tensor& output_masks) {
+    int64_t length = input_keys.GetLength();
+    int64_t new_size = Size() + length;
+    int64_t capacity = GetCapacity();
+    int64_t bucket_count = GetBucketCount();
+
+    if (new_size > capacity) {
+        float avg_capacity_per_bucket = float(capacity) / float(bucket_count);
+        int64_t expected_buckets = std::max(
+                int64_t(bucket_count * 2),
+                int64_t(std::ceil(new_size / avg_capacity_per_bucket)));
+        Rehash(expected_buckets);
+    }
     InsertImpl(input_keys, input_values_soa, output_buf_indices, output_masks);
 }
 
 void HashMap::Activate(const Tensor& input_keys,
                        Tensor& output_buf_indices,
                        Tensor& output_masks) {
-    CheckKeyLength(input_keys);
-    CheckKeyCompatibility(input_keys);
-
     int64_t length = input_keys.GetLength();
-    PrepareIndicesOutput(output_buf_indices, length);
-    PrepareMasksOutput(output_masks, length);
+    int64_t new_size = Size() + length;
+    int64_t capacity = GetCapacity();
+    int64_t bucket_count = GetBucketCount();
 
-    device_hashmap_->Activate(
-            input_keys.GetDataPtr(),
-            static_cast<buf_index_t*>(output_buf_indices.GetDataPtr()),
-            output_masks.GetDataPtr<bool>(), length);
+    if (new_size > capacity) {
+        float avg_capacity_per_bucket = float(capacity) / float(bucket_count);
+        int64_t expected_buckets = std::max(
+                int64_t(bucket_count * 2),
+                int64_t(std::ceil(new_size / avg_capacity_per_bucket)));
+        Rehash(expected_buckets);
+    }
+
+    std::vector<Tensor> null_tensors_soa;
+    InsertImpl(input_keys, null_tensors_soa, output_buf_indices, output_masks,
+               /* is_activate_op */ true);
 }
 
 void HashMap::Find(const Tensor& input_keys,
@@ -381,7 +432,7 @@ void HashMap::CheckValueCompatibility(
         utility::LogError(
                 "Input number of value arrays ({}) mismatches with stored "
                 "({})",
-                input_values_soa.size() != element_shapes_value_.size());
+                input_values_soa.size(), element_shapes_value_.size());
     }
 
     for (size_t i = 0; i < input_values_soa.size(); ++i) {

--- a/cpp/open3d/core/hashmap/HashMap.cpp
+++ b/cpp/open3d/core/hashmap/HashMap.cpp
@@ -67,6 +67,7 @@ void HashMap::Reserve(int64_t capacity) {
     int64_t count = Size();
     if (capacity <= count) {
         utility::LogDebug("Target capacity smaller then current size, abort.");
+        return;
     }
 
     Tensor active_keys;

--- a/cpp/open3d/core/hashmap/HashMap.cpp
+++ b/cpp/open3d/core/hashmap/HashMap.cpp
@@ -67,6 +67,44 @@ void HashMap::Rehash(int64_t buckets) {
     return device_hashmap_->Rehash(buckets);
 }
 
+std::pair<Tensor, Tensor> HashMap::Insert(const Tensor& input_keys,
+                                          const Tensor& input_values) {
+    Tensor output_buf_indices, output_masks;
+    Insert(input_keys, input_values, output_buf_indices, output_masks);
+    return std::make_pair(output_buf_indices, output_masks);
+}
+
+std::pair<Tensor, Tensor> HashMap::Insert(
+        const Tensor& input_keys, const std::vector<Tensor>& input_values_soa) {
+    Tensor output_buf_indices, output_masks;
+    Insert(input_keys, input_values_soa, output_buf_indices, output_masks);
+    return std::make_pair(output_buf_indices, output_masks);
+}
+
+std::pair<Tensor, Tensor> HashMap::Activate(const Tensor& input_keys) {
+    Tensor output_buf_indices, output_masks;
+    Activate(input_keys, output_buf_indices, output_masks);
+    return std::make_pair(output_buf_indices, output_masks);
+}
+
+std::pair<Tensor, Tensor> HashMap::Find(const Tensor& input_keys) {
+    Tensor output_buf_indices, output_masks;
+    Find(input_keys, output_buf_indices, output_masks);
+    return std::make_pair(output_buf_indices, output_masks);
+}
+
+Tensor HashMap::Erase(const Tensor& input_keys) {
+    Tensor output_masks;
+    Erase(input_keys, output_masks);
+    return output_masks;
+}
+
+Tensor HashMap::GetActiveIndices() const {
+    Tensor output_buf_indices;
+    GetActiveIndices(output_buf_indices);
+    return output_buf_indices;
+}
+
 void HashMap::InsertImpl(const Tensor& input_keys,
                          const std::vector<Tensor>& input_values_soa,
                          Tensor& output_buf_indices,

--- a/cpp/open3d/core/hashmap/HashMap.cpp
+++ b/cpp/open3d/core/hashmap/HashMap.cpp
@@ -85,8 +85,7 @@ void HashMap::Rehash(int64_t buckets) {
     device_hashmap_->Free();
     device_hashmap_->Allocate(
             std::max(int64_t(std::ceil(buckets * avg_capacity_per_bucket)),
-                     active_keys.GetLength()),
-            buckets);
+                     active_keys.GetLength()));
 
     if (count > 0) {
         Tensor output_buf_indices, output_masks;

--- a/cpp/open3d/core/hashmap/HashMap.cpp
+++ b/cpp/open3d/core/hashmap/HashMap.cpp
@@ -46,8 +46,6 @@ HashMap::HashMap(int64_t init_capacity,
       key_element_shape_(key_element_shape),
       dtypes_value_({value_dtype}),
       element_shapes_value_({value_element_shape}) {
-    std::tie(common_block_size_, blocks_per_element_) =
-            GetCommonValueSizeDivisor();
     Init(init_capacity, device, backend);
 }
 
@@ -62,8 +60,6 @@ HashMap::HashMap(int64_t init_capacity,
       key_element_shape_(key_element_shape),
       dtypes_value_(dtypes_value),
       element_shapes_value_(element_shapes_value) {
-    std::tie(common_block_size_, blocks_per_element_) =
-            GetCommonValueSizeDivisor();
     Init(init_capacity, device, backend);
 }
 
@@ -478,25 +474,5 @@ void HashMap::PrepareMasksOutput(Tensor& output_masks, int64_t length) const {
     }
 }
 
-std::pair<int64_t, std::vector<int64_t>> HashMap::GetCommonValueSizeDivisor() {
-    const std::vector<int64_t> kDivisors = {16, 12, 8, 4, 2, 1};
-
-    std::vector<int64_t> blocks_per_element;
-
-    for (const auto& divisor : kDivisors) {
-        bool valid = true;
-        blocks_per_element.clear();
-        for (size_t i = 0; i < dtypes_value_.size(); ++i) {
-            int64_t bytesize = element_shapes_value_[i].NumElements() *
-                               dtypes_value_[i].ByteSize();
-            valid = valid && (bytesize % divisor == 0);
-            blocks_per_element.push_back(bytesize / divisor);
-        }
-        if (valid) return std::make_pair(divisor, blocks_per_element);
-    }
-
-    // should never reach here
-    return std::make_pair(1, blocks_per_element);
-}
 }  // namespace core
 }  // namespace open3d

--- a/cpp/open3d/core/hashmap/HashMap.h
+++ b/cpp/open3d/core/hashmap/HashMap.h
@@ -210,7 +210,8 @@ protected:
     void InsertImpl(const Tensor& input_keys,
                     const std::vector<Tensor>& input_values_soa,
                     Tensor& output_buf_indices,
-                    Tensor& output_masks);
+                    Tensor& output_masks,
+                    bool is_activate_op = false);
 
     void CheckKeyLength(const Tensor& input_keys) const;
     void CheckKeyValueLengthCompatibility(

--- a/cpp/open3d/core/hashmap/HashMap.h
+++ b/cpp/open3d/core/hashmap/HashMap.h
@@ -224,6 +224,8 @@ protected:
     void PrepareIndicesOutput(Tensor& output_buf_indices, int64_t length) const;
     void PrepareMasksOutput(Tensor& output_masks, int64_t length) const;
 
+    std::pair<int64_t, std::vector<int64_t>> GetCommonValueSizeDivisor();
+
 private:
     std::shared_ptr<DeviceHashBackend> device_hashmap_;
 
@@ -232,6 +234,9 @@ private:
 
     std::vector<Dtype> dtypes_value_;
     std::vector<SizeVector> element_shapes_value_;
+
+    int64_t common_block_size_;
+    std::vector<int64_t> blocks_per_element_;
 };
 
 }  // namespace core

--- a/cpp/open3d/core/hashmap/HashMap.h
+++ b/cpp/open3d/core/hashmap/HashMap.h
@@ -62,8 +62,8 @@ public:
     /// Default destructor.
     ~HashMap() = default;
 
-    /// Rehash the internal hash map with the given number of buckets.
-    void Rehash(int64_t buckets);
+    /// Reserve the internal hash map with the given capacity by rehashing.
+    void Reserve(int64_t capacity);
 
     /// Parallel insert arrays of keys and values in Tensors.
     /// Return: output_buf_indices stores buffer indices that access buffer

--- a/cpp/open3d/core/hashmap/HashMap.h
+++ b/cpp/open3d/core/hashmap/HashMap.h
@@ -66,53 +66,83 @@ public:
     void Rehash(int64_t buckets);
 
     /// Parallel insert arrays of keys and values in Tensors.
-    /// The output_buf_indices and output_masks will be overwritten, to be used
-    /// with tensor buffers.
-    /// output_buf_indices stores buffer indices that access buffer tensors
-    /// obtained from GetKeyTensor() and GetValueTensor() via advanced indexing.
-    /// NOTE: output_buf_indices are stored in Int32. A conversion to Int64 is
-    /// required for further indexing.
-    /// output_masks stores if the insertion is
+    /// Return: output_buf_indices stores buffer indices that access buffer
+    /// tensors obtained from GetKeyTensor() and GetValueTensor() via advanced
+    /// indexing.
+    /// NOTE: output_buf_indices are stored in Int32. A conversion to
+    /// Int64 is required for further indexing.
+    /// Return: output_masks stores if the insertion is
     /// a success or failure (key already exists).
+    std::pair<Tensor, Tensor> Insert(const Tensor& input_keys,
+                                     const Tensor& input_values);
+
+    /// Parallel insert arrays of keys and a structure of value arrays in
+    /// Tensors.
+    /// Return: output_buf_indices and output_masks, their role are the same as
+    /// in single value Insert interface.
+    std::pair<Tensor, Tensor> Insert(
+            const Tensor& input_keys,
+            const std::vector<Tensor>& input_values_soa);
+
+    /// Parallel activate arrays of keys in Tensor.
+    /// Specifically useful for large value elements (e.g., a 3D tensor), where
+    /// we can do in-place management after activation.
+    /// Return: output_buf_indices and output_masks, their roles are the same
+    /// as in Insert.
+    std::pair<Tensor, Tensor> Activate(const Tensor& input_keys);
+
+    /// Parallel find an array of keys in Tensor.
+    /// Return: output_buf_indices, its role is the same as in Insert.
+    /// Return: output_masks stores if the finding is a success or failure (key
+    /// not found).
+    std::pair<Tensor, Tensor> Find(const Tensor& input_keys);
+
+    /// Parallel erase an array of keys in Tensor.
+    /// Return: output_masks stores if the erase is a success or failure (key
+    /// not found all already erased in another thread).
+    Tensor Erase(const Tensor& input_keys);
+
+    /// Parallel collect all indices in the buffer corresponding to the active
+    /// entries in the hash map.
+    /// Return output_buf_indices, collected buffer indices.
+    Tensor GetActiveIndices() const;
+
+    /// Same as Insert with a single value array, but takes output_buf_indices
+    /// and output_masks as input. If their shapes and types match, reallocation
+    /// is not needed.
     void Insert(const Tensor& input_keys,
                 const Tensor& input_values,
                 Tensor& output_buf_indices,
                 Tensor& output_masks);
 
-    /// Parallel insert arrays of keys and a structure of value arrays in
-    /// Tensors.
-    /// The roles of output_buf_indices and output_masks are the same as Insert
-    /// with a single input_value tensor input.
+    /// Same as Insert with a SoA of values, but takes output_buf_indices
+    /// and output_masks as input. If their shapes and types match, reallocation
+    /// is not needed.
     void Insert(const Tensor& input_keys,
                 const std::vector<Tensor>& input_values_soa,
                 Tensor& output_buf_indices,
                 Tensor& output_masks);
 
-    /// Parallel activate arrays of keys in Tensor.
-    /// Specifically useful for large value elements (e.g., a 3D tensor), where
-    /// we can do in-place management after activation.
-    /// The roles of output_buf_indices and output_masks are the same as Insert.
+    /// Same as Activate, but takes output_buf_indices
+    /// and output_masks as input. If their shapes and types match, reallocation
+    /// is not needed.
     void Activate(const Tensor& input_keys,
                   Tensor& output_buf_indices,
                   Tensor& output_masks);
 
-    /// Parallel find an array of keys in Tensor.
-    /// The roles of output_buf_indices is the same as Insert.
-    /// output_masks stores if the finding is a success or failure (key
-    /// not found).
+    /// Same as Find, but takes output_buf_indices
+    /// and output_masks as input. If their shapes and types match, reallocation
+    /// is not needed.
     void Find(const Tensor& input_keys,
               Tensor& output_buf_indices,
               Tensor& output_masks);
 
-    /// Parallel erase an array of keys in Tensor.
-    /// The output_masks will be overwritten, to be used
-    /// with tensor buffers.
-    /// output_masks stores if the erase is a success or failure (key not found
-    /// all already erased in another thread).
+    /// Same as Erase, but takes output_masks as input. If its shape and
+    /// type matches, reallocation is not needed.
     void Erase(const Tensor& input_keys, Tensor& output_masks);
 
-    /// Parallel collect all indices in the buffer corresponding to the active
-    /// entries in the hash map. Stored in output_buf_indices.
+    /// Same as GetActiveIndices, but takes output_buf_indices as input. If its
+    /// shape and type matches, reallocation is not needed.
     void GetActiveIndices(Tensor& output_buf_indices) const;
 
     /// Clear stored map without reallocating the buffers.

--- a/cpp/open3d/core/hashmap/HashMap.h
+++ b/cpp/open3d/core/hashmap/HashMap.h
@@ -234,9 +234,6 @@ private:
 
     std::vector<Dtype> dtypes_value_;
     std::vector<SizeVector> element_shapes_value_;
-
-    int64_t common_block_size_;
-    std::vector<int64_t> blocks_per_element_;
 };
 
 }  // namespace core

--- a/cpp/open3d/core/hashmap/HashSet.cpp
+++ b/cpp/open3d/core/hashmap/HashSet.cpp
@@ -45,7 +45,7 @@ HashSet::HashSet(int64_t init_capacity,
             std::vector<SizeVector>{}, device, backend);
 }
 
-void HashSet::Rehash(int64_t buckets) { return internal_->Rehash(buckets); }
+void HashSet::Reserve(int64_t capacity) { return internal_->Reserve(capacity); }
 
 std::pair<Tensor, Tensor> HashSet::Insert(const Tensor& input_keys) {
     Tensor output_buf_indices, output_masks;

--- a/cpp/open3d/core/hashmap/HashSet.cpp
+++ b/cpp/open3d/core/hashmap/HashSet.cpp
@@ -47,6 +47,30 @@ HashSet::HashSet(int64_t init_capacity,
 
 void HashSet::Rehash(int64_t buckets) { return internal_->Rehash(buckets); }
 
+std::pair<Tensor, Tensor> HashSet::Insert(const Tensor& input_keys) {
+    Tensor output_buf_indices, output_masks;
+    Insert(input_keys, output_buf_indices, output_masks);
+    return std::make_pair(output_buf_indices, output_masks);
+}
+
+std::pair<Tensor, Tensor> HashSet::Find(const Tensor& input_keys) {
+    Tensor output_buf_indices, output_masks;
+    Find(input_keys, output_buf_indices, output_masks);
+    return std::make_pair(output_buf_indices, output_masks);
+}
+
+Tensor HashSet::Erase(const Tensor& input_keys) {
+    Tensor output_masks;
+    Erase(input_keys, output_masks);
+    return output_masks;
+}
+
+Tensor HashSet::GetActiveIndices() const {
+    Tensor output_buf_indices;
+    GetActiveIndices(output_buf_indices);
+    return output_buf_indices;
+}
+
 void HashSet::Insert(const Tensor& input_keys,
                      Tensor& output_buf_indices,
                      Tensor& output_masks) {

--- a/cpp/open3d/core/hashmap/HashSet.h
+++ b/cpp/open3d/core/hashmap/HashSet.h
@@ -50,35 +50,51 @@ public:
     void Rehash(int64_t buckets);
 
     /// Parallel insert arrays of keys and values in Tensors.
-    /// The output_buf_indices and output_masks will be overwritten, to be used
-    /// with tensor buffers.
-    /// output_buf_indices stores buffer indices that access buffer tensors
-    /// obtained from GetKeyTensor() via advanced indexing.
-    /// NOTE: output_buf_indices are stored in Int32. A conversion to Int64 is
-    /// required for further indexing.
-    /// output_masks stores if the insertion is
+    /// Return: output_buf_indices stores buffer indices that access buffer
+    /// tensors obtained from GetKeyTensor() and GetValueTensor() via advanced
+    /// indexing.
+    /// NOTE: output_buf_indices are stored in Int32. A conversion to
+    /// Int64 is required for further indexing.
+    /// Return: output_masks stores if the insertion is
     /// a success or failure (key already exists).
+    std::pair<Tensor, Tensor> Insert(const Tensor& input_keys);
+
+    /// Parallel find an array of keys in Tensor.
+    /// Return: output_buf_indices, its role is the same as in Insert.
+    /// Return: output_masks stores if the finding is a success or failure (key
+    /// not found).
+    std::pair<Tensor, Tensor> Find(const Tensor& input_keys);
+
+    /// Parallel erase an array of keys in Tensor.
+    /// Return: output_masks stores if the erase is a success or failure (key
+    /// not found all already erased in another thread).
+    Tensor Erase(const Tensor& input_keys);
+
+    /// Parallel collect all indices in the buffer corresponding to the active
+    /// entries in the hash map.
+    /// Return output_buf_indices, collected buffer indices.
+    Tensor GetActiveIndices() const;
+
+    /// Same as Insert, but takes output_buf_indices
+    /// and output_masks as input. If their shapes and types match, reallocation
+    /// is not needed.
     void Insert(const Tensor& input_keys,
                 Tensor& output_buf_indices,
                 Tensor& output_masks);
 
-    /// Parallel find an array of keys in Tensor.
-    /// The roles of output_buf_indices is the same as Insert.
-    /// output_masks stores if the finding is a success or failure (key
-    /// not found).
+    /// Same as Find, but takes output_buf_indices
+    /// and output_masks as input. If their shapes and types match, reallocation
+    /// is not needed.
     void Find(const Tensor& input_keys,
               Tensor& output_buf_indices,
               Tensor& output_masks);
 
-    /// Parallel erase an array of keys in Tensor.
-    /// The output_masks will be overwritten, to be used
-    /// with tensor buffers.
-    /// output_masks stores if the erase is a success or failure (key not found
-    /// all already erased in another thread).
+    /// Same as Erase, but takes output_masks as input. If its shape and
+    /// type matches, reallocation is not needed.
     void Erase(const Tensor& input_keys, Tensor& output_masks);
 
-    /// Parallel collect all indices in the buffer corresponding to the active
-    /// entries in the hash map. Stored in output_buf_indices.
+    /// Same as GetActiveIndices, but takes output_buf_indices as input. If its
+    /// shape and type matches, reallocation is not needed.
     void GetActiveIndices(Tensor& output_buf_indices) const;
 
     /// Clear stored map without reallocating the buffers.

--- a/cpp/open3d/core/hashmap/HashSet.h
+++ b/cpp/open3d/core/hashmap/HashSet.h
@@ -46,8 +46,8 @@ public:
     /// Default destructor.
     ~HashSet() = default;
 
-    /// Rehash the internal hash map with the given number of buckets.
-    void Rehash(int64_t buckets);
+    /// Reserve the internal hash map with the capcity by rehashing.
+    void Reserve(int64_t capacity);
 
     /// Parallel insert arrays of keys and values in Tensors.
     /// Return: output_buf_indices stores buffer indices that access buffer

--- a/cpp/open3d/t/geometry/kernel/TSDFVoxelGridImpl.h
+++ b/cpp/open3d/t/geometry/kernel/TSDFVoxelGridImpl.h
@@ -38,6 +38,7 @@
 #include "open3d/t/geometry/kernel/TSDFVoxel.h"
 #include "open3d/t/geometry/kernel/TSDFVoxelGrid.h"
 #include "open3d/utility/Logging.h"
+#include "open3d/utility/MiniVec.h"
 #include "open3d/utility/Timer.h"
 
 namespace open3d {
@@ -1121,7 +1122,7 @@ void EstimateRangeCPU
 #endif
 }
 
-struct BlockCache {
+struct MiniVecCache {
     int x;
     int y;
     int z;
@@ -1165,12 +1166,13 @@ void RayCastCPU
          float depth_min,
          float depth_max,
          float weight_threshold) {
-    using Key = core::Block<int, 3>;
-    using Hash = core::BlockHash<int, 3>;
+    using Key = utility::MiniVec<int, 3>;
+    using Hash = utility::MiniVecHash<int, 3>;
+    using Eq = utility::MiniVecEq<int, 3>;
 
 #if defined(BUILD_CUDA_MODULE) && defined(__CUDACC__)
     auto cuda_hashmap =
-            std::dynamic_pointer_cast<core::StdGPUHashBackend<Key, Hash>>(
+            std::dynamic_pointer_cast<core::StdGPUHashBackend<Key, Hash, Eq>>(
                     hashmap);
     if (cuda_hashmap == nullptr) {
         utility::LogError(
@@ -1179,7 +1181,8 @@ void RayCastCPU
     auto hashmap_impl = cuda_hashmap->GetImpl();
 #else
     auto cpu_hashmap =
-            std::dynamic_pointer_cast<core::TBBHashBackend<Key, Hash>>(hashmap);
+            std::dynamic_pointer_cast<core::TBBHashBackend<Key, Hash, Eq>>(
+                    hashmap);
     auto hashmap_impl = *cpu_hashmap->GetImpl();
 #endif
 
@@ -1230,11 +1233,11 @@ void RayCastCPU
         core::ParallelFor(
                 hashmap->GetDevice(), rows * cols,
                 [=] OPEN3D_DEVICE(int64_t workload_idx) {
-                    auto GetVoxelAtP = [&] OPEN3D_DEVICE(
-                                               int x_b, int y_b, int z_b,
-                                               int x_v, int y_v, int z_v,
-                                               core::buf_index_t block_addr,
-                                               BlockCache& cache) -> voxel_t* {
+                    auto GetVoxelAtP =
+                            [&] OPEN3D_DEVICE(int x_b, int y_b, int z_b,
+                                              int x_v, int y_v, int z_v,
+                                              core::buf_index_t block_addr,
+                                              MiniVecCache& cache) -> voxel_t* {
                         int x_vn = (x_v + block_resolution) % block_resolution;
                         int y_vn = (y_v + block_resolution) % block_resolution;
                         int z_vn = (z_v + block_resolution) % block_resolution;
@@ -1248,18 +1251,14 @@ void RayCastCPU
                                     .GetDataPtr<voxel_t>(x_v, y_v, z_v,
                                                          block_addr);
                         } else {
-                            Key key;
-                            key.Set(0, x_b + dx_b);
-                            key.Set(1, y_b + dy_b);
-                            key.Set(2, z_b + dz_b);
-
-                            int block_addr = cache.Check(key.Get(0), key.Get(1),
-                                                         key.Get(2));
+                            Key key(x_b + dx_b, y_b + dy_b, z_b + dz_b);
+                            int block_addr =
+                                    cache.Check(key[0], key[1], key[2]);
                             if (block_addr < 0) {
                                 auto iter = hashmap_impl.find(key);
                                 if (iter == hashmap_impl.end()) return nullptr;
                                 block_addr = iter->second;
-                                cache.Update(key.Get(0), key.Get(1), key.Get(2),
+                                cache.Update(key[0], key[1], key[2],
                                              block_addr);
                             }
 
@@ -1269,25 +1268,21 @@ void RayCastCPU
                         }
                     };
 
-                    auto GetVoxelAtT = [&] OPEN3D_DEVICE(
-                                               float x_o, float y_o, float z_o,
-                                               float x_d, float y_d, float z_d,
-                                               float t,
-                                               BlockCache& cache) -> voxel_t* {
+                    auto GetVoxelAtT =
+                            [&] OPEN3D_DEVICE(float x_o, float y_o, float z_o,
+                                              float x_d, float y_d, float z_d,
+                                              float t,
+                                              MiniVecCache& cache) -> voxel_t* {
                         float x_g = x_o + t * x_d;
                         float y_g = y_o + t * y_d;
                         float z_g = z_o + t * z_d;
 
-                        // Block coordinate and look up
+                        // MiniVec coordinate and look up
                         int x_b = static_cast<int>(floorf(x_g / block_size));
                         int y_b = static_cast<int>(floorf(y_g / block_size));
                         int z_b = static_cast<int>(floorf(z_g / block_size));
 
-                        Key key;
-                        key.Set(0, x_b);
-                        key.Set(1, y_b);
-                        key.Set(2, z_b);
-
+                        Key key(x_b, y_b, z_b);
                         int block_addr = cache.Check(x_b, y_b, z_b);
                         if (block_addr < 0) {
                             auto iter = hashmap_impl.find(key);
@@ -1364,7 +1359,7 @@ void RayCastCPU
                     float y_d = (y_g - y_o);
                     float z_d = (z_g - z_o);
 
-                    BlockCache cache{0, 0, 0, -1};
+                    MiniVecCache cache{0, 0, 0, -1};
                     bool surface_found = false;
                     while (t < t_max) {
                         voxel_t* voxel_ptr = GetVoxelAtT(x_o, y_o, z_o, x_d,
@@ -1422,10 +1417,7 @@ void RayCastCPU
                             float z_v = (z_g - float(z_b) * block_size) /
                                         voxel_size;
 
-                            Key key;
-                            key.Set(0, x_b);
-                            key.Set(1, y_b);
-                            key.Set(2, z_b);
+                            Key key(x_b, y_b, z_b);
 
                             int block_addr = cache.Check(x_b, y_b, z_b);
                             if (block_addr < 0) {

--- a/cpp/open3d/t/pipelines/slac/ControlGrid.cpp
+++ b/cpp/open3d/t/pipelines/slac/ControlGrid.cpp
@@ -99,7 +99,7 @@ void ControlGrid::Touch(const geometry::PointCloud& pcd) {
 }
 
 void ControlGrid::Compactify() {
-    ctr_hashmap_->Rehash(ctr_hashmap_->Size() * 2);
+    ctr_hashmap_->Reserve(ctr_hashmap_->Size() * 2);
 
     core::Tensor active_buf_indices;
     ctr_hashmap_->GetActiveIndices(active_buf_indices);

--- a/cpp/pybind/core/hashmap.cpp
+++ b/cpp/pybind/core/hashmap.cpp
@@ -68,7 +68,7 @@ const std::unordered_map<std::string, std::string> argument_docs = {
          "Input values stored in a tensor of shape (N, value_element_shape)."},
         {"list_values",
          "List of input values stored in tensors of corresponding shapes."},
-        {"buckets", "Number of buckets for rehashing."},
+        {"capacity", "New capacity for rehashing."},
         {"file_name", "File name of the corresponding .npz file."},
         {"values_buffer_id", "Index of the value buffer tensor."},
         {"device_id", "Target CUDA device ID."}};
@@ -189,9 +189,9 @@ void pybind_core_hashmap(py::module& m) {
                        "Load a hash map from a .npz file.", "file_name"_a);
     docstring::ClassMethodDocInject(m, "HashMap", "load", argument_docs);
 
-    hashmap.def("rehash", &HashMap::Rehash,
-                "Rehash the hash map given the buckets.", "buckets"_a);
-    docstring::ClassMethodDocInject(m, "HashMap", "rehash", argument_docs);
+    hashmap.def("reserve", &HashMap::Reserve,
+                "Reserve the hash map given the capacity.", "capacity"_a);
+    docstring::ClassMethodDocInject(m, "HashMap", "reserve", argument_docs);
 
     hashmap.def("key_tensor", &HashMap::GetKeyTensor,
                 "Get the key tensor stored in the buffer.");
@@ -303,9 +303,9 @@ void pybind_core_hashset(py::module& m) {
                        "Load a hash set from a .npz file.", "file_name"_a);
     docstring::ClassMethodDocInject(m, "HashSet", "load", argument_docs);
 
-    hashset.def("rehash", &HashSet::Rehash,
-                "Rehash the hash set given the buckets.", "buckets"_a);
-    docstring::ClassMethodDocInject(m, "HashSet", "rehash", argument_docs);
+    hashset.def("reserve", &HashSet::Reserve,
+                "Reserve the hash set given the capacity.", "capacity"_a);
+    docstring::ClassMethodDocInject(m, "HashSet", "reserve", argument_docs);
 
     hashset.def("key_tensor", &HashSet::GetKeyTensor,
                 "Get the key tensor stored in the buffer.");

--- a/cpp/tests/core/HashMap.cpp
+++ b/cpp/tests/core/HashMap.cpp
@@ -264,7 +264,7 @@ TEST_P(HashMapPermuteDevices, Erase) {
     }
 }
 
-TEST_P(HashMapPermuteDevices, Rehash) {
+TEST_P(HashMapPermuteDevices, Reserve) {
     core::Device device = GetParam();
     std::vector<core::HashBackendType> backends;
     if (device.GetType() == core::Device::DeviceType::CUDA) {
@@ -292,7 +292,7 @@ TEST_P(HashMapPermuteDevices, Rehash) {
         hashmap.Insert(keys, values, buf_indices, masks);
         EXPECT_EQ(masks.To(core::Int64).Sum({0}).Item<int64_t>(), slots);
 
-        hashmap.Rehash(hashmap.GetBucketCount() * 2);
+        hashmap.Reserve(hashmap.GetBucketCount() * 2);
         EXPECT_EQ(hashmap.Size(), slots);
 
         core::Tensor active_buf_indices;


### PR DESCRIPTION
- Change Block and BlockHash to MiniVec and MiniVecHash
- Remove duplicate functions in DeviceHashBackends and collect shared code snippets in the HashMap caller
- Dispatch value pointers to vectorize copy of value chunks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3986)
<!-- Reviewable:end -->
