### PR TITLE
Build Docker with scripts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 build
 tags
-.git
 .clangd
 .vscode
 docs/_static/build

--- a/.github/workflows/Dockerfile.ubuntu-cuda
+++ b/.github/workflows/Dockerfile.ubuntu-cuda
@@ -10,7 +10,7 @@ ARG CCACHE_VERSION=4.3
 ARG PYTHON_VERSION=3.6
 
 # Forward all ARG to ENV
-# ci_utils.sh require these environment variables
+# ci_utils.sh requires these environment variables
 ENV DEVELOPER_BUILD=${DEVELOPER_BUILD}
 ENV CCACHE_TAR_NAME=${CCACHE_TAR_NAME}
 ENV CMAKE_VERSION=${CMAKE_VERSION}

--- a/.github/workflows/Dockerfile.ubuntu-cuda
+++ b/.github/workflows/Dockerfile.ubuntu-cuda
@@ -4,16 +4,14 @@ FROM ${BASE_IMAGE}
 
 # Customizable build arguments from cuda.yml
 ARG DEVELOPER_BUILD=ON
-ARG BUILD_COMMON_CUDA_ARCHS=OFF
 ARG CCACHE_TAR_NAME=open3d-ubuntu-1804-cuda-ci-ccache
 ARG CMAKE_VERSION=cmake-3.19.7-Linux-x86_64
 ARG CCACHE_VERSION=4.3
 ARG PYTHON_VERSION=3.6
 
 # Forward all ARG to ENV
-# Some shell scripts require these environment variables
+# ci_utils.sh require these environment variables
 ENV DEVELOPER_BUILD=${DEVELOPER_BUILD}
-ENV BUILD_COMMON_CUDA_ARCHS=${BUILD_COMMON_CUDA_ARCHS}
 ENV CCACHE_TAR_NAME=${CCACHE_TAR_NAME}
 ENV CMAKE_VERSION=${CMAKE_VERSION}
 ARG CCACHE_VERSION=${CCACHE_VERSION}

