### PR TITLE
Refactor unittests for NearestNeighborSearch

### DIFF
--- a/cpp/tests/core/NanoFlannIndex.cpp
+++ b/cpp/tests/core/NanoFlannIndex.cpp
@@ -29,83 +29,114 @@
 #include <cmath>
 #include <limits>
 
+#include "core/CoreTest.h"
+#include "open3d/core/Device.h"
 #include "open3d/core/Dtype.h"
 #include "open3d/core/SizeVector.h"
-#include "open3d/geometry/PointCloud.h"
+#include "open3d/core/Tensor.h"
 #include "open3d/utility/Helper.h"
 #include "tests/Tests.h"
+#include "tests/core/CoreTest.h"
+
+using namespace open3d;
+using namespace std;
 
 namespace open3d {
 namespace tests {
 
 TEST(NanoFlannIndex, SearchKnn) {
-    // set up index
-    int size = 10;
-    std::vector<double> points{0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0,
-                               0.2, 0.0, 0.1, 0.0, 0.0, 0.1, 0.1, 0.0,
-                               0.1, 0.2, 0.0, 0.2, 0.0, 0.0, 0.2, 0.1,
-                               0.0, 0.2, 0.2, 0.1, 0.0, 0.0};
-    core::Tensor ref(points, {size, 3}, core::Float64);
-    core::nns::NanoFlannIndex index(ref);
+    // Define test data.
+    core::Device device = core::Device("CPU:0");
+    core::Tensor dataset_points = core::Tensor::Init<double>({{0.0, 0.0, 0.0},
+                                                              {0.0, 0.0, 0.1},
+                                                              {0.0, 0.0, 0.2},
+                                                              {0.0, 0.1, 0.0},
+                                                              {0.0, 0.1, 0.1},
+                                                              {0.0, 0.1, 0.2},
+                                                              {0.0, 0.2, 0.0},
+                                                              {0.0, 0.2, 0.1},
+                                                              {0.0, 0.2, 0.2},
+                                                              {0.1, 0.0, 0.0}},
+                                                             device);
+    core::Tensor query_points = 
+            core::Tensor::Init<double>({{0.064705, 0.043921, 0.087843}}, device);
+    core::Tensor gt_indices, gt_distances;
 
-    core::Tensor query(std::vector<double>({0.064705, 0.043921, 0.087843}),
-                       {1, 3}, core::Float64);
+    // Set up index.
+    core::nns::NanoFlannIndex index(dataset_points);
 
-    // if k is smaller or equal to 0
-    EXPECT_THROW(index.SearchKnn(query, -1), std::runtime_error);
-    EXPECT_THROW(index.SearchKnn(query, 0), std::runtime_error);
+    // if k <= 0.
+    EXPECT_THROW(index.SearchKnn(query_points, -1), std::runtime_error);
+    EXPECT_THROW(index.SearchKnn(query_points, 0), std::runtime_error);
 
     // if k == 3
-    core::Tensor indices;
-    core::Tensor distances;
-    std::tie(indices, distances) = index.SearchKnn(query, 3);
+    core::Tensor indices, distances;
+    core::SizeVector shape{1, 3};
+    gt_indices = core::Tensor::Init<int32_t>({{1, 4, 9}}, device);
+    gt_distances = core::Tensor::Init<double>(
+            {{0.00626358, 0.00747938, 0.0108912}}, device);
 
-    ExpectEQ(indices.ToFlatVector<int32_t>(), std::vector<int32_t>({1, 4, 9}));
-    ExpectEQ(distances.ToFlatVector<double>(),
-             std::vector<double>({0.00626358, 0.00747938, 0.0108912}));
-    EXPECT_EQ(indices.GetShape(), core::SizeVector({1, 3}));
-    EXPECT_EQ(distances.GetShape(), core::SizeVector({1, 3}));
+    std::tie(indices, distances) = index.SearchKnn(query_points, 3);
 
-    // if k > size
-    std::tie(indices, distances) = index.SearchKnn(query, 12);
+    EXPECT_EQ(indices.GetShape(), shape);
+    EXPECT_EQ(distances.GetShape(), shape);
+    EXPECT_TRUE(indices.AllClose(gt_indices));
+    EXPECT_TRUE(distances.AllClose(distances));
 
-    ExpectEQ(indices.ToFlatVector<int32_t>(),
-             std::vector<int32_t>({1, 4, 9, 0, 3, 2, 5, 7, 6, 8}));
-    ExpectEQ(distances.ToFlatVector<double>(),
-             std::vector<double>({0.00626358, 0.00747938, 0.0108912, 0.0138322,
-                                  0.015048, 0.018695, 0.0199108, 0.0286952,
-                                  0.0362638, 0.0411266}));
-    EXPECT_EQ(indices.GetShape(), core::SizeVector({1, 10}));
-    EXPECT_EQ(distances.GetShape(), core::SizeVector({1, 10}));
+    // if k > size.
+    shape = core::SizeVector{1, 10};
+    gt_indices = core::Tensor::Init<int32_t>({{1, 4, 9, 0, 3, 2, 5, 7, 6, 8}},
+                                             device);
+    gt_distances = core::Tensor::Init<double>(
+            {{0.00626358, 0.00747938, 0.0108912, 0.0138322, 0.015048, 0.018695,
+              0.0199108, 0.0286952, 0.0362638, 0.0411266}},
+            device);
+    std::tie(indices, distances) = index.SearchKnn(query_points, 12);
+    EXPECT_EQ(indices.GetShape(), shape);
+    EXPECT_EQ(distances.GetShape(), shape);
+    EXPECT_TRUE(indices.AllClose(gt_indices));
+    EXPECT_TRUE(distances.AllClose(gt_distances));
 }
 
 TEST(NanoFlannIndex, SearchRadius) {
-    std::vector<int> ref_indices = {1, 4};
-    std::vector<double> ref_distance = {0.00626358, 0.00747938};
+    // Define test data.
+    core::Device device = core::Device("CPU:0");
+    core::Tensor dataset_points = core::Tensor::Init<double>({{0.0, 0.0, 0.0},
+                                                              {0.0, 0.0, 0.1},
+                                                              {0.0, 0.0, 0.2},
+                                                              {0.0, 0.1, 0.0},
+                                                              {0.0, 0.1, 0.1},
+                                                              {0.0, 0.1, 0.2},
+                                                              {0.0, 0.2, 0.0},
+                                                              {0.0, 0.2, 0.1},
+                                                              {0.0, 0.2, 0.2},
+                                                              {0.1, 0.0, 0.0}},
+                                                             device);
+    core::Tensor query_points = 
+            core::Tensor::Init<double>({{0.064705, 0.043921, 0.087843}}, device);
+    core::Tensor radii = core::Tensor::Init<double>({0.1});
+    core::Tensor gt_indices, gt_distances;
 
-    int size = 10;
-    std::vector<double> points{0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0,
-                               0.2, 0.0, 0.1, 0.0, 0.0, 0.1, 0.1, 0.0,
-                               0.1, 0.2, 0.0, 0.2, 0.0, 0.0, 0.2, 0.1,
-                               0.0, 0.2, 0.2, 0.1, 0.0, 0.0};
-    core::Tensor ref(points, {size, 3}, core::Float64);
-    core::nns::NanoFlannIndex index(ref);
-
-    core::Tensor query(std::vector<double>({0.064705, 0.043921, 0.087843}),
-                       {1, 3}, core::Float64);
+    // Set up index.
+    core::nns::NanoFlannIndex index(dataset_points);
 
     // if radius <= 0
-    EXPECT_THROW(index.SearchRadius(query, -1.0), std::runtime_error);
-    EXPECT_THROW(index.SearchRadius(query, 0.0), std::runtime_error);
+    EXPECT_THROW(index.SearchRadius(query_points, -1.0), std::runtime_error);
+    EXPECT_THROW(index.SearchRadius(query_points, 0.0), std::runtime_error);
 
     // if radius == 0.1
-    std::tuple<core::Tensor, core::Tensor, core::Tensor> result =
-            index.SearchRadius(query, 0.1);
-    core::Tensor indices = std::get<0>(result).To(core::Int32);
-    core::Tensor distances = std::get<1>(result);
-    ExpectEQ(indices.ToFlatVector<int>(), std::vector<int>({1, 4}));
-    ExpectEQ(distances.ToFlatVector<double>(),
-             std::vector<double>({0.00626358, 0.00747938}));
+    core::Tensor indices, distances, neighbors_row_splits;
+    core::SizeVector shape{2};
+    gt_indices = core::Tensor::Init<int32_t>({1, 4}, device);
+    gt_distances = core::Tensor::Init<double>(
+            {0.00626358, 0.00747938}, device);
+
+    std::tie(indices, distances, neighbors_row_splits) = index.SearchRadius(query_points, radii, false);
+
+    EXPECT_EQ(indices.GetShape(), shape);
+    EXPECT_EQ(distances.GetShape(), shape);
+    EXPECT_TRUE(indices.AllClose(gt_indices));
+    EXPECT_TRUE(distances.AllClose(distances));
 }
 
 }  // namespace tests


### PR DESCRIPTION
This PR refactors NNS unittest codes to be consistent with the unittest code for KnnIndex.

- [x] NanoFlannIndex
- [ ] FixedRadiusIndex
- [ ] FaissIndex
- [ ] NearestNeighborSearch