### PR TITLE
add support for more types to InvertNeighborsListOp

### DIFF
--- a/cpp/open3d/ml/pytorch/misc/InvertNeighborsListOpKernel.cpp
+++ b/cpp/open3d/ml/pytorch/misc/InvertNeighborsListOpKernel.cpp
@@ -73,6 +73,9 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> InvertNeighborsListCPU(
                                           const torch::Tensor&,          \
                                           const torch::Tensor&);
 
+INSTANTIATE(int32_t, uint8_t)
+INSTANTIATE(int32_t, int8_t)
+INSTANTIATE(int32_t, int16_t)
 INSTANTIATE(int32_t, int32_t)
 INSTANTIATE(int32_t, int64_t)
 INSTANTIATE(int32_t, float)

--- a/cpp/open3d/ml/pytorch/misc/InvertNeighborsListOpKernel.cu
+++ b/cpp/open3d/ml/pytorch/misc/InvertNeighborsListOpKernel.cu
@@ -103,6 +103,9 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> InvertNeighborsListCUDA(
                                            const torch::Tensor&,          \
                                            const torch::Tensor&);
 
+INSTANTIATE(int32_t, uint8_t)
+INSTANTIATE(int32_t, int8_t)
+INSTANTIATE(int32_t, int16_t)
 INSTANTIATE(int32_t, int32_t)
 INSTANTIATE(int32_t, int64_t)
 INSTANTIATE(int32_t, float)

--- a/cpp/open3d/ml/pytorch/misc/InvertNeighborsListOps.cpp
+++ b/cpp/open3d/ml/pytorch/misc/InvertNeighborsListOps.cpp
@@ -72,6 +72,9 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> InvertNeighborsList(
     if (inp_neighbors_index.is_cuda()) {
 #ifdef BUILD_CUDA_MODULE
         // pass to cuda function
+        CALL(int32_t, uint8_t, InvertNeighborsListCUDA)
+        CALL(int32_t, int8_t, InvertNeighborsListCUDA)
+        CALL(int32_t, int16_t, InvertNeighborsListCUDA)
         CALL(int32_t, int32_t, InvertNeighborsListCUDA)
         CALL(int32_t, int64_t, InvertNeighborsListCUDA)
         CALL(int32_t, float, InvertNeighborsListCUDA)
@@ -81,6 +84,9 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> InvertNeighborsList(
                     "InvertNeighborsList was not compiled with CUDA support")
 #endif
     } else {
+        CALL(int32_t, uint8_t, InvertNeighborsListCPU)
+        CALL(int32_t, int8_t, InvertNeighborsListCPU)
+        CALL(int32_t, int16_t, InvertNeighborsListCPU)
         CALL(int32_t, int32_t, InvertNeighborsListCPU)
         CALL(int32_t, int64_t, InvertNeighborsListCPU)
         CALL(int32_t, float, InvertNeighborsListCPU)

--- a/cpp/open3d/ml/tensorflow/misc/InvertNeighborsListOpKernel.cpp
+++ b/cpp/open3d/ml/tensorflow/misc/InvertNeighborsListOpKernel.cpp
@@ -68,6 +68,9 @@ public:
                                     .TypeConstraint<type>("TIndex")     \
                                     .TypeConstraint<attrtype>("TAttr"), \
                             InvertNeighborsListOpKernelCPU<type, attrtype>);
+REG_KB(int32_t, uint8_t)
+REG_KB(int32_t, int8_t)
+REG_KB(int32_t, int16_t)
 REG_KB(int32_t, int32_t)
 REG_KB(int32_t, int64)
 REG_KB(int32_t, float)

--- a/cpp/open3d/ml/tensorflow/misc/InvertNeighborsListOpKernel.cu
+++ b/cpp/open3d/ml/tensorflow/misc/InvertNeighborsListOpKernel.cu
@@ -108,6 +108,9 @@ private:
                                     .TypeConstraint<attrtype>("TAttr") \
                                     .HostMemory("num_points"),         \
                             InvertNeighborsListOpKernelCUDA<type, attrtype>);
+REG_KB(int32_t, uint8_t)
+REG_KB(int32_t, int8_t)
+REG_KB(int32_t, int16_t)
 REG_KB(int32_t, int32_t)
 REG_KB(int32_t, int64)
 REG_KB(int32_t, float)

--- a/cpp/open3d/ml/tensorflow/misc/InvertNeighborsListOps.cpp
+++ b/cpp/open3d/ml/tensorflow/misc/InvertNeighborsListOps.cpp
@@ -34,7 +34,7 @@ using namespace tensorflow;
 
 REGISTER_OP("Open3DInvertNeighborsList")
         .Attr("TIndex: {int32}")
-        .Attr("TAttr: {int32, int64, float, double}")
+        .Attr("TAttr: {uint8, int8, int16, int32, int64, float, double}")
         .Input("num_points: int64")
         .Input("inp_neighbors_index: TIndex")
         .Input("inp_neighbors_row_splits: int64")

--- a/python/test/ml_ops/test_invert_neighbors_list.py
+++ b/python/test/ml_ops/test_invert_neighbors_list.py
@@ -34,7 +34,8 @@ pytestmark = mltest.default_marks
 
 # the supported dtypes for the attributes
 value_dtypes = pytest.mark.parametrize(
-    'dtype', [np.int32, np.int64, np.float32, np.float64])
+    'dtype',
+    [np.uint8, np.int8, np.int16, np.int32, np.int64, np.float32, np.float64])
 
 attributes = pytest.mark.parametrize('attributes',
                                      ['scalar', 'none', 'multidim'])


### PR DESCRIPTION
This PR extends the number of types supported by the InvertNeighborsListOp

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4048)
<!-- Reviewable:end -->