--- a/.github/workflows/docker_build.sh
+++ b/.github/workflows/docker_build.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+#
+# docker_build.sh is used to build Open3D docker images for all supported
+# scenarios. This can be used in CI and on local machines. The objective is to
+# allow developers to emulate CI environments for debugging or build release
+# artifacts such as Python wheels locally.
+#
+# Guidelines:
+# - Use a flat list of options.
+#   We don't want to have a cartesian product of different combinations of
+#   options. E.g., to support Ubuntu {18.04, 20.04} with Python {3.7, 3.8}, we
+#   don't specify the OS and Python version separately, instead, we have a flat
+#   list of combinations: [u1804_py37, u1804_py38, u2004_py37, u2004_py38].
+# - No external environment variables.
+#   This script should not make assumptions on external environment variables.
+#   This make the Docker image reproducible across different machines.
+set -euo pipefail
+
+__usage="USAGE:
+    $(basename $0) [OPTION]
+
+OPTION:
+    openblas_x86_64    : Build OpenBLAS x86_64 with Python wheel
+    openblas_arm64     : Build OpenBLAS ARM64 with Python wheel
+    cuda_wheel_py36_dev: Build CUDA Python 3.6 wheel, developer mode
+    cuda_wheel_py37_dev: Build CUDA Python 3.7 wheel, developer mode
+    cuda_wheel_py38_dev: Build CUDA Python 3.8 wheel, developer mode
+    cuda_wheel_py39_dev: Build CUDA Python 3.9 wheel, developer mode
+    cuda_wheel_py36    : Build CUDA Python 3.6 wheel, release mode
+    cuda_wheel_py37    : Build CUDA Python 3.7 wheel, release mode
+    cuda_wheel_py38    : Build CUDA Python 3.8 wheel, release mode
+    cuda_wheel_py39    : Build CUDA Python 3.9 wheel, release mode
+"
+
+OPEN3D_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. >/dev/null 2>&1 && pwd)"
+
+print_usage_and_exit() {
+    echo "$__usage"
+    exit 1
+}
+
+openblas() {
+    options="$(echo "$@" | tr ' ' '|')"
+    echo "[openblas()] options: ${options}"
+    if [[ "x86_64" =~ ^($options)$ ]]; then
+        BASE_IMAGE=ubuntu:20.04
+        CMAKE_VER=cmake-3.19.7-Linux-x86_64
+        CCACHE_TAR_NAME=open3d-x86_64-ci-ccache
+    elif [[ "arm64" =~ ^($options)$ ]]; then
+        BASE_IMAGE=arm64v8/ubuntu:20.04
+        CMAKE_VER=cmake-3.19.7-Linux-aarch64
+        CCACHE_TAR_NAME=open3d-arm64-ci-ccache
+        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+    else
+        echo "Invalid architecture."
+        print_usage_and_exit
+    fi
+    echo "[cuda_wheel()] BASE_IMAGE: ${BASE_IMAGE}"
+    echo "[cuda_wheel()] CMAKE_VER: ${CMAKE_VER}"
+    echo "[cuda_wheel()] CCACHE_TAR_NAME: ${CCACHE_TAR_NAME}"
+
+    # Docker build
+    pushd ${OPEN3D_ROOT}
+    docker build --build-arg BASE_IMAGE=${BASE_IMAGE} \
+                 --build-arg CMAKE_VER=${CMAKE_VER} \
+                 --build-arg CCACHE_TAR_NAME=${CCACHE_TAR_NAME} \
+                 -t open3d-openblas-ci:latest \
+                 -f .github/workflows/Dockerfile.openblas .
+    popd
+
+    # Extract ccache
+    docker run -v ${PWD}:/opt/mount --rm open3d-openblas-ci:latest \
+        cp /${CCACHE_TAR_NAME}.tar.gz /opt/mount
+    sudo chown $(id -u):$(id -g) ${CCACHE_TAR_NAME}.tar.gz
+}
+
+cuda_wheel() {
+    BASE_IMAGE=nvidia/cuda:11.0.3-cudnn8-devel-ubuntu18.04
+    CCACHE_TAR_NAME=open3d-ubuntu-1804-cuda-ci-ccache
+    CMAKE_VERSION=cmake-3.19.7-Linux-x86_64
+    CCACHE_VERSION=4.3
+
+    options="$(echo "$@" | tr ' ' '|')"
+    echo "[cuda_wheel()] options: ${options}"
+    if [[ "py36" =~ ^($options)$ ]]; then
+        PYTHON_VERSION=3.6
+    elif [[ "py37" =~ ^($options)$ ]]; then
+        PYTHON_VERSION=3.7
+    elif [[ "py38" =~ ^($options)$ ]]; then
+        PYTHON_VERSION=3.8
+    elif [[ "py39" =~ ^($options)$ ]]; then
+        PYTHON_VERSION=3.9
+    else
+        echo "Invalid python version."
+        print_usage_and_exit
+    fi
+    if [[ "dev" =~ ^($options)$ ]]; then
+        DEVELOPER_BUILD=ON
+    else
+        DEVELOPER_BUILD=OFF
+    fi
+    echo "[cuda_wheel()] PYTHON_VERSION: ${PYTHON_VERSION}"
+    echo "[cuda_wheel()] DEVELOPER_BUILD: ${DEVELOPER_BUILD}"
+
+    # Docker build
+    pushd ${OPEN3D_ROOT}
+    docker build \
+        --build-arg BASE_IMAGE=${BASE_IMAGE} \
+        --build-arg DEVELOPER_BUILD=${DEVELOPER_BUILD} \
+        --build-arg CCACHE_TAR_NAME=${CCACHE_TAR_NAME} \
+        --build-arg CMAKE_VERSION=${CMAKE_VERSION} \
+        --build-arg CCACHE_VERSION=${CCACHE_VERSION} \
+        --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
+        -t open3d-ubuntu-cuda-ci:latest \
+        -f .github/workflows/Dockerfile.ubuntu-cuda .
+    popd
+
+    # Extract pip wheel, conda package, ccache
+    python_package_dir=/root/Open3D/build/lib/python_package
+    docker run -v ${PWD}:/opt/mount --rm open3d-ubuntu-cuda-ci:latest \
+        bash -c "cp ${python_package_dir}/pip_package/open3d*.whl                /opt/mount && \
+                 cp ${python_package_dir}/conda_package/linux-64/open3d*.tar.bz2 /opt/mount && \
+                 cp /${CCACHE_TAR_NAME}.tar.gz                                   /opt/mount"
+    sudo chown $(id -u):$(id -g) open3d*.whl
+    sudo chown $(id -u):$(id -g) open3d*.tar.bz2
+    sudo chown $(id -u):$(id -g) ${CCACHE_TAR_NAME}.tar.gz
+}
+
+if [[ "$#" -ne 1 ]]; then
+    echo "Error: invalid number of arguments." >&2
+    print_usage_and_exit
+fi
+echo "[$(basename $0)] building $1"
+case "$1" in
+    openblas_x86_64)
+        openblas x86_64
+        ;;
+    openblas_arm64)
+        openblas arm64
+        ;;
+    cuda_wheel_py36_dev)
+        cuda_wheel py36 dev
+        ;;
+    cuda_wheel_py37_dev)
+        cuda_wheel py37 dev
+        ;;
+    cuda_wheel_py38_dev)
+        cuda_wheel py38 dev
+        ;;
+    cuda_wheel_py39_dev)
+        cuda_wheel py39 dev
+        ;;
+    cuda_wheel_py36)
+        cuda_wheel py36
+        ;;
+    cuda_wheel_py37)
+        cuda_wheel py37
+        ;;
+    cuda_wheel_py38)
+        cuda_wheel py38
+        ;;
+    cuda_wheel_py39)
+        cuda_wheel py39
+        ;;
+    *)
+        echo "Error: invalid argument: ${1}." >&2
+        print_usage_and_exit
+        ;;
+esac

