### PR TITLE
Support for multiple depth format in Python reconstruction example

### DIFF
--- a/examples/python/reconstruction_system/make_fragments.py
+++ b/examples/python/reconstruction_system/make_fragments.py
@@ -29,8 +29,8 @@
 import math
 import re
 import sys
-import numpy as np
 import matplotlib.image as mpimg
+import numpy as np
 import open3d as o3d
 sys.path.append("../utility")
 from file import join, make_clean_folder, get_rgbd_file_lists

--- a/examples/python/utility/file.py
+++ b/examples/python/utility/file.py
@@ -72,8 +72,10 @@ def get_rgbd_folders(path_dataset):
 def get_rgbd_file_lists(path_dataset):
     path_color, path_depth = get_rgbd_folders(path_dataset)
     color_files = get_file_list(path_color, ".jpg") + \
-            get_file_list(path_color, ".png")
-    depth_files = get_file_list(path_depth, ".png")
+            get_file_list(path_color, ".png") + \
+            get_file_list(path_color, ".ppm")
+    depth_files = get_file_list(path_depth, ".png") + \
+            get_file_list(path_depth, ".pgm")
     return color_files, depth_files
 
 


### PR DESCRIPTION
The purpose of this PR is to support multiple formats of depth images in `examples/python/reconstruction_system`.
The current reconstruction_system does not reflect the `depth_map_type` parameter in `reconstruction_system/initialize_config.py`.

So I improved it to load depth images with the corresponding function `o3d.geometry,RGBDImage.create_rgbd_from_<depth_map_type>_format` when the `depth_map_type` parameter is `redwood`, `sun`, `nyu`, and `tum`. 
I have also improved it to read depth images with `o3d.geometry.RGBDImage.create_from_color_and_depth` if parameters other than `redwood`, `sun`, `nyu`, and `tum` are set.
Also, since the color and depth images in the NYU dataset have ppm and pgm extensions, I modified `example/python/utility/file.py` to read them.
I referred to the [tutorial RGBD images](http://www.open3d.org/docs/release/tutorial/geometry/rgbd_image.html) when implementing `read_nyu_pgm`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4097)
<!-- Reviewable:end -->
