### PR TITLE
Consistently specify pthread preference

### DIFF
--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -457,8 +457,6 @@ if(BUILD_CUDA_MODULE)
 endif()
 
 # Threads
-set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
-set(THREADS_PREFER_PTHREAD_FLAG TRUE) # -pthread instead of -lpthread
 open3d_find_package_3rdparty_library(3rdparty_threads
     REQUIRED
     PACKAGE Threads

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,6 +297,12 @@ add_compile_options("${HARDENING_CFLAGS}")
 add_link_options("${HARDENING_LDFLAGS}")
 add_compile_definitions("${HARDENING_DEFINITIONS}")
 
+# Explicitly specifiy the preference of using -pthread over -lpthread.
+# This must be defined here since CUDA calls find_package(Threads) internally.
+# -pthread is disabled since some compilers, e.g. the ISPC compiler, have
+# problems with this compile flag and issue errors.
+set(THREADS_PREFER_PTHREAD_FLAG FALSE)
+
 # Build CUDA module by default if CUDA is available
 if(BUILD_CUDA_MODULE)
     include(Open3DMakeCudaArchitectures)


### PR DESCRIPTION
The flag to specify that `-pthread` should be preferred over `-lpthread` is inconsistently used:

- Non-CUDA builds: `THREADS_PREFER_PTHREAD_FLAG` is correctly recognized.
- CUDA build: `THREADS_PREFER_PTHREAD_FLAG` is defined too late since the `CUDAToolkit` package internally calls `find_package(Threads)` before the flag is set.
- `CMAKE_THREAD_PREFER_PTHREAD` is no longer recognized by CMake and can be dropped.

Move the definition of the preference flag before enabling CUDA support. Furthermore, disable `-pthread` since the ISPC compiler has problems with it and throws errors.

Required for #3996.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4004)
<!-- Reviewable:end -->
