### PR TITLE
Simplify ISPC language emulation module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,8 +341,12 @@ if (BUILD_ISPC_MODULE)
 
     message(STATUS "Using ISPC instruction sets: ${CMAKE_ISPC_INSTRUCTION_SETS}")
 
-    option(ISPC_FORCE_LEGACY "Force legacy ISPC language emulation over first-class CMake support" OFF)
-    mark_as_advanced(ISPC_FORCE_LEGACY)
+    if (CMAKE_ISPC_COMPILER_LOADED OR (CMAKE_GENERATOR MATCHES "Make" OR CMAKE_GENERATOR MATCHES "Ninja"))
+        option(ISPC_USE_LEGACY_EMULATION "Use legacy ISPC language emulation over first-class CMake support" OFF)
+    else()
+        option(ISPC_USE_LEGACY_EMULATION "Use legacy ISPC language emulation over first-class CMake support" ON)
+    endif()
+    mark_as_advanced(ISPC_USE_LEGACY_EMULATION)
     option(ISPC_PRINT_LEGACY_COMPILE_COMMANDS "Prints legacy compile commands on CMake configuration time" ON)
     mark_as_advanced(ISPC_PRINT_LEGACY_COMPILE_COMMANDS)
 

--- a/cpp/benchmarks/core/CMakeLists.txt
+++ b/cpp/benchmarks/core/CMakeLists.txt
@@ -7,7 +7,7 @@ target_sources(benchmarks PRIVATE
 )
 
 if (BUILD_ISPC_MODULE)
-    open3d_ispc_target_sources(benchmarks PRIVATE
+    target_sources(benchmarks PRIVATE
         ParallelFor.ispc
     )
 endif()

--- a/cpp/open3d/utility/CMakeLists.txt
+++ b/cpp/open3d/utility/CMakeLists.txt
@@ -14,7 +14,7 @@ target_sources(utility PRIVATE
 )
 
 if (BUILD_ISPC_MODULE)
-    open3d_ispc_target_sources(utility PRIVATE
+    target_sources(utility PRIVATE
         ISAInfo.ispc
     )
 endif()

--- a/cpp/tests/core/CMakeLists.txt
+++ b/cpp/tests/core/CMakeLists.txt
@@ -28,7 +28,7 @@ if (BUILD_CUDA_MODULE)
 endif()
 
 if (BUILD_ISPC_MODULE)
-    open3d_ispc_target_sources(tests PRIVATE
+    target_sources(tests PRIVATE
         ParallelFor.ispc
     )
 endif()

--- a/cpp/tests/utility/CMakeLists.txt
+++ b/cpp/tests/utility/CMakeLists.txt
@@ -10,7 +10,7 @@ target_sources(tests PRIVATE
 )
 
 if (BUILD_ISPC_MODULE)
-    open3d_ispc_target_sources(tests PRIVATE
+    target_sources(tests PRIVATE
         Helper.ispc
     )
 endif()


### PR DESCRIPTION
This PR simplifies parts of the logic of the ISPC language emulation module and relaxes some limitations:

- Replace `ISPC_FORCE_LEGACY` with `ISPC_USE_LEGACY_EMULATION` to expose precise control to enable and disable (not support by old option) emulation.
- Move the default condition, i.e. checking for Make and Ninja generators, to the top-level CMake file to a single and consistent place. Furthermore, check for `CMAKE_ISPC_COMPILER_LOADED` to not use emulation if first-class support is already enabled.
- Recursively process the target dependency tree rather than only considering first-level dependenciesto capture (almost) all properties. `PROCESSED_TARGET_LIBRARIES` is used to break potential cyclic dependencies.
- Remove `open3d_ispc_target_sources` macro and process the `SOURCES` property instead of the custom `ISPC_SOURCES` property to setup build rules.
- Support sources files with absolute file paths.
- Infer ISPC output extension from either C or C++ language and issue an error if none is available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4080)
<!-- Reviewable:end -->
