### PR TITLE
Add template overloads of Tensor indexing functions

### DIFF
--- a/cpp/open3d/core/Indexer.h
+++ b/cpp/open3d/core/Indexer.h
@@ -430,6 +430,25 @@ public:
                                   inputs_contiguous_[input_idx], workload_idx);
     }
 
+    /// Get input Tensor data pointer based on \p workload_idx.
+    ///
+    /// \param input_idx Input tensor index.
+    /// \param workload_idx The index of the compute workload, similar to
+    /// thread_id, if a thread only processes one workload.
+    ///
+    /// Note: Assumes that sizeof(T) matches the input's dtype size, but does
+    /// not check this constraint for performance reasons.
+    template <typename T>
+    OPEN3D_HOST_DEVICE T* GetInputPtr(int64_t input_idx,
+                                      int64_t workload_idx) const {
+        if (input_idx < 0 || input_idx >= num_inputs_) {
+            return nullptr;
+        }
+        return GetWorkloadDataPtr<T>(inputs_[input_idx],
+                                     inputs_contiguous_[input_idx],
+                                     workload_idx);
+    }
+
     /// Get output Tensor data pointer based on \p workload_idx.
     ///
     /// \param workload_idx The index of the compute workload, similar to
@@ -437,6 +456,19 @@ public:
     OPEN3D_HOST_DEVICE char* GetOutputPtr(int64_t workload_idx) const {
         return GetWorkloadDataPtr(outputs_[0], outputs_contiguous_[0],
                                   workload_idx);
+    }
+
+    /// Get output Tensor data pointer based on \p workload_idx.
+    ///
+    /// \param workload_idx The index of the compute workload, similar to
+    /// thread_id, if a thread only processes one workload.
+    ///
+    /// Note: Assumes that sizeof(T) matches the output's dtype size, but does
+    /// not check this constraint for performance reasons.
+    template <typename T>
+    OPEN3D_HOST_DEVICE T* GetOutputPtr(int64_t workload_idx) const {
+        return GetWorkloadDataPtr<T>(outputs_[0], outputs_contiguous_[0],
+                                     workload_idx);
     }
 
     /// Get output Tensor data pointer based on \p workload_idx.
@@ -449,6 +481,19 @@ public:
         return GetWorkloadDataPtr(outputs_[output_idx],
                                   outputs_contiguous_[output_idx],
                                   workload_idx);
+    }
+
+    /// Get output Tensor data pointer based on \p workload_idx.
+    ///
+    /// \param output_idx Output tensor index.
+    /// \param workload_idx The index of the compute workload, similar to
+    /// thread_id, if a thread only processes one workload.
+    template <typename T>
+    OPEN3D_HOST_DEVICE T* GetOutputPtr(int64_t output_idx,
+                                       int64_t workload_idx) const {
+        return GetWorkloadDataPtr<T>(outputs_[output_idx],
+                                     outputs_contiguous_[output_idx],
+                                     workload_idx);
     }
 
 #ifdef BUILD_ISPC_MODULE
@@ -520,18 +565,47 @@ protected:
         if (workload_idx < 0) {
             return nullptr;
         }
-        int64_t offset = 0;
         if (tr_contiguous) {
             return static_cast<char*>(tr.data_ptr_) +
                    workload_idx * tr.dtype_byte_size_;
         } else {
+            int64_t offset = 0;
             for (int64_t i = 0; i < ndims_; ++i) {
                 offset +=
                         workload_idx / master_strides_[i] * tr.byte_strides_[i];
                 workload_idx = workload_idx % master_strides_[i];
             }
+            return static_cast<char*>(tr.data_ptr_) + offset;
         }
-        return static_cast<char*>(tr.data_ptr_) + offset;
+    }
+
+    /// Get data pointer from a TensorRef with \p workload_idx.
+    /// Note: can be optimized by computing all input ptrs and output ptr
+    /// together.
+    ///
+    /// Note: Assumes that sizeof(T) matches the data's dtype size, but does
+    /// not check this constraint for performance reasons.
+    template <typename T>
+    OPEN3D_HOST_DEVICE T* GetWorkloadDataPtr(const TensorRef& tr,
+                                             bool tr_contiguous,
+                                             int64_t workload_idx) const {
+        // For 0-sized input reduction op, the output Tensor
+        // workload_idx == 1 > NumWorkloads() == 0.
+        if (workload_idx < 0) {
+            return nullptr;
+        }
+        if (tr_contiguous) {
+            return static_cast<T*>(tr.data_ptr_) + workload_idx;
+        } else {
+            int64_t offset = 0;
+            for (int64_t i = 0; i < ndims_; ++i) {
+                offset +=
+                        workload_idx / master_strides_[i] * tr.byte_strides_[i];
+                workload_idx = workload_idx % master_strides_[i];
+            }
+            return static_cast<T*>(static_cast<void*>(
+                    static_cast<char*>(tr.data_ptr_) + offset));
+        }
     }
 
     /// Number of input and output Tensors.

--- a/cpp/open3d/core/Indexer.isph
+++ b/cpp/open3d/core/Indexer.isph
@@ -102,8 +102,8 @@ static inline uint8_t* Indexer_GetWorkloadDataPtr(
         const uniform TensorRef* const uniform tr,
         uniform bool tr_contiguous,
         int64_t workload_idx) {
-    // For 0-sized input reduction op, the output Tensor
-    // workload_idx == 1 > NumWorkloads() == 0.
+    /* For 0-sized input reduction op, the output Tensor
+    workload_idx == 1 > NumWorkloads() == 0. */
     cif(workload_idx < 0) { return NULL; }
     if (tr_contiguous) {
         return (uint8_t*)(tr->data_ptr_) + workload_idx * tr->dtype_byte_size_;
@@ -121,6 +121,31 @@ static inline uint8_t* Indexer_GetWorkloadDataPtr(
         return (uint8_t*)(tr->data_ptr_) + offset;
     }
 }
+
+/// Get data pointer from a TensorRef with \p workload_idx.
+/// Note: can be optimized by computing all input ptrs and output ptr
+/// together.
+#define TEMPLATE(T)                                                     \
+    static inline T* OPEN3D_SPECIALIZED(T, Indexer_GetWorkloadDataPtr)( \
+            const uniform Indexer* const uniform self,                  \
+            const uniform TensorRef* const uniform tr,                  \
+            uniform bool tr_contiguous, int64_t workload_idx) {         \
+        cif(workload_idx < 0) { return NULL; }                          \
+        if (tr_contiguous) {                                            \
+            return (T*)(tr->data_ptr_) + workload_idx;                  \
+        } else {                                                        \
+            int64_t offset = 0;                                         \
+            for (uniform int64_t i = 0; i < self->ndims_; ++i) {        \
+                offset += workload_idx / self->master_strides_[i] *     \
+                          tr->byte_strides_[i];                         \
+                workload_idx = workload_idx % self->master_strides_[i]; \
+            }                                                           \
+            return (T*)((uint8_t*)(tr->data_ptr_) + offset);            \
+        }                                                               \
+    }
+#pragma ignore warning(perf)
+OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
+#undef TEMPLATE
 
 /// Get input Tensor data pointer based on \p workload_idx.
 ///
@@ -140,6 +165,27 @@ static inline uint8_t* Indexer_GetInputPtr(const uniform Indexer* const uniform
                                       workload_idx);
 }
 
+/// Get input Tensor data pointer based on \p workload_idx.
+///
+/// \param self The indexer instance.
+/// \param input_idx Input tensor index.
+/// \param workload_idx The index of the compute workload, similar to
+/// thread_id, if a thread only processes one workload.
+#define TEMPLATE(T)                                                 \
+    static inline T* OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(    \
+            const uniform Indexer* const uniform self,              \
+            uniform int64_t input_idx, int64_t workload_idx) {      \
+        if (input_idx < 0 || input_idx >= self->num_inputs_) {      \
+            return NULL;                                            \
+        }                                                           \
+        return OPEN3D_SPECIALIZED(T, Indexer_GetWorkloadDataPtr)(   \
+                self, &(self->inputs_[input_idx]),                  \
+                self->inputs_contiguous_[input_idx], workload_idx); \
+    }
+#pragma ignore warning(perf)
+OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
+#undef TEMPLATE
+
 /// Get output Tensor data pointer based on \p workload_idx.
 ///
 /// \param self The indexer instance.
