### PR TITLE
Tensor Registration - `GetInformationMatrixFromPointClouds`

### DIFF
--- a/cpp/open3d/t/pipelines/CMakeLists.txt
+++ b/cpp/open3d/t/pipelines/CMakeLists.txt
@@ -3,8 +3,8 @@ add_subdirectory(kernel)
 add_library(tpipelines OBJECT $<TARGET_OBJECTS:tpipelines_kernel>)
 
 target_sources(tpipelines PRIVATE
-    kernel/ComputeTransform.cpp
-    kernel/ComputeTransformCPU.cpp
+    kernel/Registration.cpp
+    kernel/RegistrationCPU.cpp
     kernel/FillInLinearSystem.cpp
     kernel/FillInLinearSystemCPU.cpp
     kernel/RGBDOdometry.cpp
@@ -14,7 +14,7 @@ target_sources(tpipelines PRIVATE
 
 if (BUILD_CUDA_MODULE)
     target_sources(tpipelines PRIVATE
-        kernel/ComputeTransformCUDA.cu
+        kernel/RegistrationCUDA.cu
         kernel/FillInLinearSystemCUDA.cu
         kernel/RGBDOdometryCUDA.cu
         kernel/TransformationConverter.cu

--- a/cpp/open3d/t/pipelines/kernel/CMakeLists.txt
+++ b/cpp/open3d/t/pipelines/kernel/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_library(tpipelines_kernel OBJECT)
 
 target_sources(tpipelines_kernel  PRIVATE
-    ComputeTransform.cpp
-    ComputeTransformCPU.cpp
+    Registration.cpp
+    RegistrationCPU.cpp
     FillInLinearSystem.cpp
     FillInLinearSystemCPU.cpp
     RGBDOdometry.cpp
@@ -12,7 +12,7 @@ target_sources(tpipelines_kernel  PRIVATE
 
 if (BUILD_CUDA_MODULE)
     target_sources(tpipelines_kernel  PRIVATE
-        ComputeTransformCUDA.cu
+        RegistrationCUDA.cu
         FillInLinearSystemCUDA.cu
         RGBDOdometryCUDA.cu
         TransformationConverter.cu

--- a/cpp/open3d/t/pipelines/kernel/Registration.cpp
+++ b/cpp/open3d/t/pipelines/kernel/Registration.cpp
@@ -24,9 +24,9 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
-#include "open3d/t/pipelines/kernel/ComputeTransform.h"
+#include "open3d/t/pipelines/kernel/Registration.h"
 
-#include "open3d/t/pipelines/kernel/ComputeTransformImpl.h"
+#include "open3d/t/pipelines/kernel/RegistrationImpl.h"
 
 namespace open3d {
 namespace t {
@@ -173,6 +173,42 @@ std::tuple<core::Tensor, core::Tensor> ComputeRtPointToPoint(
         utility::LogError("Unimplemented device.");
     }
     return std::make_tuple(R, t);
+}
+
+core::Tensor ComputeInformationMatrix(
+        const core::Tensor &target_points,
+        const core::Tensor &correspondence_indices) {
+    const core::Device device = target_points.GetDevice();
+    const core::Dtype dtype = target_points.GetDtype();
+
+    if (dtype != core::Float64 && dtype != core::Float32) {
+        utility::LogError("Only Float32 and Float64 dtypes are supported.");
+    }
+
+    if (target_points.GetLength() == 0) {
+        utility::LogError("Target point cloud is empty.");
+    }
+    if (correspondence_indices.GetLength() == 0) {
+        utility::LogError("No correspondence present.");
+    }
+
+    core::Tensor information_matrix =
+            core::Tensor::Empty({6, 6}, dtype, device);
+
+    const core::Device::DeviceType device_type = device.GetType();
+    if (device_type == core::Device::DeviceType::CPU) {
+        ComputeInformationMatrixCPU(target_points.Contiguous(),
+                                    correspondence_indices.Contiguous(),
+                                    information_matrix, dtype, device);
+    } else if (device_type == core::Device::DeviceType::CUDA) {
+        CUDA_CALL(ComputeInformationMatrixCUDA, target_points.Contiguous(),
+                  correspondence_indices.Contiguous(), information_matrix,
+                  dtype, device);
+    } else {
+        utility::LogError("Unimplemented device.");
+    }
+
+    return information_matrix;
 }
 
 }  // namespace kernel

--- a/cpp/open3d/t/pipelines/kernel/Registration.cpp
+++ b/cpp/open3d/t/pipelines/kernel/Registration.cpp
@@ -193,7 +193,7 @@ core::Tensor ComputeInformationMatrix(
     }
 
     core::Tensor information_matrix =
-            core::Tensor::Empty({6, 6}, dtype, device);
+            core::Tensor::Empty({6, 6}, core::Float64, core::Device("CPU:0"));
 
     const core::Device::DeviceType device_type = device.GetType();
     if (device_type == core::Device::DeviceType::CPU) {

--- a/cpp/open3d/t/pipelines/kernel/Registration.h
+++ b/cpp/open3d/t/pipelines/kernel/Registration.h
@@ -68,7 +68,7 @@ std::tuple<core::Tensor, core::Tensor> ComputeRtPointToPoint(
 /// \brief Computes `Information Matrix` of shape {6, 6}, of dtype `Float64` on
 /// device `CPU:0`, from the target point cloud and correspondence indices
 /// w.r.t. target point cloud.
-/// Only target point cloud, and correspondence indices are required.
+/// Only target points and correspondence indices are required.
 ///
 /// \param target_points The target point positions.
 /// \param correspondence_indices Tensor of type Int64 containing indices of

--- a/cpp/open3d/t/pipelines/kernel/Registration.h
+++ b/cpp/open3d/t/pipelines/kernel/Registration.h
@@ -66,8 +66,9 @@ std::tuple<core::Tensor, core::Tensor> ComputeRtPointToPoint(
         const core::Tensor &correspondence_indices);
 
 /// \brief Computes `Information Matrix` of shape {6, 6}, of dtype `Float64` on
-/// device `CPU:0`, from the target point cloud and correspondence indices wrt
-/// to the source point cloud.
+/// device `CPU:0`, from the target point cloud and correspondence indices of
+/// source point cloud w.r.t. to the target point cloud.
+/// Only target point cloud, and correspondence indices are required.
 ///
 /// \param target_points The target point positions.
 /// \param correspondence_indices Tensor of type Int64 containing indices of

--- a/cpp/open3d/t/pipelines/kernel/Registration.h
+++ b/cpp/open3d/t/pipelines/kernel/Registration.h
@@ -65,6 +65,15 @@ std::tuple<core::Tensor, core::Tensor> ComputeRtPointToPoint(
         const core::Tensor &target_points,
         const core::Tensor &correspondence_indices);
 
+/// \brief Computes `Information Matrix` of shape {6, 6}, of dtype `Float64` on
+/// device `CPU:0`, from the target point cloud and correspondence indices wrt
+/// to the source point cloud.
+///
+/// \param target_points The target point positions.
+/// \param correspondence_indices Tensor of type Int64 containing indices of
+/// corresponding target points, where the value is the target index and the
+/// index of the value itself is the source index. It contains -1 as value
+/// at index with no correspondence.
 core::Tensor ComputeInformationMatrix(
         const core::Tensor &target_points,
         const core::Tensor &correspondence_indices);

--- a/cpp/open3d/t/pipelines/kernel/Registration.h
+++ b/cpp/open3d/t/pipelines/kernel/Registration.h
@@ -66,8 +66,8 @@ std::tuple<core::Tensor, core::Tensor> ComputeRtPointToPoint(
         const core::Tensor &correspondence_indices);
 
 /// \brief Computes `Information Matrix` of shape {6, 6}, of dtype `Float64` on
-/// device `CPU:0`, from the target point cloud and correspondence indices of
-/// source point cloud w.r.t. to the target point cloud.
+/// device `CPU:0`, from the target point cloud and correspondence indices
+/// w.r.t. target point cloud.
 /// Only target point cloud, and correspondence indices are required.
 ///
 /// \param target_points The target point positions.

--- a/cpp/open3d/t/pipelines/kernel/Registration.h
+++ b/cpp/open3d/t/pipelines/kernel/Registration.h
@@ -65,6 +65,10 @@ std::tuple<core::Tensor, core::Tensor> ComputeRtPointToPoint(
         const core::Tensor &target_points,
         const core::Tensor &correspondence_indices);
 
+core::Tensor ComputeInformationMatrix(
+        const core::Tensor &target_points,
+        const core::Tensor &correspondence_indices);
+
 }  // namespace kernel
 }  // namespace pipelines
 }  // namespace t

--- a/cpp/open3d/t/pipelines/kernel/RegistrationCPU.cpp
+++ b/cpp/open3d/t/pipelines/kernel/RegistrationCPU.cpp
@@ -379,12 +379,17 @@ void ComputeInformationMatrixCPU(const core::Tensor &target_points,
                 correspondence_indices.GetDataPtr<int64_t>(), n,
                 global_sum_ptr);
 
-        scalar_t *GTG_ptr = information_matrix.GetDataPtr<scalar_t>();
+        core::Tensor global_sum_cpu =
+                global_sum.To(core::Device("CPU:0"), core::Float64);
+        double *sum_ptr = global_sum_cpu.GetDataPtr<double>();
+
+        // Information matrix is on CPU of type Float64.
+        double *GTG_ptr = information_matrix.GetDataPtr<double>();
 
         int i = 0;
         for (int j = 0; j < 6; j++) {
             for (int k = 0; k <= j; k++) {
-                GTG_ptr[j * 6 + k] = GTG_ptr[k * 6 + j] = global_sum_ptr[i];
+                GTG_ptr[j * 6 + k] = GTG_ptr[k * 6 + j] = sum_ptr[i];
                 ++i;
             }
         }

--- a/cpp/open3d/t/pipelines/kernel/RegistrationCUDA.cu
+++ b/cpp/open3d/t/pipelines/kernel/RegistrationCUDA.cu
@@ -194,12 +194,17 @@ void ComputeInformationMatrixCUDA(const core::Tensor &target_points,
 
         core::cuda::Synchronize();
 
-        scalar_t *GTG_ptr = information_matrix.GetDataPtr<scalar_t>();
+        core::Tensor global_sum_cpu =
+                global_sum.To(core::Device("CPU:0"), core::Float64);
+        double *sum_ptr = global_sum_cpu.GetDataPtr<double>();
+
+        // Information matrix is on CPU of type Float64.
+        double *GTG_ptr = information_matrix.GetDataPtr<double>();
 
         int i = 0;
         for (int j = 0; j < 6; j++) {
             for (int k = 0; k <= j; k++) {
-                GTG_ptr[j * 6 + k] = GTG_ptr[k * 6 + j] = global_sum_ptr[i];
+                GTG_ptr[j * 6 + k] = GTG_ptr[k * 6 + j] = sum_ptr[i];
                 ++i;
             }
         }

--- a/cpp/open3d/t/pipelines/kernel/RegistrationCUDA.cu
+++ b/cpp/open3d/t/pipelines/kernel/RegistrationCUDA.cu
@@ -29,8 +29,8 @@
 #include "open3d/core/CUDAUtils.h"
 #include "open3d/core/ParallelFor.h"
 #include "open3d/core/Tensor.h"
-#include "open3d/t/pipelines/kernel/ComputeTransformImpl.h"
 #include "open3d/t/pipelines/kernel/Reduction6x6Impl.cuh"
+#include "open3d/t/pipelines/kernel/RegistrationImpl.h"
 #include "open3d/t/pipelines/kernel/TransformationConverter.h"
 #include "open3d/t/pipelines/registration/RobustKernel.h"
 #include "open3d/t/pipelines/registration/RobustKernelImpl.h"
@@ -128,6 +128,82 @@ void ComputePosePointToPlaneCUDA(const core::Tensor &source_points,
     core::cuda::Synchronize();
 
     DecodeAndSolve6x6(global_sum, pose, residual, inlier_count);
+}
+
+template <typename scalar_t>
+__global__ void ComputeInformationMatrixKernelCUDA(
+        const scalar_t *target_points_ptr,
+        const int64_t *correspondence_indices,
+        const int n,
+        scalar_t *global_sum) {
+    __shared__ scalar_t local_sum0[kThread1DUnit];
+    __shared__ scalar_t local_sum1[kThread1DUnit];
+    __shared__ scalar_t local_sum2[kThread1DUnit];
+
+    const int tid = threadIdx.x;
+
+    local_sum0[tid] = 0;
+    local_sum1[tid] = 0;
+    local_sum2[tid] = 0;
+
+    const int workload_idx = threadIdx.x + blockIdx.x * blockDim.x;
+
+    if (workload_idx >= n) return;
+
+    scalar_t J_x[6] = {0}, J_y[6] = {0}, J_z[6] = {0}, reduction[21] = {0};
+
+    bool valid = GetInformationJacobians<scalar_t>(
+            workload_idx, target_points_ptr, correspondence_indices, J_x, J_y,
+            J_z);
+
+    if (valid) {
+        int i = 0;
+        for (int j = 0; j < 6; ++j) {
+            for (int k = 0; k <= j; ++k) {
+                reduction[i] +=
+                        J_x[j] * J_x[k] + J_y[j] * J_y[k] + J_z[j] * J_z[k];
+                ++i;
+            }
+        }
+    }
+
+    ReduceSum6x6InformationJacobian<scalar_t, kThread1DUnit>(
+            tid, valid, reduction, local_sum0, local_sum1, local_sum2,
+            global_sum);
+}
+
+void ComputeInformationMatrixCUDA(const core::Tensor &target_points,
+                                  const core::Tensor &correspondence_indices,
+                                  core::Tensor &information_matrix,
+                                  const core::Dtype &dtype,
+                                  const core::Device &device) {
+    int n = correspondence_indices.GetLength();
+
+    core::Tensor global_sum = core::Tensor::Zeros({21}, dtype, device);
+    const dim3 blocks((n + kThread1DUnit - 1) / kThread1DUnit);
+    const dim3 threads(kThread1DUnit);
+
+    DISPATCH_FLOAT_DTYPE_TO_TEMPLATE(dtype, [&]() {
+        scalar_t *global_sum_ptr = global_sum.GetDataPtr<scalar_t>();
+
+        ComputeInformationMatrixKernelCUDA<<<blocks, threads, 0,
+                                             core::cuda::GetStream()>>>(
+                target_points.GetDataPtr<scalar_t>(),
+                correspondence_indices.GetDataPtr<int64_t>(), n,
+                global_sum_ptr);
+
+        core::cuda::Synchronize();
+
+        scalar_t *GTG_ptr = information_matrix.GetDataPtr<scalar_t>();
+
+        int i = 0;
+        for (int j = 0; j < 6; j++) {
+            for (int k = 0; k <= j; k++) {
+                GTG_ptr[j * 6 + k] = GTG_ptr[k * 6 + j] = global_sum_ptr[i];
+                ++i;
+            }
+        }
+    });
 }
 
 }  // namespace kernel

--- a/cpp/open3d/t/pipelines/kernel/RegistrationImpl.h
+++ b/cpp/open3d/t/pipelines/kernel/RegistrationImpl.h
@@ -152,17 +152,17 @@ OPEN3D_HOST_DEVICE inline bool GetInformationJacobians(
 
     const int64_t target_idx = 3 * correspondence_indices[workload_idx];
 
-    jacobian_x[0] = jacobian_x[4] = jacobian_x[5] = 0;
+    jacobian_x[0] = jacobian_x[4] = jacobian_x[5] = 0.0;
     jacobian_x[1] = target_points_ptr[target_idx + 2];
     jacobian_x[2] = -target_points_ptr[target_idx + 1];
     jacobian_x[3] = 1.0;
 
-    jacobian_y[1] = jacobian_x[3] = jacobian_x[5] = 0;
+    jacobian_y[1] = jacobian_y[3] = jacobian_y[5] = 0.0;
     jacobian_y[0] = -target_points_ptr[target_idx + 2];
     jacobian_y[2] = target_points_ptr[target_idx];
     jacobian_y[4] = 1.0;
 
-    jacobian_z[2] = jacobian_x[3] = jacobian_x[4] = 0;
+    jacobian_z[2] = jacobian_z[3] = jacobian_z[4] = 0.0;
     jacobian_z[0] = target_points_ptr[target_idx + 1];
     jacobian_z[1] = -target_points_ptr[target_idx];
     jacobian_z[5] = 1.0;

--- a/cpp/open3d/t/pipelines/registration/Registration.cpp
+++ b/cpp/open3d/t/pipelines/registration/Registration.cpp
@@ -359,8 +359,7 @@ core::Tensor GetInformationMatrixFromPointClouds(
                                     max_correspondence_distance, 1);
 
     correspondences = correspondences.To(core::Int64);
-    double num_correspondences =
-            counts.Sum({0}).To(core::Float64).Item<double>();
+    int32_t num_correspondences = counts.Sum({0}).Item<int32_t>();
 
     if (num_correspondences == 0) {
         utility::LogError(

--- a/cpp/open3d/t/pipelines/registration/Registration.cpp
+++ b/cpp/open3d/t/pipelines/registration/Registration.cpp
@@ -338,20 +338,22 @@ RegistrationResult RegistrationMultiScaleICP(
 core::Tensor GetInformationMatrixFromPointClouds(
         const geometry::PointCloud &source,
         const geometry::PointCloud &target,
-        double max_correspondence_distance,
-        const core::Tensor &init_source_to_target) {
+        const double max_correspondence_distance,
+        const core::Tensor &transformation) {
     core::Device device = source.GetDevice();
     core::Dtype dtype = source.GetPointPositions().GetDtype();
+    target.GetPointPositions().AssertDtype(dtype);
+    target.GetPointPositions().AssertDevice(device);
 
     geometry::PointCloud source_transformed = source.Clone();
-    source_transformed.Transform(init_source_to_target.To(device, dtype));
+    source_transformed.Transform(transformation.To(device, dtype));
 
     open3d::core::nns::NearestNeighborSearch target_nns(
             target.GetPointPositions());
 
     target_nns.HybridIndex(max_correspondence_distance);
 
-    core::Tensor distances, counts, correspondences;
+    core::Tensor correspondences, distances, counts;
     std::tie(correspondences, distances, counts) =
             target_nns.HybridSearch(source_transformed.GetPointPositions(),
                                     max_correspondence_distance, 1);

--- a/cpp/open3d/t/pipelines/registration/Registration.h
+++ b/cpp/open3d/t/pipelines/registration/Registration.h
@@ -178,11 +178,21 @@ RegistrationResult RegistrationMultiScaleICP(
         const TransformationEstimation &estimation =
                 TransformationEstimationPointToPoint());
 
+/// \brief Computes `Information Matrix`, from the transfromation between source
+/// and target pointcloud. It returns the `Information Matrix` of shape {6, 6},
+/// of dtype `Float64` on device `CPU:0`.
+///
+/// \param source The source point cloud.
+/// \param target The target point cloud.
+/// \param max_correspondence_distance Maximum correspondence points-pair
+/// distance.
+/// \param transformation The 4x4 transformation matrix to transform
+/// `source` to `target`.
 core::Tensor GetInformationMatrixFromPointClouds(
         const geometry::PointCloud &source,
         const geometry::PointCloud &target,
-        double max_correspondence_distance,
-        const core::Tensor &init_source_to_target);
+        const double max_correspondence_distance,
+        const core::Tensor &transformation);
 
 }  // namespace registration
 }  // namespace pipelines

--- a/cpp/open3d/t/pipelines/registration/Registration.h
+++ b/cpp/open3d/t/pipelines/registration/Registration.h
@@ -178,6 +178,12 @@ RegistrationResult RegistrationMultiScaleICP(
         const TransformationEstimation &estimation =
                 TransformationEstimationPointToPoint());
 
+core::Tensor GetInformationMatrixFromPointClouds(
+        const geometry::PointCloud &source,
+        const geometry::PointCloud &target,
+        double max_correspondence_distance,
+        const core::Tensor &init_source_to_target);
+
 }  // namespace registration
 }  // namespace pipelines
 }  // namespace t

--- a/cpp/open3d/t/pipelines/registration/TransformationEstimation.cpp
+++ b/cpp/open3d/t/pipelines/registration/TransformationEstimation.cpp
@@ -26,7 +26,7 @@
 
 #include "open3d/t/pipelines/registration/TransformationEstimation.h"
 
-#include "open3d/t/pipelines/kernel/ComputeTransform.h"
+#include "open3d/t/pipelines/kernel/Registration.h"
 #include "open3d/t/pipelines/kernel/TransformationConverter.h"
 
 namespace open3d {

--- a/cpp/pybind/pipelines/registration/registration.cpp
+++ b/cpp/pybind/pipelines/registration/registration.cpp
@@ -575,12 +575,9 @@ static const std::unordered_map<std::string, std::string>
                 {"checkers",
                  "Vector of Checker class to check if two point "
                  "clouds can be aligned. One of "
-                 "(``"
-                 "CorrespondenceCheckerBasedOnEdgeLength``, "
-                 "``"
-                 "CorrespondenceCheckerBasedOnDistance``, "
-                 "``"
-                 "CorrespondenceCheckerBasedOnNormal``)"},
+                 "(``CorrespondenceCheckerBasedOnEdgeLength``, "
+                 "``CorrespondenceCheckerBasedOnDistance``, "
+                 "``CorrespondenceCheckerBasedOnNormal``)"},
                 {"confidence",
                  "Desired probability of success for RANSAC. Used for "
                  "estimating early termination by k = log(1 - "
@@ -591,14 +588,10 @@ static const std::unordered_map<std::string, std::string>
                 {"criteria", "Convergence criteria"},
                 {"estimation_method",
                  "Estimation method. One of "
-                 "(``"
-                 "TransformationEstimationPointToPoint``, "
-                 "``"
-                 "TransformationEstimationPointToPlane``, "
-                 "``"
-                 "TransformationEstimationForGeneralizedICP``, "
-                 "``"
-                 "TransformationEstimationForColoredICP``)"},
+                 "(``TransformationEstimationPointToPoint``, "
+                 "``TransformationEstimationPointToPlane``, "
+                 "``TransformationEstimationForGeneralizedICP``, "
+                 "``TransformationEstimationForColoredICP``)"},
                 {"init", "Initial transformation estimation"},
                 {"lambda_geometric", "lambda_geometric value"},
                 {"epsilon", "epsilon value"},

--- a/cpp/pybind/t/pipelines/registration/registration.cpp
+++ b/cpp/pybind/t/pipelines/registration/registration.cpp
@@ -270,6 +270,17 @@ void pybind_registration_methods(py::module &m) {
           "estimation_method"_a = TransformationEstimationPointToPoint());
     docstring::FunctionDocInject(m, "registration_multi_scale_icp",
                                  map_shared_argument_docstrings);
+
+    m.def("get_information_matrix_from_point_clouds",
+          &GetInformationMatrixFromPointClouds,
+          py::call_guard<py::gil_scoped_release>(),
+          "Function for computing information matrix from transformation "
+          "matrix. Information matrix is tensor of shape {6, 6}, dtype Float64 "
+          "on CPU device.",
+          "source"_a, "target"_a, "max_correspondence_distance"_a,
+          "transformation"_a);
+    docstring::FunctionDocInject(m, "get_information_matrix_from_point_clouds",
+                                 map_shared_argument_docstrings);
 }
 
 void pybind_registration(py::module &m) {

--- a/cpp/tests/t/pipelines/registration/Registration.cpp
+++ b/cpp/tests/t/pipelines/registration/Registration.cpp
@@ -420,14 +420,12 @@ TEST_P(RegistrationPermuteDevices, GetInformationMatrixFromPointCloud) {
                         source_lpcd, target_lpcd, max_correspondence_dist,
                         initial_transform_l);
 
-        auto information_matrix_from_legacy =
-                core::eigen_converter::EigenMatrixToTensor(information_matrix_l)
-                        .To(dtype);
+        core::Tensor information_matrix_from_legacy =
+                core::eigen_converter::EigenMatrixToTensor(
+                        information_matrix_l);
 
-        utility::LogInfo("Information Matrix Tensor : \n{}\n",
-                         information_matrix_t.ToString());
-        utility::LogInfo("Information Matrix Legacy : \n{}\n",
-                         information_matrix_from_legacy.ToString());
+        EXPECT_TRUE(information_matrix_t.AllClose(
+                information_matrix_from_legacy, 1e-1, 1e-1));
     }
 }
 

--- a/cpp/tests/t/pipelines/registration/Registration.cpp
+++ b/cpp/tests/t/pipelines/registration/Registration.cpp
@@ -388,5 +388,48 @@ TEST_P(RegistrationPermuteDevices, RobustKernel) {
     }
 }
 
+TEST_P(RegistrationPermuteDevices, GetInformationMatrixFromPointCloud) {
+    core::Device device = GetParam();
+
+    for (auto dtype : {core::Float32, core::Float64}) {
+        t::geometry::PointCloud source_tpcd(device), target_tpcd(device);
+        std::tie(source_tpcd, target_tpcd) = GetTestPointClouds(dtype, device);
+
+        open3d::geometry::PointCloud source_lpcd = source_tpcd.ToLegacy();
+        open3d::geometry::PointCloud target_lpcd = target_tpcd.ToLegacy();
+
+        // Initial transformation input for tensor implementation.
+        core::Tensor initial_transform_t =
+                core::Tensor::Eye(4, core::Float64, core::Device("CPU:0"));
+
+        // Initial transformation input for legacy implementation.
+        Eigen::Matrix4d initial_transform_l = Eigen::Matrix4d::Identity();
+
+        // Identity transformation.
+        double max_correspondence_dist = 3.0;
+
+        // Tensor information matrix.
+        core::Tensor information_matrix_t =
+                t_reg::GetInformationMatrixFromPointClouds(
+                        source_tpcd, target_tpcd, max_correspondence_dist,
+                        initial_transform_t);
+
+        // Legacy evaluation.
+        Eigen::Matrix6d information_matrix_l =
+                l_reg::GetInformationMatrixFromPointClouds(
+                        source_lpcd, target_lpcd, max_correspondence_dist,
+                        initial_transform_l);
+
+        auto information_matrix_from_legacy =
+                core::eigen_converter::EigenMatrixToTensor(information_matrix_l)
+                        .To(dtype);
+
+        utility::LogInfo("Information Matrix Tensor : \n{}\n",
+                         information_matrix_t.ToString());
+        utility::LogInfo("Information Matrix Legacy : \n{}\n",
+                         information_matrix_from_legacy.ToString());
+    }
+}
+
 }  // namespace tests
 }  // namespace open3d

