### PR TITLE
Add vectorized ParallelFor function and helper macros

### DIFF
--- a/cmake/Open3DISPC.cmake
+++ b/cmake/Open3DISPC.cmake
@@ -321,12 +321,7 @@ function(open3d_ispc_make_build_rules_ target)
 
         # Add files to ISPC_OBJECTS property.
         # This will later be used to resolve library.
-        get_target_property(TARGET_ISPC_OBJECTS ${target} ISPC_OBJECTS)
-        if (NOT TARGET_ISPC_OBJECTS)
-            set(TARGET_ISPC_OBJECTS "")
-        endif()
-        list(APPEND TARGET_ISPC_OBJECTS ${TARGET_OBJECT_FILES})
-        set_target_properties(${target} PROPERTIES ISPC_OBJECTS "${TARGET_ISPC_OBJECTS}")
+        set_property(TARGET ${target} APPEND PROPERTY ISPC_OBJECTS "${TARGET_OBJECT_FILES}")
     endif()
 endfunction()
 
@@ -522,7 +517,7 @@ function(open3d_ispc_target_sources target)
             endif()
         endforeach()
 
-        set_target_properties(${target} PROPERTIES ISPC_SOURCES "${TARGET_ISPC_SOURCES}")
+        set_property(TARGET ${target} APPEND PROPERTY ISPC_SOURCES "${TARGET_ISPC_SOURCES}")
     endif()
 endfunction()
 

--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(benchmarks)
+open3d_ispc_add_executable(benchmarks)
 
 add_subdirectory(core)
 add_subdirectory(geometry)

--- a/cpp/benchmarks/core/CMakeLists.txt
+++ b/cpp/benchmarks/core/CMakeLists.txt
@@ -1,6 +1,13 @@
 target_sources(benchmarks PRIVATE
     HashMap.cpp
     MemoryManager.cpp
+    ParallelFor.cpp
     Reduction.cpp
     Zeros.cpp
 )
+
+if (BUILD_ISPC_MODULE)
+    open3d_ispc_target_sources(benchmarks PRIVATE
+        ParallelFor.ispc
+    )
+endif()

