### PR TITLE
SizeVector implict conversion in Pybind

### DIFF
--- a/cpp/pybind/core/hashmap.cpp
+++ b/cpp/pybind/core/hashmap.cpp
@@ -35,7 +35,6 @@
 #include "open3d/core/hashmap/HashSet.h"
 #include "open3d/utility/Logging.h"
 #include "pybind/core/core.h"
-#include "pybind/core/tensor_converter.h"
 #include "pybind/docstring.h"
 #include "pybind/open3d_pybind.h"
 
@@ -78,43 +77,17 @@ void pybind_core_hashmap(py::module& m) {
                                 "A HashMap is an unordered map from key to "
                                 "value wrapped by Tensors.");
 
-    hashmap.def(py::init([](int64_t init_capacity, const Dtype& key_dtype,
-                            const py::handle& key_element_shape,
-                            const Dtype& value_dtype,
-                            const py::handle& value_element_shape,
-                            const Device& device) {
-                    SizeVector key_element_shape_sv =
-                            PyHandleToSizeVector(key_element_shape);
-                    SizeVector value_element_shape_sv =
-                            PyHandleToSizeVector(value_element_shape);
-                    return HashMap(init_capacity, key_dtype,
-                                   key_element_shape_sv, value_dtype,
-                                   value_element_shape_sv, device);
-                }),
+    hashmap.def(py::init<int64_t, const Dtype&, const SizeVector&, const Dtype&,
+                         const SizeVector&, const Device&>(),
                 "init_capacity"_a, "key_dtype"_a, "key_element_shape"_a,
                 "value_dtype"_a, "value_element_shape"_a,
                 "device"_a = Device("CPU:0"));
-    hashmap.def(
-            py::init([](int64_t init_capacity, const Dtype& key_dtype,
-                        const py::handle& key_element_shape,
-                        const std::vector<Dtype>& value_dtypes,
-                        const std::vector<py::handle>& value_element_shapes,
-                        const Device& device) {
-                SizeVector key_element_shape_sv =
-                        PyHandleToSizeVector(key_element_shape);
-
-                std::vector<SizeVector> value_element_shapes_sv;
-                for (auto& handle : value_element_shapes) {
-                    SizeVector value_element_shape_sv =
-                            PyHandleToSizeVector(handle);
-                    value_element_shapes_sv.push_back(value_element_shape_sv);
-                }
-                return HashMap(init_capacity, key_dtype, key_element_shape_sv,
-                               value_dtypes, value_element_shapes_sv, device);
-            }),
-            "init_capacity"_a, "key_dtype"_a, "key_element_shape"_a,
-            "value_dtypes"_a, "value_element_shapes"_a,
-            "device"_a = Device("CPU:0"));
+    hashmap.def(py::init<int64_t, const Dtype&, const SizeVector&,
+                         const std::vector<Dtype>&,
+                         const std::vector<SizeVector>&, const Device&>(),
+                "init_capacity"_a, "key_dtype"_a, "key_element_shape"_a,
+                "value_dtypes"_a, "value_element_shapes"_a,
+                "device"_a = Device("CPU:0"));
     docstring::ClassMethodDocInject(m, "HashMap", "__init__", argument_docs);
 
     hashmap.def(
@@ -243,16 +216,10 @@ void pybind_core_hashset(py::module& m) {
             m, "HashSet",
             "A HashSet is an unordered set of keys wrapped by Tensors.");
 
-    hashset.def(py::init([](int64_t init_capacity, const Dtype& key_dtype,
-                            const py::handle& key_element_shape,
-                            const Device& device) {
-                    SizeVector key_element_shape_sv =
-                            PyHandleToSizeVector(key_element_shape);
-                    return HashSet(init_capacity, key_dtype,
-                                   key_element_shape_sv, device);
-                }),
-                "init_capacity"_a, "key_dtype"_a, "key_element_shape"_a,
-                "device"_a = Device("CPU:0"));
+    hashset.def(
+            py::init<int64_t, const Dtype&, const SizeVector&, const Device&>(),
+            "init_capacity"_a, "key_dtype"_a, "key_element_shape"_a,
+            "device"_a = Device("CPU:0"));
     docstring::ClassMethodDocInject(m, "HashSet", "__init__", argument_docs);
 
     hashset.def(

--- a/cpp/pybind/core/size_vector.cpp
+++ b/cpp/pybind/core/size_vector.cpp
@@ -38,6 +38,27 @@ void pybind_core_size_vector(py::module& m) {
             m, "SizeVector",
             "A vector of integers for specifying shape, strides, etc.");
 
+    // In Python, We want (3), (3,), [3] and [3,] to represent the same thing.
+    // The followings are all equivalent to core::SizeVector({3}):
+    // - o3d.core.SizeVector(3)     # int
+    // - o3d.core.SizeVector((3))   # int, not tuple
+    // - o3d.core.SizeVector((3,))  # tuple
+    // - o3d.core.SizeVector([3])   # list
+    // - o3d.core.SizeVector([3,])  # list
+    //
+    // Difference between C++ and Python:
+    // - o3d.core.SizeVector(3) creates a 1-D SizeVector: {3}.
+    // - core::SizeVector(3) creates a 3-D SizeVector: {0, 0, 0}.
+    //
+    // The API difference is due to the NumPy convention which allows integer to
+    // represent a 1-element tuple, and the C++ constructor for vectors.
+    sv.def(py::init([](int64_t i) { return SizeVector({i}); }));
+    py::implicitly_convertible<py::int_, SizeVector>();
+
+    // Allows tuple and list implicit conversions to SizeVector.
+    py::implicitly_convertible<py::tuple, SizeVector>();
+    py::implicitly_convertible<py::list, SizeVector>();
+
     auto dsv = py::bind_vector<DynamicSizeVector>(
             m, "DynamicSizeVector",
             "A vector of integers for specifying shape, strides, etc. Some "

--- a/cpp/pybind/core/tensor_converter.cpp
+++ b/cpp/pybind/core/tensor_converter.cpp
@@ -252,57 +252,5 @@ Tensor PyHandleToTensor(const py::handle& handle,
     }
 }
 
-SizeVector PyTupleToSizeVector(const py::tuple& tuple) {
-    SizeVector shape;
-    for (const py::handle item : tuple) {
-        if (std::string(py::str(item.get_type())) == "<class 'int'>") {
-            shape.push_back(static_cast<int64_t>(item.cast<py::int_>()));
-        } else {
-            utility::LogError(
-                    "The tuple must be a 1D tuple of integers, but got {}.",
-                    item.attr("__str__")());
-        }
-    }
-    return shape;
-}
-
-SizeVector PyListToSizeVector(const py::list& list) {
-    SizeVector shape;
-    for (const py::handle item : list) {
-        if (std::string(py::str(item.get_type())) == "<class 'int'>") {
-            shape.push_back(static_cast<int64_t>(item.cast<py::int_>()));
-        } else {
-            utility::LogError(
-                    "The list must be a 1D list of integers, but got {}.",
-                    item.attr("__str__")());
-        }
-    }
-    return shape;
-}
-
-SizeVector PyHandleToSizeVector(const py::handle& handle) {
-    std::string class_name(py::str(handle.get_type()));
-    if (class_name == "<class 'int'>") {
-        return SizeVector{static_cast<int64_t>(handle.cast<py::int_>())};
-    } else if (class_name == "<class 'list'>") {
-        return PyListToSizeVector(handle.cast<py::list>());
-    } else if (class_name == "<class 'tuple'>") {
-        return PyTupleToSizeVector(handle.cast<py::tuple>());
-    } else if (class_name.find("SizeVector") != std::string::npos) {
-        try {
-            SizeVector* sv = handle.cast<SizeVector*>();
-            return SizeVector(sv->begin(), sv->end());
-        } catch (...) {
-            utility::LogError(
-                    "PyHandleToSizeVector: cannot cast to SizeVector.");
-        }
-    } else {
-        utility::LogError(
-                "PyHandleToSizeVector has invalid input type {}. Only int, "
-                "tuple and list are supported.",
-                class_name);
-    }
-}
-
 }  // namespace core
 }  // namespace open3d

--- a/cpp/pybind/core/tensor_converter.h
+++ b/cpp/pybind/core/tensor_converter.h
@@ -124,25 +124,5 @@ Tensor PyHandleToTensor(const py::handle& handle,
                         utility::optional<Device> device = utility::nullopt,
                         bool force_copy = false);
 
-/// Convert py::tuple to SizeVector.
-///
-/// The tuple must contain a list of (1D) integers. Floats are not allowed.
-SizeVector PyTupleToSizeVector(const py::tuple& tuple);
-
-/// Convert py::list to SizeVector.
-///
-/// The list must contain a list of (1D) integers. Floats are not allowed.
-SizeVector PyListToSizeVector(const py::list& list);
-
-/// Convert supported python types to reduction dimensions.
-///
-/// Supported types:
-/// 1) int
-/// 3) list of ints (1D)
-/// 4) tuple of ints (1D)
-///
-/// An exception will be thrown if the type is not supported.
-SizeVector PyHandleToSizeVector(const py::handle& handle);
-
 }  // namespace core
 }  // namespace open3d

