### PR TITLE
Fixed wrong maximum count character in strncpy.

### DIFF
--- a/cpp/open3d/core/Dtype.cpp
+++ b/cpp/open3d/core/Dtype.cpp
@@ -72,8 +72,6 @@ const Dtype Bool = Dtype::Bool;
 
 Dtype::Dtype(DtypeCode dtype_code, int64_t byte_size, const std::string &name)
     : dtype_code_(dtype_code), byte_size_(byte_size) {
-    (void)dtype_code_;
-    (void)byte_size_;
     if (name.size() > max_name_len_ - 1) {
         utility::LogError("Name {} must be shorter.", name);
     } else {

--- a/cpp/open3d/core/Dtype.cpp
+++ b/cpp/open3d/core/Dtype.cpp
@@ -77,7 +77,7 @@ Dtype::Dtype(DtypeCode dtype_code, int64_t byte_size, const std::string &name)
     if (name.size() > max_name_len_ - 1) {
         utility::LogError("Name {} must be shorter.", name);
     } else {
-        std::strncpy(name_, name.c_str(), max_name_len_);
+        std::strncpy(name_, name.c_str(), max_name_len_ - 1);
     }
 }
 

--- a/cpp/open3d/core/Dtype.cpp
+++ b/cpp/open3d/core/Dtype.cpp
@@ -75,7 +75,8 @@ Dtype::Dtype(DtypeCode dtype_code, int64_t byte_size, const std::string &name)
     if (name.size() > max_name_len_ - 1) {
         utility::LogError("Name {} must be shorter.", name);
     } else {
-        std::strncpy(name_, name.c_str(), max_name_len_ - 1);
+        std::strncpy(name_, name.c_str(), max_name_len_);
+        name_[max_name_len_ - 1] = '\0';
     }
 }
 


### PR DESCRIPTION
- Fixed #3990 .
- Fixed strncpy compilation error with GCC 11 on Fedora 34.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3991)
<!-- Reviewable:end -->