--- a/.github/workflows/docker_build.sh
+++ b/.github/workflows/docker_build.sh
@@ -20,8 +20,8 @@ __usage="USAGE:
     $(basename $0) [OPTION]
 
 OPTION:
-    openblas_x86_64    : Build OpenBLAS x86_64 with Python wheel
-    openblas_arm64     : Build OpenBLAS ARM64 with Python wheel
+    openblas_x86_64    : Build with OpenBLAS x86_64
+    openblas_arm64     : Build with OpenBLAS ARM64
     cuda_wheel_py36_dev: Build CUDA Python 3.6 wheel, developer mode
     cuda_wheel_py37_dev: Build CUDA Python 3.7 wheel, developer mode
     cuda_wheel_py38_dev: Build CUDA Python 3.8 wheel, developer mode

--- a/.github/workflows/openblas.yml
+++ b/.github/workflows/openblas.yml
@@ -1,6 +1,3 @@
-# Minium test for Open3D with OpenBLAS/LAPACK on both x86_64 and aarch64.
-# This test is intentionally kept minimal and self-contained.
-
 name: Ubuntu OpenBLAS CI
 
 on:
@@ -19,10 +16,6 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
-    env:
-      BASE_IMAGE: ubuntu:20.04
-      CMAKE_VER: cmake-3.19.7-Linux-x86_64
-      CCACHE_TAR_NAME: open3d-x86_64-ci-ccache
     steps:
       - name: Cancel outdated
         uses: fkirc/skip-duplicate-actions@master
@@ -41,11 +34,7 @@ jobs:
 
       - name: Docker build
         run: |