--- a/cpp/benchmarks/core/ParallelFor.cpp
+++ b/cpp/benchmarks/core/ParallelFor.cpp
@@ -1,0 +1,108 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "open3d/core/ParallelFor.h"
+
+#include <benchmark/benchmark.h>
+
+#include <vector>
+
+#ifdef BUILD_ISPC_MODULE
+#include "ParallelFor_ispc.h"
+#endif
+
+namespace open3d {
+namespace core {
+
+void ParallelForScalar(benchmark::State& state, int size) {
+    std::vector<float> input(size);
+    std::vector<float> output(size);
+    std::iota(input.begin(), input.end(), 0.0f);
+
+    // Warmup.
+    {
+        core::ParallelFor(core::Device("CPU:0"), size, [&](int64_t idx) {
+            float x = input[idx];
+            float x2 = x * x;
+            output[idx] = x2;
+        });
+    }
+
+    for (auto _ : state) {
+        core::ParallelFor(core::Device("CPU:0"), size, [&](int64_t idx) {
+            float x = input[idx];
+            float x2 = x * x;
+            output[idx] = x2;
+        });
+    }
+}
+
+void ParallelForVectorized(benchmark::State& state, int size) {
+    std::vector<float> input(size);
+    std::vector<float> output(size);
+    std::iota(input.begin(), input.end(), 0.0f);
+
+    // Warmup.
+    {
+        core::ParallelFor(
+                core::Device("CPU:0"), size,
+                [&](int64_t idx) {
+                    float x = input[idx];
+                    float x2 = x * x;
+                    output[idx] = x2;
+                },
+                OPEN3D_VECTORIZED(SquareKernel, input.data(), output.data()));
+    }
+
+    for (auto _ : state) {
+        core::ParallelFor(
+                core::Device("CPU:0"), size,
+                [&](int64_t idx) {
+                    float x = input[idx];
+                    float x2 = x * x;
+                    output[idx] = x2;
+                },
+                OPEN3D_VECTORIZED(SquareKernel, input.data(), output.data()));
+    }
+}
+
+#define ENUM_BM_SIZE(FN)                                                       \
+    BENCHMARK_CAPTURE(FN, CPU##100, 100)->Unit(benchmark::kMicrosecond);       \
+    BENCHMARK_CAPTURE(FN, CPU##1000, 1000)->Unit(benchmark::kMicrosecond);     \
+    BENCHMARK_CAPTURE(FN, CPU##10000, 10000)->Unit(benchmark::kMicrosecond);   \
+    BENCHMARK_CAPTURE(FN, CPU##100000, 100000)->Unit(benchmark::kMicrosecond); \
+    BENCHMARK_CAPTURE(FN, CPU##1000000, 1000000)                               \
+            ->Unit(benchmark::kMicrosecond);                                   \
+    BENCHMARK_CAPTURE(FN, CPU##10000000, 10000000)                             \
+            ->Unit(benchmark::kMicrosecond);                                   \
+    BENCHMARK_CAPTURE(FN, CPU##100000000, 100000000)                           \
+            ->Unit(benchmark::kMicrosecond);
+
+ENUM_BM_SIZE(ParallelForScalar)
+ENUM_BM_SIZE(ParallelForVectorized)
+
+}  // namespace core
+}  // namespace open3d

--- a/cpp/benchmarks/core/ParallelFor.ispc
+++ b/cpp/benchmarks/core/ParallelFor.ispc
@@ -23,30 +23,15 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
-// Copyright 2018 Google Inc. All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
-#include <benchmark/benchmark.h>
+#include "open3d/core/ParallelFor.isph"
 
-#include "open3d/Open3D.h"
-
-int main(int argc, char** argv) {
-    open3d::utility::CPUInfo::GetInstance().Print();
-    open3d::utility::ISAInfo::GetInstance().Print();
-    benchmark::Initialize(&argc, argv);
-    if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-        return 1;
-    }
-    benchmark::RunSpecifiedBenchmarks();
+static inline void Square(int64_t idx,
+                          float* uniform input,
+                          float* uniform output) {
+    float x = input[idx];
+    float x2 = x * x;
+    output[idx] = x2;
 }
+
+OPEN3D_EXPORT_VECTORIZED(SquareKernel, Square, float* uniform, float* uniform)

--- a/cpp/open3d/Macro.h
+++ b/cpp/open3d/Macro.h
@@ -28,9 +28,6 @@
 
 #include <cassert>
 
-#define OPEN3D_CONCAT_IMPL(s1, s2) s1##s2
-#define OPEN3D_CONCAT(s1, s2) OPEN3D_CONCAT_IMPL(s1, s2)
-
 // https://gcc.gnu.org/wiki/Visibility updated to use C++11 attribute syntax
 #if defined(_WIN32) || defined(__CYGWIN__)
 #define OPEN3D_DLL_IMPORT __declspec(dllimport)

--- a/cpp/open3d/core/ParallelFor.h
+++ b/cpp/open3d/core/ParallelFor.h
@@ -27,11 +27,13 @@
 #pragma once
 
 #include <cstdint>
-#include <vector>
+#include <type_traits>
 
 #include "open3d/core/Device.h"
 #include "open3d/utility/Logging.h"
+#include "open3d/utility/Overload.h"
 #include "open3d/utility/Parallel.h"
+#include "open3d/utility/Preprocessor.h"
 
 #ifdef __CUDACC__
 #include <cuda.h>
@@ -50,7 +52,7 @@ static constexpr int64_t OPEN3D_PARFOR_THREAD = 4;
 
 /// Calls f(n) with the "grid-stride loops" pattern.
 template <int64_t block_size, int64_t thread_size, typename func_t>
-__global__ void __ElementWiseKernel(int64_t n, func_t f) {
+__global__ void ElementWiseKernel_(int64_t n, func_t f) {
     int64_t items_per_block = block_size * thread_size;
     int64_t idx = blockIdx.x * items_per_block + threadIdx.x;
 #pragma unroll
@@ -62,20 +64,9 @@ __global__ void __ElementWiseKernel(int64_t n, func_t f) {
     }
 }
 
-/// Run a function in parallel with CUDA.
-///
-/// \param device The device for the ParallelFor to run on.
-/// \param n The number of workloads.
-/// \param func The function to be executed in parallel. The function should
-/// take an int64_t workload index and returns void, i.e., `void func(int64_t)`.
-///
-/// \note This is optimized for uniform work items, i.e. where each call to \p
-/// func takes the same time.
-/// \note If you use a lambda function, capture only the required variables
-/// instead of all to prevent accidental race conditions. If you want the
-/// kernel to be used on both CPU and CUDA, capture the variables by value.
+/// Run a function in parallel on CUDA.
 template <typename func_t>
-void ParallelFor(const Device& device, int64_t n, const func_t& func) {
+void ParallelForCUDA_(const Device& device, int64_t n, const func_t& func) {
     if (device.GetType() != Device::DeviceType::CUDA) {
         utility::LogError("ParallelFor for CUDA cannot run on device {}.",
                           device.ToString());
@@ -88,7 +79,7 @@ void ParallelFor(const Device& device, int64_t n, const func_t& func) {
     int64_t items_per_block = OPEN3D_PARFOR_BLOCK * OPEN3D_PARFOR_THREAD;
     int64_t grid_size = (n + items_per_block - 1) / items_per_block;
 
-    __ElementWiseKernel<OPEN3D_PARFOR_BLOCK, OPEN3D_PARFOR_THREAD>
+    ElementWiseKernel_<OPEN3D_PARFOR_BLOCK, OPEN3D_PARFOR_THREAD>
             <<<grid_size, OPEN3D_PARFOR_BLOCK, 0, core::cuda::GetStream()>>>(
                     n, func);
     OPEN3D_GET_LAST_CUDA_ERROR("ParallelFor failed.");
@@ -96,20 +87,9 @@ void ParallelFor(const Device& device, int64_t n, const func_t& func) {
 
 #else
 
-/// \brief Run a function in parallel on CPU.
-///
-/// \param device The device for the ParallelFor to run on.
-/// \param n The number of workloads.
-/// \param func The function to be executed in parallel. The function should
-/// take an int64_t workload index and returns void, i.e., `void func(int64_t)`.
-///
-/// \note This is optimized for uniform work items, i.e. where each call to \p
-/// func takes the same time.
-/// \note If you use a lambda function, capture only the required variables
-/// instead of all to prevent accidental race conditions. If you want the
-/// kernel to be used on both CPU and CUDA, capture the variables by value.
+/// Run a function in parallel on CPU.
 template <typename func_t>
-void ParallelFor(const Device& device, int64_t n, const func_t& func) {
+void ParallelForCPU_(const Device& device, int64_t n, const func_t& func) {
     if (device.GetType() != Device::DeviceType::CPU) {
         utility::LogError("ParallelFor for CPU cannot run on device {}.",
                           device.ToString());
@@ -125,6 +105,179 @@ void ParallelFor(const Device& device, int64_t n, const func_t& func) {
 }
 
 #endif
+
+/// Run a function in parallel on CPU or CUDA.
+///
+/// \param device The device for the parallel for loop to run on.
+/// \param n The number of workloads.
+/// \param func The function to be executed in parallel. The function should
+/// take an int64_t workload index and returns void, i.e., `void func(int64_t)`.
+///
+/// \note This is optimized for uniform work items, i.e. where each call to \p
+/// func takes the same time.
+/// \note If you use a lambda function, capture only the required variables
+/// instead of all to prevent accidental race conditions. If you want the
+/// kernel to be used on both CPU and CUDA, capture the variables by value.
+template <typename func_t>
+void ParallelFor(const Device& device, int64_t n, const func_t& func) {
+#ifdef __CUDACC__
+    ParallelForCUDA_(device, n, func);
+#else
+    ParallelForCPU_(device, n, func);
+#endif
+}
+
+/// Run a potentially vectorized function in parallel on CPU or CUDA.
+///
+/// \param device The device for the parallel for loop to run on.
+/// \param n The number of workloads.
+/// \param func The function to be executed in parallel. The function should
+/// take an int64_t workload index and returns void, i.e., `void func(int64_t)`.
+/// \param vec_func The vectorized function to be executed in parallel. The
+/// function should be provided using the OPEN3D_VECTORIZED macro, e.g.,
+/// `OPEN3D_VECTORIZED(MyISPCKernel, some_used_variable)`.
+///
+/// \note This is optimized for uniform work items, i.e. where each call to \p
+/// func takes the same time.
+/// \note If you use a lambda function, capture only the required variables
+/// instead of all to prevent accidental race conditions. If you want the
+/// kernel to be used on both CPU and CUDA, capture the variables by value.
+///
+/// Example:
+///
+/// \code
+/// /* MyFile.cpp */
+/// #ifdef BUILD_ISPC_MODULE
+/// #include "MyFile_ispc.h"
+/// #endif
+///
+/// std::vector<float> v(1000);
+/// float fill_value = 42.0f;
+/// core::ParallelFor(
+///         core::Device("CPU:0"),
+///         v.size(),
+///         [&](int64_t idx) { v[idx] = fill_value; },
+///         OPEN3D_VECTORIZED(MyFillKernel, v.data(), fill_value));
+///
+/// /* MyFile.ispc */
+/// #include "open3d/core/ParallelFor.isph"
+///
+/// static inline void MyFillFunction(int64_t idx,
+///                                   float* uniform v,
+///                                   uniform float fill_value) {
+///     v[idx] = fill_value;
+/// }
+///
+/// OPEN3D_EXPORT_VECTORIZED(MyFillKernel,
+///                          MyFillFunction,
+///                          float* uniform,
+///                          uniform float)
+/// \endcode
+template <typename vec_func_t, typename func_t>
+void ParallelFor(const Device& device,
+                 int64_t n,
+                 const func_t& func,
+                 const vec_func_t& vec_func) {
+#ifdef BUILD_ISPC_MODULE
+
+#ifdef __CUDACC__
+    ParallelForCUDA_(device, n, func);
+#else
+    int num_threads = utility::EstimateMaxThreads();
+    ParallelForCPU_(device, num_threads, [&](int64_t i) {
+        int64_t start = n * i / num_threads;
+        int64_t end = std::min<int64_t>(n * (i + 1) / num_threads, n);
+        vec_func(start, end);
+    });
+#endif
+
+#else
+
+#ifdef __CUDACC__
+    ParallelForCUDA_(device, n, func);
+#else
+    ParallelForCPU_(device, n, func);
+#endif
+
+#endif
+}
+
+#ifdef BUILD_ISPC_MODULE
+
+// Internal helper macro.
+#define OPEN3D_CALL_ISPC_KERNEL_(ISPCKernel, start, end, ...) \
+    using namespace ispc;                                     \
+    ISPCKernel(start, end, __VA_ARGS__);
+
+#else
+
+// Internal helper macro.
+#define OPEN3D_CALL_ISPC_KERNEL_(ISPCKernel, start, end, ...)            \
+    utility::LogError(                                                   \
+            "ISPC module disabled. Unable to call vectorized kernel {}", \
+            OPEN3D_STRINGIFY(ISPCKernel));
+
+#endif
+
+/// Internal helper macro.
+#define OPEN3D_OVERLOADED_LAMBDA_(T, ISPCKernel, ...)                       \
+    [&](T, int64_t start, int64_t end) {                                    \
+        OPEN3D_CALL_ISPC_KERNEL_(                                           \
+                OPEN3D_CONCAT(ISPCKernel, OPEN3D_CONCAT(_, T)), start, end, \
+                __VA_ARGS__);                                               \
+    }
+
+/// OPEN3D_VECTORIZED(ISPCKernel, ...)
+///
+/// Defines a lambda function to call the provided kernel.
+///
+/// Use the OPEN3D_EXPORT_TEMPLATE_VECTORIZED macro to define the
+/// kernel in the ISPC source file.
+///
+/// Note: The arguments to the kernel only have to exist if ISPC support is
+/// enabled via BUILD_ISPC_MODULE=ON.
+#define OPEN3D_VECTORIZED(ISPCKernel, ...)                             \
+    [&](int64_t start, int64_t end) {                                  \
+        OPEN3D_CALL_ISPC_KERNEL_(ISPCKernel, start, end, __VA_ARGS__); \
+    }
+
+/// OPEN3D_TEMPLATE_VECTORIZED(T, ISPCKernel, ...)
+///
+/// Defines a lambda function to call the provided template-like kernel.
+/// Supported types:
+/// - bool
+/// - unsigned + signed {8,16,32,64} bit integers,
+/// - float, double
+///
+/// Use the OPEN3D_EXPORT_TEMPLATE_VECTORIZED macro to define the
+/// kernel in the ISPC source file.
+///
+/// Note: The arguments to the kernel only have to exist if ISPC support is
+/// enabled via BUILD_ISPC_MODULE=ON.
+#define OPEN3D_TEMPLATE_VECTORIZED(T, ISPCKernel, ...)                        \
+    [&](int64_t start, int64_t end) {                                         \
+        static_assert(std::is_arithmetic<T>::value,                           \
+                      "Data type is not an arithmetic type");                 \
+        utility::Overload(                                                    \
+                OPEN3D_OVERLOADED_LAMBDA_(bool, ISPCKernel, __VA_ARGS__),     \
+                OPEN3D_OVERLOADED_LAMBDA_(uint8_t, ISPCKernel, __VA_ARGS__),  \
+                OPEN3D_OVERLOADED_LAMBDA_(int8_t, ISPCKernel, __VA_ARGS__),   \
+                OPEN3D_OVERLOADED_LAMBDA_(uint16_t, ISPCKernel, __VA_ARGS__), \
+                OPEN3D_OVERLOADED_LAMBDA_(int16_t, ISPCKernel, __VA_ARGS__),  \
+                OPEN3D_OVERLOADED_LAMBDA_(uint32_t, ISPCKernel, __VA_ARGS__), \
+                OPEN3D_OVERLOADED_LAMBDA_(int32_t, ISPCKernel, __VA_ARGS__),  \
+                OPEN3D_OVERLOADED_LAMBDA_(uint64_t, ISPCKernel, __VA_ARGS__), \
+                OPEN3D_OVERLOADED_LAMBDA_(int64_t, ISPCKernel, __VA_ARGS__),  \
+                OPEN3D_OVERLOADED_LAMBDA_(float, ISPCKernel, __VA_ARGS__),    \
+                OPEN3D_OVERLOADED_LAMBDA_(double, ISPCKernel, __VA_ARGS__),   \
+                [&](auto&& generic, int64_t start, int64_t end) {             \
+                    utility::LogError(                                        \
+                            "Unsupported data type {} for calling "           \
+                            "vectorized kernel {}",                           \
+                            typeid(generic).name(),                           \
+                            OPEN3D_STRINGIFY(ISPCKernel));                    \
+                })(T{}, start, end);                                          \
+    }
 
 }  // namespace core
 }  // namespace open3d

--- a/cpp/open3d/core/ParallelFor.isph
+++ b/cpp/open3d/core/ParallelFor.isph
@@ -1,0 +1,213 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include "open3d/utility/Helper.isph"
+
+// This C/C++ header is compatible with ISPC.
+// Variadic macros, i.e. ellipsis (...) and __VA_ARGS__ are also supported.
+#include "open3d/utility/Preprocessor.h"
+
+/// OPEN3D_SPECIALIZED(T, ISPCFunction)
+///
+/// Resolves the given template-like function to its specialization of type T.
+#define OPEN3D_SPECIALIZED(T, ISPCFunction) \
+    OPEN3D_CONCAT(ISPCFunction, OPEN3D_CONCAT(_, T))
+
+/// OPEN3D_INSTANTIATE_TEMPLATE()
+///
+/// Instantiates a template-like function defined by the TEMPLATE(T) macro for
+/// the following types:
+/// - unsigned + signed {8,16,32,64} bit integers,
+/// - float, double
+///
+/// Example:
+///
+/// \code
+/// #define TEMPLATE(T)                                         \
+///     static inline void OPEN3D_SPECIALIZED(T, TemplateFunc)( \
+///             int64_t idx, /* more parameters */) {           \
+///         // Do something ...
+/// }
+///
+/// OPEN3D_INSTANTIATE_TEMPLATE()
+///
+/// #undef TEMPLATE
+/// \endcode
+#define OPEN3D_INSTANTIATE_TEMPLATE() \
+    TEMPLATE(uint8_t)                 \
+    TEMPLATE(int8_t)                  \
+    TEMPLATE(uint16_t)                \
+    TEMPLATE(int16_t)                 \
+    TEMPLATE(uint32_t)                \
+    TEMPLATE(int32_t)                 \
+    TEMPLATE(uint64_t)                \
+    TEMPLATE(int64_t)                 \
+    TEMPLATE(float)                   \
+    TEMPLATE(double)
+
+/// OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
+///
+/// Instantiates a template-like function defined by the TEMPLATE(T) macro for
+/// the following types:
+/// - bool
+/// - unsigned + signed {8,16,32,64} bit integers,
+/// - float, double
+///
+/// See OPEN3D_INSTANTIATE_TEMPLATE() for more details.
+#define OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL() \
+    TEMPLATE(bool)                              \
+    OPEN3D_INSTANTIATE_TEMPLATE()
+
+/// OPEN3D_EXPORT_VECTORIZED(ISPCKernel, ISPCFunction, ...)
+///
+/// Defines a kernel which calls the provided function.
+///
+/// Use the OPEN3D_VECTORIZED macro to call the kernel in the C++
+/// source file.
+#define OPEN3D_EXPORT_VECTORIZED(ISPCKernel, ISPCFunction, ...) \
+    OPEN3D_OVERLOAD(OPEN3D_EXPORT_VECTORIZED_, __VA_ARGS__)     \
+    (ISPCKernel, ISPCFunction, __VA_ARGS__)
+
+/// Internal helper macro.
+#define OPEN3D_EXPORT_OVERLOADED_(T, ISPCKernel, ISPCFunction, ...) \
+    OPEN3D_EXPORT_VECTORIZED(OPEN3D_SPECIALIZED(T, ISPCKernel),     \
+                             OPEN3D_SPECIALIZED(T, ISPCFunction), __VA_ARGS__)
+
+/// OPEN3D_EXPORT_TEMPLATE_VECTORIZED(ISPCKernel, ISPCFunction, ...)
+///
+/// Defines a kernel which calls the provided function.
+///
+/// Use the OPEN3D_TEMPLATE_VECTORIZED macro to call the kernel in the
+/// C++ source file.
+///
+/// Use either
+/// - OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
+/// - OPEN3D_INSTANTIATE_TEMPLATE() + custom bool specialization
+/// to define a function.
+#define OPEN3D_EXPORT_TEMPLATE_VECTORIZED(ISPCKernel, ISPCFunction, ...)       \
+    OPEN3D_EXPORT_OVERLOADED_(bool, ISPCKernel, ISPCFunction, __VA_ARGS__)     \
+    OPEN3D_EXPORT_OVERLOADED_(uint8_t, ISPCKernel, ISPCFunction, __VA_ARGS__)  \
+    OPEN3D_EXPORT_OVERLOADED_(int8_t, ISPCKernel, ISPCFunction, __VA_ARGS__)   \
+    OPEN3D_EXPORT_OVERLOADED_(uint16_t, ISPCKernel, ISPCFunction, __VA_ARGS__) \
+    OPEN3D_EXPORT_OVERLOADED_(int16_t, ISPCKernel, ISPCFunction, __VA_ARGS__)  \
+    OPEN3D_EXPORT_OVERLOADED_(uint32_t, ISPCKernel, ISPCFunction, __VA_ARGS__) \
+    OPEN3D_EXPORT_OVERLOADED_(int32_t, ISPCKernel, ISPCFunction, __VA_ARGS__)  \
+    OPEN3D_EXPORT_OVERLOADED_(uint64_t, ISPCKernel, ISPCFunction, __VA_ARGS__) \
+    OPEN3D_EXPORT_OVERLOADED_(int64_t, ISPCKernel, ISPCFunction, __VA_ARGS__)  \
+    OPEN3D_EXPORT_OVERLOADED_(float, ISPCKernel, ISPCFunction, __VA_ARGS__)    \
+    OPEN3D_EXPORT_OVERLOADED_(double, ISPCKernel, ISPCFunction, __VA_ARGS__)
+
+/// See OPEN3D_EXPORT_VECTORIZED(...) for details.
+#define OPEN3D_EXPORT_VECTORIZED_1(ISPCKernel, ISPCFunction, type1)    \
+    export void ISPCKernel(uniform int64_t start, uniform int64_t end, \
+                           type1 arg1) {                               \
+        foreach (i = start... end) { ISPCFunction(i, arg1); }          \
+    }
+
+/// See OPEN3D_EXPORT_VECTORIZED(...) for details.
+#define OPEN3D_EXPORT_VECTORIZED_2(ISPCKernel, ISPCFunction, type1, type2) \
+    export void ISPCKernel(uniform int64_t start, uniform int64_t end,     \
+                           type1 arg1, type2 arg2) {                       \
+        foreach (i = start... end) { ISPCFunction(i, arg1, arg2); }        \
+    }
+
+/// See OPEN3D_EXPORT_VECTORIZED(...) for details.
+#define OPEN3D_EXPORT_VECTORIZED_3(ISPCKernel, ISPCFunction, type1, type2, \
+                                   type3)                                  \
+    export void ISPCKernel(uniform int64_t start, uniform int64_t end,     \
+                           type1 arg1, type2 arg2, type3 arg3) {           \
+        foreach (i = start... end) { ISPCFunction(i, arg1, arg2, arg3); }  \
+    }
+
+/// See OPEN3D_EXPORT_VECTORIZED(...) for details.
+#define OPEN3D_EXPORT_VECTORIZED_4(ISPCKernel, ISPCFunction, type1, type2,   \
+                                   type3, type4)                             \
+    export void ISPCKernel(uniform int64_t start, uniform int64_t end,       \
+                           type1 arg1, type2 arg2, type3 arg3, type4 arg4) { \
+        foreach (i = start... end) {                                         \
+            ISPCFunction(i, arg1, arg2, arg3, arg4);                         \
+        }                                                                    \
+    }
+
+/// See OPEN3D_EXPORT_VECTORIZED(...) for details.
+#define OPEN3D_EXPORT_VECTORIZED_5(ISPCKernel, ISPCFunction, type1, type2, \
+                                   type3, type4, type5)                    \
+    export void ISPCKernel(uniform int64_t start, uniform int64_t end,     \
+                           type1 arg1, type2 arg2, type3 arg3, type4 arg4, \
+                           type5 arg5) {                                   \
+        foreach (i = start... end) {                                       \
+            ISPCFunction(i, arg1, arg2, arg3, arg4, arg5);                 \
+        }                                                                  \
+    }
+
+/// See OPEN3D_EXPORT_VECTORIZED(...) for details.
+#define OPEN3D_EXPORT_VECTORIZED_6(ISPCKernel, ISPCFunction, type1, type2, \
+                                   type3, type4, type5, type6)             \
+    export void ISPCKernel(uniform int64_t start, uniform int64_t end,     \
+                           type1 arg1, type2 arg2, type3 arg3, type4 arg4, \
+                           type5 arg5, type6 arg6) {                       \
+        foreach (i = start... end) {                                       \
+            ISPCFunction(i, arg1, arg2, arg3, arg4, arg5, arg6);           \
+        }                                                                  \
+    }
+
+/// See OPEN3D_EXPORT_VECTORIZED(...) for details.
+#define OPEN3D_EXPORT_VECTORIZED_7(ISPCKernel, ISPCFunction, type1, type2, \
+                                   type3, type4, type5, type6, type7)      \
+    export void ISPCKernel(uniform int64_t start, uniform int64_t end,     \
+                           type1 arg1, type2 arg2, type3 arg3, type4 arg4, \
+                           type5 arg5, type6 arg6, type7 arg7) {           \
+        foreach (i = start... end) {                                       \
+            ISPCFunction(i, arg1, arg2, arg3, arg4, arg5, arg6, arg7);     \
+        }                                                                  \
+    }
+
+/// See OPEN3D_EXPORT_VECTORIZED(...) for details.
+#define OPEN3D_EXPORT_VECTORIZED_8(ISPCKernel, ISPCFunction, type1, type2,   \
+                                   type3, type4, type5, type6, type7, type8) \
+    export void ISPCKernel(uniform int64_t start, uniform int64_t end,       \
+                           type1 arg1, type2 arg2, type3 arg3, type4 arg4,   \
+                           type5 arg5, type6 arg6, type7 arg7, type8 arg8) { \
+        foreach (i = start... end) {                                         \
+            ISPCFunction(i, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); \
+        }                                                                    \
+    }
+
+/// See OPEN3D_EXPORT_VECTORIZED(...) for details.
+#define OPEN3D_EXPORT_VECTORIZED_9(ISPCKernel, ISPCFunction, type1, type2,   \
+                                   type3, type4, type5, type6, type7, type8, \
+                                   type9)                                    \
+    export void ISPCKernel(uniform int64_t start, uniform int64_t end,       \
+                           type1 arg1, type2 arg2, type3 arg3, type4 arg4,   \
+                           type5 arg5, type6 arg6, type7 arg7, type8 arg8,   \
+                           type9 arg9) {                                     \
+        foreach (i = start... end) {                                         \
+            ISPCFunction(i, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8,  \
+                         arg9);                                              \
+        }                                                                    \
+    }

--- a/cpp/open3d/utility/Helper.isph
+++ b/cpp/open3d/utility/Helper.isph
@@ -23,30 +23,35 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
-// Copyright 2018 Google Inc. All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
-#include <benchmark/benchmark.h>
+#pragma once
 
-#include "open3d/Open3D.h"
+// This C/C++ header is compatible with ISPC.
+// Variadic macros, i.e. ellipsis (...) and __VA_ARGS__ are also supported.
+#include "open3d/utility/Preprocessor.h"
 
-int main(int argc, char** argv) {
-    open3d::utility::CPUInfo::GetInstance().Print();
-    open3d::utility::ISAInfo::GetInstance().Print();
-    benchmark::Initialize(&argc, argv);
-    if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-        return 1;
-    }
-    benchmark::RunSpecifiedBenchmarks();
-}
+/// CHAR_BIT
+///
+/// The number of bits per byte.
+#define CHAR_BIT 8
+
+/// Enable C/C++ fixed size integer types.
+typedef uint8 uint8_t;
+typedef int8 int8_t;
+typedef uint16 uint16_t;
+typedef int16 int16_t;
+typedef uint32 uint32_t;
+typedef int32 int32_t;
+typedef uint64 uint64_t;
+typedef int64 int64_t;
+
+/// OPEN3D_ENSURE_EXPORTED(StructOrEnum)
+///
+/// Ensures that the provided struct or enum is exported to the C++ side.
+///
+/// This is useful if no other exported function directly or indirectly
+/// references the struct or enum via its arguments.
+#define OPEN3D_ENSURE_EXPORTED(StructOrEnum) \
+    export void OPEN3D_CONCAT(               \
+            DummyToEnsureExported_,          \
+            OPEN3D_CONCAT(StructOrEnum, _))(uniform StructOrEnum * uniform) {}

--- a/cpp/open3d/utility/ISAInfo.isph
+++ b/cpp/open3d/utility/ISAInfo.isph
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include "open3d/utility/Helper.isph"
+
 /// Set of known ISA targets.
 enum ISATarget {
     /* x86 */
@@ -45,29 +47,29 @@ enum ISATarget {
 
 /// Properties of an ISA target.
 struct ISAInfo {
-    ISATarget int32 target;
-    uniform int32 width;
-    uniform int32 element_width;
+    uniform ISATarget target;
+    uniform int32_t width;
+    uniform int32_t element_width;
 };
 
 /// Defines functions for querying properties of the selected ISA at runtime.
 /// This can be useful in libraries or executables with ISPC source files which
 /// are compiled with different sets of ISAs.
-#define OPEN3D_DEFINE_ISA_INFO_GETTERS(prefix)                               \
-    export uniform ISATarget prefix##GetISATarget() {                        \
-        return GetISATargetImpl();                                           \
-    }                                                                        \
-                                                                             \
-    export uniform int32 prefix##GetISAWidth() { return GetISAWidthImpl(); } \
-                                                                             \
-    export uniform int32 prefix##GetISAElementWidth() {                      \
-        return GetISAElementWidthImpl();                                     \
-    }                                                                        \
-                                                                             \
-    export void prefix##GetISAInfo(uniform ISAInfo* uniform info) {          \
-        info->target = prefix##GetISATarget();                               \
-        info->width = prefix##GetISAWidth();                                 \
-        info->element_width = prefix##GetISAElementWidth();                  \
+#define OPEN3D_DEFINE_ISA_INFO_GETTERS(prefix)                                 \
+    export uniform ISATarget prefix##GetISATarget() {                          \
+        return GetISATargetImpl();                                             \
+    }                                                                          \
+                                                                               \
+    export uniform int32_t prefix##GetISAWidth() { return GetISAWidthImpl(); } \
+                                                                               \
+    export uniform int32_t prefix##GetISAElementWidth() {                      \
+        return GetISAElementWidthImpl();                                       \
+    }                                                                          \
+                                                                               \
+    export void prefix##GetISAInfo(uniform ISAInfo* uniform info) {            \
+        info->target = prefix##GetISATarget();                                 \
+        info->width = prefix##GetISAWidth();                                   \
+        info->element_width = prefix##GetISAElementWidth();                    \
     }
 
 static inline uniform ISATarget GetISATargetImpl() {
@@ -92,10 +94,8 @@ static inline uniform ISATarget GetISATargetImpl() {
 #endif
 }
 
-static inline uniform int32 GetISAWidthImpl() { return TARGET_WIDTH; }
+static inline uniform int32_t GetISAWidthImpl() { return TARGET_WIDTH; }
 
-static inline uniform int32 GetISAElementWidthImpl() {
-    // All supported platforms implement 1 byte as 8 bits.
-    const uniform int32 CHAR_BIT = 8;
+static inline uniform int32_t GetISAElementWidthImpl() {
     return TARGET_ELEMENT_WIDTH * CHAR_BIT;
 }

--- a/cpp/open3d/utility/Preprocessor.h
+++ b/cpp/open3d/utility/Preprocessor.h
@@ -1,0 +1,84 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+/// OPEN3D_FIX_MSVC_(...)
+///
+/// Internal helper function which defers the evaluation of the enclosed
+/// expression.
+///
+/// Use this macro only to workaround non-compliant behaviour of the MSVC
+/// preprocessor.
+///
+/// Note: Could be dropped in the future if the compile flag /Zc:preprocessor
+/// can be applied.
+#define OPEN3D_FIX_MSVC_(...) __VA_ARGS__
+
+/// OPEN3D_CONCAT(s1, s2)
+///
+/// Concatenates the expanded expressions s1 and s2.
+#define OPEN3D_CONCAT_IMPL_(s1, s2) s1##s2
+#define OPEN3D_CONCAT(s1, s2) OPEN3D_CONCAT_IMPL_(s1, s2)
+
+/// OPEN3D_STRINGIFY(s)
+///
+/// Converts the expanded expression s to a string.
+#define OPEN3D_STRINGIFY_IMPL_(s) #s
+#define OPEN3D_STRINGIFY(s) OPEN3D_STRINGIFY_IMPL_(s)
+
+/// OPEN3D_NUM_ARGS(...)
+///
+/// Returns the number of supplied arguments.
+///
+/// Note: Only works for 1-10 arguments.
+#define OPEN3D_GET_NTH_ARG_(...) \
+    OPEN3D_FIX_MSVC_(OPEN3D_GET_NTH_ARG_IMPL_(__VA_ARGS__))
+#define OPEN3D_GET_NTH_ARG_IMPL_(arg1, arg2, arg3, arg4, arg5, arg6, arg7, \
+                                 arg8, arg9, arg10, N, ...)                \
+    N
+#define OPEN3D_REVERSE_NUM_SEQUENCE_() 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0
+#define OPEN3D_NUM_ARGS(...) \
+    OPEN3D_GET_NTH_ARG_(__VA_ARGS__, OPEN3D_REVERSE_NUM_SEQUENCE_())
+
+/// OPEN3D_OVERLOAD(func, ...)
+///
+/// Overloads the enumerated macros func1, func2, etc. based on the number of
+/// additional arguments.
+///
+/// Example:
+///
+/// \code
+/// #define FOO_1(x1) foo(x1)
+/// #define FOO_2(x1, x2) bar(x1, x2)
+/// #define FOO(...) '\'
+///     OPEN3D_FIX_MSVC_(OPEN3D_OVERLOAD(FOO_, __VA_ARGS__)(__VA_ARGS__))
+///
+/// FOO(1)    -> foo(1)
+/// FOO(2, 3) -> bar(2, 3)
+/// \endcode
+#define OPEN3D_OVERLOAD(func, ...) \
+    OPEN3D_CONCAT(func, OPEN3D_NUM_ARGS(__VA_ARGS__))

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(tests)
+open3d_ispc_add_executable(tests)
 
 add_subdirectory(camera)
 add_subdirectory(core)
@@ -35,13 +35,18 @@ else()
     target_compile_definitions(tests PRIVATE IPP_CONDITIONAL_TEST_STR=DISABLED_)
 endif()
 
-find_package(Threads REQUIRED)
 target_link_libraries(tests PRIVATE
     Open3D::Open3D
     Open3D::3rdparty_jsoncpp
     Open3D::3rdparty_googletest
     Open3D::3rdparty_threads
 )
+
+if (TARGET Open3D::3rdparty_openmp)
+    target_link_libraries(tests PRIVATE
+        Open3D::3rdparty_openmp
+    )
+endif()
 
 open3d_show_and_abort_on_warning(tests)
 open3d_set_global_properties(tests)

--- a/cpp/tests/core/CMakeLists.txt
+++ b/cpp/tests/core/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(tests PRIVATE
     MemoryManager.cpp
     NanoFlannIndex.cpp
     NearestNeighborSearch.cpp
+    ParallelFor.cpp
     Scalar.cpp
     ShapeUtil.cpp
     SizeVector.cpp
@@ -22,6 +23,13 @@ if (BUILD_CUDA_MODULE)
     target_sources(tests PRIVATE
         FixedRadiusIndex.cpp
         KnnIndex.cpp
+        ParallelFor.cu
+    )
+endif()
+
+if (BUILD_ISPC_MODULE)
+    open3d_ispc_target_sources(tests PRIVATE
+        ParallelFor.ispc
     )
 endif()
 

--- a/cpp/tests/core/CoreTest.h
+++ b/cpp/tests/core/CoreTest.h
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "open3d/core/Device.h"
+#include "open3d/core/Dtype.h"
 #include "open3d/core/SizeVector.h"
 #include "tests/Tests.h"
 
@@ -38,6 +39,17 @@
 
 namespace open3d {
 namespace tests {
+
+class PermuteDtypesWithBool : public testing::TestWithParam<core::Dtype> {
+public:
+    static std::vector<core::Dtype> TestCases() {
+        return {
+                core::Bool,  core::UInt8,   core::Int8,    core::UInt16,
+                core::Int16, core::UInt32,  core::Int32,   core::UInt64,
+                core::Int64, core::Float32, core::Float64,
+        };
+    }
+};
 
 class PermuteDevices : public testing::TestWithParam<core::Device> {
 public:

--- a/cpp/tests/core/ParallelFor.cpp
+++ b/cpp/tests/core/ParallelFor.cpp
@@ -1,0 +1,644 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "open3d/core/ParallelFor.h"
+
+#include <vector>
+
+#include "open3d/Macro.h"
+#include "open3d/core/Dispatch.h"
+#include "open3d/core/Dtype.h"
+#include "open3d/core/Tensor.h"
+#include "tests/Tests.h"
+#include "tests/core/CoreTest.h"
+
+#ifdef BUILD_ISPC_MODULE
+#include "ParallelFor_ispc.h"
+#endif
+
+namespace open3d {
+namespace tests {
+
+TEST(ParallelFor, LambdaCPU) {
+    const core::Device device("CPU:0");
+    const size_t N = 10000000;
+    core::Tensor tensor({N, 1}, core::Int64, device);
+
+    core::ParallelFor(device, tensor.NumElements(), [&](int64_t idx) {
+        tensor.GetDataPtr<int64_t>()[idx] = idx;
+    });
+
+    for (int64_t i = 0; i < tensor.NumElements(); ++i) {
+        ASSERT_EQ(tensor.GetDataPtr<int64_t>()[i], i);
+    }
+}
+
+TEST(ParallelFor, VectorizedLambda1) {
+    const size_t N = 10000000;
+    std::vector<int64_t> v(N);
+
+    core::ParallelFor(
+            core::Device("CPU:0"), v.size(), [&](int64_t idx) { v[idx] = idx; },
+            OPEN3D_VECTORIZED(ISPCKernel1, v.data()));
+
+    for (int64_t i = 0; i < static_cast<int64_t>(v.size()); ++i) {
+        ASSERT_EQ(v[i], i);
+    }
+}
+
+TEST(ParallelFor, VectorizedLambda2) {
+    const size_t N = 10000000;
+    std::vector<int64_t> v(N);
+    bool arg2 = false;
+
+    core::ParallelFor(
+            core::Device("CPU:0"), v.size(),
+            [&](int64_t idx) {
+                v[idx] = idx;
+                arg2 = true;
+            },
+            OPEN3D_VECTORIZED(ISPCKernel2, v.data(), &arg2));
+
+    for (int64_t i = 0; i < static_cast<int64_t>(v.size()); ++i) {
+        ASSERT_EQ(v[i], i);
+    }
+    EXPECT_TRUE(arg2);
+}
+
+TEST(ParallelFor, VectorizedLambda3) {
+    const size_t N = 10000000;
+    std::vector<int64_t> v(N);
+    bool arg2 = false;
+    uint8_t arg3 = 0;
+
+    core::ParallelFor(
+            core::Device("CPU:0"), v.size(),
+            [&](int64_t idx) {
+                v[idx] = idx;
+                arg2 = true;
+                arg3 = 3;
+            },
+            OPEN3D_VECTORIZED(ISPCKernel3, v.data(), &arg2, &arg3));
+
+    for (int64_t i = 0; i < static_cast<int64_t>(v.size()); ++i) {
+        ASSERT_EQ(v[i], i);
+    }
+    EXPECT_TRUE(arg2);
+    EXPECT_EQ(arg3, static_cast<uint8_t>(3));
+}
+
+TEST(ParallelFor, VectorizedLambda4) {
+    const size_t N = 10000000;
+    std::vector<int64_t> v(N);
+    bool arg2 = false;
+    uint8_t arg3 = 0;
+    int8_t arg4 = 0;
+
+    core::ParallelFor(
+            core::Device("CPU:0"), v.size(),
+            [&](int64_t idx) {
+                v[idx] = idx;
+                arg2 = true;
+                arg3 = 3;
+                arg4 = 4;
+            },
+            OPEN3D_VECTORIZED(ISPCKernel4, v.data(), &arg2, &arg3, &arg4));
+
+    for (int64_t i = 0; i < static_cast<int64_t>(v.size()); ++i) {
+        ASSERT_EQ(v[i], i);
+    }
+    EXPECT_TRUE(arg2);
+    EXPECT_EQ(arg3, static_cast<uint8_t>(3));
+    EXPECT_EQ(arg4, static_cast<int8_t>(4));
+}
+
+TEST(ParallelFor, VectorizedLambda5) {
+    const size_t N = 10000000;
+    std::vector<int64_t> v(N);
+    bool arg2 = false;
+    uint8_t arg3 = 0;
+    int8_t arg4 = 0;
+    uint16_t arg5 = 0;
+
+    core::ParallelFor(
+            core::Device("CPU:0"), v.size(),
+            [&](int64_t idx) {
+                v[idx] = idx;
+                arg2 = true;
+                arg3 = 3;
+                arg4 = 4;
+                arg5 = 5;
+            },
+            OPEN3D_VECTORIZED(ISPCKernel5, v.data(), &arg2, &arg3, &arg4,
+                              &arg5));
+
+    for (int64_t i = 0; i < static_cast<int64_t>(v.size()); ++i) {
+        ASSERT_EQ(v[i], i);
+    }
+    EXPECT_TRUE(arg2);
+    EXPECT_EQ(arg3, static_cast<uint8_t>(3));
+    EXPECT_EQ(arg4, static_cast<int8_t>(4));
+    EXPECT_EQ(arg5, static_cast<uint16_t>(5));
+}
+
+TEST(ParallelFor, VectorizedLambda6) {
+    const size_t N = 10000000;
+    std::vector<int64_t> v(N);
+    bool arg2 = false;
+    uint8_t arg3 = 0;
+    int8_t arg4 = 0;
+    uint16_t arg5 = 0;
+    int16_t arg6 = 0;
+
+    core::ParallelFor(
+            core::Device("CPU:0"), v.size(),
+            [&](int64_t idx) {
+                v[idx] = idx;
+                arg2 = true;
+                arg3 = 3;
+                arg4 = 4;
+                arg5 = 5;
+                arg6 = 6;
+            },
+            OPEN3D_VECTORIZED(ISPCKernel6, v.data(), &arg2, &arg3, &arg4, &arg5,
+                              &arg6));
+
+    for (int64_t i = 0; i < static_cast<int64_t>(v.size()); ++i) {
+        ASSERT_EQ(v[i], i);
+    }
+    EXPECT_TRUE(arg2);
+    EXPECT_EQ(arg3, static_cast<uint8_t>(3));
+    EXPECT_EQ(arg4, static_cast<int8_t>(4));
+    EXPECT_EQ(arg5, static_cast<uint16_t>(5));
+    EXPECT_EQ(arg6, static_cast<int16_t>(6));
+}
+
+TEST(ParallelFor, VectorizedLambda7) {
+    const size_t N = 10000000;
+    std::vector<int64_t> v(N);
+    bool arg2 = false;
+    uint8_t arg3 = 0;
+    int8_t arg4 = 0;
+    uint16_t arg5 = 0;
+    int16_t arg6 = 0;
+    uint32_t arg7 = 0;
+
+    core::ParallelFor(
+            core::Device("CPU:0"), v.size(),
+            [&](int64_t idx) {
+                v[idx] = idx;
+                arg2 = true;
+                arg3 = 3;
+                arg4 = 4;
+                arg5 = 5;
+                arg6 = 6;
+                arg7 = 7;
+            },
+            OPEN3D_VECTORIZED(ISPCKernel7, v.data(), &arg2, &arg3, &arg4, &arg5,
+                              &arg6, &arg7));
+
+    for (int64_t i = 0; i < static_cast<int64_t>(v.size()); ++i) {
+        ASSERT_EQ(v[i], i);
+    }
+    EXPECT_TRUE(arg2);
+    EXPECT_EQ(arg3, static_cast<uint8_t>(3));
+    EXPECT_EQ(arg4, static_cast<int8_t>(4));
+    EXPECT_EQ(arg5, static_cast<uint16_t>(5));
+    EXPECT_EQ(arg6, static_cast<int16_t>(6));
+    EXPECT_EQ(arg7, static_cast<uint32_t>(7));
+}
+
+TEST(ParallelFor, VectorizedLambda8) {
+    const size_t N = 10000000;
+    std::vector<int64_t> v(N);
+    bool arg2 = false;
+    uint8_t arg3 = 0;
+    int8_t arg4 = 0;
+    uint16_t arg5 = 0;
+    int16_t arg6 = 0;
+    uint32_t arg7 = 0;
+    int32_t arg8 = 0;
+
+    core::ParallelFor(
+            core::Device("CPU:0"), v.size(),
+            [&](int64_t idx) {
+                v[idx] = idx;
+                arg2 = true;
+                arg3 = 3;
+                arg4 = 4;
+                arg5 = 5;
+                arg6 = 6;
+                arg7 = 7;
+                arg8 = 8;
+            },
+            OPEN3D_VECTORIZED(ISPCKernel8, v.data(), &arg2, &arg3, &arg4, &arg5,
+                              &arg6, &arg7, &arg8));
+
+    for (int64_t i = 0; i < static_cast<int64_t>(v.size()); ++i) {
+        ASSERT_EQ(v[i], i);
+    }
+    EXPECT_TRUE(arg2);
+    EXPECT_EQ(arg3, static_cast<uint8_t>(3));
+    EXPECT_EQ(arg4, static_cast<int8_t>(4));
+    EXPECT_EQ(arg5, static_cast<uint16_t>(5));
+    EXPECT_EQ(arg6, static_cast<int16_t>(6));
+    EXPECT_EQ(arg7, static_cast<uint32_t>(7));
+    EXPECT_EQ(arg8, static_cast<int32_t>(8));
+}
+
+TEST(ParallelFor, VectorizedLambda9) {
+    const size_t N = 10000000;
+    std::vector<int64_t> v(N);
+    bool arg2 = false;
+    uint8_t arg3 = 0;
+    int8_t arg4 = 0;
+    uint16_t arg5 = 0;
+    int16_t arg6 = 0;
+    uint32_t arg7 = 0;
+    int32_t arg8 = 0;
+    uint64_t arg9 = 0;
+
+    core::ParallelFor(
+            core::Device("CPU:0"), v.size(),
+            [&](int64_t idx) {
+                v[idx] = idx;
+                arg2 = true;
+                arg3 = 3;
+                arg4 = 4;
+                arg5 = 5;
+                arg6 = 6;
+                arg7 = 7;
+                arg8 = 8;
+                arg9 = 9;
+            },
+            OPEN3D_VECTORIZED(ISPCKernel9, v.data(), &arg2, &arg3, &arg4, &arg5,
+                              &arg6, &arg7, &arg8, &arg9));
+
+    for (int64_t i = 0; i < static_cast<int64_t>(v.size()); ++i) {
+        ASSERT_EQ(v[i], i);
+    }
+    EXPECT_TRUE(arg2);
+    EXPECT_EQ(arg3, static_cast<uint8_t>(3));
+    EXPECT_EQ(arg4, static_cast<int8_t>(4));
+    EXPECT_EQ(arg5, static_cast<uint16_t>(5));
+    EXPECT_EQ(arg6, static_cast<int16_t>(6));
+    EXPECT_EQ(arg7, static_cast<uint32_t>(7));
+    EXPECT_EQ(arg8, static_cast<int32_t>(8));
+    EXPECT_EQ(arg9, static_cast<uint64_t>(9));
+}
+
+template <typename T>
+int64_t GetInitialValue() = delete;
+
+#define GET_INITIAL_VALUE(T, value) \
+    template <>                     \
+    int64_t GetInitialValue<T>() {  \
+        return value;               \
+    }
+
+GET_INITIAL_VALUE(bool, -1)
+GET_INITIAL_VALUE(uint8_t, -2)
+GET_INITIAL_VALUE(int8_t, -3)
+GET_INITIAL_VALUE(uint16_t, -4)
+GET_INITIAL_VALUE(int16_t, -5)
+GET_INITIAL_VALUE(uint32_t, -6)
+GET_INITIAL_VALUE(int32_t, -7)
+GET_INITIAL_VALUE(uint64_t, -8)
+GET_INITIAL_VALUE(int64_t, -9)
+GET_INITIAL_VALUE(float, -10)
+GET_INITIAL_VALUE(double, -11)
+
+#undef GET_INITIAL_VALUE
+
+class ParallelForPermuteDtypesWithBool : public PermuteDtypesWithBool {};
+INSTANTIATE_TEST_SUITE_P(ParallelFor,
+                         ParallelForPermuteDtypesWithBool,
+                         testing::ValuesIn(PermuteDtypesWithBool::TestCases()));
+
+TEST_P(ParallelForPermuteDtypesWithBool, VectorizedTemplateLambda1) {
+    core::Dtype dtype = GetParam();
+
+    const size_t N = 10000000;
+    std::vector<int64_t> v(N);
+
+    DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(dtype, [&]() {
+        core::ParallelFor(
+                core::Device("CPU:0"), v.size(),
+                [&](int64_t idx) {
+                    v[idx] = idx == 0 ? GetInitialValue<scalar_t>() : idx;
+                },
+                OPEN3D_TEMPLATE_VECTORIZED(scalar_t, TemplateISPCKernel1,
+                                           v.data()));
+
+        for (int64_t i = 0; i < static_cast<int64_t>(v.size()); ++i) {
+            ASSERT_EQ(v[i], i == 0 ? GetInitialValue<scalar_t>() : i);
+        }
+    });
+}
+
+TEST_P(ParallelForPermuteDtypesWithBool, VectorizedTemplateLambda2) {
+    core::Dtype dtype = GetParam();
+
+    const size_t N = 10000000;
+    std::vector<int64_t> v(N);
+    bool arg2 = false;
+
+    DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(dtype, [&]() {
+        core::ParallelFor(
+                core::Device("CPU:0"), v.size(),
+                [&](int64_t idx) {
+                    v[idx] = idx == 0 ? GetInitialValue<scalar_t>() : idx;
+                    arg2 = true;
+                },
+                OPEN3D_TEMPLATE_VECTORIZED(scalar_t, TemplateISPCKernel2,
+                                           v.data(), &arg2));
+
+        for (int64_t i = 0; i < static_cast<int64_t>(v.size()); ++i) {
+            ASSERT_EQ(v[i], i == 0 ? GetInitialValue<scalar_t>() : i);
+        }
+        EXPECT_TRUE(arg2);
+    });
+}
+
+TEST_P(ParallelForPermuteDtypesWithBool, VectorizedTemplateLambda3) {
+    core::Dtype dtype = GetParam();
+
+    const size_t N = 10000000;
+    std::vector<int64_t> v(N);
+    bool arg2 = false;
+    uint8_t arg3 = 0;
+
+    DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(dtype, [&]() {
+        core::ParallelFor(
+                core::Device("CPU:0"), v.size(),
+                [&](int64_t idx) {
+                    v[idx] = idx == 0 ? GetInitialValue<scalar_t>() : idx;
+                    arg2 = true;
+                    arg3 = 3;
+                },
+                OPEN3D_TEMPLATE_VECTORIZED(scalar_t, TemplateISPCKernel3,
+                                           v.data(), &arg2, &arg3));
+
+        for (int64_t i = 0; i < static_cast<int64_t>(v.size()); ++i) {
+            ASSERT_EQ(v[i], i == 0 ? GetInitialValue<scalar_t>() : i);
+        }
+        EXPECT_TRUE(arg2);
+        EXPECT_EQ(arg3, static_cast<uint8_t>(3));
+    });
+}
+
+TEST_P(ParallelForPermuteDtypesWithBool, VectorizedTemplateLambda4) {
+    core::Dtype dtype = GetParam();
+
+    const size_t N = 10000000;
+    std::vector<int64_t> v(N);
+    bool arg2 = false;
+    uint8_t arg3 = 0;
+    int8_t arg4 = 0;
+
+    DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(dtype, [&]() {
+        core::ParallelFor(
+                core::Device("CPU:0"), v.size(),
+                [&](int64_t idx) {
+                    v[idx] = idx == 0 ? GetInitialValue<scalar_t>() : idx;
+                    arg2 = true;
+                    arg3 = 3;
+                    arg4 = 4;
+                },
+                OPEN3D_TEMPLATE_VECTORIZED(scalar_t, TemplateISPCKernel4,
+                                           v.data(), &arg2, &arg3, &arg4));
+
+        for (int64_t i = 0; i < static_cast<int64_t>(v.size()); ++i) {
+            ASSERT_EQ(v[i], i == 0 ? GetInitialValue<scalar_t>() : i);
+        }
+        EXPECT_TRUE(arg2);
+        EXPECT_EQ(arg3, static_cast<uint8_t>(3));
+        EXPECT_EQ(arg4, static_cast<int8_t>(4));
+    });
+}
+
+TEST_P(ParallelForPermuteDtypesWithBool, VectorizedTemplateLambda5) {
+    core::Dtype dtype = GetParam();
+
+    const size_t N = 10000000;
+    std::vector<int64_t> v(N);
+    bool arg2 = false;
+    uint8_t arg3 = 0;
+    int8_t arg4 = 0;
+    uint16_t arg5 = 0;
+
+    DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(dtype, [&]() {
+        core::ParallelFor(
+                core::Device("CPU:0"), v.size(),
+                [&](int64_t idx) {
+                    v[idx] = idx == 0 ? GetInitialValue<scalar_t>() : idx;
+                    arg2 = true;
+                    arg3 = 3;
+                    arg4 = 4;
+                    arg5 = 5;
+                },
+                OPEN3D_TEMPLATE_VECTORIZED(scalar_t, TemplateISPCKernel5,
+                                           v.data(), &arg2, &arg3, &arg4,
+                                           &arg5));
+
+        for (int64_t i = 0; i < static_cast<int64_t>(v.size()); ++i) {
+            ASSERT_EQ(v[i], i == 0 ? GetInitialValue<scalar_t>() : i);
+        }
+        EXPECT_TRUE(arg2);
+        EXPECT_EQ(arg3, static_cast<uint8_t>(3));
+        EXPECT_EQ(arg4, static_cast<int8_t>(4));
+        EXPECT_EQ(arg5, static_cast<uint16_t>(5));
+    });
+}
+
+TEST_P(ParallelForPermuteDtypesWithBool, VectorizedTemplateLambda6) {
+    core::Dtype dtype = GetParam();
+
+    const size_t N = 10000000;
+    std::vector<int64_t> v(N);
+    bool arg2 = false;
+    uint8_t arg3 = 0;
+    int8_t arg4 = 0;
+    uint16_t arg5 = 0;
+    int16_t arg6 = 0;
+
+    DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(dtype, [&]() {
+        core::ParallelFor(
+                core::Device("CPU:0"), v.size(),
+                [&](int64_t idx) {
+                    v[idx] = idx == 0 ? GetInitialValue<scalar_t>() : idx;
+                    arg2 = true;
+                    arg3 = 3;
+                    arg4 = 4;
+                    arg5 = 5;
+                    arg6 = 6;
+                },
+                OPEN3D_TEMPLATE_VECTORIZED(scalar_t, TemplateISPCKernel6,
+                                           v.data(), &arg2, &arg3, &arg4, &arg5,
+                                           &arg6));
+
+        for (int64_t i = 0; i < static_cast<int64_t>(v.size()); ++i) {
+            ASSERT_EQ(v[i], i == 0 ? GetInitialValue<scalar_t>() : i);
+        }
+        EXPECT_TRUE(arg2);
+        EXPECT_EQ(arg3, static_cast<uint8_t>(3));
+        EXPECT_EQ(arg4, static_cast<int8_t>(4));
+        EXPECT_EQ(arg5, static_cast<uint16_t>(5));
+        EXPECT_EQ(arg6, static_cast<int16_t>(6));
+    });
+}
+
+TEST_P(ParallelForPermuteDtypesWithBool, VectorizedTemplateLambda7) {
+    core::Dtype dtype = GetParam();
+
+    const size_t N = 10000000;
+    std::vector<int64_t> v(N);
+    bool arg2 = false;
+    uint8_t arg3 = 0;
+    int8_t arg4 = 0;
+    uint16_t arg5 = 0;
+    int16_t arg6 = 0;
+    uint32_t arg7 = 0;
+
+    DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(dtype, [&]() {
+        core::ParallelFor(
+                core::Device("CPU:0"), v.size(),
+                [&](int64_t idx) {
+                    v[idx] = idx == 0 ? GetInitialValue<scalar_t>() : idx;
+                    arg2 = true;
+                    arg3 = 3;
+                    arg4 = 4;
+                    arg5 = 5;
+                    arg6 = 6;
+                    arg7 = 7;
+                },
+                OPEN3D_TEMPLATE_VECTORIZED(scalar_t, TemplateISPCKernel7,
+                                           v.data(), &arg2, &arg3, &arg4, &arg5,
+                                           &arg6, &arg7));
+
+        for (int64_t i = 0; i < static_cast<int64_t>(v.size()); ++i) {
+            ASSERT_EQ(v[i], i == 0 ? GetInitialValue<scalar_t>() : i);
+        }
+        EXPECT_TRUE(arg2);
+        EXPECT_EQ(arg3, static_cast<uint8_t>(3));
+        EXPECT_EQ(arg4, static_cast<int8_t>(4));
+        EXPECT_EQ(arg5, static_cast<uint16_t>(5));
+        EXPECT_EQ(arg6, static_cast<int16_t>(6));
+        EXPECT_EQ(arg7, static_cast<uint32_t>(7));
+    });
+}
+
+TEST_P(ParallelForPermuteDtypesWithBool, VectorizedTemplateLambda8) {
+    core::Dtype dtype = GetParam();
+
+    const size_t N = 10000000;
+    std::vector<int64_t> v(N);
+    bool arg2 = false;
+    uint8_t arg3 = 0;
+    int8_t arg4 = 0;
+    uint16_t arg5 = 0;
+    int16_t arg6 = 0;
+    uint32_t arg7 = 0;
+    int32_t arg8 = 0;
+
+    DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(dtype, [&]() {
+        core::ParallelFor(
+                core::Device("CPU:0"), v.size(),
+                [&](int64_t idx) {
+                    v[idx] = idx == 0 ? GetInitialValue<scalar_t>() : idx;
+                    arg2 = true;
+                    arg3 = 3;
+                    arg4 = 4;
+                    arg5 = 5;
+                    arg6 = 6;
+                    arg7 = 7;
+                    arg8 = 8;
+                },
+                OPEN3D_TEMPLATE_VECTORIZED(scalar_t, TemplateISPCKernel8,
+                                           v.data(), &arg2, &arg3, &arg4, &arg5,
+                                           &arg6, &arg7, &arg8));
+
+        for (int64_t i = 0; i < static_cast<int64_t>(v.size()); ++i) {
+            ASSERT_EQ(v[i], i == 0 ? GetInitialValue<scalar_t>() : i);
+        }
+        EXPECT_TRUE(arg2);
+        EXPECT_EQ(arg3, static_cast<uint8_t>(3));
+        EXPECT_EQ(arg4, static_cast<int8_t>(4));
+        EXPECT_EQ(arg5, static_cast<uint16_t>(5));
+        EXPECT_EQ(arg6, static_cast<int16_t>(6));
+        EXPECT_EQ(arg7, static_cast<uint32_t>(7));
+        EXPECT_EQ(arg8, static_cast<int32_t>(8));
+    });
+}
+
+TEST_P(ParallelForPermuteDtypesWithBool, VectorizedTemplateLambda9) {
+    core::Dtype dtype = GetParam();
+
+    const size_t N = 10000000;
+    std::vector<int64_t> v(N);
+    bool arg2 = false;
+    uint8_t arg3 = 0;
+    int8_t arg4 = 0;
+    uint16_t arg5 = 0;
+    int16_t arg6 = 0;
+    uint32_t arg7 = 0;
+    int32_t arg8 = 0;
+    uint64_t arg9 = 0;
+
+    DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(dtype, [&]() {
+        core::ParallelFor(
+                core::Device("CPU:0"), v.size(),
+                [&](int64_t idx) {
+                    v[idx] = idx == 0 ? GetInitialValue<scalar_t>() : idx;
+                    arg2 = true;
+                    arg3 = 3;
+                    arg4 = 4;
+                    arg5 = 5;
+                    arg6 = 6;
+                    arg7 = 7;
+                    arg8 = 8;
+                    arg9 = 9;
+                },
+                OPEN3D_TEMPLATE_VECTORIZED(scalar_t, TemplateISPCKernel9,
+                                           v.data(), &arg2, &arg3, &arg4, &arg5,
+                                           &arg6, &arg7, &arg8, &arg9));
+
+        for (int64_t i = 0; i < static_cast<int64_t>(v.size()); ++i) {
+            ASSERT_EQ(v[i], i == 0 ? GetInitialValue<scalar_t>() : i);
+        }
+        EXPECT_TRUE(arg2);
+        EXPECT_EQ(arg3, static_cast<uint8_t>(3));
+        EXPECT_EQ(arg4, static_cast<int8_t>(4));
+        EXPECT_EQ(arg5, static_cast<uint16_t>(5));
+        EXPECT_EQ(arg6, static_cast<int16_t>(6));
+        EXPECT_EQ(arg7, static_cast<uint32_t>(7));
+        EXPECT_EQ(arg8, static_cast<int32_t>(8));
+        EXPECT_EQ(arg9, static_cast<uint64_t>(9));
+    });
+}
+
+}  // namespace tests
+}  // namespace open3d

--- a/cpp/tests/core/ParallelFor.ispc
+++ b/cpp/tests/core/ParallelFor.ispc
@@ -1,0 +1,352 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "open3d/core/ParallelFor.isph"
+
+static inline void ISPCFunction1(int64_t idx, int64_t* uniform v) {
+    v[idx] = idx;
+}
+static inline void ISPCFunction2(int64_t idx,
+                                 int64_t* uniform v,
+                                 bool* uniform arg2) {
+    ISPCFunction1(idx, v);
+    *arg2 = true;
+}
+static inline void ISPCFunction3(int64_t idx,
+                                 int64_t* uniform v,
+                                 bool* uniform arg2,
+                                 uint8_t* uniform arg3) {
+    ISPCFunction2(idx, v, arg2);
+    *arg3 = 3;
+}
+static inline void ISPCFunction4(int64_t idx,
+                                 int64_t* uniform v,
+                                 bool* uniform arg2,
+                                 uint8_t* uniform arg3,
+                                 int8_t* uniform arg4) {
+    ISPCFunction3(idx, v, arg2, arg3);
+    *arg4 = 4;
+}
+static inline void ISPCFunction5(int64_t idx,
+                                 int64_t* uniform v,
+                                 bool* uniform arg2,
+                                 uint8_t* uniform arg3,
+                                 int8_t* uniform arg4,
+                                 uint16_t* uniform arg5) {
+    ISPCFunction4(idx, v, arg2, arg3, arg4);
+    *arg5 = 5;
+}
+static inline void ISPCFunction6(int64_t idx,
+                                 int64_t* uniform v,
+                                 bool* uniform arg2,
+                                 uint8_t* uniform arg3,
+                                 int8_t* uniform arg4,
+                                 uint16_t* uniform arg5,
+                                 int16_t* uniform arg6) {
+    ISPCFunction5(idx, v, arg2, arg3, arg4, arg5);
+    *arg6 = 6;
+}
+static inline void ISPCFunction7(int64_t idx,
+                                 int64_t* uniform v,
+                                 bool* uniform arg2,
+                                 uint8_t* uniform arg3,
+                                 int8_t* uniform arg4,
+                                 uint16_t* uniform arg5,
+                                 int16_t* uniform arg6,
+                                 uint32_t* uniform arg7) {
+    ISPCFunction6(idx, v, arg2, arg3, arg4, arg5, arg6);
+    *arg7 = 7;
+}
+static inline void ISPCFunction8(int64_t idx,
+                                 int64_t* uniform v,
+                                 bool* uniform arg2,
+                                 uint8_t* uniform arg3,
+                                 int8_t* uniform arg4,
+                                 uint16_t* uniform arg5,
+                                 int16_t* uniform arg6,
+                                 uint32_t* uniform arg7,
+                                 int32_t* uniform arg8) {
+    ISPCFunction7(idx, v, arg2, arg3, arg4, arg5, arg6, arg7);
+    *arg8 = 8;
+}
+
+static inline void ISPCFunction9(int64_t idx,
+                                 int64_t* uniform v,
+                                 bool* uniform arg2,
+                                 uint8_t* uniform arg3,
+                                 int8_t* uniform arg4,
+                                 uint16_t* uniform arg5,
+                                 int16_t* uniform arg6,
+                                 uint32_t* uniform arg7,
+                                 int32_t* uniform arg8,
+                                 uint64_t* uniform arg9) {
+    ISPCFunction8(idx, v, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+    *arg9 = 9;
+}
+
+OPEN3D_EXPORT_VECTORIZED(ISPCKernel1, ISPCFunction1, int64_t* uniform)
+OPEN3D_EXPORT_VECTORIZED(ISPCKernel2,
+                         ISPCFunction2,
+                         int64_t* uniform,
+                         bool* uniform)
+OPEN3D_EXPORT_VECTORIZED(ISPCKernel3,
+                         ISPCFunction3,
+                         int64_t* uniform,
+                         bool* uniform,
+                         uint8_t* uniform)
+OPEN3D_EXPORT_VECTORIZED(ISPCKernel4,
+                         ISPCFunction4,
+                         int64_t* uniform,
+                         bool* uniform,
+                         uint8_t* uniform,
+                         int8_t* uniform)
+OPEN3D_EXPORT_VECTORIZED(ISPCKernel5,
+                         ISPCFunction5,
+                         int64_t* uniform,
+                         bool* uniform,
+                         uint8_t* uniform,
+                         int8_t* uniform,
+                         uint16_t* uniform)
+OPEN3D_EXPORT_VECTORIZED(ISPCKernel6,
+                         ISPCFunction6,
+                         int64_t* uniform,
+                         bool* uniform,
+                         uint8_t* uniform,
+                         int8_t* uniform,
+                         uint16_t* uniform,
+                         int16_t* uniform)
+OPEN3D_EXPORT_VECTORIZED(ISPCKernel7,
+                         ISPCFunction7,
+                         int64_t* uniform,
+                         bool* uniform,
+                         uint8_t* uniform,
+                         int8_t* uniform,
+                         uint16_t* uniform,
+                         int16_t* uniform,
+                         uint32_t* uniform)
+OPEN3D_EXPORT_VECTORIZED(ISPCKernel8,
+                         ISPCFunction8,
+                         int64_t* uniform,
+                         bool* uniform,
+                         uint8_t* uniform,
+                         int8_t* uniform,
+                         uint16_t* uniform,
+                         int16_t* uniform,
+                         uint32_t* uniform,
+                         int32_t* uniform)
+OPEN3D_EXPORT_VECTORIZED(ISPCKernel9,
+                         ISPCFunction9,
+                         int64_t* uniform,
+                         bool* uniform,
+                         uint8_t* uniform,
+                         int8_t* uniform,
+                         uint16_t* uniform,
+                         int16_t* uniform,
+                         uint32_t* uniform,
+                         int32_t* uniform,
+                         uint64_t* uniform)
+
+#define GET_INITIAL_VALUE(T, value) \
+    int64_t OPEN3D_SPECIALIZED(T, GetInitialValue)() { return value; }
+
+GET_INITIAL_VALUE(bool, -1)
+GET_INITIAL_VALUE(uint8_t, -2)
+GET_INITIAL_VALUE(int8_t, -3)
+GET_INITIAL_VALUE(uint16_t, -4)
+GET_INITIAL_VALUE(int16_t, -5)
+GET_INITIAL_VALUE(uint32_t, -6)
+GET_INITIAL_VALUE(int32_t, -7)
+GET_INITIAL_VALUE(uint64_t, -8)
+GET_INITIAL_VALUE(int64_t, -9)
+GET_INITIAL_VALUE(float, -10)
+GET_INITIAL_VALUE(double, -11)
+
+#undef GET_INITIAL_VALUE
+
+#define TEMPLATE(T)                                                         \
+    static inline void OPEN3D_SPECIALIZED(T, TemplateISPCFunction1)(        \
+            int64_t idx, int64_t * uniform v) {                             \
+        v[idx] = idx == 0 ? OPEN3D_SPECIALIZED(T, GetInitialValue)() : idx; \
+    }
+OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
+#undef TEMPLATE
+
+#define TEMPLATE(T)                                                  \
+    static inline void OPEN3D_SPECIALIZED(T, TemplateISPCFunction2)( \
+            int64_t idx, int64_t * uniform v, bool* uniform arg2) {  \
+        OPEN3D_SPECIALIZED(T, TemplateISPCFunction1)(idx, v);        \
+        *arg2 = true;                                                \
+    }
+OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
+#undef TEMPLATE
+
+#define TEMPLATE(T)                                                  \
+    static inline void OPEN3D_SPECIALIZED(T, TemplateISPCFunction3)( \
+            int64_t idx, int64_t * uniform v, bool* uniform arg2,    \
+            uint8_t* uniform arg3) {                                 \
+        OPEN3D_SPECIALIZED(T, TemplateISPCFunction2)(idx, v, arg2);  \
+        *arg3 = 3;                                                   \
+    }
+OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
+#undef TEMPLATE
+
+#define TEMPLATE(T)                                                       \
+    static inline void OPEN3D_SPECIALIZED(T, TemplateISPCFunction4)(      \
+            int64_t idx, int64_t * uniform v, bool* uniform arg2,         \
+            uint8_t* uniform arg3, int8_t* uniform arg4) {                \
+        OPEN3D_SPECIALIZED(T, TemplateISPCFunction3)(idx, v, arg2, arg3); \
+        *arg4 = 4;                                                        \
+    }
+OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
+#undef TEMPLATE
+
+#define TEMPLATE(T)                                                  \
+    static inline void OPEN3D_SPECIALIZED(T, TemplateISPCFunction5)( \
+            int64_t idx, int64_t * uniform v, bool* uniform arg2,    \
+            uint8_t* uniform arg3, int8_t* uniform arg4,             \
+            uint16_t* uniform arg5) {                                \
+        OPEN3D_SPECIALIZED(T, TemplateISPCFunction4)                 \
+        (idx, v, arg2, arg3, arg4);                                  \
+        *arg5 = 5;                                                   \
+    }
+OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
+#undef TEMPLATE
+
+#define TEMPLATE(T)                                                  \
+    static inline void OPEN3D_SPECIALIZED(T, TemplateISPCFunction6)( \
+            int64_t idx, int64_t * uniform v, bool* uniform arg2,    \
+            uint8_t* uniform arg3, int8_t* uniform arg4,             \
+            uint16_t* uniform arg5, int16_t* uniform arg6) {         \
+        OPEN3D_SPECIALIZED(T, TemplateISPCFunction5)                 \
+        (idx, v, arg2, arg3, arg4, arg5);                            \
+        *arg6 = 6;                                                   \
+    }
+OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
+#undef TEMPLATE
+
+#define TEMPLATE(T)                                                  \
+    static inline void OPEN3D_SPECIALIZED(T, TemplateISPCFunction7)( \
+            int64_t idx, int64_t * uniform v, bool* uniform arg2,    \
+            uint8_t* uniform arg3, int8_t* uniform arg4,             \
+            uint16_t* uniform arg5, int16_t* uniform arg6,           \
+            uint32_t* uniform arg7) {                                \
+        OPEN3D_SPECIALIZED(T, TemplateISPCFunction6)                 \
+        (idx, v, arg2, arg3, arg4, arg5, arg6);                      \
+        *arg7 = 7;                                                   \
+    }
+OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
+#undef TEMPLATE
+
+#define TEMPLATE(T)                                                  \
+    static inline void OPEN3D_SPECIALIZED(T, TemplateISPCFunction8)( \
+            int64_t idx, int64_t * uniform v, bool* uniform arg2,    \
+            uint8_t* uniform arg3, int8_t* uniform arg4,             \
+            uint16_t* uniform arg5, int16_t* uniform arg6,           \
+            uint32_t* uniform arg7, int32_t* uniform arg8) {         \
+        OPEN3D_SPECIALIZED(T, TemplateISPCFunction7)                 \
+        (idx, v, arg2, arg3, arg4, arg5, arg6, arg7);                \
+        *arg8 = 8;                                                   \
+    }
+OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
+#undef TEMPLATE
+
+#define TEMPLATE(T)                                                  \
+    static inline void OPEN3D_SPECIALIZED(T, TemplateISPCFunction9)( \
+            int64_t idx, int64_t * uniform v, bool* uniform arg2,    \
+            uint8_t* uniform arg3, int8_t* uniform arg4,             \
+            uint16_t* uniform arg5, int16_t* uniform arg6,           \
+            uint32_t* uniform arg7, int32_t* uniform arg8,           \
+            uint64_t* uniform arg9) {                                \
+        OPEN3D_SPECIALIZED(T, TemplateISPCFunction8)                 \
+        (idx, v, arg2, arg3, arg4, arg5, arg6, arg7, arg8);          \
+        *arg9 = 9;                                                   \
+    }
+OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
+#undef TEMPLATE
+
+OPEN3D_EXPORT_TEMPLATE_VECTORIZED(TemplateISPCKernel1,
+                                  TemplateISPCFunction1,
+                                  int64_t* uniform)
+OPEN3D_EXPORT_TEMPLATE_VECTORIZED(TemplateISPCKernel2,
+                                  TemplateISPCFunction2,
+                                  int64_t* uniform,
+                                  bool* uniform)
+OPEN3D_EXPORT_TEMPLATE_VECTORIZED(TemplateISPCKernel3,
+                                  TemplateISPCFunction3,
+                                  int64_t* uniform,
+                                  bool* uniform,
+                                  uint8_t* uniform)
+OPEN3D_EXPORT_TEMPLATE_VECTORIZED(TemplateISPCKernel4,
+                                  TemplateISPCFunction4,
+                                  int64_t* uniform,
+                                  bool* uniform,
+                                  uint8_t* uniform,
+                                  int8_t* uniform)
+OPEN3D_EXPORT_TEMPLATE_VECTORIZED(TemplateISPCKernel5,
+                                  TemplateISPCFunction5,
+                                  int64_t* uniform,
+                                  bool* uniform,
+                                  uint8_t* uniform,
+                                  int8_t* uniform,
+                                  uint16_t* uniform)
+OPEN3D_EXPORT_TEMPLATE_VECTORIZED(TemplateISPCKernel6,
+                                  TemplateISPCFunction6,
+                                  int64_t* uniform,
+                                  bool* uniform,
+                                  uint8_t* uniform,
+                                  int8_t* uniform,
+                                  uint16_t* uniform,
+                                  int16_t* uniform)
+OPEN3D_EXPORT_TEMPLATE_VECTORIZED(TemplateISPCKernel7,
+                                  TemplateISPCFunction7,
+                                  int64_t* uniform,
+                                  bool* uniform,
+                                  uint8_t* uniform,
+                                  int8_t* uniform,
+                                  uint16_t* uniform,
+                                  int16_t* uniform,
+                                  uint32_t* uniform)
+OPEN3D_EXPORT_TEMPLATE_VECTORIZED(TemplateISPCKernel8,
+                                  TemplateISPCFunction8,
+                                  int64_t* uniform,
+                                  bool* uniform,
+                                  uint8_t* uniform,
+                                  int8_t* uniform,
+                                  uint16_t* uniform,
+                                  int16_t* uniform,
+                                  uint32_t* uniform,
+                                  int32_t* uniform)
+OPEN3D_EXPORT_TEMPLATE_VECTORIZED(TemplateISPCKernel9,
+                                  TemplateISPCFunction9,
+                                  int64_t* uniform,
+                                  bool* uniform,
+                                  uint8_t* uniform,
+                                  int8_t* uniform,
+                                  uint16_t* uniform,
+                                  int16_t* uniform,
+                                  uint32_t* uniform,
+                                  int32_t* uniform,
+                                  uint64_t* uniform)

--- a/cpp/tests/t/geometry/Image.cpp
+++ b/cpp/tests/t/geometry/Image.cpp
@@ -33,6 +33,7 @@
 #include "open3d/io/ImageIO.h"
 #include "open3d/io/PinholeCameraTrajectoryIO.h"
 #include "open3d/t/io/ImageIO.h"
+#include "open3d/utility/Preprocessor.h"
 #include "open3d/visualization/utility/DrawGeometry.h"
 #include "tests/Tests.h"
 

--- a/cpp/tests/utility/CMakeLists.txt
+++ b/cpp/tests/utility/CMakeLists.txt
@@ -5,5 +5,12 @@ target_sources(tests PRIVATE
     IJsonConvertible.cpp
     ISAInfo.cpp
     Logging.cpp
+    Preprocessor.cpp
     Timer.cpp
 )
+
+if (BUILD_ISPC_MODULE)
+    open3d_ispc_target_sources(tests PRIVATE
+        Helper.ispc
+    )
+endif()

--- a/cpp/tests/utility/Helper.cpp
+++ b/cpp/tests/utility/Helper.cpp
@@ -28,6 +28,10 @@
 
 #include "tests/Tests.h"
 
+#ifdef BUILD_ISPC_MODULE
+#include "Helper_ispc.h"
+#endif
+
 namespace open3d {
 namespace tests {
 
@@ -59,6 +63,26 @@ TEST(Helper, UniformRandIntGeneratorWithRandomSeed) {
             *it = new_rand_generator();
         EXPECT_FALSE(values == new_values);
     }
+}
+
+TEST(Helper, CHAR_BIT_constant) {
+#ifdef BUILD_ISPC_MODULE
+    int32_t value;
+    ispc::GetCharBit(&value);
+
+    EXPECT_EQ(value, CHAR_BIT);
+#endif
+}
+
+TEST(Helper, ENSURE_EXPORTED) {
+#ifdef BUILD_ISPC_MODULE
+    ispc::NotAutomaticallyExportedStruct s;
+    s.i = 1;
+    s.b = 255;
+
+    EXPECT_EQ(s.i, 1);
+    EXPECT_EQ(s.b, 255);
+#endif
 }
 
 }  // namespace tests

--- a/cpp/tests/utility/Helper.ispc
+++ b/cpp/tests/utility/Helper.ispc
@@ -23,30 +23,14 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
-// Copyright 2018 Google Inc. All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
-#include <benchmark/benchmark.h>
+#include "open3d/utility/Helper.isph"
 
-#include "open3d/Open3D.h"
+struct NotAutomaticallyExportedStruct {
+    int32_t i;
+    uint8_t b;
+};
 
-int main(int argc, char** argv) {
-    open3d::utility::CPUInfo::GetInstance().Print();
-    open3d::utility::ISAInfo::GetInstance().Print();
-    benchmark::Initialize(&argc, argv);
-    if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-        return 1;
-    }
-    benchmark::RunSpecifiedBenchmarks();
-}
+OPEN3D_ENSURE_EXPORTED(NotAutomaticallyExportedStruct)
+
+export void GetCharBit(uniform int32_t* uniform value) { *value = CHAR_BIT; }

--- a/cpp/tests/utility/Preprocessor.cpp
+++ b/cpp/tests/utility/Preprocessor.cpp
@@ -1,0 +1,99 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "open3d/utility/Preprocessor.h"
+
+#include "tests/Tests.h"
+
+namespace open3d {
+namespace tests {
+
+TEST(Preprocessor, CONCAT) {
+#define PREFIX_MACRO 10
+#define SUFFIX_MACRO 4
+
+    EXPECT_EQ(OPEN3D_CONCAT(10, 4), 104);
+    EXPECT_EQ(OPEN3D_CONCAT(10, SUFFIX_MACRO), 104);
+    EXPECT_EQ(OPEN3D_CONCAT(PREFIX_MACRO, 4), 104);
+    EXPECT_EQ(OPEN3D_CONCAT(PREFIX_MACRO, SUFFIX_MACRO), 104);
+
+#undef PREFIX_MACRO
+#undef SUFFIX_MACRO
+}
+
+TEST(Preprocessor, STRINGIFY) {
+#define STRING_MACRO test
+
+    EXPECT_EQ(std::string(OPEN3D_STRINGIFY(test)), std::string("test"));
+    EXPECT_EQ(std::string(OPEN3D_STRINGIFY(STRING_MACRO)), std::string("test"));
+
+#undef STRING_MACRO
+}
+
+TEST(Preprocessor, NUM_ARGS_Zero) {
+    // Detecting 0 arguments is not supported and instead returns 1.
+    EXPECT_EQ(OPEN3D_NUM_ARGS(), 1);
+}
+
+TEST(Preprocessor, NUM_ARGS) {
+    EXPECT_EQ(OPEN3D_NUM_ARGS(x1, x2), 2);
+    EXPECT_EQ(OPEN3D_NUM_ARGS(x1, x2, x3), 3);
+    EXPECT_EQ(OPEN3D_NUM_ARGS(x1, x2, x3, x4), 4);
+    EXPECT_EQ(OPEN3D_NUM_ARGS(x1, x2, x3, x4, x5), 5);
+    EXPECT_EQ(OPEN3D_NUM_ARGS(x1, x2, x3, x4, x5, x6), 6);
+    EXPECT_EQ(OPEN3D_NUM_ARGS(x1, x2, x3, x4, x5, x6, x7), 7);
+    EXPECT_EQ(OPEN3D_NUM_ARGS(x1, x2, x3, x4, x5, x6, x7, x8), 8);
+    EXPECT_EQ(OPEN3D_NUM_ARGS(x1, x2, x3, x4, x5, x6, x7, x8, x9), 9);
+    EXPECT_EQ(OPEN3D_NUM_ARGS(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10), 10);
+    // Detecting >10 Arguments is not supported and results in compiler errors.
+    // EXPECT_EQ(OPEN3D_NUM_ARGS(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11),
+    // 11);
+    // ...
+}
+
+TEST(Preprocessor, OVERLOAD) {
+#define FUNC_1(x1) (x1) + 1
+#define FUNC_2(x1, x2) (x1) * (x2)
+
+#define FUNC(...) \
+    OPEN3D_FIX_MSVC_(OPEN3D_OVERLOAD(FUNC_, __VA_ARGS__)(__VA_ARGS__))
+
+    EXPECT_EQ(FUNC(0), 0 + 1);
+    EXPECT_EQ(FUNC(1), 0 + 2);
+    EXPECT_EQ(FUNC(2), 0 + 3);
+
+    EXPECT_EQ(FUNC(0, 1), 0 * 1);
+    EXPECT_EQ(FUNC(1, 2), 1 * 2);
+    EXPECT_EQ(FUNC(2, 3), 2 * 3);
+
+#undef FUNC
+
+#undef FUNC_1
+#undef FUNC_2
+}
+
+}  // namespace tests
+}  // namespace open3d


### PR DESCRIPTION
#### Highlights:

- `ParallelFor` with additional argument to call the vectorized code path. Falls back to other `ParallelFor` if `BUILD_ISPC_MODULE` is `OFF`.
- `OPEN3D_VECTORIZED` and `OPEN3D_TEMPLATE_VECTORIZED` macros to automatically create a lambda function calling the specified ISPC kernel. Only work for up to 9 additional parameters.
- `OPEN3D_EXPORT_VECTORIZED` and `OPEN3D_EXPORT_TEMPLATE_VECTORIZED` macros to define the ISPC kernels to be called by `ParallelFor`. Only work for up to 9 additional parameters.
- `OPEN3D_INSTANTIATE_TEMPLATE` and `OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL` macros to emulate template functions and their instantiation in ISPC code.
- Unit tests to cover the introduced functions and macros.

#### Benchmarks (Intel i7-10750H):

Command: `./bin/benchmarks --benchmark_filter=ParallelFor`

```
[Open3D INFO] CPUInfo: 6 cores, 12 threads.
[Open3D INFO] ISAInfo: AVX2 instruction set used in ISPC code.
2021-09-14T11:44:43+02:00
Running ./bin/benchmarks
Run on (12 X 4727.5 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 256 KiB (x6)
  L3 Unified 12288 KiB (x1)
Load Average: 1.76, 1.27, 1.13
-----------------------------------------------------------------------------
Benchmark                                   Time             CPU   Iterations
-----------------------------------------------------------------------------
ParallelForScalar/CPU100                 1.27 us         1.27 us       542632
ParallelForScalar/CPU1000                1.26 us         1.26 us       533485
ParallelForScalar/CPU10000               2.14 us         2.14 us       329166
ParallelForScalar/CPU100000              11.4 us         11.4 us        55214
ParallelForScalar/CPU1000000              105 us          105 us         6769
ParallelForScalar/CPU10000000            3714 us         3714 us          188
ParallelForScalar/CPU100000000          39998 us        39995 us           18
ParallelForVectorized/CPU100             1.38 us         1.38 us       510147
ParallelForVectorized/CPU1000            1.40 us         1.40 us       496748
ParallelForVectorized/CPU10000           1.51 us         1.51 us       462849
ParallelForVectorized/CPU100000          3.59 us         3.59 us       197242
ParallelForVectorized/CPU1000000         42.2 us         42.2 us        16401
ParallelForVectorized/CPU10000000        3659 us         3658 us          194
ParallelForVectorized/CPU100000000      39473 us        39473 us           18
```

Command: `OPENMP_NUM_THREADS=1 ./bin/benchmarks --benchmark_filter=ParallelFor`

```
[Open3D INFO] CPUInfo: 6 cores, 12 threads.
[Open3D INFO] ISAInfo: AVX2 instruction set used in ISPC code.
2021-09-14T12:08:34+02:00
Running ./bin/benchmarks
Run on (12 X 4795.83 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 256 KiB (x6)
  L3 Unified 12288 KiB (x1)
Load Average: 0.61, 0.46, 0.57
-----------------------------------------------------------------------------
Benchmark                                   Time             CPU   Iterations
-----------------------------------------------------------------------------
ParallelForScalar/CPU100                0.554 us        0.554 us      1252981
ParallelForScalar/CPU1000               0.940 us        0.940 us       733749
ParallelForScalar/CPU10000               4.97 us         4.97 us       139518
ParallelForScalar/CPU100000              44.6 us         44.6 us        15436
ParallelForScalar/CPU1000000              444 us          444 us         1570
ParallelForScalar/CPU10000000            5207 us         5207 us          130
ParallelForScalar/CPU100000000          52967 us        52968 us           13
ParallelForVectorized/CPU100            0.597 us        0.597 us      1170738
ParallelForVectorized/CPU1000           0.662 us        0.662 us      1039586
ParallelForVectorized/CPU10000           1.40 us         1.40 us       502559
ParallelForVectorized/CPU100000          14.0 us         14.0 us        50152
ParallelForVectorized/CPU1000000          145 us          145 us         4678
ParallelForVectorized/CPU10000000        3924 us         3924 us          178
ParallelForVectorized/CPU100000000      42717 us        42718 us           16
```
#### Observations:
- Performance improvement becomes more significant with less cores used.
- Array size in relation to CPU Cache seems to have significant positive effect:
   - **Small**: Compute-bound, overhead exceeds actual work.
   - **Mid-sized**: Compute-bound, 2-4x speed improvements with `AVX2`.
   - **Large**: Memory-bound, acceleration less significant.
- More compute-intense kernels could benefit more from vectorization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4039)
<!-- Reviewable:end -->
