### PR TITLE
Close window on ESC keypress

### DIFF
--- a/cpp/open3d/visualization/gui/Window.cpp
+++ b/cpp/open3d/visualization/gui/Window.cpp
@@ -1174,6 +1174,8 @@ void Window::OnKeyEvent(const KeyEvent& e) {
         this_mod = int(KeyModifier::ALT);
     } else if (e.key == KEY_META) {
         this_mod = int(KeyModifier::META);
+    } else if (e.key == KEY_ESCAPE) {
+        Close();
     }
 
     if (e.type == KeyEvent::UP) {


### PR DESCRIPTION
Pressing ESC will close both Open3DViewer standalone app and Windows created by O3DVisualizer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3992)
<!-- Reviewable:end -->