-          docker build --build-arg BASE_IMAGE=${{ env.BASE_IMAGE }} \
-                       --build-arg CMAKE_VER=${{ env.CMAKE_VER }} \
-                       --build-arg CCACHE_TAR_NAME=${{ env.CCACHE_TAR_NAME }} \
-                       -t open3d-openblas-ci:latest \
-                       -f .github/workflows/Dockerfile.openblas .
+          .github/workflows/docker_build.sh openblas_x86_64
 
       - name: C++ tests
         run: |
@@ -54,15 +43,9 @@ jobs:
       - name: Python tests
         run: |
           docker run --rm open3d-openblas-ci:latest \
-            pytest python/test/ --ignore python/test/ml_ops/ --ignore python/test/t/io/test_realsense.py
-
-      # https://stackoverflow.com/a/49357803/1255535
-      - name: Copy ccache out from the container
-        run: |
-          docker run -v ${GITHUB_WORKSPACE}:/opt/mount \
-            --rm --entrypoint \
-            cp open3d-openblas-ci:latest /${{ env.CCACHE_TAR_NAME }}.tar.gz /opt/mount/${{ env.CCACHE_TAR_NAME }}.tar.gz
-          sudo chown $(id -u):$(id -g) ${{ env.CCACHE_TAR_NAME }}.tar.gz
+            pytest python/test/ \
+            --ignore python/test/ml_ops/ \
+            --ignore python/test/t/io/test_realsense.py
 
       - name: GCloud CLI setup
         uses: google-github-actions/setup-gcloud@master
@@ -74,17 +57,24 @@ jobs:
 
       - name: Upload ccache to GCS
         run: |
-          gsutil cp ${GITHUB_WORKSPACE}/${{ env.CCACHE_TAR_NAME }}.tar.gz gs://open3d-ci-cache/ || true
+          gsutil cp ${GITHUB_WORKSPACE}/open3d-x86_64-ci-ccache.tar.gz gs://open3d-ci-cache/ || true
 
 
+  # How to resolve GitHub Actions ARM64 build timeout.
+  #
+  # When there are large amount of code change (e.g. changed some headers that
+  # causes re-compilation of many files), the GitHub Actions build could timeout
+  # due to excessive ccache misses. The solution is to build the branch manually
+  # and update the ccache artifacts on the Google Cloud bucket. Run:
+  #
+  # ```bash
+  # .github/workflows/docker_build.sh openblas_arm64
+  # gsutil cp open3d-arm64-ci-ccache.tar.gz gs://open3d-ci-cache/
+  # ```
   openblas_arm64:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
-    env:
-      BASE_IMAGE: arm64v8/ubuntu:20.04
-      CMAKE_VER: cmake-3.19.7-Linux-aarch64
-      CCACHE_TAR_NAME: open3d-arm64-ci-ccache
     steps:
       - name: Cancel outdated
         uses: fkirc/skip-duplicate-actions@master
@@ -102,19 +92,14 @@ jobs:
           maximize_ubuntu_github_actions_build_space
 
       # https://www.stereolabs.com/docs/docker/building-arm-container-on-x86/
-      - name: Setup Docker with QEMU
+      - name: Install QEMU dependencies
         run: |
           sudo apt-get update
           sudo apt-get --yes install qemu binfmt-support qemu-user-static
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
       - name: Docker build
         run: |
-          docker build --build-arg BASE_IMAGE=${{ env.BASE_IMAGE }} \
-                       --build-arg CMAKE_VER=${{ env.CMAKE_VER }} \
-                       --build-arg CCACHE_TAR_NAME=${{ env.CCACHE_TAR_NAME }} \
-                       -t open3d-openblas-ci:latest \
-                       -f .github/workflows/Dockerfile.openblas .
+          .github/workflows/docker_build.sh openblas_arm64
 
       - name: C++ tests
         run: |
@@ -123,15 +108,9 @@ jobs:
       - name: Python tests
         run: |
           docker run --rm open3d-openblas-ci:latest \
