### PR TITLE
Add fast path for indexing contiguous tensors

### DIFF
--- a/cpp/open3d/core/kernel/UnaryEWCPU.cpp
+++ b/cpp/open3d/core/kernel/UnaryEWCPU.cpp
@@ -231,7 +231,6 @@ void UnaryEWCPU(const Tensor& src, Tensor& dst, UnaryEWOpCode op_code) {
                 LaunchUnaryEWKernel(indexer, CPUIsNanElementKernel<scalar_t>);
             } else if (op_code == UnaryEWOpCode::IsInf) {
                 LaunchUnaryEWKernel(indexer, CPUIsInfElementKernel<scalar_t>);
-
             } else if (op_code == UnaryEWOpCode::IsFinite) {
                 LaunchUnaryEWKernel(indexer,
                                     CPUIsFiniteElementKernel<scalar_t>);

--- a/cpp/tests/core/Indexer.cpp
+++ b/cpp/tests/core/Indexer.cpp
@@ -177,19 +177,24 @@ TEST_P(IndexerPermuteDevices, IsContiguous) {
 
     core::Tensor input0({3, 1, 1}, core::Float32, device);
     core::Tensor input1({2, 1}, core::Float32, device);
+    core::Tensor input2_full({3, 4, 1}, core::Float32, device);
+    core::Tensor input2 = input2_full.Slice(1, 0, 4, 2);  // Shape {3, 2, 1}.
     core::Tensor output({3, 2, 1}, core::Float32, device);
-    core::Indexer indexer({input0, input1}, output);
+    core::Indexer indexer({input0, input1, input2}, output);
 
     EXPECT_FALSE(indexer.GetInput(0).IsContiguous());  // Broadcasted.
     EXPECT_FALSE(indexer.GetInput(1).IsContiguous());  // Broadcasted.
+    EXPECT_FALSE(indexer.GetInput(2).IsContiguous());  // Sliced.
     EXPECT_TRUE(indexer.GetOutput().IsContiguous());
 
     EXPECT_TRUE(core::TensorRef(input0).IsContiguous());
     EXPECT_TRUE(core::TensorRef(input1).IsContiguous());
+    EXPECT_FALSE(core::TensorRef(input2).IsContiguous());
     EXPECT_TRUE(core::TensorRef(output).IsContiguous());
 
     EXPECT_TRUE(input0.IsContiguous());
     EXPECT_TRUE(input1.IsContiguous());
+    EXPECT_FALSE(input2.IsContiguous());
     EXPECT_TRUE(output.IsContiguous());
 }
 

--- a/cpp/tests/core/Indexer.cpp
+++ b/cpp/tests/core/Indexer.cpp
@@ -172,5 +172,26 @@ TEST_P(IndexerPermuteDevices, GetPointers) {
     EXPECT_EQ(indexer.GetOutputPtr(5), output_base_ptr + 5 * dtype_byte_size);
 }
 
+TEST_P(IndexerPermuteDevices, IsContiguous) {
+    core::Device device = GetParam();
+
+    core::Tensor input0({3, 1, 1}, core::Float32, device);
+    core::Tensor input1({2, 1}, core::Float32, device);
+    core::Tensor output({3, 2, 1}, core::Float32, device);
+    core::Indexer indexer({input0, input1}, output);
+
+    EXPECT_FALSE(indexer.GetInput(0).IsContiguous());  // Broadcasted.
+    EXPECT_FALSE(indexer.GetInput(1).IsContiguous());  // Broadcasted.
+    EXPECT_TRUE(indexer.GetOutput().IsContiguous());
+
+    EXPECT_TRUE(core::TensorRef(input0).IsContiguous());
+    EXPECT_TRUE(core::TensorRef(input1).IsContiguous());
+    EXPECT_TRUE(core::TensorRef(output).IsContiguous());
+
+    EXPECT_TRUE(input0.IsContiguous());
+    EXPECT_TRUE(input1.IsContiguous());
+    EXPECT_TRUE(output.IsContiguous());
+}
+
 }  // namespace tests
 }  // namespace open3d


### PR DESCRIPTION
#### Highlights:

- Add `IsContiguous()` function to `TensorRef` similar to the one in `Tensor`.
- Add `bool` array of contiguous flags to avoid costly computations in `IsContiguous()` during indexing.
- Add fast indexing path based on the contiguous flags.
- Refactor Binary EW ops to prepare for vectorized code path.

#### Benchmarks (Intel Core i7-10750H):

Tested on all Binary and Unary EW Operations with consistent performance improvements of ~10x for tensors with sizes of 100k and 100m entries.

#### Future work:

The element size `dtype_byte_size_` could be inferred at compile-time, i.e. by making the indexing functions templates, to emit machine code that runs even faster (~10-30% for initial experiments).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4084)
<!-- Reviewable:end -->
