### PR TITLE
Add nthreads argument to RaycastingScene

### DIFF
--- a/cpp/open3d/t/geometry/RaycastingScene.cpp
+++ b/cpp/open3d/t/geometry/RaycastingScene.cpp
@@ -32,6 +32,7 @@
 
 // This header is in the embree src dir (embree/src/ext_embree/..).
 #include <embree3/rtcore.h>
+#include <tbb/parallel_for.h>
 #include <tutorials/common/math/closest_point.h>
 
 #include <Eigen/Core>
@@ -41,9 +42,6 @@
 #include "open3d/core/TensorCheck.h"
 #include "open3d/utility/Helper.h"
 #include "open3d/utility/Logging.h"
-
-// The maximum number of rays used in calls to embree.
-static const size_t MAX_BATCH_SIZE = 1048576;
 
 namespace {
 
@@ -199,6 +197,8 @@ namespace t {
 namespace geometry {
 
 struct RaycastingScene::Impl {
+    // The maximum number of rays used in calls to embree.
+    const size_t BATCH_SIZE = 1024;
     RTCDevice device_;
     RTCScene scene_;
     bool scene_committed_;  // true if the scene has been committed.
@@ -214,7 +214,8 @@ struct RaycastingScene::Impl {
                   unsigned int* geometry_ids,
                   unsigned int* primitive_ids,
                   float* primitive_uvs,
-                  float* primitive_normals) {
+                  float* primitive_normals,
+                  const int nthreads) {
         if (!scene_committed_) {
             rtcCommitScene(scene_);
             scene_committed_ = true;
@@ -223,16 +224,11 @@ struct RaycastingScene::Impl {
         struct RTCIntersectContext context;
         rtcInitIntersectContext(&context);
 
-        std::vector<RTCRayHit> rayhits(std::min(num_rays, MAX_BATCH_SIZE));
+        auto LoopFn = [&](const tbb::blocked_range<size_t>& range) {
+            std::vector<RTCRayHit> rayhits(range.size());
 
-        const int num_batches = utility::DivUp(num_rays, rayhits.size());
-
-        for (int n = 0; n < num_batches; ++n) {
-            size_t start_idx = n * rayhits.size();
-            size_t end_idx = std::min(num_rays, (n + 1) * rayhits.size());
-
-            for (size_t i = start_idx; i < end_idx; ++i) {
-                RTCRayHit& rh = rayhits[i - start_idx];
+            for (size_t i = range.begin(); i < range.end(); ++i) {
+                RTCRayHit& rh = rayhits[i - range.begin()];
                 const float* r = &rays[i * 6];
                 rh.ray.org_x = r[0];
                 rh.ray.org_y = r[1];
@@ -253,18 +249,18 @@ struct RaycastingScene::Impl {
                     rh.ray.tfar = std::numeric_limits<float>::infinity();
                 }
                 rh.ray.mask = 0;
-                rh.ray.id = i - start_idx;
+                rh.ray.id = i - range.begin();
                 rh.ray.flags = 0;
                 rh.hit.geomID = RTC_INVALID_GEOMETRY_ID;
                 rh.hit.instID[0] = RTC_INVALID_GEOMETRY_ID;
             }
 
-            rtcIntersect1M(scene_, &context, &rayhits[0], end_idx - start_idx,
+            rtcIntersect1M(scene_, &context, &rayhits[0], range.size(),
                            sizeof(RTCRayHit));
 
-            for (size_t i = start_idx; i < end_idx; ++i) {
-                RTCRayHit rh = rayhits[i - start_idx];
-                size_t idx = rh.ray.id + start_idx;
+            for (size_t i = range.begin(); i < range.end(); ++i) {
+                RTCRayHit rh = rayhits[i - range.begin()];
+                size_t idx = rh.ray.id + range.begin();
                 t_hit[idx] = rh.ray.tfar;
                 if (rh.hit.geomID != RTC_INVALID_GEOMETRY_ID) {
                     geometry_ids[idx] = rh.hit.geomID;
@@ -287,6 +283,19 @@ struct RaycastingScene::Impl {
                     primitive_normals[idx * 3 + 2] = 0;
                 }
             }
+        };
+
+        if (nthreads > 0) {
+            tbb::task_arena arena(nthreads);
+            arena.execute([&]() {
+                tbb::parallel_for(
+                        tbb::blocked_range<size_t>(0, num_rays, BATCH_SIZE),
+                        LoopFn);
+            });
+        } else {
+            tbb::parallel_for(
+                    tbb::blocked_range<size_t>(0, num_rays, BATCH_SIZE),
+                    LoopFn);
         }
     }
 
@@ -294,7 +303,8 @@ struct RaycastingScene::Impl {
                         const size_t num_rays,
                         const float tnear,
                         const float tfar,
-                        int8_t* occluded) {
+                        int8_t* occluded,
+                        const int nthreads) {
         if (!scene_committed_) {
             rtcCommitScene(scene_);
             scene_committed_ = true;
@@ -303,16 +313,10 @@ struct RaycastingScene::Impl {
         struct RTCIntersectContext context;
         rtcInitIntersectContext(&context);
 
-        std::vector<RTCRay> rayvec(std::min(num_rays, MAX_BATCH_SIZE));
-
-        const int num_batches = utility::DivUp(num_rays, rayvec.size());
-
-        for (int n = 0; n < num_batches; ++n) {
-            size_t start_idx = n * rayvec.size();
-            size_t end_idx = std::min(num_rays, (n + 1) * rayvec.size());
-
-            for (size_t i = start_idx; i < end_idx; ++i) {
-                RTCRay& ray = rayvec[i - start_idx];
+        auto LoopFn = [&](const tbb::blocked_range<size_t>& range) {
+            std::vector<RTCRay> rayvec(range.size());
+            for (size_t i = range.begin(); i < range.end(); ++i) {
+                RTCRay& ray = rayvec[i - range.begin()];
                 const float* r = &rays[i * 6];
                 ray.org_x = r[0];
                 ray.org_y = r[1];
@@ -323,25 +327,39 @@ struct RaycastingScene::Impl {
                 ray.tnear = tnear;
                 ray.tfar = tfar;
                 ray.mask = 0;
-                ray.id = i - start_idx;
+                ray.id = i - range.begin();
                 ray.flags = 0;
             }
 
-            rtcOccluded1M(scene_, &context, &rayvec[0], end_idx - start_idx,
+            rtcOccluded1M(scene_, &context, &rayvec[0], range.size(),
                           sizeof(RTCRay));
 
-            for (size_t i = start_idx; i < end_idx; ++i) {
-                RTCRay ray = rayvec[i - start_idx];
-                size_t idx = ray.id + start_idx;
+            for (size_t i = range.begin(); i < range.end(); ++i) {
+                RTCRay ray = rayvec[i - range.begin()];
+                size_t idx = ray.id + range.begin();
                 occluded[idx] = int8_t(
                         -std::numeric_limits<float>::infinity() == ray.tfar);
             }
+        };
+
+        if (nthreads > 0) {
+            tbb::task_arena arena(nthreads);
+            arena.execute([&]() {
+                tbb::parallel_for(
+                        tbb::blocked_range<size_t>(0, num_rays, BATCH_SIZE),
+                        LoopFn);
+            });
+        } else {
+            tbb::parallel_for(
+                    tbb::blocked_range<size_t>(0, num_rays, BATCH_SIZE),
+                    LoopFn);
         }
     }
 
     void CountIntersections(const float* const rays,
                             const size_t num_rays,
-                            int* intersections) {
+                            int* intersections,
+                            const int nthreads) {
         if (!scene_committed_) {
             rtcCommitScene(scene_);
             scene_committed_ = true;
@@ -362,16 +380,11 @@ struct RaycastingScene::Impl {
         context.previous_geom_prim_ID_tfar = &previous_geom_prim_ID_tfar;
         context.intersections = intersections;
 
-        std::vector<RTCRayHit> rayhits(std::min(num_rays, MAX_BATCH_SIZE));
+        auto LoopFn = [&](const tbb::blocked_range<size_t>& range) {
+            std::vector<RTCRayHit> rayhits(range.size());
 
-        const int num_batches = utility::DivUp(num_rays, rayhits.size());
-
-        for (int n = 0; n < num_batches; ++n) {
-            size_t start_idx = n * rayhits.size();
-            size_t end_idx = std::min(num_rays, (n + 1) * rayhits.size());
-
-            for (size_t i = start_idx; i < end_idx; ++i) {
-                RTCRayHit* rh = &rayhits[i - start_idx];
+            for (size_t i = range.begin(); i < range.end(); ++i) {
+                RTCRayHit* rh = &rayhits[i - range.begin()];
                 const float* r = &rays[i * 6];
                 rh->ray.org_x = r[0];
                 rh->ray.org_y = r[1];
@@ -387,9 +400,21 @@ struct RaycastingScene::Impl {
                 rh->hit.geomID = RTC_INVALID_GEOMETRY_ID;
                 rh->hit.instID[0] = RTC_INVALID_GEOMETRY_ID;
             }
+            rtcIntersect1M(scene_, &context.context, &rayhits[0], range.size(),
+                           sizeof(RTCRayHit));
+        };
 
-            rtcIntersect1M(scene_, &context.context, &rayhits[0],
-                           end_idx - start_idx, sizeof(RTCRayHit));
+        if (nthreads > 0) {
+            tbb::task_arena arena(nthreads);
+            arena.execute([&]() {
+                tbb::parallel_for(
+                        tbb::blocked_range<size_t>(0, num_rays, BATCH_SIZE),
+                        LoopFn);
+            });
+        } else {
+            tbb::parallel_for(
+                    tbb::blocked_range<size_t>(0, num_rays, BATCH_SIZE),
+                    LoopFn);
         }
     }
 
@@ -397,33 +422,49 @@ struct RaycastingScene::Impl {
                               const size_t num_query_points,
                               float* closest_points,
                               unsigned int* geometry_ids,
-                              unsigned int* primitive_ids) {
+                              unsigned int* primitive_ids,
+                              const int nthreads) {
         if (!scene_committed_) {
             rtcCommitScene(scene_);
             scene_committed_ = true;
         }
 
-        for (size_t i = 0; i < num_query_points; ++i) {
-            RTCPointQuery query;
-            query.x = query_points[i * 3 + 0];
-            query.y = query_points[i * 3 + 1];
-            query.z = query_points[i * 3 + 2];
-            query.radius = std::numeric_limits<float>::infinity();
-            query.time = 0.f;
+        auto LoopFn = [&](const tbb::blocked_range<size_t>& range) {
+            for (size_t i = range.begin(); i < range.end(); ++i) {
+                RTCPointQuery query;
+                query.x = query_points[i * 3 + 0];
+                query.y = query_points[i * 3 + 1];
+                query.z = query_points[i * 3 + 2];
+                query.radius = std::numeric_limits<float>::infinity();
+                query.time = 0.f;
 
-            ClosestPointResult result;
-            result.geometry_ptrs_ptr = &geometry_ptrs_;
+                ClosestPointResult result;
+                result.geometry_ptrs_ptr = &geometry_ptrs_;
 
-            RTCPointQueryContext instStack;
-            rtcInitPointQueryContext(&instStack);
-            rtcPointQuery(scene_, &query, &instStack, &ClosestPointFunc,
-                          (void*)&result);
+                RTCPointQueryContext instStack;
+                rtcInitPointQueryContext(&instStack);
+                rtcPointQuery(scene_, &query, &instStack, &ClosestPointFunc,
+                              (void*)&result);
 
-            closest_points[3 * i + 0] = result.p.x;
-            closest_points[3 * i + 1] = result.p.y;
-            closest_points[3 * i + 2] = result.p.z;
-            geometry_ids[i] = result.geomID;
-            primitive_ids[i] = result.primID;
+                closest_points[3 * i + 0] = result.p.x;
+                closest_points[3 * i + 1] = result.p.y;
+                closest_points[3 * i + 2] = result.p.z;
+                geometry_ids[i] = result.geomID;
+                primitive_ids[i] = result.primID;
+            }
+        };
+
+        if (nthreads > 0) {
+            tbb::task_arena arena(nthreads);
+            arena.execute([&]() {
+                tbb::parallel_for(tbb::blocked_range<size_t>(
+                                          0, num_query_points, BATCH_SIZE),
+                                  LoopFn);
+            });
+        } else {
+            tbb::parallel_for(
+                    tbb::blocked_range<size_t>(0, num_query_points, BATCH_SIZE),
+                    LoopFn);
         }
     }
 };
@@ -505,7 +546,7 @@ uint32_t RaycastingScene::AddTriangles(const TriangleMesh& mesh) {
 }
 
 std::unordered_map<std::string, core::Tensor> RaycastingScene::CastRays(
-        const core::Tensor& rays) {
+        const core::Tensor& rays, const int nthreads) {
     AssertTensorDtypeLastDimDeviceMinNDim<float>(rays, "rays", 6,
                                                  impl_->tensor_device_);
     auto shape = rays.GetShape();
@@ -528,14 +569,16 @@ std::unordered_map<std::string, core::Tensor> RaycastingScene::CastRays(
                            result["geometry_ids"].GetDataPtr<uint32_t>(),
                            result["primitive_ids"].GetDataPtr<uint32_t>(),
                            result["primitive_uvs"].GetDataPtr<float>(),
-                           result["primitive_normals"].GetDataPtr<float>());
+                           result["primitive_normals"].GetDataPtr<float>(),
+                           nthreads);
 
     return result;
 }
 
 core::Tensor RaycastingScene::TestOcclusions(const core::Tensor& rays,
                                              const float tnear,
-                                             const float tfar) {
+                                             const float tfar,
+                                             const int nthreads) {
     AssertTensorDtypeLastDimDeviceMinNDim<float>(rays, "rays", 6,
                                                  impl_->tensor_device_);
     auto shape = rays.GetShape();
@@ -547,12 +590,14 @@ core::Tensor RaycastingScene::TestOcclusions(const core::Tensor& rays,
 
     auto data = rays.Contiguous();
     impl_->TestOcclusions(data.GetDataPtr<float>(), num_rays, tnear, tfar,
-                          reinterpret_cast<int8_t*>(result.GetDataPtr<bool>()));
+                          reinterpret_cast<int8_t*>(result.GetDataPtr<bool>()),
+                          nthreads);
 
     return result;
 }
 
-core::Tensor RaycastingScene::CountIntersections(const core::Tensor& rays) {
+core::Tensor RaycastingScene::CountIntersections(const core::Tensor& rays,
+                                                 const int nthreads) {
     AssertTensorDtypeLastDimDeviceMinNDim<float>(rays, "rays", 6,
                                                  impl_->tensor_device_);
     auto shape = rays.GetShape();
@@ -565,12 +610,13 @@ core::Tensor RaycastingScene::CountIntersections(const core::Tensor& rays) {
     auto data = rays.Contiguous();
 
     impl_->CountIntersections(data.GetDataPtr<float>(), num_rays,
-                              intersections.GetDataPtr<int>());
+                              intersections.GetDataPtr<int>(), nthreads);
     return intersections;
 }
 
 std::unordered_map<std::string, core::Tensor>
-RaycastingScene::ComputeClosestPoints(const core::Tensor& query_points) {
+RaycastingScene::ComputeClosestPoints(const core::Tensor& query_points,
+                                      const int nthreads) {
     AssertTensorDtypeLastDimDeviceMinNDim<float>(query_points, "query_points",
                                                  3, impl_->tensor_device_);
     auto shape = query_points.GetShape();
@@ -588,13 +634,14 @@ RaycastingScene::ComputeClosestPoints(const core::Tensor& query_points) {
     impl_->ComputeClosestPoints(data.GetDataPtr<float>(), num_query_points,
                                 result["points"].GetDataPtr<float>(),
                                 result["geometry_ids"].GetDataPtr<uint32_t>(),
-                                result["primitive_ids"].GetDataPtr<uint32_t>());
+                                result["primitive_ids"].GetDataPtr<uint32_t>(),
+                                nthreads);
 
     return result;
 }
 
-core::Tensor RaycastingScene::ComputeDistance(
-        const core::Tensor& query_points) {
+core::Tensor RaycastingScene::ComputeDistance(const core::Tensor& query_points,
+                                              const int nthreads) {
     AssertTensorDtypeLastDimDeviceMinNDim<float>(query_points, "query_points",
                                                  3, impl_->tensor_device_);
     auto shape = query_points.GetShape();
@@ -602,7 +649,7 @@ core::Tensor RaycastingScene::ComputeDistance(
                        // results.
 
     auto data = query_points.Contiguous();
-    auto closest_points = ComputeClosestPoints(data);
+    auto closest_points = ComputeClosestPoints(data, nthreads);
 
     size_t num_query_points = shape.NumElements();
     Eigen::Map<Eigen::MatrixXf> query_points_map(data.GetDataPtr<float>(), 3,
@@ -618,7 +665,7 @@ core::Tensor RaycastingScene::ComputeDistance(
 }
 
 core::Tensor RaycastingScene::ComputeSignedDistance(
-        const core::Tensor& query_points) {
+        const core::Tensor& query_points, const int nthreads) {
     AssertTensorDtypeLastDimDeviceMinNDim<float>(query_points, "query_points",
                                                  3, impl_->tensor_device_);
     auto shape = query_points.GetShape();
@@ -627,7 +674,7 @@ core::Tensor RaycastingScene::ComputeSignedDistance(
     size_t num_query_points = shape.NumElements();
 
     auto data = query_points.Contiguous();
-    auto distance = ComputeDistance(data);
+    auto distance = ComputeDistance(data, nthreads);
     core::Tensor rays({int64_t(num_query_points), 6}, core::Float32);
     rays.SetItem({core::TensorKey::Slice(0, num_query_points, 1),
                   core::TensorKey::Slice(0, 3, 1)},
@@ -636,7 +683,7 @@ core::Tensor RaycastingScene::ComputeSignedDistance(
                   core::TensorKey::Slice(3, 6, 1)},
                  core::Tensor::Ones({1}, core::Float32, impl_->tensor_device_)
                          .Expand({int64_t(num_query_points), 3}));
-    auto intersections = CountIntersections(rays);
+    auto intersections = CountIntersections(rays, nthreads);
 
     Eigen::Map<Eigen::VectorXf> distance_map(distance.GetDataPtr<float>(),
                                              num_query_points);
@@ -648,8 +695,8 @@ core::Tensor RaycastingScene::ComputeSignedDistance(
     return distance;
 }
 
-core::Tensor RaycastingScene::ComputeOccupancy(
-        const core::Tensor& query_points) {
+core::Tensor RaycastingScene::ComputeOccupancy(const core::Tensor& query_points,
+                                               const int nthreads) {
     AssertTensorDtypeLastDimDeviceMinNDim<float>(query_points, "query_points",
                                                  3, impl_->tensor_device_);
     auto shape = query_points.GetShape();
@@ -665,7 +712,7 @@ core::Tensor RaycastingScene::ComputeOccupancy(
                   core::TensorKey::Slice(3, 6, 1)},
                  core::Tensor::Ones({1}, core::Float32, impl_->tensor_device_)
                          .Expand({int64_t(num_query_points), 3}));
-    auto intersections = CountIntersections(rays);
+    auto intersections = CountIntersections(rays, nthreads);
     Eigen::Map<Eigen::VectorXi> intersections_map(
             intersections.GetDataPtr<int>(), num_query_points);
     intersections_map =

--- a/cpp/open3d/t/geometry/RaycastingScene.h
+++ b/cpp/open3d/t/geometry/RaycastingScene.h
@@ -74,6 +74,7 @@ public:
     /// with [ox,oy,oz] as the origin and [dx,dy,dz] as the direction. It is not
     /// necessary to normalize the direction but the returned hit distance uses
     /// the length of the direction vector as unit.
+    /// \param nthreads The number of threads to use. Set to 0 for automatic.
     /// \return The returned dictionary contains:
     ///         - \b t_hit A tensor with the distance to the first hit. The
     ///           shape is {..}. If there is no intersection the hit distance
@@ -88,7 +89,7 @@ public:
     ///         - \b primitive_normals A tensor with the normals of the hit
     ///           triangles. The shape is {.., 3}.
     std::unordered_map<std::string, core::Tensor> CastRays(
-            const core::Tensor &rays);
+            const core::Tensor &rays, const int nthreads = 0);
 
     /// \brief Checks if the rays have any intersection with the scene.
     /// \param rays A tensor with >=2 dims, shape {.., 6}, and Dtype Float32
@@ -100,12 +101,14 @@ public:
     /// necessary to normalize the direction.
     /// \param tnear The tnear offset for the rays. The default is 0.
     /// \param tfar The tfar value for the ray. The default is infinity.
+    /// \param nthreads The number of threads to use. Set to 0 for automatic.
     /// \return A boolean tensor which indicates if the ray is occluded by the
     /// scene (true) or not (false).
     core::Tensor TestOcclusions(
             const core::Tensor &rays,
             const float tnear = 0.f,
-            const float tfar = std::numeric_limits<float>::infinity());
+            const float tfar = std::numeric_limits<float>::infinity(),
+            const int nthreads = 0);
 
     /// \brief Computes the number of intersection of the rays with the scene.
     /// \param rays A tensor with >=2 dims, shape {.., 6}, and Dtype Float32
@@ -115,15 +118,19 @@ public:
     /// The last dimension must be 6 and has the format [ox, oy, oz, dx, dy, dz]
     /// with [ox,oy,oz] as the origin and [dx,dy,dz] as the direction. It is not
     /// necessary to normalize the direction.
+    /// \param nthreads The number of threads to use. Set to 0 for automatic.
     /// \return A tensor with the number of intersections. The shape is {..}.
-    core::Tensor CountIntersections(const core::Tensor &rays);
+    core::Tensor CountIntersections(const core::Tensor &rays,
+                                    const int nthreads = 0);
 
     /// \brief Computes the closest points on the surfaces of the scene.
     /// \param query_points A tensor with >=2 dims, shape {.., 3} and Dtype
     /// Float32 describing the query points. {..} can be any number of
     /// dimensions, e.g., to organize the query_point to create a 3D grid the
     /// shape can be {depth, height, width, 3}. The last dimension must be 3 and
-    /// has the format [x, y, z]. \return The returned dictionary contains:
+    /// has the format [x, y, z].
+    /// \param nthreads The number of threads to use. Set to 0 for automatic.
+    /// \return The returned dictionary contains:
     ///         - \b points A tensor with the closest surface points. The shape
     ///           is {..}.
     ///         - \b geometry_ids A tensor with the geometry IDs. The shape is
@@ -131,16 +138,19 @@ public:
     ///         - \b primitive_ids A tensor with the primitive IDs, which
     ///           corresponds to the triangle index. The shape is {..}.
     std::unordered_map<std::string, core::Tensor> ComputeClosestPoints(
-            const core::Tensor &query_points);
+            const core::Tensor &query_points, const int nthreads = 0);
 
     /// \brief Computes the distance to the surface of the scene.
     /// \param query_points A tensor with >=2 dims, shape {.., 3} and Dtype
     /// Float32 describing the query points. {..} can be any number of
     /// dimensions, e.g., to organize the query_point to create a 3D grid the
     /// shape can be {depth, height, width, 3}. The last dimension must be 3 and
-    /// has the format [x, y, z]. \return A tensor with the distances to the
+    /// has the format [x, y, z].
+    /// \param nthreads The number of threads to use. Set to 0 for automatic.
+    /// \return A tensor with the distances to the
     /// surface. The shape is {..}.
-    core::Tensor ComputeDistance(const core::Tensor &query_points);
+    core::Tensor ComputeDistance(const core::Tensor &query_points,
+                                 const int nthreads = 0);
 
     /// \brief Computes the signed distance to the surface of the scene.
     ///
@@ -154,10 +164,13 @@ public:
     /// Float32 describing the query points. {..} can be any number of
     /// dimensions, e.g., to organize the query_point to create a 3D grid the
     /// shape can be {depth, height, width, 3}. The last dimension must be 3 and
-    /// has the format [x, y, z]. \return A tensor with the signed distances to
+    /// has the format [x, y, z].
+    /// \param nthreads The number of threads to use. Set to 0 for automatic.
+    /// \return A tensor with the signed distances to
     /// the surface. The shape is
     /// {..}. Negative distances mean a point is inside a closed surface.
-    core::Tensor ComputeSignedDistance(const core::Tensor &query_points);
+    core::Tensor ComputeSignedDistance(const core::Tensor &query_points,
+                                       const int nthreads = 0);
 
     /// \brief Computes the occupancy at the query point positions.
     ///
@@ -173,9 +186,11 @@ public:
     /// organize the query_point to create a 3D grid the shape can be
     /// {depth, height, width, 3}.
     /// The last dimension must be 3 and has the format [x, y, z].
+    /// \param nthreads The number of threads to use. Set to 0 for automatic.
     /// \return A tensor with the occupancy values. The shape is {..}. Values
     /// are either 0 or 1. A point is occupied or inside if the value is 1.
-    core::Tensor ComputeOccupancy(const core::Tensor &query_points);
+    core::Tensor ComputeOccupancy(const core::Tensor &query_points,
+                                  const int nthreads = 0);
 
     /// \brief Creates rays for the given camera parameters.
     ///

--- a/cpp/pybind/t/geometry/raycasting_scene.cpp
+++ b/cpp/pybind/t/geometry/raycasting_scene.cpp
@@ -106,6 +106,7 @@ Returns:
 )doc");
 
     raycasting_scene.def("cast_rays", &RaycastingScene::CastRays, "rays"_a,
+                         "nthreads"_a = 0,
                          R"doc(
 Computes the first intersection of the rays with the scene.
 
@@ -118,6 +119,8 @@ Args:
         with [ox,oy,oz] as the origin and [dx,dy,dz] as the direction. It is
         not necessary to normalize the direction but the returned hit distance
         uses the length of the direction vector as unit.
+
+    nthreads (int): The number of threads to use. Set to 0 for automatic.
 
 Returns:
     A dictionary which contains the following keys
@@ -146,6 +149,7 @@ Returns:
     raycasting_scene.def("test_occlusions", &RaycastingScene::TestOcclusions,
                          "rays"_a, "tnear"_a = 0.f,
                          "tfar"_a = std::numeric_limits<float>::infinity(),
+                         "nthreads"_a = 0,
                          R"doc(
 Checks if the rays have any intersection with the scene.
 
@@ -162,13 +166,16 @@ Args:
 
     tfar (float): The tfar value for the ray. The default is infinity.
 
+    nthreads (int): The number of threads to use. Set to 0 for automatic.
+
 Returns:
     A boolean tensor which indicates if the ray is occluded by the scene (true)
     or not (false).
 )doc");
 
     raycasting_scene.def("count_intersections",
-                         &RaycastingScene::CountIntersections, "rays"_a, R"doc(
+                         &RaycastingScene::CountIntersections, "rays"_a,
+                         "nthreads"_a = 0, R"doc(
 Computes the number of intersection of the rays with the scene.
 
 Args:
@@ -180,13 +187,15 @@ Args:
         with [ox,oy,oz] as the origin and [dx,dy,dz] as the direction. It is not
         necessary to normalize the direction.
 
+    nthreads (int): The number of threads to use. Set to 0 for automatic.
+
 Returns:
     A tensor with the number of intersections. The shape is {..}.
 )doc");
 
     raycasting_scene.def("compute_closest_points",
                          &RaycastingScene::ComputeClosestPoints,
-                         "query_points"_a, R"doc(
+                         "query_points"_a, "nthreads"_a = 0, R"doc(
 Computes the closest points on the surfaces of the scene.
 
 Args:
@@ -195,6 +204,8 @@ Args:
         {..} can be any number of dimensions, e.g., to organize the query_point
         to create a 3D grid the shape can be {depth, height, width, 3}.
         The last dimension must be 3 and has the format [x, y, z].
+
+    nthreads (int): The number of threads to use. Set to 0 for automatic.
 
 Returns:
     The returned dictionary contains
@@ -212,7 +223,7 @@ Returns:
 )doc");
 
     raycasting_scene.def("compute_distance", &RaycastingScene::ComputeDistance,
-                         "query_points"_a, R"doc(
+                         "query_points"_a, "nthreads"_a = 0, R"doc(
 Computes the distance to the surface of the scene.
 
 Args:
@@ -223,13 +234,15 @@ Args:
         {depth, height, width, 3}.
         The last dimension must be 3 and has the format [x, y, z].
 
+    nthreads (int): The number of threads to use. Set to 0 for automatic.
+
 Returns:
     A tensor with the distances to the surface. The shape is {..}.
 )doc");
 
     raycasting_scene.def("compute_signed_distance",
                          &RaycastingScene::ComputeSignedDistance,
-                         "query_points"_a, R"doc(
+                         "query_points"_a, "nthreads"_a = 0, R"doc(
 Computes the signed distance to the surface of the scene.
 
 This function computes the signed distance to the meshes in the scene.
@@ -246,6 +259,8 @@ Args:
         {depth, height, width, 3}.
         The last dimension must be 3 and has the format [x, y, z].
 
+    nthreads (int): The number of threads to use. Set to 0 for automatic.
+
 Returns:
     A tensor with the signed distances to the surface. The shape is {..}.
     Negative distances mean a point is inside a closed surface.
@@ -253,6 +268,7 @@ Returns:
 
     raycasting_scene.def("compute_occupancy",
                          &RaycastingScene::ComputeOccupancy, "query_points"_a,
+                         "nthreads"_a = 0,
                          R"doc(
 Computes the occupancy at the query point positions.
 
@@ -269,6 +285,8 @@ Args:
         query points to create a 3D grid the shape can be
         {depth, height, width, 3}.
         The last dimension must be 3 and has the format [x, y, z].
+
+    nthreads (int): The number of threads to use. Set to 0 for automatic.
 
 Returns:
     A tensor with the occupancy values. The shape is {..}. Values are either 0

--- a/python/test/t/geometry/test_raycasting_scene.py
+++ b/python/test/t/geometry/test_raycasting_scene.py
@@ -184,7 +184,7 @@ def test_compute_lots_of_closest_points():
     triangles = o3d.core.Tensor([[0, 1, 2]], dtype=o3d.core.uint32)
 
     scene = o3d.t.geometry.RaycastingScene()
-    geom_id = scene.add_triangles(vertices, triangles)
+    scene.add_triangles(vertices, triangles)
 
     rs = np.random.RandomState(123)
     query_points = o3d.core.Tensor.from_numpy(

--- a/python/test/t/geometry/test_raycasting_scene.py
+++ b/python/test/t/geometry/test_raycasting_scene.py
@@ -176,6 +176,22 @@ def test_compute_closest_points():
                                atol=1e-6)
 
 
+# compute lots of closest points to test the internal batching
+# we expect no errors for this test
+def test_compute_lots_of_closest_points():
+    vertices = o3d.core.Tensor([[0, 0, 0], [1, 0, 0], [1, 1, 0]],
+                               dtype=o3d.core.float32)
+    triangles = o3d.core.Tensor([[0, 1, 2]], dtype=o3d.core.uint32)
+
+    scene = o3d.t.geometry.RaycastingScene()
+    geom_id = scene.add_triangles(vertices, triangles)
+
+    rs = np.random.RandomState(123)
+    query_points = o3d.core.Tensor.from_numpy(
+        rs.rand(1234567, 3).astype(np.float32))
+    _ = scene.compute_closest_points(query_points)
+
+
 def test_compute_distance():
     cube = o3d.t.geometry.TriangleMesh.from_legacy(
         o3d.geometry.TriangleMesh.create_box())


### PR DESCRIPTION
This PR adds an argument to the functions of RaycastingScene to allow the user to control the number of threads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4100)
<!-- Reviewable:end -->