--- a/python/test/t/registration/test_registration.py
+++ b/python/test/t/registration/test_registration.py
@@ -184,7 +184,7 @@ def test_registration_icp_point_to_point(device):
 
 
 @pytest.mark.parametrize("device", list_devices())
-def test_test_registration_icp_point_to_plane(device):
+def test_registration_icp_point_to_plane(device):
 
     supported_dtypes = [o3c.float32, o3c.float64]
     for dtype in supported_dtypes:
@@ -219,3 +219,34 @@ def test_test_registration_icp_point_to_plane(device):
                                    reg_p2plane_legacy.inlier_rmse, 0.001)
         np.testing.assert_allclose(reg_p2plane_t.fitness,
                                    reg_p2plane_legacy.fitness, 0.001)
+
+
+@pytest.mark.parametrize("device", list_devices())
+def test_get_information_matrix_from_pointclouds(device):
+
+    supported_dtypes = [o3c.float32, o3c.float64]
+    for dtype in supported_dtypes:
+        source_t, target_t = get_pcds(dtype, device)
+
+        source_legacy = source_t.to_legacy()
+        target_legacy = target_t.to_legacy()
+
+        max_correspondence_distance = 3.0
+
+        transformation_legacy = np.array([[0.862, 0.011, -0.507, 0.5],
+                                          [-0.139, 0.967, -0.215, 0.7],
+                                          [0.487, 0.255, 0.835, -1.4],
+                                          [0.0, 0.0, 0.0, 1.0]])
+        transformation_t = o3c.Tensor(transformation_legacy,
+                                      dtype=o3c.float64,
+                                      device=device)
+
+        info_matrix_t = o3d.t.pipelines.registration.get_information_matrix_from_pointclouds(
+            source_t, target_t, max_correspondence_distance, transformation_t)
+
+        info_matrix_legacy = o3d.pipelines.registration.registration_icp(
+            source_legacy, target_legacy, max_correspondence_distance,
+            transformation_legacy)
+
+        np.testing.assert_allclose(info_matrix_t.cpu().numpy(),
+                                   info_matrix_legacy, 1e-1)

