### PR TITLE
Fix inconsistent kernel object library handling

### DIFF
--- a/cpp/open3d/CMakeLists.txt
+++ b/cpp/open3d/CMakeLists.txt
@@ -62,6 +62,7 @@ target_sources(Open3D PRIVATE
     $<TARGET_OBJECTS:ml_contrib>
     $<TARGET_OBJECTS:pipelines>
     $<TARGET_OBJECTS:tpipelines>
+    $<TARGET_OBJECTS:tpipelines_kernel>
     $<TARGET_OBJECTS:utility>
     $<TARGET_OBJECTS:visualization>
 )

--- a/cpp/open3d/t/geometry/CMakeLists.txt
+++ b/cpp/open3d/t/geometry/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_subdirectory(kernel)
 
-add_library(tgeometry OBJECT $<TARGET_OBJECTS:tgeometry_kernel>)
+add_library(tgeometry OBJECT)
 
 target_sources(tgeometry PRIVATE
     Image.cpp

--- a/cpp/open3d/t/pipelines/CMakeLists.txt
+++ b/cpp/open3d/t/pipelines/CMakeLists.txt
@@ -1,25 +1,6 @@
 add_subdirectory(kernel)
 
-add_library(tpipelines OBJECT $<TARGET_OBJECTS:tpipelines_kernel>)
-
-target_sources(tpipelines PRIVATE
-    kernel/Registration.cpp
-    kernel/RegistrationCPU.cpp
-    kernel/FillInLinearSystem.cpp
-    kernel/FillInLinearSystemCPU.cpp
-    kernel/RGBDOdometry.cpp
-    kernel/RGBDOdometryCPU.cpp
-    kernel/TransformationConverter.cpp
-)
-
-if (BUILD_CUDA_MODULE)
-    target_sources(tpipelines PRIVATE
-        kernel/RegistrationCUDA.cu
-        kernel/FillInLinearSystemCUDA.cu
-        kernel/RGBDOdometryCUDA.cu
-        kernel/TransformationConverter.cu
-    )
-endif()
+add_library(tpipelines OBJECT)
 
 target_sources(tpipelines PRIVATE
     odometry/RGBDOdometry.cpp

--- a/cpp/open3d/t/pipelines/kernel/CMakeLists.txt
+++ b/cpp/open3d/t/pipelines/kernel/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_library(tpipelines_kernel OBJECT)
 
-target_sources(tpipelines_kernel  PRIVATE
+target_sources(tpipelines_kernel PRIVATE
     Registration.cpp
     RegistrationCPU.cpp
     FillInLinearSystem.cpp
@@ -11,7 +11,7 @@ target_sources(tpipelines_kernel  PRIVATE
 )
 
 if (BUILD_CUDA_MODULE)
-    target_sources(tpipelines_kernel  PRIVATE
+    target_sources(tpipelines_kernel PRIVATE
         RegistrationCUDA.cu
         FillInLinearSystemCUDA.cu
         RGBDOdometryCUDA.cu
@@ -21,7 +21,9 @@ endif()
 
 open3d_show_and_abort_on_warning(tpipelines_kernel)
 open3d_set_global_properties(tpipelines_kernel)
-open3d_set_open3d_lib_properties(tpipelines_kernel HIDDEN)
+# The kernels are used in the unit tests, so they cannot be hidden for now.
+open3d_set_open3d_lib_properties(tpipelines_kernel)
+#open3d_set_open3d_lib_properties(tpipelines_kernel HIDDEN)
 open3d_link_3rdparty_libraries(tpipelines_kernel)
 
 if(BUILD_CUDA_MODULE)


### PR DESCRIPTION
The `tpipelines_kernel` object library is inconsistently handled:

- It is compiled with `HIDDEN` visibility and its object files are added to the `tpipelines` object library.
- `tpipelines` compiles the kernel source files again without `HIDDEN`visibility.
- Only the non-hidden `tpipelines` object files are considered and the hidden `tpipelines_kernel` are implicitly dropped.

Explicitly adding the object files of `tpipelines_kernel`'s to the Open3D library causes linker errors for `BUILD_SHARED_LIBS=ON `.  The non-hidden version is required since the `TransformationConverter` unit test directly calls some kernel functions. Therefore, drop the `HIDDEN` flag and clean up the inconsistent and duplicate behavior.

This is required for ISPC support in #3996.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/3997)
<!-- Reviewable:end -->