--- a/python/test/core/test_core.py
+++ b/python/test/core/test_core.py
@@ -145,49 +145,6 @@ def test_device():
     assert o3c.Device("CUDA", 1).__str__() == "CUDA:1"
 
 
-def test_size_vector():
-    # List
-    sv = o3c.SizeVector([-1, 2, 3])
-    assert "{}".format(sv) == "SizeVector[-1, 2, 3]"
-
-    # Tuple
-    sv = o3c.SizeVector((-1, 2, 3))
-    assert "{}".format(sv) == "SizeVector[-1, 2, 3]"
-
-    # Numpy 1D array
-    sv = o3c.SizeVector(np.array([-1, 2, 3]))
-    assert "{}".format(sv) == "SizeVector[-1, 2, 3]"
-
-    # Empty
-    sv = o3c.SizeVector()
-    assert "{}".format(sv) == "SizeVector[]"
-    sv = o3c.SizeVector([])
-    assert "{}".format(sv) == "SizeVector[]"
-    sv = o3c.SizeVector(())
-    assert "{}".format(sv) == "SizeVector[]"
-    sv = o3c.SizeVector(np.array([]))
-    assert "{}".format(sv) == "SizeVector[]"
-
-    # Not integer: thorws exception
-    with pytest.raises(Exception):
-        sv = o3c.SizeVector([1.9, 2, 3])
-
-    with pytest.raises(Exception):
-        sv = o3c.SizeVector([-1.5, 2, 3])
-
-    # 2D list exception
-    with pytest.raises(Exception):
-        sv = o3c.SizeVector([[1, 2], [3, 4]])
-
-    # 2D Numpy array exception
-    with pytest.raises(Exception):
-        sv = o3c.SizeVector(np.array([[1, 2], [3, 4]]))
-
-    # Garbage input
-    with pytest.raises(Exception):
-        sv = o3c.SizeVector(["foo", "bar"])
-
-
 @pytest.mark.parametrize("dtype", list_dtypes())
 @pytest.mark.parametrize("device", list_devices())
 def test_tensor_constructor(dtype, device):