-            pytest python/test/ --ignore python/test/ml_ops/ --ignore python/test/t/io/test_realsense.py
-
-      # https://stackoverflow.com/a/49357803/1255535
-      - name: Copy ccache out from the container
-        run: |
-          docker run -v ${GITHUB_WORKSPACE}:/opt/mount \
-            --rm --entrypoint \
-            cp open3d-openblas-ci:latest /${{ env.CCACHE_TAR_NAME }}.tar.gz /opt/mount/${{ env.CCACHE_TAR_NAME }}.tar.gz
-          sudo chown $(id -u):$(id -g) ${{ env.CCACHE_TAR_NAME }}.tar.gz
+            pytest python/test/ \
+            --ignore python/test/ml_ops/ \
+            --ignore python/test/t/io/test_realsense.py
 
       - name: GCloud CLI setup
         uses: google-github-actions/setup-gcloud@master
@@ -143,4 +122,4 @@ jobs:
 
       - name: Upload ccache to GCS
         run: |
-          gsutil cp ${GITHUB_WORKSPACE}/${{ env.CCACHE_TAR_NAME }}.tar.gz gs://open3d-ci-cache/ || true
+          gsutil cp ${GITHUB_WORKSPACE}/open3d-arm64-ci-ccache.tar.gz gs://open3d-ci-cache/ || true

--- a/.github/workflows/ubuntu-cuda.yml
+++ b/.github/workflows/ubuntu-cuda.yml
@@ -79,6 +79,7 @@ jobs:
             ${{ env.CONDA_PKG_NAME }}
           if-no-files-found: error
       - name: GCloud CLI setup (GCE_SA_KEY_DOCS_CI)
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: google-github-actions/setup-gcloud@master
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
@@ -86,9 +87,11 @@ jobs:
           project_id: ${{ secrets.GCE_DOCS_PROJECT }}
           export_default_credentials: true
       - name: Upload ccache to GCS
+        if: ${{ github.ref == 'refs/heads/master' }}
         run: |
           gsutil cp ${GITHUB_WORKSPACE}/${{ env.CCACHE_TAR_NAME }}.tar.gz gs://open3d-ci-cache/
       - name: GCloud CLI setup (GCE_SA_KEY_GPU_CI)
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: google-github-actions/setup-gcloud@master
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
@@ -96,6 +99,7 @@ jobs:
           project_id: ${{ secrets.GCE_DOCS_PROJECT }}
           export_default_credentials: true
       - name: Upload wheel to GCS
+        if: ${{ github.ref == 'refs/heads/master' }}
         run: |
           gsutil cp ${GITHUB_WORKSPACE}/${{ env.PIP_PKG_NAME }} gs://open3d-releases-master/python-wheels/
           echo "Download pip package at: https://storage.googleapis.com/open3d-releases-master/python-wheels/${{ env.PIP_PKG_NAME }}"

--- a/.github/workflows/ubuntu-cuda.yml
+++ b/.github/workflows/ubuntu-cuda.yml
@@ -31,16 +31,9 @@ jobs:
           - is_master: false
             python_version: 3.9
     env:
-      # Environment variables are used as Docker build args.
-      # - Keep the default values consistent with Dockerfile.cuda
-      # - Keep the usage orders consistent.
-      BASE_IMAGE: nvidia/cuda:11.0.3-cudnn8-devel-ubuntu18.04
-      DEVELOPER_BUILD: ${{ github.event.inputs.developer_build }}
-      BUILD_COMMON_CUDA_ARCHS: ${{ matrix.is_master && 'ON' || 'OFF' }}
-      CCACHE_TAR_NAME: open3d-ubuntu-1804-cuda-ci-ccache
-      CMAKE_VERSION: cmake-3.19.7-Linux-x86_64
-      CCACHE_VERSION: 4.3
+      DEVELOPER_BUILD: ${{ github.event.inputs.developer_build || 'ON' }}
       PYTHON_VERSION: ${{ matrix.python_version }}
