### PR TITLE
Fix unresolved symbols with BUILD_SHARED_LIBS=ON and BUILD_GUI=OFF

### DIFF
--- a/cpp/open3d/visualization/CMakeLists.txt
+++ b/cpp/open3d/visualization/CMakeLists.txt
@@ -26,7 +26,6 @@ target_sources(visualization PRIVATE
 )
 
 target_sources(visualization PRIVATE
-    visualizer/MessageProcessor.cpp
     visualizer/RenderOption.cpp
     visualizer/RenderOptionWithEditing.cpp
     visualizer/ViewControl.cpp
@@ -81,6 +80,7 @@ if (BUILD_GUI)
     )
 
     target_sources(visualization PRIVATE
+        visualizer/MessageProcessor.cpp
         visualizer/GuiSettingsModel.cpp
         visualizer/GuiSettingsView.cpp
         visualizer/GuiVisualizer.cpp


### PR DESCRIPTION
This PR fixes unresolved symbols when linking to the shared libs without gui module by moving MessageProcessor.cpp to the gui source files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4062)
<!-- Reviewable:end -->
