### PR TITLE
Avoid -pthread flag with ISPC compiler

### DIFF
--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -462,12 +462,6 @@ open3d_find_package_3rdparty_library(3rdparty_threads
     PACKAGE Threads
     TARGETS Threads::Threads
 )
-if(THREADS_HAVE_PTHREAD_ARG)
-    set_property(TARGET Threads::Threads
-                 PROPERTY INTERFACE_COMPILE_OPTIONS
-                 "$<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:SHELL:-Xcompiler -pthread>"
-                 "$<$<AND:$<NOT:$<COMPILE_LANGUAGE:ISPC>>,$<NOT:$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>>>:-pthread>")
-endif()
 
 # Assimp
 include(${Open3D_3RDPARTY_DIR}/assimp/assimp.cmake)

--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -462,6 +462,12 @@ open3d_find_package_3rdparty_library(3rdparty_threads
     PACKAGE Threads
     TARGETS Threads::Threads
 )
+if(THREADS_HAVE_PTHREAD_ARG)
+    set_property(TARGET Threads::Threads
+                 PROPERTY INTERFACE_COMPILE_OPTIONS
+                 "$<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:SHELL:-Xcompiler -pthread>"
+                 "$<$<AND:$<NOT:$<COMPILE_LANGUAGE:ISPC>>,$<NOT:$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>>>:-pthread>")
+endif()
 
 # Assimp
 include(${Open3D_3RDPARTY_DIR}/assimp/assimp.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,9 +309,20 @@ add_compile_definitions("${HARDENING_DEFINITIONS}")
 
 # Explicitly specifiy the preference of using -pthread over -lpthread.
 # This must be defined here since CUDA calls find_package(Threads) internally.
-# -pthread is disabled since some compilers, e.g. the ISPC compiler, have
-# problems with this compile flag and issue errors.
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+
+# Overwrites property for Thread::Threads in find_package(Threads)
+# For CUDA, "-pthread" is replaced with "-Xcompiler -pthread" (CMake's default)
+# For ISPC, "-pthread" is disabled
+macro(open3d_patch_findthreads_module_)
+    if(TARGET Threads::Threads AND THREADS_HAVE_PTHREAD_ARG)
+        set_property(TARGET Threads::Threads
+                     PROPERTY INTERFACE_COMPILE_OPTIONS
+                     "$<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:SHELL:-Xcompiler -pthread>"
+                     "$<$<AND:$<NOT:$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>>,$<NOT:$<COMPILE_LANGUAGE:ISPC>>>:-pthread>")
+    endif()
+endmacro()
+cmake_language(EVAL CODE "cmake_language(DEFER CALL open3d_patch_findthreads_module_)")
 
 # Build CUDA module by default if CUDA is available
 if(BUILD_CUDA_MODULE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,7 +311,7 @@ add_compile_definitions("${HARDENING_DEFINITIONS}")
 # This must be defined here since CUDA calls find_package(Threads) internally.
 # -pthread is disabled since some compilers, e.g. the ISPC compiler, have
 # problems with this compile flag and issue errors.
-set(THREADS_PREFER_PTHREAD_FLAG FALSE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 
 # Build CUDA module by default if CUDA is available
 if(BUILD_CUDA_MODULE)


### PR DESCRIPTION
### Fix
This overwrites the default flags for `Threads::Threads`:
https://github.com/Kitware/CMake/blob/efed2f8706b46d2f5c7711a9426b7e23a08b9709/Modules/FindThreads.cmake#L243-L247

### Testing

Copy and run this script as to the root Open3D directory (as `Open3D/build_and_rebuild.sh`).

```bash
#!/usr/bin/env bash
set -eu

# Clean up
rm -rf build
mkdir build
rm -f build.log
rm -f rebuild.log

# First build
pushd build
cmake -DBUILD_BENCHMARKS=ON -DBUILD_UNIT_TESTS=ON .. &> >(tee -a "../build.log")
make VERBOSE=1 Open3D -j$(nproc) &> >(tee -a "../build.log")
popd

# Critical step: touch
touch CMakeLists.txt

# Second build
pushd build
make VERBOSE=1 Open3D -j$(nproc) &> >(tee -a "../rebuild.log")
popd
```

- On `master` :
    - First build: no `-pthread` flag at all.
    - Second build:  `-pthread` added for every file, causing recompilations. `-pthread` is also used in ISPC, causing the compilation to fail with
        ```bash
        Error: Unknown option "-pthread".
        ```
- With this PR:
    - First build:  `-pthread` added for every file, except for ISPC. 
    - Second build:  `-pthread` added for every file, except for ISPC. No recompilations, since it is the same as the first build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4076)
<!-- Reviewable:end -->