+      CCACHE_TAR_NAME: open3d-ubuntu-1804-cuda-ci-ccache
     steps:
       - name: Cancel outdated
         uses: fkirc/skip-duplicate-actions@master
@@ -56,41 +49,36 @@ jobs:
           maximize_ubuntu_github_actions_build_space
       - name: Docker build
         run: |
-          docker build \
-            --build-arg BASE_IMAGE=${{ env.BASE_IMAGE }} \
-            --build-arg DEVELOPER_BUILD=${{ env.DEVELOPER_BUILD }} \
-            --build-arg BUILD_COMMON_CUDA_ARCHS=${{ env.BUILD_COMMON_CUDA_ARCHS }} \
-            --build-arg CCACHE_TAR_NAME=${{ env.CCACHE_TAR_NAME }} \
-            --build-arg CMAKE_VERSION=${{ env.CMAKE_VERSION }} \
-            --build-arg CCACHE_VERSION=${{ env.CCACHE_VERSION }} \
-            --build-arg PYTHON_VERSION=${{ env.PYTHON_VERSION }} \
-            -t open3d-ubuntu-cuda-ci:latest \
-            -f .github/workflows/Dockerfile.ubuntu-cuda .
-      - name: Extract wheel from Docker
-        run: |
-          mkdir -p ${GITHUB_WORKSPACE}/artifacts
-          docker run --rm \
-            -v ${GITHUB_WORKSPACE}/artifacts:/opt/mount \
-            open3d-ubuntu-cuda-ci:latest \
-            bash -c "cp /root/Open3D/build/lib/python_package/pip_package/open3d*.whl                /opt/mount && \
-                     cp /root/Open3D/build/lib/python_package/conda_package/linux-64/open3d*.tar.bz2 /opt/mount && \
-                     cp /${{ env.CCACHE_TAR_NAME }}.tar.gz                                           /opt/mount"
-          sudo chown -R $(id -u):$(id -g) ${GITHUB_WORKSPACE}/artifacts
-          ls -alh ${GITHUB_WORKSPACE}/artifacts
-          PIP_PKG_NAME="$(basename ${GITHUB_WORKSPACE}/artifacts/open3d*.whl)"
+          if   [ "${{ env.PYTHON_VERSION }}" = "3.6" ] && [ "${{ env.DEVELOPER_BUILD }}" = "ON"  ]; then
+            .github/workflows/docker_build.sh cuda_wheel_py36_dev
+          elif [ "${{ env.PYTHON_VERSION }}" = "3.7" ] && [ "${{ env.DEVELOPER_BUILD }}" = "ON"  ]; then
+            .github/workflows/docker_build.sh cuda_wheel_py37_dev
+          elif [ "${{ env.PYTHON_VERSION }}" = "3.8" ] && [ "${{ env.DEVELOPER_BUILD }}" = "ON"  ]; then
+            .github/workflows/docker_build.sh cuda_wheel_py38_dev
+          elif [ "${{ env.PYTHON_VERSION }}" = "3.9" ] && [ "${{ env.DEVELOPER_BUILD }}" = "ON"  ]; then
+            .github/workflows/docker_build.sh cuda_wheel_py39_dev
+          elif [ "${{ env.PYTHON_VERSION }}" = "3.6" ] && [ "${{ env.DEVELOPER_BUILD }}" = "OFF" ]; then
+            .github/workflows/docker_build.sh cuda_wheel_py36
+          elif [ "${{ env.PYTHON_VERSION }}" = "3.7" ] && [ "${{ env.DEVELOPER_BUILD }}" = "OFF" ]; then
+            .github/workflows/docker_build.sh cuda_wheel_py37
+          elif [ "${{ env.PYTHON_VERSION }}" = "3.8" ] && [ "${{ env.DEVELOPER_BUILD }}" = "OFF" ]; then
+            .github/workflows/docker_build.sh cuda_wheel_py38
+          elif [ "${{ env.PYTHON_VERSION }}" = "3.9" ] && [ "${{ env.DEVELOPER_BUILD }}" = "OFF" ]; then
+            .github/workflows/docker_build.sh cuda_wheel_py39
+          fi
+          PIP_PKG_NAME="$(basename ${GITHUB_WORKSPACE}/open3d*.whl)"
+          CONDA_PKG_NAME="$(basename ${GITHUB_WORKSPACE}/open3d*.tar.bz2)"
           echo "PIP_PKG_NAME=$PIP_PKG_NAME" >> $GITHUB_ENV