--- a/python/test/t/registration/test_registration.py
+++ b/python/test/t/registration/test_registration.py
@@ -241,12 +241,12 @@ def test_get_information_matrix_from_pointclouds(device):
                                       dtype=o3c.float64,
                                       device=device)
 
-        info_matrix_t = o3d.t.pipelines.registration.get_information_matrix_from_pointclouds(
+        info_matrix_t = o3d.t.pipelines.registration.get_information_matrix_from_point_clouds(
             source_t, target_t, max_correspondence_distance, transformation_t)
 
-        info_matrix_legacy = o3d.pipelines.registration.registration_icp(
+        info_matrix_legacy = o3d.pipelines.registration.get_information_matrix_from_point_clouds(
             source_legacy, target_legacy, max_correspondence_distance,
             transformation_legacy)
 
         np.testing.assert_allclose(info_matrix_t.cpu().numpy(),
-                                   info_matrix_legacy, 1e-1)
+                                   info_matrix_legacy, 1e-1, 1e-1)


### PR DESCRIPTION
Changes:
- Renamed `ComputeTransform*` kernel codes, to `Registration*` kernel codes, for consistency with other kernel code naming patterns.
- Added `GetInformationMatrixFromPointClouds` function, kernels, unit-tests, pybinds.

The contribution has been derived from https://github.com/theNded/Open3D/blob/cuda/src/Cuda/Registration/RegistrationCuda.h

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3987)
<!-- Reviewable:end -->
