### PR TITLE
CI utils stop on error

### DIFF
--- a/util/ci_utils.sh
+++ b/util/ci_utils.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # The following environment variables are required:
 SUDO=${SUDO:=sudo}


### PR DESCRIPTION
I found that the Docker build (which uses `util/ci_utils.sh`'s `build_pip_conda_package`) continues even if there are errors. 

`set -euo pipefail` let the build stop immediately when the error occurs during `build_pip_conda_package`.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4010)
<!-- Reviewable:end -->