-          CONDA_PKG_NAME="$(basename ${GITHUB_WORKSPACE}/artifacts/open3d*.tar.bz2)"
           echo "CONDA_PKG_NAME=$CONDA_PKG_NAME" >> $GITHUB_ENV
       - name: Upload wheel to GitHub artifacts
         uses: actions/upload-artifact@v2
         with:
           name: open3d_linux_x86_64_wheels
           path: |
-            artifacts/${{ env.PIP_PKG_NAME }}
-            artifacts/${{ env.CONDA_PKG_NAME }}
+            ${{ env.PIP_PKG_NAME }}
+            ${{ env.CONDA_PKG_NAME }}
           if-no-files-found: error
       - name: GCloud CLI setup (GCE_SA_KEY_DOCS_CI)
-        if: ${{ github.ref == 'refs/heads/master' }}
         uses: google-github-actions/setup-gcloud@master
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
@@ -98,11 +86,9 @@ jobs:
           project_id: ${{ secrets.GCE_DOCS_PROJECT }}
           export_default_credentials: true
       - name: Upload ccache to GCS
-        if: ${{ github.ref == 'refs/heads/master' }}
         run: |
-          gsutil cp ${GITHUB_WORKSPACE}/artifacts/${{ env.CCACHE_TAR_NAME }}.tar.gz gs://open3d-ci-cache/
+          gsutil cp ${GITHUB_WORKSPACE}/${{ env.CCACHE_TAR_NAME }}.tar.gz gs://open3d-ci-cache/
       - name: GCloud CLI setup (GCE_SA_KEY_GPU_CI)
-        if: ${{ github.ref == 'refs/heads/master' }}
         uses: google-github-actions/setup-gcloud@master
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
@@ -110,11 +96,10 @@ jobs:
           project_id: ${{ secrets.GCE_DOCS_PROJECT }}
           export_default_credentials: true
       - name: Upload wheel to GCS
-        if: ${{ github.ref == 'refs/heads/master' }}
         run: |
-          gsutil cp ${GITHUB_WORKSPACE}/artifacts/${{ env.PIP_PKG_NAME }} gs://open3d-releases-master/python-wheels/
+          gsutil cp ${GITHUB_WORKSPACE}/${{ env.PIP_PKG_NAME }} gs://open3d-releases-master/python-wheels/
           echo "Download pip package at: https://storage.googleapis.com/open3d-releases-master/python-wheels/${{ env.PIP_PKG_NAME }}"
-          gsutil cp ${GITHUB_WORKSPACE}/artifacts/${{ env.CONDA_PKG_NAME }} gs://open3d-releases-master/conda_package/linux-64/
+          gsutil cp ${GITHUB_WORKSPACE}/${{ env.CONDA_PKG_NAME }} gs://open3d-releases-master/conda_package/linux-64/
           echo "Download conda package at: https://storage.googleapis.com/open3d-releases-master/conda_package/linux-64/${{ env.CONDA_PKG_NAME }}"
 
   test-wheel-cpu:

--- a/.github/workflows/ubuntu-cuda.yml
+++ b/.github/workflows/ubuntu-cuda.yml
@@ -47,6 +47,8 @@ jobs:
         run: |
           source util/ci_utils.sh
           maximize_ubuntu_github_actions_build_space
