### PR TITLE
Fix Tensor API check in PCD IO

### DIFF
--- a/cpp/open3d/t/io/file_format/FilePCD.cpp
+++ b/cpp/open3d/t/io/file_format/FilePCD.cpp
@@ -1192,9 +1192,8 @@ bool ReadPointCloudFromPCD(const std::string &filename,
 bool WritePointCloudToPCD(const std::string &filename,
                           const geometry::PointCloud &pointcloud,
                           const WritePointCloudOption &params) {
-    pointcloud.GetPointPositions().AssertDevice(
-            core::Device("CPU:0"),
-            "Write PCD failed: expects point cloud to be on CPU device.");
+    core::AssertTensorDevice(pointcloud.GetPointPositions(),
+                             core::Device("CPU:0"));
 
     PCDHeader header;
     if (!GenerateHeader(pointcloud, bool(params.write_ascii),


### PR DESCRIPTION
Merging #3998 before rebasing to master after #3978 got merged caused a conflict where one tensor check is not properly updated to the new API. This causes all CI jobs to fail. Port the offending check to unblock all upcoming users of the master branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4001)
<!-- Reviewable:end -->
