### PR TITLE
Rename tensor-registration functions

### DIFF
--- a/cpp/benchmarks/pipelines/registration/Registration.cpp
+++ b/cpp/benchmarks/pipelines/registration/Registration.cpp
@@ -81,8 +81,8 @@ static std::tuple<geometry::PointCloud, geometry::PointCloud> LoadPointCloud(
     return std::make_tuple(source, target);
 }
 
-static void BenchmarkRegistrationICPLegacy(
-        benchmark::State& state, const TransformationEstimationType& type) {
+static void BenchmarkICPLegacy(benchmark::State& state,
+                               const TransformationEstimationType& type) {
     geometry::PointCloud source;
     geometry::PointCloud target;
 
@@ -122,12 +122,12 @@ static void BenchmarkRegistrationICPLegacy(
                       reg_result.inlier_rmse_);
 }
 
-BENCHMARK_CAPTURE(BenchmarkRegistrationICPLegacy,
+BENCHMARK_CAPTURE(BenchmarkICPLegacy,
                   PointToPlane / CPU,
                   TransformationEstimationType::PointToPlane)
         ->Unit(benchmark::kMillisecond);
 
-BENCHMARK_CAPTURE(BenchmarkRegistrationICPLegacy,
+BENCHMARK_CAPTURE(BenchmarkICPLegacy,
                   PointToPoint / CPU,
                   TransformationEstimationType::PointToPoint)
         ->Unit(benchmark::kMillisecond);

--- a/cpp/open3d/t/pipelines/registration/Registration.cpp
+++ b/cpp/open3d/t/pipelines/registration/Registration.cpp
@@ -100,15 +100,15 @@ RegistrationResult EvaluateRegistration(const geometry::PointCloud &source,
             transformation);
 }
 
-RegistrationResult RegistrationICP(const geometry::PointCloud &source,
-                                   const geometry::PointCloud &target,
-                                   double max_correspondence_distance,
-                                   const core::Tensor &init_source_to_target,
-                                   const TransformationEstimation &estimation,
-                                   const ICPConvergenceCriteria &criteria) {
-    return RegistrationMultiScaleICP(source, target, {-1}, {criteria},
-                                     {max_correspondence_distance},
-                                     init_source_to_target, estimation);
+RegistrationResult ICP(const geometry::PointCloud &source,
+                       const geometry::PointCloud &target,
+                       double max_correspondence_distance,
+                       const core::Tensor &init_source_to_target,
+                       const TransformationEstimation &estimation,
+                       const ICPConvergenceCriteria &criteria) {
+    return MultiScaleICP(source, target, {-1}, {criteria},
+                         {max_correspondence_distance}, init_source_to_target,
+                         estimation);
 }
 
 static void AssertInputMultiScaleICP(
@@ -143,7 +143,7 @@ static void AssertInputMultiScaleICP(
     if (!(criterias.size() == voxel_sizes.size() &&
           criterias.size() == max_correspondence_distances.size())) {
         utility::LogError(
-                " [RegistrationMultiScaleICP]: Size of criterias, voxel_size,"
+                " [MultiScaleICP]: Size of criterias, voxel_size,"
                 " max_correspondence_distances vectors must be same.");
     }
     if (estimation.GetTransformationEstimationType() ==
@@ -296,7 +296,7 @@ static RegistrationResult DoSingleScaleIterationsICP(
     return result;
 }
 
-RegistrationResult RegistrationMultiScaleICP(
+RegistrationResult MultiScaleICP(
         const geometry::PointCloud &source,
         const geometry::PointCloud &target,
         const std::vector<double> &voxel_sizes,
@@ -361,11 +361,10 @@ RegistrationResult RegistrationMultiScaleICP(
     return result;
 }
 
-core::Tensor GetInformationMatrixFromPointClouds(
-        const geometry::PointCloud &source,
-        const geometry::PointCloud &target,
-        const double max_correspondence_distance,
-        const core::Tensor &transformation) {
+core::Tensor GetInformationMatrix(const geometry::PointCloud &source,
+                                  const geometry::PointCloud &target,
+                                  const double max_correspondence_distance,
+                                  const core::Tensor &transformation) {
     core::Device device = source.GetDevice();
     core::Dtype dtype = source.GetPointPositions().GetDtype();
     core::AssertTensorDtype(target.GetPointPositions(), dtype);

--- a/cpp/open3d/t/pipelines/registration/Registration.h
+++ b/cpp/open3d/t/pipelines/registration/Registration.h
@@ -136,7 +136,7 @@ RegistrationResult EvaluateRegistration(
 /// Float64 on CPU.
 /// \param estimation Estimation method.
 /// \param criteria Convergence criteria.
-RegistrationResult RegistrationICP(
+RegistrationResult ICP(
         const geometry::PointCloud &source,
         const geometry::PointCloud &target,
         double max_correspondence_distance,
@@ -167,7 +167,7 @@ RegistrationResult RegistrationICP(
 /// \param init_source_to_target Initial transformation estimation of type
 /// Float64 on CPU.
 /// \param estimation Estimation method.
-RegistrationResult RegistrationMultiScaleICP(
+RegistrationResult MultiScaleICP(
         const geometry::PointCloud &source,
         const geometry::PointCloud &target,
         const std::vector<double> &voxel_sizes,
@@ -188,11 +188,10 @@ RegistrationResult RegistrationMultiScaleICP(
 /// distance.
 /// \param transformation The 4x4 transformation matrix to transform
 /// `source` to `target`.
-core::Tensor GetInformationMatrixFromPointClouds(
-        const geometry::PointCloud &source,
-        const geometry::PointCloud &target,
-        const double max_correspondence_distance,
-        const core::Tensor &transformation);
+core::Tensor GetInformationMatrix(const geometry::PointCloud &source,
+                                  const geometry::PointCloud &target,
+                                  const double max_correspondence_distance,
+                                  const core::Tensor &transformation);
 
 }  // namespace registration
 }  // namespace pipelines

--- a/cpp/pybind/t/pipelines/registration/registration.cpp
+++ b/cpp/pybind/t/pipelines/registration/registration.cpp
@@ -296,36 +296,33 @@ void pybind_registration_methods(py::module &m) {
     docstring::FunctionDocInject(m, "evaluate_registration",
                                  map_shared_argument_docstrings);
 
-    m.def("registration_icp", &RegistrationICP,
-          py::call_guard<py::gil_scoped_release>(),
+    m.def("icp", &ICP, py::call_guard<py::gil_scoped_release>(),
           "Function for ICP registration", "source"_a, "target"_a,
           "max_correspondence_distance"_a,
           "init_source_to_target"_a =
                   core::Tensor::Eye(4, core::Float64, core::Device("CPU:0")),
           "estimation_method"_a = TransformationEstimationPointToPoint(),
           "criteria"_a = ICPConvergenceCriteria());
-    docstring::FunctionDocInject(m, "registration_icp",
-                                 map_shared_argument_docstrings);
+    docstring::FunctionDocInject(m, "icp", map_shared_argument_docstrings);
 
-    m.def("registration_multi_scale_icp", &RegistrationMultiScaleICP,
+    m.def("multi_scale_icp", &MultiScaleICP,
           py::call_guard<py::gil_scoped_release>(),
           "Function for Multi-Scale ICP registration", "source"_a, "target"_a,
           "voxel_sizes"_a, "criteria_list"_a, "max_correspondence_distances"_a,
           "init_source_to_target"_a =
                   core::Tensor::Eye(4, core::Float64, core::Device("CPU:0")),
           "estimation_method"_a = TransformationEstimationPointToPoint());
-    docstring::FunctionDocInject(m, "registration_multi_scale_icp",
+    docstring::FunctionDocInject(m, "multi_scale_icp",
                                  map_shared_argument_docstrings);
 
-    m.def("get_information_matrix_from_point_clouds",
-          &GetInformationMatrixFromPointClouds,
+    m.def("get_information_matrix", &GetInformationMatrix,
           py::call_guard<py::gil_scoped_release>(),
           "Function for computing information matrix from transformation "
           "matrix. Information matrix is tensor of shape {6, 6}, dtype Float64 "
           "on CPU device.",
           "source"_a, "target"_a, "max_correspondence_distance"_a,
           "transformation"_a);
-    docstring::FunctionDocInject(m, "get_information_matrix_from_point_clouds",
+    docstring::FunctionDocInject(m, "get_information_matrix",
                                  map_shared_argument_docstrings);
 }
 

--- a/cpp/tests/t/pipelines/registration/Registration.cpp
+++ b/cpp/tests/t/pipelines/registration/Registration.cpp
@@ -203,7 +203,7 @@ TEST_P(RegistrationPermuteDevices, EvaluateRegistration) {
     }
 }
 
-TEST_P(RegistrationPermuteDevices, RegistrationICPPointToPoint) {
+TEST_P(RegistrationPermuteDevices, ICPPointToPoint) {
     core::Device device = GetParam();
 
     for (auto dtype : {core::Float32, core::Float64}) {
@@ -232,7 +232,7 @@ TEST_P(RegistrationPermuteDevices, RegistrationICPPointToPoint) {
         int max_iterations = 2;
 
         // PointToPoint - Tensor.
-        t_reg::RegistrationResult reg_p2p_t = t_reg::RegistrationICP(
+        t_reg::RegistrationResult reg_p2p_t = t_reg::ICP(
                 source_tpcd, target_tpcd, max_correspondence_dist,
                 initial_transform_t,
                 t_reg::TransformationEstimationPointToPoint(),
@@ -252,7 +252,7 @@ TEST_P(RegistrationPermuteDevices, RegistrationICPPointToPoint) {
     }
 }
 
-TEST_P(RegistrationPermuteDevices, RegistrationICPPointToPlane) {
+TEST_P(RegistrationPermuteDevices, ICPPointToPlane) {
     core::Device device = GetParam();
 
     for (auto dtype : {core::Float32, core::Float64}) {
@@ -283,7 +283,7 @@ TEST_P(RegistrationPermuteDevices, RegistrationICPPointToPlane) {
         // L1Loss Method:
 
         // PointToPlane - Tensor.
-        t_reg::RegistrationResult reg_p2plane_t = t_reg::RegistrationICP(
+        t_reg::RegistrationResult reg_p2plane_t = t_reg::ICP(
                 source_tpcd, target_tpcd, max_correspondence_dist,
                 initial_transform_t,
                 t_reg::TransformationEstimationPointToPlane(
@@ -356,7 +356,7 @@ TEST_P(RegistrationPermuteDevices, RegistrationColoredICP) {
         int max_iterations = 2;
 
         // PointToPlane - Tensor.
-        t_reg::RegistrationResult reg_p2plane_t = t_reg::RegistrationICP(
+        t_reg::RegistrationResult reg_p2plane_t = t_reg::ICP(
                 source_tpcd, target_tpcd, max_correspondence_dist,
                 initial_transform_t,
                 t_reg::TransformationEstimationForColoredICP(),
@@ -479,10 +479,9 @@ TEST_P(RegistrationPermuteDevices, GetInformationMatrixFromPointCloud) {
         double max_correspondence_dist = 3.0;
 
         // Tensor information matrix.
-        core::Tensor information_matrix_t =
-                t_reg::GetInformationMatrixFromPointClouds(
-                        source_tpcd, target_tpcd, max_correspondence_dist,
-                        initial_transform_t);
+        core::Tensor information_matrix_t = t_reg::GetInformationMatrix(
+                source_tpcd, target_tpcd, max_correspondence_dist,
+                initial_transform_t);
 
         // Legacy evaluation.
         Eigen::Matrix6d information_matrix_l =

--- a/examples/cpp/TICPOdometry.cpp
+++ b/examples/cpp/TICPOdometry.cpp
@@ -210,10 +210,10 @@ private:
         voxel_sizes_[icp_scale_levels_ - 1] = DONT_RESAMPLE;
 
         // ---------------- Warm up -----------------------
-        auto result = RegistrationMultiScaleICP(
-                pointclouds_device_[0].To(device_),
-                pointclouds_device_[1].To(device_), voxel_sizes_, criterias_,
-                search_radius_, initial_transform, *estimation_);
+        auto result = MultiScaleICP(pointclouds_device_[0].To(device_),
+                                    pointclouds_device_[1].To(device_),
+                                    voxel_sizes_, criterias_, search_radius_,
+                                    initial_transform, *estimation_);
         // ------------------------------------------------
 
         utility::SetVerbosityLevel(verbosity_);
@@ -244,9 +244,9 @@ private:
 
             // Computes the transformation from pcd_[i] to pcd_[i + 1], for
             // `Frame to Frame Odometry`.
-            auto result = RegistrationMultiScaleICP(
-                    source, target, voxel_sizes_, criterias_, search_radius_,
-                    initial_transform, *estimation_);
+            auto result = MultiScaleICP(source, target, voxel_sizes_,
+                                        criterias_, search_radius_,
+                                        initial_transform, *estimation_);
 
             // `cumulative_transform` before update is from `i to 0`.
             // `result.transformation_` is from i to i + 1.
@@ -695,7 +695,7 @@ private:
     bool visualize_output_;
 
 private:
-    // RegistrationMultiScaleICP parameters.
+    // MultiScaleICP parameters.
     std::vector<double> voxel_sizes_;
     std::vector<double> search_radius_;
     std::vector<ICPConvergenceCriteria> criterias_;

--- a/examples/cpp/TICPReconstruction.cpp
+++ b/examples/cpp/TICPReconstruction.cpp
@@ -306,7 +306,7 @@ protected:
 
     void UpdateMain() {
         // ----- Class members passed to function arguments
-        // ----- in t::pipeline::registration::RegistrationMultiScaleICP
+        // ----- in t::pipeline::registration::MultiScaleICP
         const t::geometry::PointCloud source = source_.To(device_);
         const t::geometry::PointCloud target = target_.To(device_);
         const std::vector<double> voxel_sizes = voxel_sizes_;
@@ -316,7 +316,7 @@ protected:
         const core::Tensor init_source_to_target = transformation_;
         auto& estimation = *estimation_;
 
-        // ----- RegistrationMultiScaleICP Function directly taken from
+        // ----- MultiScaleICP Function directly taken from
         // ----- t::pipelines::registration, and added O3DVisualizer to it.
         core::Device device = source.GetDevice();
         core::Dtype dtype = source.GetPointPositions().GetDtype();
@@ -780,7 +780,7 @@ private:
         if (!(criterias.size() == voxel_sizes.size() &&
               criterias.size() == max_correspondence_distances.size())) {
             utility::LogError(
-                    " [RegistrationMultiScaleICP]: Size of criterias, "
+                    " [MultiScaleICP]: Size of criterias, "
                     "voxel_size,"
                     " max_correspondence_distances vectors must be same.");
         }

--- a/python/test/t/registration/test_registration.py
+++ b/python/test/t/registration/test_registration.py
@@ -171,7 +171,7 @@ def test_icp_point_to_point(device):
             o3d.t.pipelines.registration.ICPConvergenceCriteria(
                 max_iteration=2))
 
-        reg_p2p_legacy = o3d.pipelines.registration.icp(
+        reg_p2p_legacy = o3d.pipelines.registration.registration_icp(
             source_legacy, target_legacy, max_correspondence_distance,
             init_trans_legacy,
             o3d.pipelines.registration.TransformationEstimationPointToPoint(),
@@ -209,7 +209,7 @@ def test_icp_point_to_plane(device):
             o3d.t.pipelines.registration.ICPConvergenceCriteria(
                 max_iteration=2))
 
-        reg_p2plane_legacy = o3d.pipelines.registration.icp(
+        reg_p2plane_legacy = o3d.pipelines.registration.registration_icp(
             source_legacy, target_legacy, max_correspondence_distance,
             init_trans_legacy,
             o3d.pipelines.registration.TransformationEstimationPointToPlane(),
@@ -222,7 +222,7 @@ def test_icp_point_to_plane(device):
 
 
 @pytest.mark.parametrize("device", list_devices())
-def test_get_information_matrix_from_pointclouds(device):
+def test_get_information_matrix(device):
 
     supported_dtypes = [o3c.float32, o3c.float64]
     for dtype in supported_dtypes:
@@ -241,7 +241,7 @@ def test_get_information_matrix_from_pointclouds(device):
                                       dtype=o3c.float64,
                                       device=device)
 
-        info_matrix_t = o3d.t.pipelines.registration.get_information_matrix_from_point_clouds(
+        info_matrix_t = o3d.t.pipelines.registration.get_information_matrix(
             source_t, target_t, max_correspondence_distance, transformation_t)
 
         info_matrix_legacy = o3d.pipelines.registration.get_information_matrix_from_point_clouds(

--- a/python/test/t/registration/test_registration.py
+++ b/python/test/t/registration/test_registration.py
@@ -146,7 +146,7 @@ def test_evaluate_registration(device):
 
 
 @pytest.mark.parametrize("device", list_devices())
-def test_registration_icp_point_to_point(device):
+def test_icp_point_to_point(device):
 
     supported_dtypes = [o3c.float32, o3c.float64]
     for dtype in supported_dtypes:
@@ -165,13 +165,13 @@ def test_registration_icp_point_to_point(device):
                                   dtype=o3c.float64,
                                   device=device)
 
-        reg_p2p_t = o3d.t.pipelines.registration.registration_icp(
+        reg_p2p_t = o3d.t.pipelines.registration.icp(
             source_t, target_t, max_correspondence_distance, init_trans_t,
             o3d.t.pipelines.registration.TransformationEstimationPointToPoint(),
             o3d.t.pipelines.registration.ICPConvergenceCriteria(
                 max_iteration=2))
 
-        reg_p2p_legacy = o3d.pipelines.registration.registration_icp(
+        reg_p2p_legacy = o3d.pipelines.registration.icp(
             source_legacy, target_legacy, max_correspondence_distance,
             init_trans_legacy,
             o3d.pipelines.registration.TransformationEstimationPointToPoint(),
@@ -184,7 +184,7 @@ def test_registration_icp_point_to_point(device):
 
 
 @pytest.mark.parametrize("device", list_devices())
-def test_registration_icp_point_to_plane(device):
+def test_icp_point_to_plane(device):
 
     supported_dtypes = [o3c.float32, o3c.float64]
     for dtype in supported_dtypes:
@@ -203,13 +203,13 @@ def test_registration_icp_point_to_plane(device):
                                   dtype=o3c.float64,
                                   device=device)
 
-        reg_p2plane_t = o3d.t.pipelines.registration.registration_icp(
+        reg_p2plane_t = o3d.t.pipelines.registration.icp(
             source_t, target_t, max_correspondence_distance, init_trans_t,
             o3d.t.pipelines.registration.TransformationEstimationPointToPlane(),
             o3d.t.pipelines.registration.ICPConvergenceCriteria(
                 max_iteration=2))
 
-        reg_p2plane_legacy = o3d.pipelines.registration.registration_icp(
+        reg_p2plane_legacy = o3d.pipelines.registration.icp(
             source_legacy, target_legacy, max_correspondence_distance,
             init_trans_legacy,
             o3d.pipelines.registration.TransformationEstimationPointToPlane(),


### PR DESCRIPTION
- renamed `RegistrationICP` to `ICP`, `RegistrationMultiScaleICP` to `MultiScaleICP`, `GetInformationMatrixFromPointClouds` to `GetInformationMatrix`, for `t-pipelines`.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4072)
<!-- Reviewable:end -->
