### PR TITLE
Default AABB and OBB color to white instead of black

### DIFF
--- a/cpp/open3d/geometry/BoundingVolume.cpp
+++ b/cpp/open3d/geometry/BoundingVolume.cpp
@@ -41,8 +41,9 @@ OrientedBoundingBox& OrientedBoundingBox::Clear() {
     center_.setZero();
     extent_.setZero();
     R_ = Eigen::Matrix3d::Identity();
-    color_.setZero();
+    color_.setOnes();
     return *this;
+
 }
 
 bool OrientedBoundingBox::IsEmpty() const { return Volume() <= 0; }

--- a/cpp/open3d/geometry/BoundingVolume.h
+++ b/cpp/open3d/geometry/BoundingVolume.h
@@ -51,7 +51,7 @@ public:
           center_(0, 0, 0),
           R_(Eigen::Matrix3d::Identity()),
           extent_(0, 0, 0),
-          color_(0, 0, 0) {}
+          color_(1, 1, 1) {}
     /// \brief Parameterized constructor.
     ///
     /// \param center Specifies the center position of the bounding box.
@@ -156,7 +156,7 @@ public:
         : Geometry3D(Geometry::GeometryType::AxisAlignedBoundingBox),
           min_bound_(0, 0, 0),
           max_bound_(0, 0, 0),
-          color_(0, 0, 0) {}
+          color_(1, 1, 1) {}
     /// \brief Parameterized constructor.
     ///
     /// \param min_bound Lower bounds of the bounding box for all axes.
@@ -166,7 +166,7 @@ public:
         : Geometry3D(Geometry::GeometryType::AxisAlignedBoundingBox),
           min_bound_(min_bound),
           max_bound_(max_bound),
-          color_(0, 0, 0) {}
+          color_(1, 1, 1) {}
     ~AxisAlignedBoundingBox() override {}
 
 public:


### PR DESCRIPTION
Legacy OBB and AABB volumes default to black for color. When converting OBB and AABB to LineSets to use with new visualizer this results in black per-vertex colors which makes it impossible to specify a color since (per-vertex black * any color) = black. This PR changes the default to white which will work with the new visualizer more sensibly.