### PR TITLE
Upgrade Eigen dependency

### DIFF
--- a/3rdparty/README.txt
+++ b/3rdparty/README.txt
@@ -9,7 +9,7 @@ libusb. Run corresponding script file under "script" directory to automatically
 config them.
 
 --------------------------------------------------------------------------------
-Eigen                       3.4-rc1                            Mainly MPL2 license
+Eigen                       3.4                              Mainly MPL2 license
 A high-level C++ library of template headers for linear algebra, matrix and
 vector operations, numerical solvers and related algorithms
 http://eigen.tuxfamily.org/

--- a/3rdparty/eigen/eigen.cmake
+++ b/3rdparty/eigen/eigen.cmake
@@ -3,8 +3,8 @@ include(ExternalProject)
 ExternalProject_Add(
     ext_eigen
     PREFIX eigen
-    URL https://gitlab.com/libeigen/eigen/-/archive/3.4-rc1/eigen-3.4-rc1.tar.bz2
-    URL_HASH SHA256=92641cb17a92bcf311c7fc095a555ca0e32990503573dda80eb1764dc37dcac9
+    URL https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.bz2
+    URL_HASH SHA256=b4c198460eba6f28d34894e3a5710998818515104d6e74e5cc331ce31e46e626
     DOWNLOAD_DIR "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/eigen"
     UPDATE_COMMAND ""
     CONFIGURE_COMMAND ""


### PR DESCRIPTION
`Eigen 3.4` has been released August 18, 2021. In particular, it includes a fix for building on Windows + CUDA which will resolve the build issues observed [here](https://github.com/isl-org/Open3D/pull/4039/checks?check_run_id=3597186732).

Required for #4039

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4046)
<!-- Reviewable:end -->