+      # Be verbose and explicit here such that a developer can directly copy the
+      # `.github/workflows/docker_build.sh xxx` command to execute locally.
       - name: Docker build
         run: |
           if   [ "${{ env.PYTHON_VERSION }}" = "3.6" ] && [ "${{ env.DEVELOPER_BUILD }}" = "ON"  ]; then

--- a/util/ci_utils.sh
+++ b/util/ci_utils.sh
@@ -14,7 +14,6 @@ if [ -z "${BUILD_CUDA_MODULE:+x}" ]; then
         BUILD_CUDA_MODULE=OFF
     fi
 fi
-BUILD_COMMON_CUDA_ARCHS=${BUILD_COMMON_CUDA_ARCHS:-OFF}
 BUILD_TENSORFLOW_OPS=${BUILD_TENSORFLOW_OPS:-ON}
 BUILD_PYTORCH_OPS=${BUILD_PYTORCH_OPS:-ON}
 if [[ "$OSTYPE" == "linux-gnu"* ]] && [ "$BUILD_CUDA_MODULE" == OFF ]; then
@@ -225,7 +224,7 @@ build_all() {
         -DCMAKE_BUILD_TYPE=Release
         -DBUILD_LIBREALSENSE=ON
         -DBUILD_CUDA_MODULE="$BUILD_CUDA_MODULE"
-        -DBUILD_COMMON_CUDA_ARCHS=OFF
+        -DBUILD_COMMON_CUDA_ARCHS=ON
         -DBUILD_TENSORFLOW_OPS="$BUILD_TENSORFLOW_OPS"
         -DBUILD_PYTORCH_OPS="$BUILD_PYTORCH_OPS"
         -DCMAKE_INSTALL_PREFIX="$OPEN3D_INSTALL_DIR"
@@ -322,7 +321,8 @@ build_pip_conda_package() {
         rm -r "${rebuild_list[@]}" || true
         set -x # Echo commands on
         cmake -DBUILD_CUDA_MODULE=ON \
-            -DBUILD_COMMON_CUDA_ARCHS="${BUILD_COMMON_CUDA_ARCHS}" "${cmakeOptions[@]}" ..
+              -DBUILD_COMMON_CUDA_ARCHS=ON \
+              "${cmakeOptions[@]}" ..
         set +x # Echo commands off
     fi
     echo


### PR DESCRIPTION
`docker_build.sh` is used to build Open3D docker images for all supported scenarios. This can be used in CI and on local machines. The objective is to allow developers to emulate CI environments for debugging or build release artifacts such as Python wheels locally.

### Example usage
```bash
./docker_build.sh openblas_arm64
./docker_build.sh cuda_wheel_py36_dev
```

### Design decisions
- Use a flat list of options.
  We don't want to have a cartesian product of different combinations of options. E.g., to support Ubuntu {18.04, 20.04} with Python {3.7, 3.8}, we don't specify the OS and Python version separately, instead, we have a flat list of combinations: [u1804_py37, u1804_py38, u2004_py37, u2004_py38].
- No external environment variables.
  This script should not make assumptions on external environment variables. This make the Docker image reproducible across different machines.

### Other changes
`BUILD_COMMON_CUDA_ARCHS=ON` for CI, always. With ccache, the time gap between the two cases is not significant. Setting it to `ON` reduces the combination of cases that we need to take care of.

E.g. in #4008
- `BUILD_COMMON_CUDA_ARCHS=OFF` (in PR): 58m 25s (https://github.com/isl-org/Open3D/runs/3488679056)
- `BUILD_COMMON_CUDA_ARCHS=ON`(in master): 1h 1m 5s (https://github.com/isl-org/Open3D/runs/3490723783)

### Next
`docker_build.sh` can be used to build Dcoker images on Github Actions for GPU CI (merging with `gce-ubuntu-docker.yml`). Hopefully this will give us a more stable GPU CI.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4009)
<!-- Reviewable:end -->