@@ -155,6 +201,22 @@ static inline uint8_t* Indexer_GetOutputPtr(
 /// Get output Tensor data pointer based on \p workload_idx.
 ///
 /// \param self The indexer instance.
+/// \param workload_idx The index of the compute workload, similar to
+/// thread_id, if a thread only processes one workload.
+#define TEMPLATE(T)                                                            \
+    static inline T* OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(              \
+            const uniform Indexer* const uniform self, int64_t workload_idx) { \
+        return OPEN3D_SPECIALIZED(T, Indexer_GetWorkloadDataPtr)(              \
+                self, &(self->outputs_[0]), self->outputs_contiguous_[0],      \
+                workload_idx);                                                 \
+    }
+#pragma ignore warning(perf)
+OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
+#undef TEMPLATE
+
+/// Get output Tensor data pointer based on \p workload_idx.
+///
+/// \param self The indexer instance.
 /// \param output_idx Output tensor index.
 /// \param workload_idx The index of the compute workload, similar to
 /// thread_id, if a thread only processes one workload.
@@ -166,3 +228,21 @@ static inline uint8_t* Indexer_GetOutputPtr(const uniform Indexer* const uniform
                                       self->outputs_contiguous_[output_idx],
                                       workload_idx);
 }
+
+/// Get output Tensor data pointer based on \p workload_idx.
+///
+/// \param self The indexer instance.
+/// \param output_idx Output tensor index.
+/// \param workload_idx The index of the compute workload, similar to
+/// thread_id, if a thread only processes one workload.
+#define TEMPLATE(T)                                                   \
+    static inline T* OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(     \
+            const uniform Indexer* const uniform self,                \
+            uniform int64_t output_idx, int64_t workload_idx) {       \
+        return OPEN3D_SPECIALIZED(T, Indexer_GetWorkloadDataPtr)(     \
+                self, &(self->outputs_[output_idx]),                  \
+                self->outputs_contiguous_[output_idx], workload_idx); \
+    }
+#pragma ignore warning(perf)
+OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
+#undef TEMPLATE