--- a/python/test/core/test_size_vector.py
+++ b/python/test/core/test_size_vector.py
@@ -1,0 +1,130 @@
+# ----------------------------------------------------------------------------
+# -                        Open3D: www.open3d.org                            -
+# ----------------------------------------------------------------------------
+# The MIT License (MIT)
+#
+# Copyright (c) 2018-2021 www.open3d.org
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ----------------------------------------------------------------------------
+
+import open3d as o3d
+import numpy as np
+import pytest
+
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/..")
+from open3d_test import list_devices
+
+
+def test_size_vector():
+    # List
+    sv = o3d.core.SizeVector([-1, 2, 3])
+    assert "{}".format(sv) == "SizeVector[-1, 2, 3]"
+
+    # Tuple
+    sv = o3d.core.SizeVector((-1, 2, 3))
+    assert "{}".format(sv) == "SizeVector[-1, 2, 3]"
+
+    # Numpy 1D array
+    sv = o3d.core.SizeVector(np.array([-1, 2, 3]))
+    assert "{}".format(sv) == "SizeVector[-1, 2, 3]"
+
+    # Empty
+    sv = o3d.core.SizeVector()
+    assert "{}".format(sv) == "SizeVector[]"
+    sv = o3d.core.SizeVector([])
+    assert "{}".format(sv) == "SizeVector[]"
+    sv = o3d.core.SizeVector(())
+    assert "{}".format(sv) == "SizeVector[]"
+    sv = o3d.core.SizeVector(np.array([]))
+    assert "{}".format(sv) == "SizeVector[]"
+
+    # 1-dimensional SizeVector
+    assert o3d.core.SizeVector(3) == (3,)
+    assert o3d.core.SizeVector((3)) == (3,)
+    assert o3d.core.SizeVector((3,)) == (3,)
+    assert o3d.core.SizeVector([3]) == (3,)
+    assert o3d.core.SizeVector([
+        3,
+    ]) == (3,)
+
+    # Not integer: thorws exception
+    with pytest.raises(Exception):
+        sv = o3d.core.SizeVector([1.9, 2, 3])
+
+    with pytest.raises(Exception):
+        sv = o3d.core.SizeVector([-1.5, 2, 3])
+
+    # 2D list exception
+    with pytest.raises(Exception):
+        sv = o3d.core.SizeVector([[1, 2], [3, 4]])
+
+    # 2D Numpy array exception
+    with pytest.raises(Exception):
+        sv = o3d.core.SizeVector(np.array([[1, 2], [3, 4]]))
+
+    # Garbage input
+    with pytest.raises(Exception):
+        sv = o3d.core.SizeVector(["foo", "bar"])
+
+
+@pytest.mark.parametrize("device", list_devices())
+def test_implicit_conversion(device):
+    # Reshape
+    t = o3d.core.Tensor.ones((3, 4), device=device)
+    assert t.reshape(o3d.core.SizeVector((4, 3))).shape == (4, 3)
+    assert t.reshape(o3d.core.SizeVector([4, 3])).shape == (4, 3)
+    assert t.reshape((4, 3)).shape == (4, 3)
+    assert t.reshape([4, 3]).shape == (4, 3)
+    with pytest.raises(TypeError, match="incompatible function arguments"):
+        t.reshape((4, 3.0))
+    with pytest.raises(TypeError, match="incompatible function arguments"):
+        t.reshape((4.0, 3.0))
+    with pytest.raises(RuntimeError, match="Invalid shape dimension"):
+        t.reshape((4, -3))
+
+    # 0-dimensional
+    assert o3d.core.Tensor.ones((), device=device).shape == ()
+    assert o3d.core.Tensor.ones([], device=device).shape == ()
+
+    # 1-dimensional
+    assert o3d.core.Tensor.ones(3, device=device).shape == (3,)
+    assert o3d.core.Tensor.ones((3), device=device).shape == (3,)
+    assert o3d.core.Tensor.ones((3,), device=device).shape == (3,)
+    assert o3d.core.Tensor.ones([3], device=device).shape == (3,)
+    assert o3d.core.Tensor.ones([
+        3,
+    ], device=device).shape == (3,)
+
+    # Tensor creation
+    assert o3d.core.Tensor.empty((3, 4), device=device).shape == (3, 4)
+    assert o3d.core.Tensor.ones((3, 4), device=device).shape == (3, 4)
+    assert o3d.core.Tensor.zeros((3, 4), device=device).shape == (3, 4)
+    assert o3d.core.Tensor.full((3, 4), 10, device=device).shape == (3, 4)
+
+    # Reduction
+    t = o3d.core.Tensor.ones((3, 4, 5), device=device)
+    assert t.sum(o3d.core.SizeVector([0, 2])).shape == (4,)
+    assert t.sum(o3d.core.SizeVector([0, 2]), keepdim=True).shape == (1, 4, 1)
+    assert t.sum((0, 2)).shape == (4,)
+    assert t.sum([0, 2]).shape == (4,)
+    assert t.sum((0, 2), keepdim=True).shape == (1, 4, 1)
+    assert t.sum([0, 2], keepdim=True).shape == (1, 4, 1)


### PR DESCRIPTION
Full automatic implicit conversion of `SizeVector` class in Python.

E.g.:
```python
o3d.core.Tensor.ones((3, 4))
# Before
t.reshape(o3d.core.SizeVector([12]))
t.reshape(o3d.core.SizeVector([4, 3]))
# Now
t.reshape(12)
t.reshape((12))
t.reshape((12,))
t.reshape([12])
t.reshape([12,])
t.reshape((4, 3))
t.reshape([4, 3])
```

This also works for other locations where `SizeVector` is used as input. Updated reduction, tensor creation, hash map/set in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4045)
<!-- Reviewable:end -->