--- a/cpp/open3d/core/kernel/BinaryEWCPU.cpp
+++ b/cpp/open3d/core/kernel/BinaryEWCPU.cpp
@@ -42,27 +42,30 @@ namespace open3d {
 namespace core {
 namespace kernel {
 
-template <typename element_func_t>
+template <typename src_t, typename dst_t, typename element_func_t>
 static void LaunchBinaryEWKernel(const Indexer& indexer,
                                  const element_func_t& element_func) {
     ParallelFor(Device("CPU:0"), indexer.NumWorkloads(),
                 [&indexer, &element_func](int64_t i) {
-                    element_func(indexer.GetInputPtr(0, i),
-                                 indexer.GetInputPtr(1, i),
-                                 indexer.GetOutputPtr(i));
+                    element_func(indexer.GetInputPtr<src_t>(0, i),
+                                 indexer.GetInputPtr<src_t>(1, i),
+                                 indexer.GetOutputPtr<dst_t>(i));
                 });
 }
 
-template <typename element_func_t, typename vec_func_t>
+template <typename src_t,
+          typename dst_t,
+          typename element_func_t,
+          typename vec_func_t>
 static void LaunchBinaryEWKernel(const Indexer& indexer,
                                  const element_func_t& element_func,
                                  const vec_func_t& vec_func) {
     ParallelFor(
             Device("CPU:0"), indexer.NumWorkloads(),
             [&indexer, &element_func](int64_t i) {
-                element_func(indexer.GetInputPtr(0, i),
-                             indexer.GetInputPtr(1, i),
-                             indexer.GetOutputPtr(i));
+                element_func(indexer.GetInputPtr<src_t>(0, i),
+                             indexer.GetInputPtr<src_t>(1, i),
+                             indexer.GetOutputPtr<dst_t>(i));
             },
             vec_func);
 }
@@ -174,7 +177,7 @@ void BinaryEWCPU(const Tensor& lhs,
             DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(src_dtype, [&]() {
                 switch (op_code) {
                     case BinaryEWOpCode::LogicalAnd:
-                        LaunchBinaryEWKernel(
+                        LaunchBinaryEWKernel<scalar_t, scalar_t>(
                                 indexer,
                                 CPULogicalAndElementKernel<scalar_t, scalar_t>,
                                 OPEN3D_TEMPLATE_VECTORIZED(
@@ -182,7 +185,7 @@ void BinaryEWCPU(const Tensor& lhs,
                                         &ispc_indexer));
                         break;
                     case BinaryEWOpCode::LogicalOr:
-                        LaunchBinaryEWKernel(
+                        LaunchBinaryEWKernel<scalar_t, scalar_t>(
                                 indexer,
                                 CPULogicalOrElementKernel<scalar_t, scalar_t>,
                                 OPEN3D_TEMPLATE_VECTORIZED(
@@ -190,7 +193,7 @@ void BinaryEWCPU(const Tensor& lhs,
                                         &ispc_indexer));
                         break;
                     case BinaryEWOpCode::LogicalXor:
-                        LaunchBinaryEWKernel(
+                        LaunchBinaryEWKernel<scalar_t, scalar_t>(
                                 indexer,
                                 CPULogicalXorElementKernel<scalar_t, scalar_t>,
                                 OPEN3D_TEMPLATE_VECTORIZED(
@@ -198,21 +201,21 @@ void BinaryEWCPU(const Tensor& lhs,
                                         &ispc_indexer));
                         break;
                     case BinaryEWOpCode::Gt:
-                        LaunchBinaryEWKernel(
+                        LaunchBinaryEWKernel<scalar_t, scalar_t>(
                                 indexer, CPUGtElementKernel<scalar_t, scalar_t>,
                                 OPEN3D_TEMPLATE_VECTORIZED(
                                         scalar_t, CPULogicalGtElementKernel,
                                         &ispc_indexer));
                         break;
                     case BinaryEWOpCode::Lt:
-                        LaunchBinaryEWKernel(
+                        LaunchBinaryEWKernel<scalar_t, scalar_t>(
                                 indexer, CPULtElementKernel<scalar_t, scalar_t>,
                                 OPEN3D_TEMPLATE_VECTORIZED(
                                         scalar_t, CPULogicalLtElementKernel,
                                         &ispc_indexer));
                         break;
                     case BinaryEWOpCode::Ge:
-                        LaunchBinaryEWKernel(
+                        LaunchBinaryEWKernel<scalar_t, scalar_t>(
                                 indexer,
                                 CPUGeqElementKernel<scalar_t, scalar_t>,
                                 OPEN3D_TEMPLATE_VECTORIZED(
@@ -220,7 +223,7 @@ void BinaryEWCPU(const Tensor& lhs,
                                         &ispc_indexer));
                         break;
                     case BinaryEWOpCode::Le:
-                        LaunchBinaryEWKernel(
+                        LaunchBinaryEWKernel<scalar_t, scalar_t>(
                                 indexer,
                                 CPULeqElementKernel<scalar_t, scalar_t>,
                                 OPEN3D_TEMPLATE_VECTORIZED(
@@ -228,14 +231,14 @@ void BinaryEWCPU(const Tensor& lhs,
                                         &ispc_indexer));
                         break;
                     case BinaryEWOpCode::Eq:
-                        LaunchBinaryEWKernel(
+                        LaunchBinaryEWKernel<scalar_t, scalar_t>(
                                 indexer, CPUEqElementKernel<scalar_t, scalar_t>,
                                 OPEN3D_TEMPLATE_VECTORIZED(
                                         scalar_t, CPULogicalEqElementKernel,
                                         &ispc_indexer));
                         break;
                     case BinaryEWOpCode::Ne:
-                        LaunchBinaryEWKernel(
+                        LaunchBinaryEWKernel<scalar_t, scalar_t>(
                                 indexer,
                                 CPUNeqElementKernel<scalar_t, scalar_t>,
                                 OPEN3D_TEMPLATE_VECTORIZED(
@@ -256,7 +259,7 @@ void BinaryEWCPU(const Tensor& lhs,
             DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(src_dtype, [&]() {
                 switch (op_code) {
                     case BinaryEWOpCode::LogicalAnd:
-                        LaunchBinaryEWKernel(
+                        LaunchBinaryEWKernel<scalar_t, bool>(
                                 indexer,
                                 CPULogicalAndElementKernel<scalar_t, bool>,
                                 OPEN3D_TEMPLATE_VECTORIZED(
@@ -265,7 +268,7 @@ void BinaryEWCPU(const Tensor& lhs,
                                         &ispc_indexer));
                         break;
                     case BinaryEWOpCode::LogicalOr:
-                        LaunchBinaryEWKernel(
+                        LaunchBinaryEWKernel<scalar_t, bool>(
                                 indexer,
                                 CPULogicalOrElementKernel<scalar_t, bool>,
                                 OPEN3D_TEMPLATE_VECTORIZED(
@@ -274,7 +277,7 @@ void BinaryEWCPU(const Tensor& lhs,
                                         &ispc_indexer));
                         break;
                     case BinaryEWOpCode::LogicalXor:
-                        LaunchBinaryEWKernel(
+                        LaunchBinaryEWKernel<scalar_t, bool>(
                                 indexer,
                                 CPULogicalXorElementKernel<scalar_t, bool>,
                                 OPEN3D_TEMPLATE_VECTORIZED(
@@ -283,7 +286,7 @@ void BinaryEWCPU(const Tensor& lhs,
                                         &ispc_indexer));
                         break;
                     case BinaryEWOpCode::Gt:
-                        LaunchBinaryEWKernel(
+                        LaunchBinaryEWKernel<scalar_t, bool>(
                                 indexer, CPUGtElementKernel<scalar_t, bool>,
                                 OPEN3D_TEMPLATE_VECTORIZED(
                                         scalar_t,
@@ -291,7 +294,7 @@ void BinaryEWCPU(const Tensor& lhs,
                                         &ispc_indexer));
                         break;
                     case BinaryEWOpCode::Lt:
-                        LaunchBinaryEWKernel(
+                        LaunchBinaryEWKernel<scalar_t, bool>(
                                 indexer, CPULtElementKernel<scalar_t, bool>,
                                 OPEN3D_TEMPLATE_VECTORIZED(
                                         scalar_t,
@@ -299,7 +302,7 @@ void BinaryEWCPU(const Tensor& lhs,
                                         &ispc_indexer));
                         break;
                     case BinaryEWOpCode::Ge:
-                        LaunchBinaryEWKernel(
+                        LaunchBinaryEWKernel<scalar_t, bool>(
                                 indexer, CPUGeqElementKernel<scalar_t, bool>,
                                 OPEN3D_TEMPLATE_VECTORIZED(
                                         scalar_t,
@@ -307,7 +310,7 @@ void BinaryEWCPU(const Tensor& lhs,
                                         &ispc_indexer));
                         break;
                     case BinaryEWOpCode::Le:
-                        LaunchBinaryEWKernel(
+                        LaunchBinaryEWKernel<scalar_t, bool>(
                                 indexer, CPULeqElementKernel<scalar_t, bool>,
                                 OPEN3D_TEMPLATE_VECTORIZED(
                                         scalar_t,
@@ -315,7 +318,7 @@ void BinaryEWCPU(const Tensor& lhs,
                                         &ispc_indexer));
                         break;
                     case BinaryEWOpCode::Eq:
-                        LaunchBinaryEWKernel(
+                        LaunchBinaryEWKernel<scalar_t, bool>(
                                 indexer, CPUEqElementKernel<scalar_t, bool>,
                                 OPEN3D_TEMPLATE_VECTORIZED(
                                         scalar_t,
@@ -323,7 +326,7 @@ void BinaryEWCPU(const Tensor& lhs,
                                         &ispc_indexer));
                         break;
                     case BinaryEWOpCode::Ne:
-                        LaunchBinaryEWKernel(
+                        LaunchBinaryEWKernel<scalar_t, bool>(
                                 indexer, CPUNeqElementKernel<scalar_t, bool>,
                                 OPEN3D_TEMPLATE_VECTORIZED(
                                         scalar_t,
@@ -347,28 +350,31 @@ void BinaryEWCPU(const Tensor& lhs,
         DISPATCH_DTYPE_TO_TEMPLATE(src_dtype, [&]() {
             switch (op_code) {
                 case BinaryEWOpCode::Add:
-                    LaunchBinaryEWKernel(indexer, CPUAddElementKernel<scalar_t>,
-                                         OPEN3D_TEMPLATE_VECTORIZED(
-                                                 scalar_t, CPUAddElementKernel,
-                                                 &ispc_indexer));
+                    LaunchBinaryEWKernel<scalar_t, scalar_t>(
+                            indexer, CPUAddElementKernel<scalar_t>,
+                            OPEN3D_TEMPLATE_VECTORIZED(scalar_t,
+                                                       CPUAddElementKernel,
+                                                       &ispc_indexer));
                     break;
                 case BinaryEWOpCode::Sub:
-                    LaunchBinaryEWKernel(indexer, CPUSubElementKernel<scalar_t>,
-                                         OPEN3D_TEMPLATE_VECTORIZED(
-                                                 scalar_t, CPUSubElementKernel,
-                                                 &ispc_indexer));
+                    LaunchBinaryEWKernel<scalar_t, scalar_t>(
+                            indexer, CPUSubElementKernel<scalar_t>,
+                            OPEN3D_TEMPLATE_VECTORIZED(scalar_t,
+                                                       CPUSubElementKernel,
+                                                       &ispc_indexer));
                     break;
                 case BinaryEWOpCode::Mul:
-                    LaunchBinaryEWKernel(indexer, CPUMulElementKernel<scalar_t>,
-                                         OPEN3D_TEMPLATE_VECTORIZED(
-                                                 scalar_t, CPUMulElementKernel,
-                                                 &ispc_indexer));
+                    LaunchBinaryEWKernel<scalar_t, scalar_t>(
+                            indexer, CPUMulElementKernel<scalar_t>,
+                            OPEN3D_TEMPLATE_VECTORIZED(scalar_t,
+                                                       CPUMulElementKernel,
+                                                       &ispc_indexer));
                     break;
                 case BinaryEWOpCode::Div:
                     // The vectorized Div kernel causes a crash in the Python
                     // tests, so use scalar version instead.
-                    LaunchBinaryEWKernel(indexer,
-                                         CPUDivElementKernel<scalar_t>);
+                    LaunchBinaryEWKernel<scalar_t, scalar_t>(
+                            indexer, CPUDivElementKernel<scalar_t>);
                     break;
                 default:
                     break;

--- a/cpp/open3d/core/kernel/BinaryEWCPU.ispc
+++ b/cpp/open3d/core/kernel/BinaryEWCPU.ispc
@@ -27,49 +27,57 @@
 #include "open3d/core/Indexer.isph"
 #include "open3d/core/ParallelFor.isph"
 
-#define TEMPLATE(T)                                                    \
-    static inline void OPEN3D_SPECIALIZED(T, CPUAddElement)(           \
-            int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* lhs = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        const T* rhs = (const T*)Indexer_GetInputPtr(indexer, 1, idx); \
-        T* dst = (T*)Indexer_GetOutputPtr(indexer, idx);               \
-        *dst = *lhs + *rhs;                                            \
+#define TEMPLATE(T)                                                          \
+    static inline void OPEN3D_SPECIALIZED(T, CPUAddElement)(                 \
+            int64_t idx, uniform Indexer * uniform indexer) {                \
+        const T* lhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx); \
+        const T* rhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 1, idx); \
+        T* dst = OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(indexer, idx);  \
+        *dst = *lhs + *rhs;                                                  \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                    \
-    static inline void OPEN3D_SPECIALIZED(T, CPUSubElement)(           \
-            int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* lhs = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        const T* rhs = (const T*)Indexer_GetInputPtr(indexer, 1, idx); \
-        T* dst = (T*)Indexer_GetOutputPtr(indexer, idx);               \
-        *dst = *lhs - *rhs;                                            \
+#define TEMPLATE(T)                                                          \
+    static inline void OPEN3D_SPECIALIZED(T, CPUSubElement)(                 \
+            int64_t idx, uniform Indexer * uniform indexer) {                \
+        const T* lhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx); \
+        const T* rhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 1, idx); \
+        T* dst = OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(indexer, idx);  \
+        *dst = *lhs - *rhs;                                                  \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                    \
-    static inline void OPEN3D_SPECIALIZED(T, CPUMulElement)(           \
-            int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* lhs = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        const T* rhs = (const T*)Indexer_GetInputPtr(indexer, 1, idx); \
-        T* dst = (T*)Indexer_GetOutputPtr(indexer, idx);               \
-        *dst = *lhs * *rhs;                                            \
+#define TEMPLATE(T)                                                          \
+    static inline void OPEN3D_SPECIALIZED(T, CPUMulElement)(                 \
+            int64_t idx, uniform Indexer * uniform indexer) {                \
+        const T* lhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx); \
+        const T* rhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 1, idx); \
+        T* dst = OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(indexer, idx);  \
+        *dst = *lhs * *rhs;                                                  \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                    \
-    static inline void OPEN3D_SPECIALIZED(T, CPUDivElement)(           \
-            int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* lhs = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        const T* rhs = (const T*)Indexer_GetInputPtr(indexer, 1, idx); \
-        T* dst = (T*)Indexer_GetOutputPtr(indexer, idx);               \
-        *dst = *lhs / *rhs;                                            \
+#define TEMPLATE(T)                                                          \
+    static inline void OPEN3D_SPECIALIZED(T, CPUDivElement)(                 \
+            int64_t idx, uniform Indexer * uniform indexer) {                \
+        const T* lhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx); \
+        const T* rhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 1, idx); \
+        T* dst = OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(indexer, idx);  \
+        *dst = *lhs / *rhs;                                                  \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE()
@@ -95,217 +103,262 @@ static inline void OPEN3D_SPECIALIZED(bool, CPUDivElement)(
     /* No-op */
 }
 
-#define TEMPLATE(T)                                                    \
-    static inline void OPEN3D_SPECIALIZED(T, CPULogicalAndElement)(    \
-            int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* lhs = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        const T* rhs = (const T*)Indexer_GetInputPtr(indexer, 1, idx); \
-        T* dst = (T*)Indexer_GetOutputPtr(indexer, idx);               \
-        *dst = (T)((bool)(*lhs) && (bool)(*rhs));                      \
+#define TEMPLATE(T)                                                          \
+    static inline void OPEN3D_SPECIALIZED(T, CPULogicalAndElement)(          \
+            int64_t idx, uniform Indexer * uniform indexer) {                \
+        const T* lhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx); \
+        const T* rhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 1, idx); \
+        T* dst = OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(indexer, idx);  \
+        *dst = (T)((bool)(*lhs) && (bool)(*rhs));                            \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                    \
-    static inline void OPEN3D_SPECIALIZED(T, CPULogicalOrElement)(     \
-            int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* lhs = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        const T* rhs = (const T*)Indexer_GetInputPtr(indexer, 1, idx); \
-        T* dst = (T*)Indexer_GetOutputPtr(indexer, idx);               \
-        *dst = (T)((bool)(*lhs) || (bool)(*rhs));                      \
+#define TEMPLATE(T)                                                          \
+    static inline void OPEN3D_SPECIALIZED(T, CPULogicalOrElement)(           \
+            int64_t idx, uniform Indexer * uniform indexer) {                \
+        const T* lhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx); \
+        const T* rhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 1, idx); \
+        T* dst = OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(indexer, idx);  \
+        *dst = (T)((bool)(*lhs) || (bool)(*rhs));                            \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                    \
-    static inline void OPEN3D_SPECIALIZED(T, CPULogicalXorElement)(    \
-            int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* lhs = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        const T* rhs = (const T*)Indexer_GetInputPtr(indexer, 1, idx); \
-        T* dst = (T*)Indexer_GetOutputPtr(indexer, idx);               \
-        *dst = (T)((bool)(*lhs) != (bool)(*rhs));                      \
+#define TEMPLATE(T)                                                          \
+    static inline void OPEN3D_SPECIALIZED(T, CPULogicalXorElement)(          \
+            int64_t idx, uniform Indexer * uniform indexer) {                \
+        const T* lhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx); \
+        const T* rhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 1, idx); \
+        T* dst = OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(indexer, idx);  \
+        *dst = (T)((bool)(*lhs) != (bool)(*rhs));                            \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                    \
-    static inline void OPEN3D_SPECIALIZED(T, CPULogicalGtElement)(     \
-            int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* lhs = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        const T* rhs = (const T*)Indexer_GetInputPtr(indexer, 1, idx); \
-        T* dst = (T*)Indexer_GetOutputPtr(indexer, idx);               \
-        *dst = (T)(*lhs > *rhs);                                       \
+#define TEMPLATE(T)                                                          \
+    static inline void OPEN3D_SPECIALIZED(T, CPULogicalGtElement)(           \
+            int64_t idx, uniform Indexer * uniform indexer) {                \
+        const T* lhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx); \
+        const T* rhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 1, idx); \
+        T* dst = OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(indexer, idx);  \
+        *dst = (T)(*lhs > *rhs);                                             \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                    \
-    static inline void OPEN3D_SPECIALIZED(T, CPULogicalLtElement)(     \
-            int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* lhs = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        const T* rhs = (const T*)Indexer_GetInputPtr(indexer, 1, idx); \
-        T* dst = (T*)Indexer_GetOutputPtr(indexer, idx);               \
-        *dst = (T)(*lhs < *rhs);                                       \
+#define TEMPLATE(T)                                                          \
+    static inline void OPEN3D_SPECIALIZED(T, CPULogicalLtElement)(           \
+            int64_t idx, uniform Indexer * uniform indexer) {                \
+        const T* lhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx); \
+        const T* rhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 1, idx); \
+        T* dst = OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(indexer, idx);  \
+        *dst = (T)(*lhs < *rhs);                                             \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                    \
-    static inline void OPEN3D_SPECIALIZED(T, CPULogicalGeqElement)(    \
-            int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* lhs = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        const T* rhs = (const T*)Indexer_GetInputPtr(indexer, 1, idx); \
-        T* dst = (T*)Indexer_GetOutputPtr(indexer, idx);               \
-        *dst = (T)(*lhs >= *rhs);                                      \
+#define TEMPLATE(T)                                                          \
+    static inline void OPEN3D_SPECIALIZED(T, CPULogicalGeqElement)(          \
+            int64_t idx, uniform Indexer * uniform indexer) {                \
+        const T* lhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx); \
+        const T* rhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 1, idx); \
+        T* dst = OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(indexer, idx);  \
+        *dst = (T)(*lhs >= *rhs);                                            \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                    \
-    static inline void OPEN3D_SPECIALIZED(T, CPULogicalLeqElement)(    \
-            int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* lhs = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        const T* rhs = (const T*)Indexer_GetInputPtr(indexer, 1, idx); \
-        T* dst = (T*)Indexer_GetOutputPtr(indexer, idx);               \
-        *dst = (T)(*lhs <= *rhs);                                      \
+#define TEMPLATE(T)                                                          \
+    static inline void OPEN3D_SPECIALIZED(T, CPULogicalLeqElement)(          \
+            int64_t idx, uniform Indexer * uniform indexer) {                \
+        const T* lhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx); \
+        const T* rhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 1, idx); \
+        T* dst = OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(indexer, idx);  \
+        *dst = (T)(*lhs <= *rhs);                                            \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                    \
-    static inline void OPEN3D_SPECIALIZED(T, CPULogicalEqElement)(     \
-            int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* lhs = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        const T* rhs = (const T*)Indexer_GetInputPtr(indexer, 1, idx); \
-        T* dst = (T*)Indexer_GetOutputPtr(indexer, idx);               \
-        *dst = (T)(*lhs == *rhs);                                      \
+#define TEMPLATE(T)                                                          \
+    static inline void OPEN3D_SPECIALIZED(T, CPULogicalEqElement)(           \
+            int64_t idx, uniform Indexer * uniform indexer) {                \
+        const T* lhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx); \
+        const T* rhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 1, idx); \
+        T* dst = OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(indexer, idx);  \
+        *dst = (T)(*lhs == *rhs);                                            \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                    \
-    static inline void OPEN3D_SPECIALIZED(T, CPULogicalNeqElement)(    \
-            int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* lhs = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        const T* rhs = (const T*)Indexer_GetInputPtr(indexer, 1, idx); \
-        T* dst = (T*)Indexer_GetOutputPtr(indexer, idx);               \
-        *dst = (T)(*lhs != *rhs);                                      \
+#define TEMPLATE(T)                                                          \
+    static inline void OPEN3D_SPECIALIZED(T, CPULogicalNeqElement)(          \
+            int64_t idx, uniform Indexer * uniform indexer) {                \
+        const T* lhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx); \
+        const T* rhs =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 1, idx); \
+        T* dst = OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(indexer, idx);  \
+        *dst = (T)(*lhs != *rhs);                                            \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                      \
-    static inline void OPEN3D_SPECIALIZED(T, CPULogicalAndElement_bool)( \
-            int64_t idx, uniform Indexer * uniform indexer) {            \
-        const T* lhs = (const T*)Indexer_GetInputPtr(indexer, 0, idx);   \
-        const T* rhs = (const T*)Indexer_GetInputPtr(indexer, 1, idx);   \
-        bool* dst = (bool*)Indexer_GetOutputPtr(indexer, idx);           \
-        *dst = (bool)(*lhs) && (bool)(*rhs);                             \
+#define TEMPLATE(T)                                                           \
+    static inline void OPEN3D_SPECIALIZED(T, CPULogicalAndElement_bool)(      \
+            int64_t idx, uniform Indexer * uniform indexer) {                 \
+        const T* lhs =                                                        \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx);  \
+        const T* rhs =                                                        \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 1, idx);  \
+        bool* dst =                                                           \
+                OPEN3D_SPECIALIZED(bool, Indexer_GetOutputPtr)(indexer, idx); \
+        *dst = (bool)(*lhs) && (bool)(*rhs);                                  \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                     \
-    static inline void OPEN3D_SPECIALIZED(T, CPULogicalOrElement_bool)( \
-            int64_t idx, uniform Indexer * uniform indexer) {           \
-        const T* lhs = (const T*)Indexer_GetInputPtr(indexer, 0, idx);  \
-        const T* rhs = (const T*)Indexer_GetInputPtr(indexer, 1, idx);  \
-        bool* dst = (bool*)Indexer_GetOutputPtr(indexer, idx);          \
-        *dst = (bool)(*lhs) || (bool)(*rhs);                            \
+#define TEMPLATE(T)                                                           \
+    static inline void OPEN3D_SPECIALIZED(T, CPULogicalOrElement_bool)(       \
+            int64_t idx, uniform Indexer * uniform indexer) {                 \
+        const T* lhs =                                                        \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx);  \
+        const T* rhs =                                                        \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 1, idx);  \
+        bool* dst =                                                           \
+                OPEN3D_SPECIALIZED(bool, Indexer_GetOutputPtr)(indexer, idx); \
+        *dst = (bool)(*lhs) || (bool)(*rhs);                                  \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                      \
-    static inline void OPEN3D_SPECIALIZED(T, CPULogicalXorElement_bool)( \
-            int64_t idx, uniform Indexer * uniform indexer) {            \
-        const T* lhs = (const T*)Indexer_GetInputPtr(indexer, 0, idx);   \
-        const T* rhs = (const T*)Indexer_GetInputPtr(indexer, 1, idx);   \
-        bool* dst = (bool*)Indexer_GetOutputPtr(indexer, idx);           \
-        *dst = (bool)(*lhs) != (bool)(*rhs);                             \
+#define TEMPLATE(T)                                                           \
+    static inline void OPEN3D_SPECIALIZED(T, CPULogicalXorElement_bool)(      \
+            int64_t idx, uniform Indexer * uniform indexer) {                 \
+        const T* lhs =                                                        \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx);  \
+        const T* rhs =                                                        \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 1, idx);  \
+        bool* dst =                                                           \
+                OPEN3D_SPECIALIZED(bool, Indexer_GetOutputPtr)(indexer, idx); \
+        *dst = (bool)(*lhs) != (bool)(*rhs);                                  \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                     \
-    static inline void OPEN3D_SPECIALIZED(T, CPULogicalGtElement_bool)( \
-            int64_t idx, uniform Indexer * uniform indexer) {           \
-        const T* lhs = (const T*)Indexer_GetInputPtr(indexer, 0, idx);  \
-        const T* rhs = (const T*)Indexer_GetInputPtr(indexer, 1, idx);  \
-        bool* dst = (bool*)Indexer_GetOutputPtr(indexer, idx);          \
-        *dst = (bool)(*lhs > *rhs);                                     \
+#define TEMPLATE(T)                                                           \
+    static inline void OPEN3D_SPECIALIZED(T, CPULogicalGtElement_bool)(       \
+            int64_t idx, uniform Indexer * uniform indexer) {                 \
+        const T* lhs =                                                        \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx);  \
+        const T* rhs =                                                        \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 1, idx);  \
+        bool* dst =                                                           \
+                OPEN3D_SPECIALIZED(bool, Indexer_GetOutputPtr)(indexer, idx); \
+        *dst = (bool)(*lhs > *rhs);                                           \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                     \
-    static inline void OPEN3D_SPECIALIZED(T, CPULogicalLtElement_bool)( \
-            int64_t idx, uniform Indexer * uniform indexer) {           \
-        const T* lhs = (const T*)Indexer_GetInputPtr(indexer, 0, idx);  \
-        const T* rhs = (const T*)Indexer_GetInputPtr(indexer, 1, idx);  \
-        bool* dst = (bool*)Indexer_GetOutputPtr(indexer, idx);          \
-        *dst = (T)(*lhs < *rhs);                                        \
+#define TEMPLATE(T)                                                           \
+    static inline void OPEN3D_SPECIALIZED(T, CPULogicalLtElement_bool)(       \
+            int64_t idx, uniform Indexer * uniform indexer) {                 \
+        const T* lhs =                                                        \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx);  \
+        const T* rhs =                                                        \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 1, idx);  \
+        bool* dst =                                                           \
+                OPEN3D_SPECIALIZED(bool, Indexer_GetOutputPtr)(indexer, idx); \
+        *dst = (T)(*lhs < *rhs);                                              \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                      \
-    static inline void OPEN3D_SPECIALIZED(T, CPULogicalGeqElement_bool)( \
-            int64_t idx, uniform Indexer * uniform indexer) {            \
-        const T* lhs = (const T*)Indexer_GetInputPtr(indexer, 0, idx);   \
-        const T* rhs = (const T*)Indexer_GetInputPtr(indexer, 1, idx);   \
-        bool* dst = (bool*)Indexer_GetOutputPtr(indexer, idx);           \
-        *dst = (bool)(*lhs >= *rhs);                                     \
+#define TEMPLATE(T)                                                           \
+    static inline void OPEN3D_SPECIALIZED(T, CPULogicalGeqElement_bool)(      \
+            int64_t idx, uniform Indexer * uniform indexer) {                 \
+        const T* lhs =                                                        \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx);  \
+        const T* rhs =                                                        \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 1, idx);  \
+        bool* dst =                                                           \
+                OPEN3D_SPECIALIZED(bool, Indexer_GetOutputPtr)(indexer, idx); \
+        *dst = (bool)(*lhs >= *rhs);                                          \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                      \
-    static inline void OPEN3D_SPECIALIZED(T, CPULogicalLeqElement_bool)( \
-            int64_t idx, uniform Indexer * uniform indexer) {            \
-        const T* lhs = (const T*)Indexer_GetInputPtr(indexer, 0, idx);   \
-        const T* rhs = (const T*)Indexer_GetInputPtr(indexer, 1, idx);   \
-        bool* dst = (bool*)Indexer_GetOutputPtr(indexer, idx);           \
-        *dst = (bool)(*lhs <= *rhs);                                     \
+#define TEMPLATE(T)                                                           \
+    static inline void OPEN3D_SPECIALIZED(T, CPULogicalLeqElement_bool)(      \
+            int64_t idx, uniform Indexer * uniform indexer) {                 \
+        const T* lhs =                                                        \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx);  \
+        const T* rhs =                                                        \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 1, idx);  \
+        bool* dst =                                                           \
+                OPEN3D_SPECIALIZED(bool, Indexer_GetOutputPtr)(indexer, idx); \
+        *dst = (bool)(*lhs <= *rhs);                                          \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                     \
-    static inline void OPEN3D_SPECIALIZED(T, CPULogicalEqElement_bool)( \
-            int64_t idx, uniform Indexer * uniform indexer) {           \
-        const T* lhs = (const T*)Indexer_GetInputPtr(indexer, 0, idx);  \
-        const T* rhs = (const T*)Indexer_GetInputPtr(indexer, 1, idx);  \
-        bool* dst = (bool*)Indexer_GetOutputPtr(indexer, idx);          \
-        *dst = (bool)(*lhs == *rhs);                                    \
+#define TEMPLATE(T)                                                           \
+    static inline void OPEN3D_SPECIALIZED(T, CPULogicalEqElement_bool)(       \
+            int64_t idx, uniform Indexer * uniform indexer) {                 \
+        const T* lhs =                                                        \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx);  \
+        const T* rhs =                                                        \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 1, idx);  \
+        bool* dst =                                                           \
+                OPEN3D_SPECIALIZED(bool, Indexer_GetOutputPtr)(indexer, idx); \
+        *dst = (bool)(*lhs == *rhs);                                          \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                      \
-    static inline void OPEN3D_SPECIALIZED(T, CPULogicalNeqElement_bool)( \
-            int64_t idx, uniform Indexer * uniform indexer) {            \
-        const T* lhs = (const T*)Indexer_GetInputPtr(indexer, 0, idx);   \
-        const T* rhs = (const T*)Indexer_GetInputPtr(indexer, 1, idx);   \
-        bool* dst = (bool*)Indexer_GetOutputPtr(indexer, idx);           \
-        *dst = (bool)(*lhs != *rhs);                                     \
+#define TEMPLATE(T)                                                           \
+    static inline void OPEN3D_SPECIALIZED(T, CPULogicalNeqElement_bool)(      \
+            int64_t idx, uniform Indexer * uniform indexer) {                 \
+        const T* lhs =                                                        \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx);  \
+        const T* rhs =                                                        \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 1, idx);  \
+        bool* dst =                                                           \
+                OPEN3D_SPECIALIZED(bool, Indexer_GetOutputPtr)(indexer, idx); \
+        *dst = (bool)(*lhs != *rhs);                                          \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()

--- a/cpp/open3d/core/kernel/BinaryEWCUDA.cu
+++ b/cpp/open3d/core/kernel/BinaryEWCUDA.cu
@@ -37,14 +37,15 @@ namespace kernel {
 
 // Cannot be a static function since on Windows a function enclosing
 // __host__ __device__ lambda function must have external linkage.
-template <typename func_t>
+template <typename src_t, typename dst_t, typename func_t>
 void LaunchBinaryEWKernel(const Device& device,
                           const Indexer& indexer,
                           const func_t& element_kernel) {
     OPEN3D_ASSERT_HOST_DEVICE_LAMBDA(func_t);
     auto element_func = [=] OPEN3D_HOST_DEVICE(int64_t i) {
-        element_kernel(indexer.GetInputPtr(0, i), indexer.GetInputPtr(1, i),
-                       indexer.GetOutputPtr(i));
+        element_kernel(indexer.GetInputPtr<src_t>(0, i),
+                       indexer.GetInputPtr<src_t>(1, i),
+                       indexer.GetOutputPtr<dst_t>(i));
     };
     ParallelFor(device, indexer.NumWorkloads(), element_func);
     OPEN3D_GET_LAST_CUDA_ERROR("LaunchBinaryEWKernel failed.");
@@ -166,76 +167,78 @@ void LaunchBoolBinaryEWCUDAKernel(const Tensor& lhs,
     Device device = lhs.GetDevice();
     switch (op_code) {
         case BinaryEWOpCode::LogicalAnd:
-            LaunchBinaryEWKernel(device, indexer,
-                                 [] OPEN3D_HOST_DEVICE(const void* lhs,
-                                                       void* rhs, void* dst) {
-                                     CUDALogicalAndElementKernel<src_t, dst_t>(
-                                             lhs, rhs, dst);
-                                 });
+            LaunchBinaryEWKernel<src_t, dst_t>(
+                    device, indexer,
+                    [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
+                                          void* dst) {
+                        CUDALogicalAndElementKernel<src_t, dst_t>(lhs, rhs,
+                                                                  dst);
+                    });
             break;
         case BinaryEWOpCode::LogicalOr:
-            LaunchBinaryEWKernel(device, indexer,
-                                 [] OPEN3D_HOST_DEVICE(const void* lhs,
-                                                       void* rhs, void* dst) {
-                                     CUDALogicalOrElementKernel<src_t, dst_t>(
-                                             lhs, rhs, dst);
-                                 });
+            LaunchBinaryEWKernel<src_t, dst_t>(
+                    device, indexer,
+                    [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
+                                          void* dst) {
+                        CUDALogicalOrElementKernel<src_t, dst_t>(lhs, rhs, dst);
+                    });
             break;
         case BinaryEWOpCode::LogicalXor:
-            LaunchBinaryEWKernel(device, indexer,
-                                 [] OPEN3D_HOST_DEVICE(const void* lhs,
-                                                       void* rhs, void* dst) {
-                                     CUDALogicalXorElementKernel<src_t, dst_t>(
-                                             lhs, rhs, dst);
-                                 });
+            LaunchBinaryEWKernel<src_t, dst_t>(
+                    device, indexer,
+                    [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
+                                          void* dst) {
+                        CUDALogicalXorElementKernel<src_t, dst_t>(lhs, rhs,
+                                                                  dst);
+                    });
             break;
         case BinaryEWOpCode::Gt:
-            LaunchBinaryEWKernel(device, indexer,
-                                 [] OPEN3D_HOST_DEVICE(const void* lhs,
-                                                       void* rhs, void* dst) {
-                                     CUDAGtElementKernel<src_t, dst_t>(lhs, rhs,
-                                                                       dst);
-                                 });
+            LaunchBinaryEWKernel<src_t, dst_t>(
+                    device, indexer,
+                    [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
+                                          void* dst) {
+                        CUDAGtElementKernel<src_t, dst_t>(lhs, rhs, dst);
+                    });
             break;
         case BinaryEWOpCode::Lt:
-            LaunchBinaryEWKernel(device, indexer,
-                                 [] OPEN3D_HOST_DEVICE(const void* lhs,
-                                                       void* rhs, void* dst) {
-                                     CUDALtElementKernel<src_t, dst_t>(lhs, rhs,
-                                                                       dst);
-                                 });
+            LaunchBinaryEWKernel<src_t, dst_t>(
+                    device, indexer,
+                    [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
+                                          void* dst) {
+                        CUDALtElementKernel<src_t, dst_t>(lhs, rhs, dst);
+                    });
             break;
         case BinaryEWOpCode::Ge:
-            LaunchBinaryEWKernel(device, indexer,
-                                 [] OPEN3D_HOST_DEVICE(const void* lhs,
-                                                       void* rhs, void* dst) {
-                                     CUDAGeqElementKernel<src_t, dst_t>(
-                                             lhs, rhs, dst);
-                                 });
+            LaunchBinaryEWKernel<src_t, dst_t>(
+                    device, indexer,
+                    [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
+                                          void* dst) {
+                        CUDAGeqElementKernel<src_t, dst_t>(lhs, rhs, dst);
+                    });
             break;
         case BinaryEWOpCode::Le:
-            LaunchBinaryEWKernel(device, indexer,
-                                 [] OPEN3D_HOST_DEVICE(const void* lhs,
-                                                       void* rhs, void* dst) {
-                                     CUDALeqElementKernel<src_t, dst_t>(
-                                             lhs, rhs, dst);
-                                 });
+            LaunchBinaryEWKernel<src_t, dst_t>(
+                    device, indexer,
+                    [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
+                                          void* dst) {
+                        CUDALeqElementKernel<src_t, dst_t>(lhs, rhs, dst);
+                    });
             break;
         case BinaryEWOpCode::Eq:
-            LaunchBinaryEWKernel(device, indexer,
-                                 [] OPEN3D_HOST_DEVICE(const void* lhs,
-                                                       void* rhs, void* dst) {
-                                     CUDAEqElementKernel<src_t, dst_t>(lhs, rhs,
-                                                                       dst);
-                                 });
+            LaunchBinaryEWKernel<src_t, dst_t>(
+                    device, indexer,
+                    [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
+                                          void* dst) {
+                        CUDAEqElementKernel<src_t, dst_t>(lhs, rhs, dst);
+                    });
             break;
         case BinaryEWOpCode::Ne:
-            LaunchBinaryEWKernel(device, indexer,
-                                 [] OPEN3D_HOST_DEVICE(const void* lhs,
-                                                       void* rhs, void* dst) {
-                                     CUDANeqElementKernel<src_t, dst_t>(
-                                             lhs, rhs, dst);
-                                 });
+            LaunchBinaryEWKernel<src_t, dst_t>(
+                    device, indexer,
+                    [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
+                                          void* dst) {
+                        CUDANeqElementKernel<src_t, dst_t>(lhs, rhs, dst);
+                    });
             break;
         default:
             break;
@@ -283,7 +286,7 @@ void BinaryEWCUDA(const Tensor& lhs,
         DISPATCH_DTYPE_TO_TEMPLATE(src_dtype, [&]() {
             switch (op_code) {
                 case BinaryEWOpCode::Add:
-                    LaunchBinaryEWKernel(
+                    LaunchBinaryEWKernel<scalar_t, scalar_t>(
                             src_device, indexer,
                             [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
                                                   void* dst) {
@@ -291,7 +294,7 @@ void BinaryEWCUDA(const Tensor& lhs,
                             });
                     break;
                 case BinaryEWOpCode::Sub:
-                    LaunchBinaryEWKernel(
+                    LaunchBinaryEWKernel<scalar_t, scalar_t>(
                             src_device, indexer,
                             [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
                                                   void* dst) {
@@ -299,7 +302,7 @@ void BinaryEWCUDA(const Tensor& lhs,
                             });
                     break;
                 case BinaryEWOpCode::Mul:
-                    LaunchBinaryEWKernel(
+                    LaunchBinaryEWKernel<scalar_t, scalar_t>(
                             src_device, indexer,
                             [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
                                                   void* dst) {
@@ -307,7 +310,7 @@ void BinaryEWCUDA(const Tensor& lhs,
                             });
                     break;
                 case BinaryEWOpCode::Div:
-                    LaunchBinaryEWKernel(
+                    LaunchBinaryEWKernel<scalar_t, scalar_t>(
                             src_device, indexer,
                             [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
                                                   void* dst) {

--- a/cpp/open3d/core/kernel/UnaryEWCPU.ispc
+++ b/cpp/open3d/core/kernel/UnaryEWCPU.ispc
@@ -27,122 +27,134 @@
 #include "open3d/core/Indexer.isph"
 #include "open3d/core/ParallelFor.isph"
 
-#define TEMPLATE(T)                                                    \
-    static inline void OPEN3D_SPECIALIZED(T, CPUSqrtElement)(          \
-            int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* src = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        T* dst = (T*)Indexer_GetOutputPtr(indexer, idx);               \
-        *dst = sqrt(*src);                                             \
+#define TEMPLATE(T)                                                          \
+    static inline void OPEN3D_SPECIALIZED(T, CPUSqrtElement)(                \
+            int64_t idx, uniform Indexer * uniform indexer) {                \
+        const T* src =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx); \
+        T* dst = OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(indexer, idx);  \
+        *dst = sqrt(*src);                                                   \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_FLOAT_TEMPLATE()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                    \
-    static inline void OPEN3D_SPECIALIZED(T, CPUSinElement)(           \
-            int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* src = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        T* dst = (T*)Indexer_GetOutputPtr(indexer, idx);               \
-        *dst = sin(*src);                                              \
+#define TEMPLATE(T)                                                          \
+    static inline void OPEN3D_SPECIALIZED(T, CPUSinElement)(                 \
+            int64_t idx, uniform Indexer * uniform indexer) {                \
+        const T* src =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx); \
+        T* dst = OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(indexer, idx);  \
+        *dst = sin(*src);                                                    \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_FLOAT_TEMPLATE()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                    \
-    static inline void OPEN3D_SPECIALIZED(T, CPUCosElement)(           \
-            int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* src = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        T* dst = (T*)Indexer_GetOutputPtr(indexer, idx);               \
-        *dst = cos(*src);                                              \
+#define TEMPLATE(T)                                                          \
+    static inline void OPEN3D_SPECIALIZED(T, CPUCosElement)(                 \
+            int64_t idx, uniform Indexer * uniform indexer) {                \
+        const T* src =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx); \
+        T* dst = OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(indexer, idx);  \
+        *dst = cos(*src);                                                    \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_FLOAT_TEMPLATE()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                    \
-    static inline void OPEN3D_SPECIALIZED(T, CPUNegElement)(           \
-            int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* src = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        T* dst = (T*)Indexer_GetOutputPtr(indexer, idx);               \
-        *dst = -*src;                                                  \
+#define TEMPLATE(T)                                                          \
+    static inline void OPEN3D_SPECIALIZED(T, CPUNegElement)(                 \
+            int64_t idx, uniform Indexer * uniform indexer) {                \
+        const T* src =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx); \
+        T* dst = OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(indexer, idx);  \
+        *dst = -*src;                                                        \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                    \
-    static inline void OPEN3D_SPECIALIZED(T, CPUExpElement)(           \
-            int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* src = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        T* dst = (T*)Indexer_GetOutputPtr(indexer, idx);               \
-        *dst = exp(*src);                                              \
+#define TEMPLATE(T)                                                          \
+    static inline void OPEN3D_SPECIALIZED(T, CPUExpElement)(                 \
+            int64_t idx, uniform Indexer * uniform indexer) {                \
+        const T* src =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx); \
+        T* dst = OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(indexer, idx);  \
+        *dst = exp(*src);                                                    \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_FLOAT_TEMPLATE()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                    \
-    static inline void OPEN3D_SPECIALIZED(T, CPUAbsElement)(           \
-            int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* src = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        T* dst = (T*)Indexer_GetOutputPtr(indexer, idx);               \
-        *dst = abs((double)*src);                                      \
+#define TEMPLATE(T)                                                          \
+    static inline void OPEN3D_SPECIALIZED(T, CPUAbsElement)(                 \
+            int64_t idx, uniform Indexer * uniform indexer) {                \
+        const T* src =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx); \
+        T* dst = OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(indexer, idx);  \
+        *dst = abs((double)*src);                                            \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                    \
-    static inline void OPEN3D_SPECIALIZED(T, CPUFloorElement)(         \
-            int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* src = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        T* dst = (T*)Indexer_GetOutputPtr(indexer, idx);               \
-        *dst = floor((double)*src);                                    \
+#define TEMPLATE(T)                                                          \
+    static inline void OPEN3D_SPECIALIZED(T, CPUFloorElement)(               \
+            int64_t idx, uniform Indexer * uniform indexer) {                \
+        const T* src =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx); \
+        T* dst = OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(indexer, idx);  \
+        *dst = floor((double)*src);                                          \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                    \
-    static inline void OPEN3D_SPECIALIZED(T, CPUCeilElement)(          \
-            int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* src = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        T* dst = (T*)Indexer_GetOutputPtr(indexer, idx);               \
-        *dst = ceil((double)*src);                                     \
+#define TEMPLATE(T)                                                          \
+    static inline void OPEN3D_SPECIALIZED(T, CPUCeilElement)(                \
+            int64_t idx, uniform Indexer * uniform indexer) {                \
+        const T* src =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx); \
+        T* dst = OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(indexer, idx);  \
+        *dst = ceil((double)*src);                                           \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                    \
-    static inline void OPEN3D_SPECIALIZED(T, CPURoundElement)(         \
-            int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* src = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        T* dst = (T*)Indexer_GetOutputPtr(indexer, idx);               \
-        *dst = round((double)*src);                                    \
+#define TEMPLATE(T)                                                          \
+    static inline void OPEN3D_SPECIALIZED(T, CPURoundElement)(               \
+            int64_t idx, uniform Indexer * uniform indexer) {                \
+        const T* src =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx); \
+        T* dst = OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(indexer, idx);  \
+        *dst = round((double)*src);                                          \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                    \
-    static inline void OPEN3D_SPECIALIZED(T, CPUTruncElement)(         \
-            int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* src = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        T* dst = (T*)Indexer_GetOutputPtr(indexer, idx);               \
-        *dst = trunc((double)*src);                                    \
+#define TEMPLATE(T)                                                          \
+    static inline void OPEN3D_SPECIALIZED(T, CPUTruncElement)(               \
+            int64_t idx, uniform Indexer * uniform indexer) {                \
+        const T* src =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx); \
+        T* dst = OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(indexer, idx);  \
+        *dst = trunc((double)*src);                                          \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                    \
-    static inline void OPEN3D_SPECIALIZED(T, CPUIsNanElement)(         \
-            int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* src = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        bool* dst = (bool*)Indexer_GetOutputPtr(indexer, idx);         \
-        *dst = isnan((float)*src);                                     \
+#define TEMPLATE(T)                                                           \
+    static inline void OPEN3D_SPECIALIZED(T, CPUIsNanElement)(                \
+            int64_t idx, uniform Indexer * uniform indexer) {                 \
+        const T* src =                                                        \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx);  \
+        bool* dst =                                                           \
+                OPEN3D_SPECIALIZED(bool, Indexer_GetOutputPtr)(indexer, idx); \
+        *dst = isnan((float)*src);                                            \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE()
@@ -153,8 +165,10 @@ OPEN3D_INSTANTIATE_TEMPLATE()
 #define TEMPLATE(T)                                                    \
     static inline void OPEN3D_SPECIALIZED(T, CPUIsInfElement)(         \
             int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* src = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        bool* dst = (bool*)Indexer_GetOutputPtr(indexer, idx);         \
+        const T* src = OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0,
+idx); \
+        bool* dst = OPEN3D_SPECIALIZED(bool, Indexer_GetOutputPtr)(indexer,
+idx);         \
         *dst = isinf((float)*src);                                     \
     }
 #pragma ignore warning(perf)
@@ -167,8 +181,10 @@ OPEN3D_INSTANTIATE_TEMPLATE()
 #define TEMPLATE(T)                                                    \
     static inline void OPEN3D_SPECIALIZED(T, CPUIsFiniteElement)(      \
             int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* src = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        bool* dst = (bool*)Indexer_GetOutputPtr(indexer, idx);         \
+        const T* src = OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0,
+idx); \
+        bool* dst = OPEN3D_SPECIALIZED(bool, Indexer_GetOutputPtr)(indexer,
+idx);         \
         *dst = isfinite((float)*src);                                  \
     }
 #pragma ignore warning(perf)
@@ -176,23 +192,26 @@ OPEN3D_INSTANTIATE_TEMPLATE()
 #undef TEMPLATE
 */
 
-#define TEMPLATE(T)                                                    \
-    static inline void OPEN3D_SPECIALIZED(T, CPULogicalNotElement)(    \
-            int64_t idx, uniform Indexer * uniform indexer) {          \
-        const T* src = (const T*)Indexer_GetInputPtr(indexer, 0, idx); \
-        T* dst = (T*)Indexer_GetOutputPtr(indexer, idx);               \
-        *dst = (T)(!(bool)(*src));                                     \
+#define TEMPLATE(T)                                                          \
+    static inline void OPEN3D_SPECIALIZED(T, CPULogicalNotElement)(          \
+            int64_t idx, uniform Indexer * uniform indexer) {                \
+        const T* src =                                                       \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx); \
+        T* dst = OPEN3D_SPECIALIZED(T, Indexer_GetOutputPtr)(indexer, idx);  \
+        *dst = (T)(!(bool)(*src));                                           \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()
 #undef TEMPLATE
 
-#define TEMPLATE(T)                                                      \
-    static inline void OPEN3D_SPECIALIZED(T, CPULogicalNotElement_bool)( \
-            int64_t idx, uniform Indexer * uniform indexer) {            \
-        const T* src = (const T*)Indexer_GetInputPtr(indexer, 0, idx);   \
-        bool* dst = (bool*)Indexer_GetOutputPtr(indexer, idx);           \
-        *dst = !(bool)(*src);                                            \
+#define TEMPLATE(T)                                                           \
+    static inline void OPEN3D_SPECIALIZED(T, CPULogicalNotElement_bool)(      \
+            int64_t idx, uniform Indexer * uniform indexer) {                 \
+        const T* src =                                                        \
+                OPEN3D_SPECIALIZED(T, Indexer_GetInputPtr)(indexer, 0, idx);  \
+        bool* dst =                                                           \
+                OPEN3D_SPECIALIZED(bool, Indexer_GetOutputPtr)(indexer, idx); \
+        *dst = !(bool)(*src);                                                 \
     }
 #pragma ignore warning(perf)
 OPEN3D_INSTANTIATE_TEMPLATE_WITH_BOOL()


### PR DESCRIPTION
#### Highlights:

- Add template overloads for `GetInputPtr`, `GetOutputPtr`, and `GetWorkloadDataPtr` to directly return the dispatched pointer of type `T`.
- Add the same overloads for the ISPC code path.
- Apply these overloads to all `BinaryEW` and `UnaryEW` ops.

#### Benchmarks (Intel i7-10750H):

Hitting GitHub's character limits. See all results in the comments below.

- General observations:
    - Same performance for scalar code path.
    - Consistent improvements for vectorized code path of ~1.25x.

Depends on #4107.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4110)
<!-- Reviewable:end -->
