### PR TITLE
Add Python benchmarks for Tensor's Binary and Unary EW ops

### DIFF
--- a/python/benchmarks/core/test_binary_ew.py
+++ b/python/benchmarks/core/test_binary_ew.py
@@ -1,0 +1,112 @@
+# ----------------------------------------------------------------------------
+# -                        Open3D: www.open3d.org                            -
+# ----------------------------------------------------------------------------
+# The MIT License (MIT)
+#
+# Copyright (c) 2018-2021 www.open3d.org
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ----------------------------------------------------------------------------
+
+import open3d as o3d
+import open3d.core as o3c
+import numpy as np
+import pytest
+import operator
+
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/..")
+from open3d_benchmark import list_tensor_sizes, list_non_bool_dtypes, to_numpy_dtype
+
+
+class BinaryEWOps:
+
+    @staticmethod
+    def logical_and(lhs, rhs):
+        return lhs.logical_and(rhs)
+
+    @staticmethod
+    def logical_or(lhs, rhs):
+        return lhs.logical_or(rhs)
+
+    @staticmethod
+    def logical_xor(lhs, rhs):
+        return lhs.logical_xor(rhs)
+
+
+def list_binary_ops():
+    return [
+        operator.add,
+        operator.sub,
+        operator.mul,
+        operator.truediv,
+        BinaryEWOps.logical_and,
+        BinaryEWOps.logical_or,
+        BinaryEWOps.logical_xor,
+        operator.gt,
+        operator.lt,
+        operator.ge,
+        operator.le,
+        operator.eq,
+        operator.ne,
+    ]
+
+
+def to_numpy_binary_op(op):
+    conversions = {
+        operator.add: operator.add,
+        operator.sub: operator.sub,
+        operator.mul: operator.mul,
+        operator.truediv: operator.truediv,
+        BinaryEWOps.logical_and: np.logical_and,
+        BinaryEWOps.logical_or: np.logical_or,
+        BinaryEWOps.logical_xor: np.logical_xor,
+        operator.gt: operator.gt,
+        operator.lt: operator.lt,
+        operator.ge: operator.ge,
+        operator.le: operator.le,
+        operator.eq: operator.eq,
+        operator.ne: operator.ne,
+    }
+    return conversions[op]
+
+
+@pytest.mark.parametrize("size", list_tensor_sizes())
+@pytest.mark.parametrize("dtype", list_non_bool_dtypes())
+@pytest.mark.parametrize("op", list_binary_ops())
+def test_binary_ew_ops(benchmark, size, dtype, op):
+    np_a = np.array(np.random.uniform(1, 127, size),
+                    dtype=to_numpy_dtype(dtype))
+    np_b = np.array(np.random.uniform(1, 127, size),
+                    dtype=to_numpy_dtype(dtype))
+    a = o3c.Tensor(np_a, dtype=dtype, device=o3c.Device("CPU:0"))
+    b = o3c.Tensor(np_b, dtype=dtype, device=o3c.Device("CPU:0"))
+    benchmark(op, a, b)
+
+
+@pytest.mark.parametrize("size", list_tensor_sizes())
+@pytest.mark.parametrize("dtype", list_non_bool_dtypes())
+@pytest.mark.parametrize("op", list_binary_ops())
+def test_binary_ew_ops_numpy(benchmark, size, dtype, op):
+    np_a = np.array(np.random.uniform(1, 127, size),
+                    dtype=to_numpy_dtype(dtype))
+    np_b = np.array(np.random.uniform(1, 127, size),
+                    dtype=to_numpy_dtype(dtype))
+    benchmark(to_numpy_binary_op(op), np_a, np_b)

--- a/python/benchmarks/core/test_unary_ew.py
+++ b/python/benchmarks/core/test_unary_ew.py
@@ -1,0 +1,177 @@
+# ----------------------------------------------------------------------------
+# -                        Open3D: www.open3d.org                            -
+# ----------------------------------------------------------------------------
+# The MIT License (MIT)
+#
+# Copyright (c) 2018-2021 www.open3d.org
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ----------------------------------------------------------------------------
+
+import open3d as o3d
+import open3d.core as o3c
+import numpy as np
+import pytest
+import operator
+
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/..")
+from open3d_benchmark import list_tensor_sizes, list_non_bool_dtypes, list_float_dtypes, to_numpy_dtype
+
+
+class UnaryEWOps:
+
+    @staticmethod
+    def sqrt(a):
+        return a.sqrt()
+
+    @staticmethod
+    def sin(a):
+        return a.sin()
+
+    @staticmethod
+    def cos(a):
+        return a.cos()
+
+    @staticmethod
+    def neg(a):
+        return a.neg()
+
+    @staticmethod
+    def exp(a):
+        return a.exp()
+
+    @staticmethod
+    def abs(a):
+        return a.abs()
+
+    @staticmethod
+    def isnan(a):
+        return a.isnan()
+
+    @staticmethod
+    def isinf(a):
+        return a.isinf()
+
+    @staticmethod
+    def isfinite(a):
+        return a.isfinite()
+
+    @staticmethod
+    def floor(a):
+        return a.floor()
+
+    @staticmethod
+    def ceil(a):
+        return a.ceil()
+
+    @staticmethod
+    def round(a):
+        return a.round()
+
+    @staticmethod
+    def trunc(a):
+        return a.trunc()
+
+    @staticmethod
+    def logical_not(a):
+        return a.logical_not()
+
+
+def list_unary_ops():
+    return [
+        UnaryEWOps.neg,
+        UnaryEWOps.abs,
+        UnaryEWOps.isnan,
+        UnaryEWOps.isinf,
+        UnaryEWOps.isfinite,
+        UnaryEWOps.floor,
+        UnaryEWOps.ceil,
+        UnaryEWOps.round,
+        UnaryEWOps.trunc,
+        UnaryEWOps.logical_not,
+    ]
+
+
+def list_float_unary_ops():
+    return [
+        UnaryEWOps.sqrt,
+        UnaryEWOps.sin,
+        UnaryEWOps.cos,
+        UnaryEWOps.exp,
+    ]
+
+
+def to_numpy_unary_op(op):
+    conversions = {
+        UnaryEWOps.sqrt: np.sqrt,
+        UnaryEWOps.sin: np.sin,
+        UnaryEWOps.cos: np.cos,
+        UnaryEWOps.neg: operator.neg,
+        UnaryEWOps.exp: np.exp,
+        UnaryEWOps.abs: np.abs,
+        UnaryEWOps.isnan: np.isnan,
+        UnaryEWOps.isinf: np.isinf,
+        UnaryEWOps.isfinite: np.isfinite,
+        UnaryEWOps.floor: np.floor,
+        UnaryEWOps.ceil: np.ceil,
+        UnaryEWOps.round: np.round,
+        UnaryEWOps.trunc: np.trunc,
+        UnaryEWOps.logical_not: np.logical_not,
+    }
+    return conversions[op]
+
+
+@pytest.mark.parametrize("size", list_tensor_sizes())
+@pytest.mark.parametrize("dtype", list_non_bool_dtypes())
+@pytest.mark.parametrize("op", list_unary_ops())
+def test_unary_ew_ops(benchmark, size, dtype, op):
+    # Set upper bound to 88 to avoid overflow for exp() op.
+    np_a = np.array(np.random.uniform(1, 88, size), dtype=to_numpy_dtype(dtype))
+    a = o3c.Tensor(np_a, dtype=dtype, device=o3c.Device("CPU:0"))
+    benchmark(op, a)
+
+
+@pytest.mark.parametrize("size", list_tensor_sizes())
+@pytest.mark.parametrize("dtype", list_float_dtypes())
+@pytest.mark.parametrize("op", list_float_unary_ops())
+def test_float_unary_ew_ops(benchmark, size, dtype, op):
+    # Set upper bound to 88 to avoid overflow for exp() op.
+    np_a = np.array(np.random.uniform(1, 88, size), dtype=to_numpy_dtype(dtype))
+    a = o3c.Tensor(np_a, dtype=dtype, device=o3c.Device("CPU:0"))
+    benchmark(op, a)
+
+
+@pytest.mark.parametrize("size", list_tensor_sizes())
+@pytest.mark.parametrize("dtype", list_non_bool_dtypes())
+@pytest.mark.parametrize("op", list_unary_ops())
+def test_unary_ew_ops_numpy(benchmark, size, dtype, op):
+    # Set upper bound to 88 to avoid overflow for exp() op.
+    np_a = np.array(np.random.uniform(1, 88, size), dtype=to_numpy_dtype(dtype))
+    benchmark(to_numpy_unary_op(op), np_a)
+
+
+@pytest.mark.parametrize("size", list_tensor_sizes())
+@pytest.mark.parametrize("dtype", list_float_dtypes())
+@pytest.mark.parametrize("op", list_float_unary_ops())
+def test_float_unary_ew_ops_numpy(benchmark, size, dtype, op):
+    # Set upper bound to 88 to avoid overflow for exp() op.
+    np_a = np.array(np.random.uniform(1, 88, size), dtype=to_numpy_dtype(dtype))
+    benchmark(to_numpy_unary_op(op), np_a)

--- a/python/benchmarks/open3d_benchmark.py
+++ b/python/benchmarks/open3d_benchmark.py
@@ -1,0 +1,75 @@
+# ----------------------------------------------------------------------------
+# -                        Open3D: www.open3d.org                            -
+# ----------------------------------------------------------------------------
+# The MIT License (MIT)
+#
+# Copyright (c) 2018-2021 www.open3d.org
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ----------------------------------------------------------------------------
+
+import open3d as o3d
+import open3d.core as o3c
+import numpy as np
+
+
+def list_tensor_sizes():
+    return [
+        100000000,
+    ]
+
+
+def list_non_bool_dtypes():
+    return [
+        o3c.int8,
+        o3c.uint8,
+        o3c.int16,
+        o3c.uint16,
+        o3c.int32,
+        o3c.uint32,
+        o3c.int64,
+        o3c.uint64,
+        o3c.float32,
+        o3c.float64,
+    ]
+
+
+def list_float_dtypes():
+    return [
+        o3c.float32,
+        o3c.float64,
+    ]
+
+
+def to_numpy_dtype(dtype: o3c.Dtype):
+    conversions = {
+        o3c.bool8: np.bool8,  # np.bool deprecated
+        o3c.bool: np.bool8,  # o3c.bool is an alias for o3c.bool8
+        o3c.int8: np.int8,
+        o3c.uint8: np.uint8,
+        o3c.int16: np.int16,
+        o3c.uint16: np.uint16,
+        o3c.int32: np.int32,
+        o3c.uint32: np.uint32,
+        o3c.int64: np.int64,
+        o3c.uint64: np.uint64,
+        o3c.float32: np.float32,
+        o3c.float64: np.float64,
+    }
+    return conversions[dtype]


### PR DESCRIPTION
#### Highlights:

- Introduce common directory structure for Python benchmarks that matches the C++ structure:
```
cpp
|-- benchmarks
|-- open3d
|-- ...
python
|-- benchmarks <-- This PR
|-- open3d
|-- ...
```
- Add benchmark helper functions in `python/benchmarks/open3d_benchmark.py` similar to helpers in `test`.
- Add benchmarks based on `pytest-benchmark` (which is similar to the C++ `google/benchmark` framework) for `BinaryEW` and `UnaryEW` ops of `Tensor`.
- Also add benchmarks for `numpy` to compare performance with `Tensor`.

#### Usage:

Whereas tests are executed using
```
pytest ../python/test
```
(here w.r.t the `build` directory), the benchmarks are executed similarly:
```
pytest ../python/benchmarks --benchmark-sort=name
```
Besides sorting options (for a clearer output), further options to control `pytest-benchmark`'s features could be used.

#### Benchmarks @ Intel i7-10750H:

<details>
<summary>BinaryEW</summary>

```
============================================================================================================ test session starts ============================================================================================================
platform linux -- Python 3.8.10, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
benchmark: 3.4.1 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /home/stotko/workspace/Open3D/python
plugins: anyio-3.1.0, benchmark-3.4.1
collected 260 items                                                                                                                                                                                                                         

../python/benchmarks/core/test_binary_ew.py ......................................................................................................................................................................................... [ 71%]
...........................................................................                                                                                                                                                           [100%]


----------------------------------------------------------------------------------------------------- benchmark: 260 tests -----------------------------------------------------------------------------------------------------
Name (time in ms)                                               Min                 Max                Mean             StdDev              Median                IQR            Outliers      OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_binary_ew_ops[add-dtype0-100000000]                    42.9904 (2.76)      47.2323 (2.74)      44.2335 (2.76)      1.2500 (6.50)      43.9439 (2.77)      1.2300 (11.33)         4;2  22.6073 (0.36)         21           1
test_binary_ew_ops[add-dtype1-100000000]                    42.8731 (2.75)      48.4574 (2.81)      44.0845 (2.75)      1.2943 (6.73)      43.9476 (2.77)      1.1169 (10.29)         3;3  22.6837 (0.36)         23           1
test_binary_ew_ops[add-dtype2-100000000]                    51.1807 (3.28)      58.7815 (3.40)      52.3115 (3.27)      1.6904 (8.79)      51.9018 (3.27)      0.8455 (7.79)          2;2  19.1163 (0.31)         20           1
test_binary_ew_ops[add-dtype3-100000000]                    51.3233 (3.29)      77.6575 (4.50)      55.4679 (3.46)      8.3141 (43.24)     51.8039 (3.26)      0.6324 (5.82)          2;3  18.0284 (0.29)         14           1
test_binary_ew_ops[add-dtype4-100000000]                    63.3438 (4.06)      70.2450 (4.07)      64.6459 (4.04)      1.9191 (9.98)      64.0088 (4.03)      1.2081 (11.12)         2;2  15.4689 (0.25)         16           1
test_binary_ew_ops[add-dtype5-100000000]                    63.0542 (4.04)      69.4557 (4.02)      64.7025 (4.04)      1.9102 (9.93)      63.9002 (4.03)      1.4639 (13.48)         3;3  15.4554 (0.25)         16           1
test_binary_ew_ops[add-dtype6-100000000]                   109.9482 (7.05)     113.8300 (6.59)     110.9123 (6.93)      1.3758 (7.16)     110.2118 (6.94)      1.0664 (9.82)          1;1   9.0161 (0.14)          7           1
test_binary_ew_ops[add-dtype7-100000000]                   109.8676 (7.05)     130.3415 (7.55)     113.9985 (7.12)      6.0717 (31.58)    111.6128 (7.03)      2.3954 (22.06)         1;1   8.7720 (0.14)         10           1
test_binary_ew_ops[add-dtype8-100000000]                    63.4393 (4.07)      69.0354 (4.00)      64.5846 (4.03)      1.5134 (7.87)      63.9856 (4.03)      1.2897 (11.88)         2;2  15.4836 (0.25)         16           1
test_binary_ew_ops[add-dtype9-100000000]                   109.0414 (6.99)     113.0267 (6.55)     109.9208 (6.87)      1.2089 (6.29)     109.4957 (6.90)      0.6336 (5.83)          1;2   9.0975 (0.15)         10           1
test_binary_ew_ops[eq-dtype0-100000000]                     42.6316 (2.73)      53.1582 (3.08)      44.9775 (2.81)      2.3774 (12.36)     44.0362 (2.77)      2.0383 (18.77)         3;1  22.2334 (0.36)         23           1
test_binary_ew_ops[eq-dtype1-100000000]                     42.5794 (2.73)      48.8336 (2.83)      44.1325 (2.76)      1.3527 (7.04)      43.7772 (2.76)      1.1411 (10.51)         4;2  22.6590 (0.36)         23           1
test_binary_ew_ops[eq-dtype2-100000000]                     43.1432 (2.77)      56.6083 (3.28)      46.3118 (2.89)      3.2578 (16.94)     44.5749 (2.81)      3.6138 (33.28)         3;1  21.5927 (0.35)         23           1
test_binary_ew_ops[eq-dtype3-100000000]                     43.4092 (2.78)      48.0316 (2.78)      44.5680 (2.78)      1.2804 (6.66)      44.2758 (2.79)      0.8160 (7.51)          3;3  22.4376 (0.36)         23           1
test_binary_ew_ops[eq-dtype4-100000000]                     39.4330 (2.53)      47.6174 (2.76)      41.6380 (2.60)      2.1383 (11.12)     40.6054 (2.56)      2.7759 (25.56)         3;1  24.0165 (0.38)         25           1
test_binary_ew_ops[eq-dtype5-100000000]                     40.0514 (2.57)      48.1508 (2.79)      40.9366 (2.56)      1.9898 (10.35)     40.3625 (2.54)      0.3101 (2.86)          2;2  24.4280 (0.39)         25           1
test_binary_ew_ops[eq-dtype6-100000000]                     58.5866 (3.76)      64.4876 (3.73)      59.9271 (3.74)      1.7214 (8.95)      59.2143 (3.73)      1.2517 (11.53)         3;3  16.6870 (0.27)         17           1
test_binary_ew_ops[eq-dtype7-100000000]                     58.6774 (3.76)      63.4459 (3.67)      59.5122 (3.72)      1.5349 (7.98)      58.8537 (3.71)      0.2878 (2.65)          3;3  16.8033 (0.27)         17           1
test_binary_ew_ops[eq-dtype8-100000000]                     40.2057 (2.58)      47.7313 (2.76)      41.1425 (2.57)      1.6037 (8.34)      40.6736 (2.56)      0.2424 (2.23)          3;3  24.3058 (0.39)         25           1
test_binary_ew_ops[eq-dtype9-100000000]                     58.7451 (3.77)      63.8161 (3.70)      59.6027 (3.72)      1.4027 (7.30)      59.0680 (3.72)      0.6809 (6.27)          2;2  16.7778 (0.27)         17           1
test_binary_ew_ops[ge-dtype0-100000000]                     42.6720 (2.74)      51.1547 (2.96)      45.2709 (2.83)      2.4265 (12.62)     44.0483 (2.77)      3.0046 (27.67)         6;1  22.0893 (0.35)         24           1
test_binary_ew_ops[ge-dtype1-100000000]                     42.6432 (2.74)      48.5442 (2.81)      44.1028 (2.75)      1.2285 (6.39)      43.9682 (2.77)      0.9140 (8.42)          3;2  22.6743 (0.36)         22           1
test_binary_ew_ops[ge-dtype2-100000000]                     43.5647 (2.79)      54.8538 (3.18)      46.2883 (2.89)      2.9872 (15.54)     44.4618 (2.80)      4.3295 (39.87)         5;0  21.6037 (0.35)         23           1
test_binary_ew_ops[ge-dtype3-100000000]                     43.7089 (2.80)      49.1384 (2.85)      44.5777 (2.78)      1.2773 (6.64)      44.2889 (2.79)      0.5639 (5.19)          3;3  22.4327 (0.36)         23           1
test_binary_ew_ops[ge-dtype4-100000000]                     40.5204 (2.60)      47.9466 (2.78)      42.0095 (2.62)      2.0295 (10.56)     40.9196 (2.58)      2.2148 (20.40)         2;2  23.8041 (0.38)         25           1
test_binary_ew_ops[ge-dtype5-100000000]                     40.0166 (2.57)      48.6923 (2.82)      41.7046 (2.61)      2.3978 (12.47)     40.8432 (2.57)      0.3288 (3.03)          3;4  23.9782 (0.38)         25           1
test_binary_ew_ops[ge-dtype6-100000000]                     58.5635 (3.76)      62.5527 (3.62)      59.2464 (3.70)      0.9450 (4.91)      59.0106 (3.72)      0.5718 (5.27)          1;1  16.8787 (0.27)         16           1
test_binary_ew_ops[ge-dtype7-100000000]                     59.0367 (3.79)      63.4925 (3.68)      60.6001 (3.79)      1.5970 (8.31)      60.1970 (3.79)      2.9098 (26.79)         4;0  16.5016 (0.26)         16           1
test_binary_ew_ops[ge-dtype8-100000000]                     40.3791 (2.59)      47.0214 (2.72)      41.6409 (2.60)      1.7748 (9.23)      40.6709 (2.56)      1.7941 (16.52)         5;1  24.0148 (0.38)         25           1
test_binary_ew_ops[ge-dtype9-100000000]                     58.7690 (3.77)      62.7534 (3.63)      59.5865 (3.72)      1.3213 (6.87)      59.0016 (3.72)      0.6182 (5.69)          3;3  16.7823 (0.27)         17           1
test_binary_ew_ops[gt-dtype0-100000000]                     42.8531 (2.75)      49.8355 (2.89)      45.1802 (2.82)      2.0364 (10.59)     44.2843 (2.79)      2.8950 (26.66)         8;0  22.1336 (0.35)         23           1
test_binary_ew_ops[gt-dtype1-100000000]                     42.8011 (2.75)      48.2019 (2.79)      44.3653 (2.77)      1.2712 (6.61)      43.9563 (2.77)      0.9447 (8.70)          4;2  22.5401 (0.36)         23           1
test_binary_ew_ops[gt-dtype2-100000000]                     43.4202 (2.78)      51.4545 (2.98)      47.0815 (2.94)      2.5371 (13.20)     46.9493 (2.96)      4.8464 (44.63)        11;0  21.2398 (0.34)         23           1
test_binary_ew_ops[gt-dtype3-100000000]                     43.7540 (2.81)      48.6657 (2.82)      44.8076 (2.80)      1.3301 (6.92)      44.3127 (2.79)      0.7535 (6.94)          3;3  22.3176 (0.36)         23           1
test_binary_ew_ops[gt-dtype4-100000000]                     39.7387 (2.55)      51.7227 (3.00)      41.7248 (2.61)      2.7989 (14.56)     40.4406 (2.55)      1.4934 (13.75)         2;3  23.9666 (0.38)         25           1
test_binary_ew_ops[gt-dtype5-100000000]                     40.4773 (2.60)      48.2398 (2.79)      41.5268 (2.59)      2.0081 (10.44)     40.9510 (2.58)      0.3095 (2.85)          2;4  24.0808 (0.39)         25           1
test_binary_ew_ops[gt-dtype6-100000000]                     58.2771 (3.74)      62.4674 (3.62)      59.3383 (3.71)      1.1437 (5.95)      58.8459 (3.71)      0.5788 (5.33)          3;3  16.8525 (0.27)         17           1
test_binary_ew_ops[gt-dtype7-100000000]                     58.7220 (3.77)      63.9952 (3.71)      59.6507 (3.73)      1.4751 (7.67)      59.0324 (3.72)      0.5482 (5.05)          2;3  16.7643 (0.27)         17           1
test_binary_ew_ops[gt-dtype8-100000000]                     39.9751 (2.56)      51.8714 (3.00)      41.8670 (2.62)      2.6632 (13.85)     40.8136 (2.57)      1.4060 (12.95)         2;3  23.8851 (0.38)         25           1
test_binary_ew_ops[gt-dtype9-100000000]                     58.7740 (3.77)      63.7307 (3.69)      59.6843 (3.73)      1.4753 (7.67)      59.1105 (3.72)      0.5981 (5.51)          2;3  16.7548 (0.27)         17           1
test_binary_ew_ops[le-dtype0-100000000]                     42.8200 (2.75)      51.1475 (2.96)      45.2853 (2.83)      2.2413 (11.66)     44.2979 (2.79)      3.1354 (28.87)         6;0  22.0822 (0.35)         23           1
test_binary_ew_ops[le-dtype1-100000000]                     42.6451 (2.74)      49.3246 (2.86)      44.3211 (2.77)      1.7477 (9.09)      43.7378 (2.76)      1.1812 (10.88)         3;3  22.5626 (0.36)         24           1
test_binary_ew_ops[le-dtype2-100000000]                     43.7660 (2.81)      55.4710 (3.21)      46.4050 (2.90)      3.0082 (15.65)     44.7692 (2.82)      4.8709 (44.85)         3;0  21.5494 (0.34)         23           1
test_binary_ew_ops[le-dtype3-100000000]                     43.2288 (2.77)      51.4650 (2.98)      44.7235 (2.79)      1.8676 (9.71)      44.0806 (2.78)      0.7133 (6.57)          2;3  22.3596 (0.36)         23           1
test_binary_ew_ops[le-dtype4-100000000]                     40.1027 (2.57)      44.9969 (2.61)      41.6802 (2.60)      1.3731 (7.14)      40.9711 (2.58)      1.9124 (17.61)         6;0  23.9922 (0.38)         23           1
test_binary_ew_ops[le-dtype5-100000000]                     39.8610 (2.56)      47.7759 (2.77)      41.4528 (2.59)      1.8981 (9.87)      40.8972 (2.58)      0.4188 (3.86)          2;5  24.1238 (0.39)         25           1
test_binary_ew_ops[le-dtype6-100000000]                     58.6163 (3.76)      62.9930 (3.65)      59.5968 (3.72)      1.3196 (6.86)      59.1595 (3.73)      0.7927 (7.30)          2;2  16.7794 (0.27)         18           1
test_binary_ew_ops[le-dtype7-100000000]                     58.8220 (3.77)      63.7011 (3.69)      59.6741 (3.73)      1.4374 (7.48)      59.0371 (3.72)      0.4646 (4.28)          2;3  16.7577 (0.27)         17           1
test_binary_ew_ops[le-dtype8-100000000]                     39.9687 (2.56)      53.3376 (3.09)      42.1257 (2.63)      3.0428 (15.83)     40.9391 (2.58)      1.7595 (16.20)         3;3  23.7385 (0.38)         25           1
test_binary_ew_ops[le-dtype9-100000000]                     58.8576 (3.77)      61.7681 (3.58)      59.3783 (3.71)      0.8023 (4.17)      59.0642 (3.72)      0.4570 (4.21)          2;2  16.8412 (0.27)         16           1
test_binary_ew_ops[logical_and-dtype0-100000000]            61.4980 (3.94)      66.9309 (3.88)      63.5614 (3.97)      1.6584 (8.63)      63.0453 (3.97)      1.1904 (10.96)         5;3  15.7328 (0.25)         17           1
test_binary_ew_ops[logical_and-dtype1-100000000]            61.8306 (3.97)      68.5252 (3.97)      64.2444 (4.01)      1.8123 (9.43)      63.4933 (4.00)      1.6936 (15.60)         5;1  15.5656 (0.25)         17           1
test_binary_ew_ops[logical_and-dtype2-100000000]            49.3109 (3.16)      56.2524 (3.26)      50.9238 (3.18)      1.7145 (8.92)      50.3286 (3.17)      0.4998 (4.60)          2;4  19.6372 (0.31)         20           1
test_binary_ew_ops[logical_and-dtype3-100000000]            49.7365 (3.19)      58.0064 (3.36)      52.2727 (3.27)      2.7798 (14.46)     50.7886 (3.20)      5.3055 (48.86)         5;0  19.1305 (0.31)         20           1
test_binary_ew_ops[logical_and-dtype4-100000000]            43.9832 (2.82)      53.7917 (3.12)      45.4028 (2.84)      2.5124 (13.07)     44.6710 (2.81)      0.4014 (3.70)          2;2  22.0251 (0.35)         23           1
test_binary_ew_ops[logical_and-dtype5-100000000]            43.8422 (2.81)      53.1654 (3.08)      46.0824 (2.88)      2.6232 (13.64)     44.7464 (2.82)      2.9150 (26.84)         2;2  21.7003 (0.35)         23           1
test_binary_ew_ops[logical_and-dtype6-100000000]            61.6536 (3.95)      68.0220 (3.94)      63.0363 (3.94)      1.8205 (9.47)      62.3491 (3.93)      1.2026 (11.07)         2;2  15.8639 (0.25)         17           1
test_binary_ew_ops[logical_and-dtype7-100000000]            61.2890 (3.93)      70.3710 (4.08)      63.7147 (3.98)      2.0610 (10.72)     63.6094 (4.01)      1.3844 (12.75)         2;1  15.6950 (0.25)         17           1
test_binary_ew_ops[logical_and-dtype8-100000000]            48.6950 (3.12)      58.4565 (3.39)      50.1942 (3.14)      2.5667 (13.35)     49.4107 (3.11)      0.5322 (4.90)          2;2  19.9226 (0.32)         21           1
test_binary_ew_ops[logical_and-dtype9-100000000]            61.4493 (3.94)      69.1565 (4.01)      63.0082 (3.94)      2.0511 (10.67)     61.9702 (3.90)      1.7505 (16.12)         2;1  15.8709 (0.25)         16           1
test_binary_ew_ops[logical_or-dtype0-100000000]             37.3646 (2.40)      44.8282 (2.60)      39.2459 (2.45)      2.1577 (11.22)     38.0098 (2.39)      2.9942 (27.57)         6;0  25.4804 (0.41)         27           1
test_binary_ew_ops[logical_or-dtype1-100000000]             37.3059 (2.39)      43.3078 (2.51)      38.2760 (2.39)      1.3633 (7.09)      37.9015 (2.39)      0.6109 (5.63)          2;2  26.1260 (0.42)         27           1
test_binary_ew_ops[logical_or-dtype2-100000000]             38.1282 (2.45)      42.7071 (2.47)      39.9255 (2.49)      1.7149 (8.92)      38.7471 (2.44)      3.0916 (28.47)         8;0  25.0466 (0.40)         27           1
test_binary_ew_ops[logical_or-dtype3-100000000]             37.7504 (2.42)      44.6144 (2.58)      39.0136 (2.44)      1.5881 (8.26)      38.5866 (2.43)      0.3165 (2.91)          2;3  25.6321 (0.41)         27           1
test_binary_ew_ops[logical_or-dtype4-100000000]             34.5914 (2.22)      47.2857 (2.74)      36.5583 (2.28)      2.5875 (13.46)     35.4424 (2.23)      2.0275 (18.67)         3;2  27.3536 (0.44)         29           1
test_binary_ew_ops[logical_or-dtype5-100000000]             34.8031 (2.23)      39.8085 (2.31)      35.6275 (2.23)      1.1028 (5.74)      35.3238 (2.23)      0.2989 (2.75)          3;4  28.0682 (0.45)         29           1
test_binary_ew_ops[logical_or-dtype6-100000000]             38.4038 (2.46)      46.7719 (2.71)      40.0525 (2.50)      2.0690 (10.76)     39.2556 (2.47)      0.7234 (6.66)          3;6  24.9672 (0.40)         26           1
test_binary_ew_ops[logical_or-dtype7-100000000]             38.7244 (2.48)      46.9304 (2.72)      39.9198 (2.49)      1.8196 (9.46)      39.3905 (2.48)      0.5385 (4.96)          2;2  25.0502 (0.40)         26           1
test_binary_ew_ops[logical_or-dtype8-100000000]             33.9558 (2.18)      42.4648 (2.46)      35.2335 (2.20)      1.5912 (8.28)      34.8130 (2.19)      0.3668 (3.38)          2;5  28.3821 (0.45)         27           1
test_binary_ew_ops[logical_or-dtype9-100000000]             38.7111 (2.48)      46.1354 (2.67)      39.9456 (2.50)      1.7774 (9.24)      39.3536 (2.48)      0.2118 (1.95)          3;7  25.0340 (0.40)         26           1
test_binary_ew_ops[logical_xor-dtype0-100000000]            44.5032 (2.85)      56.6278 (3.28)      47.9177 (2.99)      3.1570 (16.42)     47.4225 (2.99)      3.7350 (34.39)         5;1  20.8691 (0.33)         23           1
test_binary_ew_ops[logical_xor-dtype1-100000000]            43.9986 (2.82)      50.2982 (2.91)      45.6277 (2.85)      1.5902 (8.27)      45.3780 (2.86)      0.8647 (7.96)          3;2  21.9165 (0.35)         22           1
test_binary_ew_ops[logical_xor-dtype2-100000000]            43.3413 (2.78)      57.2521 (3.32)      46.2839 (2.89)      3.4651 (18.02)     44.3936 (2.80)      4.2162 (38.83)         3;1  21.6058 (0.35)         23           1
test_binary_ew_ops[logical_xor-dtype3-100000000]            43.3131 (2.78)      51.0379 (2.96)      44.7316 (2.79)      1.6468 (8.56)      44.2020 (2.78)      0.3901 (3.59)          3;5  22.3555 (0.36)         23           1
test_binary_ew_ops[logical_xor-dtype4-100000000]            39.6619 (2.54)      46.6748 (2.70)      41.7529 (2.61)      1.8842 (9.80)      40.6802 (2.56)      3.1812 (29.29)         7;0  23.9504 (0.38)         25           1
test_binary_ew_ops[logical_xor-dtype5-100000000]            39.9878 (2.56)      48.8883 (2.83)      41.4456 (2.59)      2.3601 (12.27)     40.6135 (2.56)      0.3446 (3.17)          3;4  24.1280 (0.39)         25           1
test_binary_ew_ops[logical_xor-dtype6-100000000]            61.2991 (3.93)      70.9560 (4.11)      63.6105 (3.97)      2.9074 (15.12)     62.1529 (3.92)      2.5615 (23.59)         4;1  15.7207 (0.25)         17           1
test_binary_ew_ops[logical_xor-dtype7-100000000]            61.6028 (3.95)      68.2411 (3.95)      62.8830 (3.93)      1.8391 (9.57)      62.3715 (3.93)      1.0487 (9.66)          2;2  15.9025 (0.25)         16           1
test_binary_ew_ops[logical_xor-dtype8-100000000]            40.2790 (2.58)      48.8533 (2.83)      42.0547 (2.63)      2.3095 (12.01)     41.0495 (2.59)      1.6113 (14.84)         3;3  23.7786 (0.38)         25           1
test_binary_ew_ops[logical_xor-dtype9-100000000]            61.7218 (3.96)      69.3945 (4.02)      63.7980 (3.99)      2.3372 (12.16)     62.6687 (3.95)      3.0546 (28.13)         3;0  15.6745 (0.25)         16           1
test_binary_ew_ops[lt-dtype0-100000000]                     42.7050 (2.74)      51.0563 (2.96)      45.2976 (2.83)      2.6408 (13.73)     44.3299 (2.79)      3.6231 (33.36)         5;0  22.0762 (0.35)         24           1
test_binary_ew_ops[lt-dtype1-100000000]                     43.1116 (2.77)      49.1690 (2.85)      44.3282 (2.77)      1.5088 (7.85)      43.7976 (2.76)      0.8416 (7.75)          2;2  22.5590 (0.36)         23           1
test_binary_ew_ops[lt-dtype2-100000000]                     43.4707 (2.79)      55.2722 (3.20)      45.9062 (2.87)      3.0881 (16.06)     44.2669 (2.79)      4.3563 (40.12)         5;1  21.7836 (0.35)         23           1
test_binary_ew_ops[lt-dtype3-100000000]                     43.6786 (2.80)      50.5572 (2.93)      45.0470 (2.81)      1.7201 (8.95)      44.5018 (2.80)      0.6136 (5.65)          2;3  22.1990 (0.36)         23           1
test_binary_ew_ops[lt-dtype4-100000000]                     39.4867 (2.53)      44.8831 (2.60)      41.6010 (2.60)      1.7398 (9.05)      40.6048 (2.56)      2.7610 (25.42)         8;0  24.0379 (0.38)         25           1
test_binary_ew_ops[lt-dtype5-100000000]                     40.6252 (2.61)      49.4190 (2.86)      41.6120 (2.60)      2.2191 (11.54)     40.9502 (2.58)      0.5065 (4.66)          2;2  24.0315 (0.38)         25           1
test_binary_ew_ops[lt-dtype6-100000000]                     58.2852 (3.74)      63.2628 (3.66)      59.5226 (3.72)      1.3140 (6.83)      58.9734 (3.72)      1.1675 (10.75)         2;2  16.8003 (0.27)         18           1
test_binary_ew_ops[lt-dtype7-100000000]                     58.6950 (3.76)      64.1435 (3.71)      59.7248 (3.73)      1.6437 (8.55)      59.1185 (3.72)      0.7092 (6.53)          2;2  16.7435 (0.27)         18           1
test_binary_ew_ops[lt-dtype8-100000000]                     41.6460 (2.67)      53.8497 (3.12)      43.9549 (2.75)      3.0456 (15.84)     42.3567 (2.67)      2.3910 (22.02)         3;3  22.7506 (0.36)         24           1
test_binary_ew_ops[lt-dtype9-100000000]                     59.7077 (3.83)      65.5590 (3.80)      60.9953 (3.81)      1.3894 (7.23)      60.6841 (3.82)      1.2125 (11.17)         1;1  16.3947 (0.26)         16           1
test_binary_ew_ops[mul-dtype0-100000000]                    43.1460 (2.77)      51.2911 (2.97)      45.4015 (2.84)      2.2679 (11.80)     44.7520 (2.82)      2.1892 (20.16)         4;3  22.0257 (0.35)         23           1
test_binary_ew_ops[mul-dtype1-100000000]                    43.2330 (2.77)      48.5558 (2.81)      44.4228 (2.77)      1.3586 (7.07)      43.9583 (2.77)      1.0674 (9.83)          3;2  22.5110 (0.36)         23           1
test_binary_ew_ops[mul-dtype2-100000000]                    51.0614 (3.27)      58.7025 (3.40)      52.5997 (3.29)      2.1058 (10.95)     51.8699 (3.27)      1.3512 (12.44)         2;2  19.0115 (0.30)         16           1
test_binary_ew_ops[mul-dtype3-100000000]                    51.1000 (3.28)      60.4371 (3.50)      52.8313 (3.30)      2.6115 (13.58)     51.7924 (3.26)      0.7954 (7.32)          3;3  18.9282 (0.30)         20           1
test_binary_ew_ops[mul-dtype4-100000000]                    60.9375 (3.91)      69.3587 (4.02)      63.6558 (3.98)      2.8008 (14.57)     62.0271 (3.91)      4.4246 (40.74)         3;0  15.7095 (0.25)         17           1
test_binary_ew_ops[mul-dtype5-100000000]                    61.1509 (3.92)      69.4408 (4.02)      62.6635 (3.91)      2.3727 (12.34)     61.8550 (3.90)      0.6102 (5.62)          2;3  15.9583 (0.26)         16           1
test_binary_ew_ops[mul-dtype6-100000000]                   109.7153 (7.04)     121.2631 (7.02)     113.9419 (7.12)      5.0511 (26.27)    110.3743 (6.95)      9.8130 (90.36)         3;0   8.7764 (0.14)          9           1
test_binary_ew_ops[mul-dtype7-100000000]                   109.5663 (7.03)     115.2108 (6.67)     110.9854 (6.93)      2.0224 (10.52)    110.1416 (6.94)      0.5076 (4.67)          2;2   9.0102 (0.14)         10           1
test_binary_ew_ops[mul-dtype8-100000000]                    60.5168 (3.88)      67.1783 (3.89)      61.9072 (3.87)      1.8891 (9.82)      61.4117 (3.87)      0.5746 (5.29)          2;2  16.1532 (0.26)         17           1
test_binary_ew_ops[mul-dtype9-100000000]                   109.4099 (7.02)     115.2204 (6.67)     110.7357 (6.92)      1.9609 (10.20)    109.8838 (6.92)      1.5525 (14.30)         2;1   9.0305 (0.14)         10           1
test_binary_ew_ops[ne-dtype0-100000000]                     42.7712 (2.74)      48.8040 (2.83)      44.2022 (2.76)      1.3709 (7.13)      43.9568 (2.77)      0.7615 (7.01)          4;3  22.6233 (0.36)         23           1
test_binary_ew_ops[ne-dtype1-100000000]                     42.7094 (2.74)      51.8195 (3.00)      45.5903 (2.85)      2.4957 (12.98)     44.5228 (2.80)      3.5687 (32.86)         6;0  21.9345 (0.35)         23           1
test_binary_ew_ops[ne-dtype2-100000000]                     43.4568 (2.79)      51.6044 (2.99)      44.9814 (2.81)      1.9636 (10.21)     44.4984 (2.80)      0.5901 (5.43)          2;3  22.2314 (0.36)         23           1
test_binary_ew_ops[ne-dtype3-100000000]                     43.6236 (2.80)      54.5636 (3.16)      46.1950 (2.89)      2.9967 (15.59)     44.4193 (2.80)      4.5725 (42.11)         5;0  21.6474 (0.35)         23           1
test_binary_ew_ops[ne-dtype4-100000000]                     39.8636 (2.56)      48.1235 (2.79)      41.5824 (2.60)      2.1447 (11.15)     40.8038 (2.57)      0.2503 (2.30)          3;7  24.0486 (0.38)         25           1
test_binary_ew_ops[ne-dtype5-100000000]                     39.9973 (2.57)      48.5376 (2.81)      41.9092 (2.62)      2.2303 (11.60)     40.9506 (2.58)      1.8476 (17.01)         3;2  23.8611 (0.38)         25           1
test_binary_ew_ops[ne-dtype6-100000000]                     58.3061 (3.74)      63.7730 (3.69)      59.4864 (3.72)      1.4541 (7.56)      58.9427 (3.71)      0.5671 (5.22)          3;3  16.8106 (0.27)         18           1
test_binary_ew_ops[ne-dtype7-100000000]                     58.4420 (3.75)      63.3940 (3.67)      59.4574 (3.71)      1.2182 (6.34)      58.9887 (3.72)      0.7538 (6.94)          2;2  16.8188 (0.27)         18           1
test_binary_ew_ops[ne-dtype8-100000000]                     40.4686 (2.60)      48.2147 (2.79)      41.3582 (2.58)      2.0694 (10.76)     40.7516 (2.57)      0.2961 (2.73)          2;2  24.1790 (0.39)         25           1
test_binary_ew_ops[ne-dtype9-100000000]                     58.6305 (3.76)      63.5092 (3.68)      59.6546 (3.73)      1.4182 (7.38)      59.0173 (3.72)      1.1828 (10.89)         3;2  16.7632 (0.27)         17           1
test_binary_ew_ops[sub-dtype0-100000000]                    42.9721 (2.76)      48.2957 (2.80)      44.1854 (2.76)      1.3566 (7.06)      44.0811 (2.78)      1.1732 (10.80)         2;2  22.6319 (0.36)         23           1
test_binary_ew_ops[sub-dtype1-100000000]                    42.9011 (2.75)      48.6121 (2.82)      44.1492 (2.76)      1.4052 (7.31)      43.9488 (2.77)      0.9176 (8.45)          2;2  22.6505 (0.36)         23           1
test_binary_ew_ops[sub-dtype2-100000000]                    51.2797 (3.29)      58.2696 (3.37)      52.3330 (3.27)      1.5574 (8.10)      51.8541 (3.27)      0.5960 (5.49)          2;3  19.1084 (0.31)         20           1
test_binary_ew_ops[sub-dtype3-100000000]                    51.0394 (3.27)      82.1431 (4.76)      54.5136 (3.41)      7.4313 (38.65)     52.0007 (3.28)      0.6678 (6.15)          2;4  18.3440 (0.29)         20           1
test_binary_ew_ops[sub-dtype4-100000000]                    60.6928 (3.89)      66.6511 (3.86)      61.8850 (3.87)      1.6764 (8.72)      61.1676 (3.85)      1.0666 (9.82)          2;2  16.1590 (0.26)         14           1
test_binary_ew_ops[sub-dtype5-100000000]                    60.6226 (3.89)      67.5207 (3.91)      61.9252 (3.87)      1.8944 (9.85)      61.3360 (3.86)      0.4198 (3.87)          2;3  16.1485 (0.26)         17           1
test_binary_ew_ops[sub-dtype6-100000000]                   109.1100 (7.00)     113.6533 (6.58)     110.1982 (6.88)      1.7338 (9.02)     109.4280 (6.89)      0.7520 (6.92)          2;2   9.0746 (0.15)         10           1
test_binary_ew_ops[sub-dtype7-100000000]                   109.0356 (6.99)     115.2785 (6.68)     110.5289 (6.90)      2.1424 (11.14)    109.4950 (6.90)      1.5001 (13.81)         2;1   9.0474 (0.14)          9           1
test_binary_ew_ops[sub-dtype8-100000000]                    60.8810 (3.90)      66.3624 (3.84)      62.7595 (3.92)      2.0308 (10.56)     61.5547 (3.88)      3.6705 (33.80)         5;0  15.9338 (0.26)         17           1
test_binary_ew_ops[sub-dtype9-100000000]                   109.2625 (7.01)     112.7110 (6.53)     110.3097 (6.89)      1.3697 (7.12)     109.5220 (6.90)      2.6911 (24.78)         3;0   9.0654 (0.15)         10           1
test_binary_ew_ops[truediv-dtype0-100000000]                69.0035 (4.43)      74.9253 (4.34)      70.4238 (4.40)      1.6034 (8.34)      69.7081 (4.39)      1.5246 (14.04)         3;1  14.1997 (0.23)         15           1
test_binary_ew_ops[truediv-dtype1-100000000]                68.8611 (4.42)      82.5199 (4.78)      73.3596 (4.58)      4.4242 (23.01)     72.7235 (4.58)      7.9503 (73.21)         4;0  13.6315 (0.22)         15           1
test_binary_ew_ops[truediv-dtype2-100000000]                77.0269 (4.94)      84.8674 (4.91)      78.6710 (4.91)      2.5388 (13.20)     77.7196 (4.90)      0.7028 (6.47)          2;2  12.7112 (0.20)         13           1
test_binary_ew_ops[truediv-dtype3-100000000]                76.6992 (4.92)      92.7827 (5.37)      81.0587 (5.06)      4.8992 (25.48)     79.3593 (5.00)      6.6212 (60.97)         3;0  12.3367 (0.20)         13           1
test_binary_ew_ops[truediv-dtype4-100000000]                91.3739 (5.86)     100.4131 (5.82)      93.2858 (5.83)      3.2578 (16.94)     91.9302 (5.79)      0.9993 (9.20)          2;2  10.7197 (0.17)         11           1
test_binary_ew_ops[truediv-dtype5-100000000]                90.8287 (5.83)     101.4816 (5.88)      94.7293 (5.92)      3.9894 (20.75)     92.5510 (5.83)      6.2714 (57.75)         2;0  10.5564 (0.17)         11           1
test_binary_ew_ops[truediv-dtype6-100000000]               207.3055 (13.30)    216.4564 (12.54)    211.3065 (13.20)     4.6212 (24.03)    208.7363 (13.15)     8.5873 (79.08)         2;0   4.7325 (0.08)          5           1
test_binary_ew_ops[truediv-dtype7-100000000]               186.8955 (11.99)    214.5664 (12.43)    196.8809 (12.30)    10.2181 (53.14)    196.2175 (12.36)    13.1236 (120.85)        1;0   5.0792 (0.08)          6           1
test_binary_ew_ops[truediv-dtype8-100000000]                73.1940 (4.69)      81.4396 (4.72)      74.4418 (4.65)      2.2980 (11.95)     73.5089 (4.63)      0.4736 (4.36)          1;3  13.4333 (0.22)         14           1
test_binary_ew_ops[truediv-dtype9-100000000]               113.3890 (7.27)     123.3569 (7.14)     116.1823 (7.26)      3.4523 (17.96)    114.6942 (7.23)      3.3295 (30.66)         2;1   8.6072 (0.14)          9           1
test_binary_ew_ops_numpy[add-dtype0-100000000]              16.4589 (1.06)      17.2671 (1.0)       16.6084 (1.04)      0.1923 (1.0)       16.5482 (1.04)      0.1370 (1.26)          1;1  60.2106 (0.96)         18           1
test_binary_ew_ops_numpy[add-dtype1-100000000]              16.4329 (1.05)      19.0605 (1.10)      16.8594 (1.05)      0.5394 (2.81)      16.6919 (1.05)      0.3100 (2.85)          4;4  59.3141 (0.95)         56           1
test_binary_ew_ops_numpy[add-dtype2-100000000]              31.4693 (2.02)      34.2337 (1.98)      32.2235 (2.01)      0.8297 (4.31)      31.8255 (2.00)      0.8077 (7.44)          5;3  31.0332 (0.50)         27           1
test_binary_ew_ops_numpy[add-dtype3-100000000]              31.4809 (2.02)      34.8938 (2.02)      32.0753 (2.00)      0.6579 (3.42)      31.9044 (2.01)      0.3079 (2.84)          2;3  31.1767 (0.50)         26           1
test_binary_ew_ops_numpy[add-dtype4-100000000]              62.5159 (4.01)      66.2624 (3.84)      63.4013 (3.96)      0.9968 (5.18)      63.0762 (3.97)      0.7856 (7.23)          2;2  15.7725 (0.25)         15           1
test_binary_ew_ops_numpy[add-dtype5-100000000]              62.4328 (4.00)      69.1004 (4.00)      63.9916 (4.00)      2.0954 (10.90)     62.8825 (3.96)      3.3214 (30.59)         3;0  15.6270 (0.25)         14           1
test_binary_ew_ops_numpy[add-dtype6-100000000]             125.0757 (8.02)     130.3338 (7.55)     126.6469 (7.91)      1.8540 (9.64)     125.7611 (7.92)      2.0703 (19.06)         2;0   7.8960 (0.13)          8           1
test_binary_ew_ops_numpy[add-dtype7-100000000]             125.6492 (8.06)     128.5341 (7.44)     127.0905 (7.94)      1.1562 (6.01)     126.9979 (8.00)      2.0132 (18.54)         2;0   7.8684 (0.13)          8           1
test_binary_ew_ops_numpy[add-dtype8-100000000]              62.6050 (4.02)      66.1658 (3.83)      63.4028 (3.96)      1.0575 (5.50)      62.8953 (3.96)      1.0405 (9.58)          2;1  15.7722 (0.25)         16           1
test_binary_ew_ops_numpy[add-dtype9-100000000]             125.4790 (8.05)     129.8667 (7.52)     126.9759 (7.93)      1.7338 (9.02)     126.1728 (7.95)      2.3114 (21.28)         2;0   7.8755 (0.13)          8           1
test_binary_ew_ops_numpy[eq-dtype0-100000000]               15.9874 (1.03)      17.6787 (1.02)      16.2630 (1.02)      0.3380 (1.76)      16.1510 (1.02)      0.2032 (1.87)          5;5  61.4892 (0.98)         61           1
test_binary_ew_ops_numpy[eq-dtype1-100000000]               15.8340 (1.02)      18.0483 (1.05)      16.2444 (1.01)      0.4417 (2.30)      16.1178 (1.02)      0.1912 (1.76)          6;9  61.5596 (0.99)         62           1
test_binary_ew_ops_numpy[eq-dtype2-100000000]               24.3653 (1.56)      26.8479 (1.55)      24.8448 (1.55)      0.4827 (2.51)      24.7273 (1.56)      0.2611 (2.40)          4;4  40.2499 (0.64)         41           1
test_binary_ew_ops_numpy[eq-dtype3-100000000]               24.2554 (1.56)      27.6724 (1.60)      24.8684 (1.55)      0.6382 (3.32)      24.7198 (1.56)      0.3765 (3.47)          2;2  40.2117 (0.64)         41           1
test_binary_ew_ops_numpy[eq-dtype4-100000000]               40.9537 (2.63)      43.1207 (2.50)      41.6164 (2.60)      0.5800 (3.02)      41.4395 (2.61)      0.6283 (5.79)          6;2  24.0290 (0.38)         25           1
test_binary_ew_ops_numpy[eq-dtype5-100000000]               41.0521 (2.63)      44.5314 (2.58)      41.5749 (2.60)      0.7106 (3.70)      41.3905 (2.61)      0.3012 (2.77)          2;3  24.0529 (0.39)         23           1
test_binary_ew_ops_numpy[eq-dtype6-100000000]               74.0155 (4.75)      77.7214 (4.50)      75.2942 (4.70)      1.2951 (6.74)      74.8103 (4.71)      0.3526 (3.25)          3;4  13.2812 (0.21)         14           1
test_binary_ew_ops_numpy[eq-dtype7-100000000]               74.2464 (4.76)      78.2685 (4.53)      75.3546 (4.71)      1.3510 (7.03)      74.6971 (4.71)      1.1180 (10.29)         2;2  13.2706 (0.21)         13           1
test_binary_ew_ops_numpy[eq-dtype8-100000000]               39.4007 (2.53)      42.7302 (2.47)      40.1987 (2.51)      0.8214 (4.27)      39.9581 (2.52)      0.3747 (3.45)          3;4  24.8764 (0.40)         25           1
test_binary_ew_ops_numpy[eq-dtype9-100000000]               69.8200 (4.48)      74.1992 (4.30)      71.0809 (4.44)      1.3380 (6.96)      70.7625 (4.46)      0.8819 (8.12)          2;2  14.0685 (0.23)         15           1
test_binary_ew_ops_numpy[ge-dtype0-100000000]               15.8702 (1.02)      18.4677 (1.07)      16.2280 (1.01)      0.4777 (2.48)      16.0978 (1.01)      0.1964 (1.81)          6;6  61.6219 (0.99)         62           1
test_binary_ew_ops_numpy[ge-dtype1-100000000]               16.0138 (1.03)      17.9733 (1.04)      16.2493 (1.01)      0.3081 (1.60)      16.1867 (1.02)      0.1350 (1.24)          4;5  61.5413 (0.99)         59           1
test_binary_ew_ops_numpy[ge-dtype2-100000000]               24.7635 (1.59)      28.1225 (1.63)      25.2005 (1.57)      0.6839 (3.56)      25.0235 (1.58)      0.2543 (2.34)          3;4  39.6817 (0.64)         40           1
test_binary_ew_ops_numpy[ge-dtype3-100000000]               24.9238 (1.60)      27.9309 (1.62)      25.4583 (1.59)      0.6120 (3.18)      25.3018 (1.59)      0.3648 (3.36)          3;3  39.2798 (0.63)         40           1
test_binary_ew_ops_numpy[ge-dtype4-100000000]               41.0693 (2.63)      44.9251 (2.60)      41.8783 (2.62)      0.9188 (4.78)      41.5909 (2.62)      0.4475 (4.12)          2;4  23.8787 (0.38)         24           1
test_binary_ew_ops_numpy[ge-dtype5-100000000]               41.6210 (2.67)      44.4892 (2.58)      42.3990 (2.65)      0.7151 (3.72)      42.1081 (2.65)      0.4297 (3.96)          5;4  23.5855 (0.38)         24           1
test_binary_ew_ops_numpy[ge-dtype6-100000000]               74.4337 (4.77)      78.8797 (4.57)      75.6509 (4.73)      1.4079 (7.32)      75.1523 (4.73)      0.7887 (7.26)          2;2  13.2186 (0.21)         14           1
test_binary_ew_ops_numpy[ge-dtype7-100000000]               74.8037 (4.80)      78.6601 (4.56)      76.0470 (4.75)      1.3459 (7.00)      75.3059 (4.74)      2.2125 (20.37)         3;0  13.1498 (0.21)         14           1
test_binary_ew_ops_numpy[ge-dtype8-100000000]               39.2522 (2.52)      46.6519 (2.70)      40.6189 (2.54)      1.9520 (10.15)     39.8262 (2.51)      1.1157 (10.27)         2;3  24.6191 (0.39)         25           1
test_binary_ew_ops_numpy[ge-dtype9-100000000]               69.8092 (4.48)      73.1517 (4.24)      71.0262 (4.44)      1.0135 (5.27)      70.7772 (4.46)      1.0213 (9.41)          5;1  14.0793 (0.23)         14           1
test_binary_ew_ops_numpy[gt-dtype0-100000000]               15.5914 (1.0)       17.7107 (1.03)      16.0091 (1.0)       0.4307 (2.24)      15.8738 (1.0)       0.3612 (3.33)          6;4  62.4643 (1.0)          64           1
test_binary_ew_ops_numpy[gt-dtype1-100000000]               15.5980 (1.00)      17.4800 (1.01)      16.0375 (1.00)      0.4096 (2.13)      15.8977 (1.00)      0.3000 (2.76)          7;6  62.3538 (1.00)         63           1
test_binary_ew_ops_numpy[gt-dtype2-100000000]               24.3414 (1.56)      27.4276 (1.59)      24.9619 (1.56)      0.6321 (3.29)      24.7907 (1.56)      0.4689 (4.32)          2;2  40.0610 (0.64)         40           1
test_binary_ew_ops_numpy[gt-dtype3-100000000]               24.4537 (1.57)      26.7536 (1.55)      25.2030 (1.57)      0.6067 (3.16)      25.1062 (1.58)      0.7307 (6.73)         10;2  39.6779 (0.64)         40           1
test_binary_ew_ops_numpy[gt-dtype4-100000000]               40.7041 (2.61)      46.9500 (2.72)      42.4964 (2.65)      1.4948 (7.77)      41.9895 (2.65)      1.8677 (17.20)         6;1  23.5314 (0.38)         25           1
test_binary_ew_ops_numpy[gt-dtype5-100000000]               41.0321 (2.63)      46.6014 (2.70)      42.4028 (2.65)      1.4082 (7.32)      41.7588 (2.63)      2.0376 (18.76)         5;1  23.5833 (0.38)         24           1
test_binary_ew_ops_numpy[gt-dtype6-100000000]               73.6260 (4.72)      77.4809 (4.49)      75.2507 (4.70)      1.1110 (5.78)      74.9354 (4.72)      0.8071 (7.43)          3;2  13.2889 (0.21)         13           1
test_binary_ew_ops_numpy[gt-dtype7-100000000]               73.0768 (4.69)      82.2025 (4.76)      75.2254 (4.70)      2.6249 (13.65)     74.4037 (4.69)      0.4009 (3.69)          2;3  13.2934 (0.21)         13           1
test_binary_ew_ops_numpy[gt-dtype8-100000000]               39.4641 (2.53)      43.0809 (2.49)      40.4796 (2.53)      0.9014 (4.69)      40.2369 (2.53)      0.9672 (8.91)          3;2  24.7038 (0.40)         25           1
test_binary_ew_ops_numpy[gt-dtype9-100000000]               69.9611 (4.49)      74.6175 (4.32)      71.5566 (4.47)      1.4984 (7.79)      71.1698 (4.48)      0.6977 (6.43)          5;3  13.9749 (0.22)         15           1
test_binary_ew_ops_numpy[le-dtype0-100000000]               15.8210 (1.01)      17.9178 (1.04)      16.2197 (1.01)      0.3897 (2.03)      16.0874 (1.01)      0.2129 (1.96)          6;5  61.6534 (0.99)         62           1
test_binary_ew_ops_numpy[le-dtype1-100000000]               15.9986 (1.03)      18.1925 (1.05)      16.3581 (1.02)      0.4176 (2.17)      16.2225 (1.02)      0.2359 (2.17)          6;6  61.1317 (0.98)         62           1
test_binary_ew_ops_numpy[le-dtype2-100000000]               24.4268 (1.57)      27.0437 (1.57)      24.8950 (1.56)      0.6043 (3.14)      24.7163 (1.56)      0.3602 (3.32)          5;5  40.1687 (0.64)         41           1
test_binary_ew_ops_numpy[le-dtype3-100000000]               24.5945 (1.58)      28.5471 (1.65)      25.2547 (1.58)      0.8406 (4.37)      24.9655 (1.57)      0.5064 (4.66)          4;4  39.5967 (0.63)         41           1
test_binary_ew_ops_numpy[le-dtype4-100000000]               40.9367 (2.63)      44.9248 (2.60)      41.6628 (2.60)      1.0054 (5.23)      41.3195 (2.60)      0.5128 (4.72)          2;2  24.0023 (0.38)         25           1
test_binary_ew_ops_numpy[le-dtype5-100000000]               41.3325 (2.65)      46.7033 (2.70)      42.2347 (2.64)      1.1994 (6.24)      41.7683 (2.63)      0.6493 (5.98)          3;3  23.6772 (0.38)         23           1
test_binary_ew_ops_numpy[le-dtype6-100000000]               74.5523 (4.78)      78.1381 (4.53)      75.7846 (4.73)      1.2444 (6.47)      75.3261 (4.75)      1.3635 (12.56)         3;0  13.1953 (0.21)         14           1
test_binary_ew_ops_numpy[le-dtype7-100000000]               73.7932 (4.73)      77.1188 (4.47)      74.7763 (4.67)      1.0268 (5.34)      74.4075 (4.69)      0.9496 (8.74)          2;2  13.3732 (0.21)         13           1
test_binary_ew_ops_numpy[le-dtype8-100000000]               39.2817 (2.52)      42.3984 (2.46)      40.0946 (2.50)      0.7548 (3.93)      39.8580 (2.51)      0.3494 (3.22)          4;4  24.9410 (0.40)         26           1
test_binary_ew_ops_numpy[le-dtype9-100000000]               69.9446 (4.49)      73.7692 (4.27)      71.4981 (4.47)      1.1335 (5.90)      71.4502 (4.50)      1.3674 (12.59)         5;0  13.9864 (0.22)         15           1
test_binary_ew_ops_numpy[logical_and-dtype0-100000000]      17.1036 (1.10)      19.6417 (1.14)      17.5423 (1.10)      0.5076 (2.64)      17.3740 (1.09)      0.3110 (2.86)          4;4  57.0052 (0.91)         54           1
test_binary_ew_ops_numpy[logical_and-dtype1-100000000]      17.0763 (1.10)      20.5685 (1.19)      17.5691 (1.10)      0.6259 (3.26)      17.3862 (1.10)      0.3971 (3.66)          4;4  56.9182 (0.91)         57           1
test_binary_ew_ops_numpy[logical_and-dtype2-100000000]      25.5938 (1.64)      29.0550 (1.68)      26.1497 (1.63)      0.7450 (3.87)      25.9149 (1.63)      0.4434 (4.08)          3;3  38.2414 (0.61)         39           1
test_binary_ew_ops_numpy[logical_and-dtype3-100000000]      25.5988 (1.64)      28.6932 (1.66)      26.1456 (1.63)      0.6623 (3.44)      25.9767 (1.64)      0.3778 (3.48)          3;4  38.2473 (0.61)         38           1
test_binary_ew_ops_numpy[logical_and-dtype4-100000000]      42.9924 (2.76)      46.3435 (2.68)      43.6305 (2.73)      0.7665 (3.99)      43.4992 (2.74)      0.4527 (4.17)          3;3  22.9197 (0.37)         24           1
test_binary_ew_ops_numpy[logical_and-dtype5-100000000]      42.9812 (2.76)      46.6151 (2.70)      43.6148 (2.72)      0.8696 (4.52)      43.3958 (2.73)      0.5270 (4.85)          2;2  22.9280 (0.37)         23           1
test_binary_ew_ops_numpy[logical_and-dtype6-100000000]      76.6411 (4.92)      81.1727 (4.70)      77.9915 (4.87)      1.4587 (7.59)      77.4852 (4.88)      0.8783 (8.09)          2;2  12.8219 (0.21)         13           1
test_binary_ew_ops_numpy[logical_and-dtype7-100000000]      76.5027 (4.91)      80.9247 (4.69)      77.7020 (4.85)      1.1938 (6.21)      77.3496 (4.87)      1.0066 (9.27)          3;1  12.8697 (0.21)         13           1
test_binary_ew_ops_numpy[logical_and-dtype8-100000000]     109.4874 (7.02)     112.8275 (6.53)     110.7765 (6.92)      1.4036 (7.30)     110.1287 (6.94)      2.9706 (27.35)         3;0   9.0272 (0.14)         10           1
test_binary_ew_ops_numpy[logical_and-dtype9-100000000]     121.6310 (7.80)     126.1352 (7.30)     123.3736 (7.71)      1.6856 (8.77)     122.6506 (7.73)      2.4419 (22.49)         3;0   8.1055 (0.13)          9           1
test_binary_ew_ops_numpy[logical_or-dtype0-100000000]       15.8477 (1.02)      18.1597 (1.05)      16.2378 (1.01)      0.4533 (2.36)      16.1181 (1.02)      0.2428 (2.24)          4;5  61.5848 (0.99)         61           1
test_binary_ew_ops_numpy[logical_or-dtype1-100000000]       15.8096 (1.01)      17.8774 (1.04)      16.2762 (1.02)      0.4100 (2.13)      16.1344 (1.02)      0.2808 (2.59)          8;7  61.4393 (0.98)         62           1
test_binary_ew_ops_numpy[logical_or-dtype2-100000000]       25.0802 (1.61)      27.9331 (1.62)      25.6778 (1.60)      0.6157 (3.20)      25.4671 (1.60)      0.3077 (2.83)          6;6  38.9442 (0.62)         39           1
test_binary_ew_ops_numpy[logical_or-dtype3-100000000]       25.0745 (1.61)      28.1253 (1.63)      25.6314 (1.60)      0.6331 (3.29)      25.4149 (1.60)      0.3487 (3.21)          5;5  39.0146 (0.62)         40           1
test_binary_ew_ops_numpy[logical_or-dtype4-100000000]       41.9068 (2.69)      46.1252 (2.67)      43.0329 (2.69)      0.9658 (5.02)      42.7535 (2.69)      0.7129 (6.57)          6;3  23.2380 (0.37)         24           1
test_binary_ew_ops_numpy[logical_or-dtype5-100000000]       42.2998 (2.71)      45.6701 (2.64)      42.9785 (2.68)      0.8404 (4.37)      42.7365 (2.69)      0.5306 (4.89)          3;3  23.2674 (0.37)         24           1
test_binary_ew_ops_numpy[logical_or-dtype6-100000000]       76.8220 (4.93)      80.9051 (4.69)      78.0380 (4.87)      1.2299 (6.40)      77.5395 (4.88)      0.9405 (8.66)          2;2  12.8143 (0.21)         13           1
test_binary_ew_ops_numpy[logical_or-dtype7-100000000]       76.7147 (4.92)      80.6932 (4.67)      77.9727 (4.87)      1.1196 (5.82)      77.5639 (4.89)      1.2125 (11.17)         4;1  12.8250 (0.21)         13           1
test_binary_ew_ops_numpy[logical_or-dtype8-100000000]      109.9803 (7.05)     113.5823 (6.58)     111.1950 (6.95)      1.3265 (6.90)     110.6924 (6.97)      2.2556 (20.77)         2;0   8.9932 (0.14)         10           1
test_binary_ew_ops_numpy[logical_or-dtype9-100000000]      121.6025 (7.80)     125.7797 (7.28)     123.3709 (7.71)      1.5479 (8.05)     123.4691 (7.78)      2.5736 (23.70)         4;0   8.1056 (0.13)          9           1
test_binary_ew_ops_numpy[logical_xor-dtype0-100000000]      70.6635 (4.53)      73.8048 (4.27)      71.6037 (4.47)      0.8801 (4.58)      71.3631 (4.50)      0.5781 (5.32)          3;2  13.9658 (0.22)         14           1
test_binary_ew_ops_numpy[logical_xor-dtype1-100000000]      71.1155 (4.56)      73.3985 (4.25)      71.8061 (4.49)      0.7527 (3.91)      71.5102 (4.50)      0.3383 (3.12)          3;3  13.9264 (0.22)         15           1
test_binary_ew_ops_numpy[logical_xor-dtype2-100000000]      72.9572 (4.68)      75.1716 (4.35)      73.6480 (4.60)      0.6823 (3.55)      73.4281 (4.63)      0.5203 (4.79)          3;2  13.5781 (0.22)         14           1
test_binary_ew_ops_numpy[logical_xor-dtype3-100000000]      72.8880 (4.67)      76.3563 (4.42)      73.6063 (4.60)      0.9934 (5.17)      73.2512 (4.61)      0.4603 (4.24)          2;2  13.5858 (0.22)         14           1
test_binary_ew_ops_numpy[logical_xor-dtype4-100000000]      85.9688 (5.51)      89.7378 (5.20)      87.3037 (5.45)      1.1422 (5.94)      87.0125 (5.48)      0.7917 (7.29)          3;2  11.4543 (0.18)         12           1
test_binary_ew_ops_numpy[logical_xor-dtype5-100000000]      85.1262 (5.46)      89.1117 (5.16)      86.9133 (5.43)      0.9458 (4.92)      86.7628 (5.47)      0.8402 (7.74)          2;2  11.5057 (0.18)         12           1
test_binary_ew_ops_numpy[logical_xor-dtype6-100000000]      90.5209 (5.81)      93.9020 (5.44)      91.6211 (5.72)      0.9983 (5.19)      91.4421 (5.76)      1.3187 (12.14)         2;0  10.9145 (0.17)         11           1
test_binary_ew_ops_numpy[logical_xor-dtype7-100000000]      90.4682 (5.80)      94.9705 (5.50)      91.9255 (5.74)      1.5081 (7.84)      91.2262 (5.75)      1.0565 (9.73)          2;2  10.8784 (0.17)         11           1
test_binary_ew_ops_numpy[logical_xor-dtype8-100000000]     108.3341 (6.95)     112.4985 (6.52)     109.6125 (6.85)      1.3101 (6.81)     109.2425 (6.88)      1.6038 (14.77)         1;1   9.1230 (0.15)         10           1
test_binary_ew_ops_numpy[logical_xor-dtype9-100000000]     118.5921 (7.61)     125.0401 (7.24)     120.6796 (7.54)      1.9378 (10.08)    120.3208 (7.58)      1.9016 (17.51)         2;1   8.2864 (0.13)          9           1
test_binary_ew_ops_numpy[lt-dtype0-100000000]               15.6752 (1.01)      17.9324 (1.04)      16.1707 (1.01)      0.4102 (2.13)      16.0775 (1.01)      0.2111 (1.94)          7;8  61.8401 (0.99)         63           1
test_binary_ew_ops_numpy[lt-dtype1-100000000]               15.9591 (1.02)      17.9630 (1.04)      16.5351 (1.03)      0.5120 (2.66)      16.3118 (1.03)      0.8361 (7.70)         16;0  60.4774 (0.97)         58           1
test_binary_ew_ops_numpy[lt-dtype2-100000000]               24.6741 (1.58)      28.0790 (1.63)      25.2066 (1.57)      0.6976 (3.63)      24.9842 (1.57)      0.4093 (3.77)          3;4  39.6722 (0.64)         40           1
test_binary_ew_ops_numpy[lt-dtype3-100000000]               25.0053 (1.60)      27.6811 (1.60)      25.4358 (1.59)      0.5577 (2.90)      25.2814 (1.59)      0.2702 (2.49)          5;5  39.3147 (0.63)         39           1
test_binary_ew_ops_numpy[lt-dtype4-100000000]               41.0846 (2.64)      45.5892 (2.64)      41.9845 (2.62)      1.0711 (5.57)      41.6988 (2.63)      0.3424 (3.15)          2;3  23.8183 (0.38)         24           1
test_binary_ew_ops_numpy[lt-dtype5-100000000]               41.6141 (2.67)      44.9010 (2.60)      42.4346 (2.65)      0.7390 (3.84)      42.1862 (2.66)      0.5977 (5.50)          4;2  23.5657 (0.38)         24           1
test_binary_ew_ops_numpy[lt-dtype6-100000000]               74.5114 (4.78)      79.5303 (4.61)      75.7530 (4.73)      1.5940 (8.29)      75.1140 (4.73)      1.0688 (9.84)          3;3  13.2008 (0.21)         14           1
test_binary_ew_ops_numpy[lt-dtype7-100000000]               74.9782 (4.81)      78.9264 (4.57)      76.0036 (4.75)      1.1950 (6.22)      75.6021 (4.76)      1.3238 (12.19)         3;1  13.1573 (0.21)         13           1
test_binary_ew_ops_numpy[lt-dtype8-100000000]               39.6871 (2.55)      43.8225 (2.54)      40.5822 (2.53)      1.0328 (5.37)      40.2333 (2.53)      0.4472 (4.12)          4;4  24.6414 (0.39)         25           1
test_binary_ew_ops_numpy[lt-dtype9-100000000]               70.4250 (4.52)      75.3375 (4.36)      71.8644 (4.49)      1.4213 (7.39)      71.3794 (4.50)      0.8434 (7.77)          3;2  13.9151 (0.22)         14           1
test_binary_ew_ops_numpy[mul-dtype0-100000000]              17.3666 (1.11)      21.8763 (1.27)      17.9835 (1.12)      0.8944 (4.65)      17.6746 (1.11)      0.4552 (4.19)          7;9  55.6065 (0.89)         55           1
test_binary_ew_ops_numpy[mul-dtype1-100000000]              17.2301 (1.11)      21.5896 (1.25)      17.9055 (1.12)      0.9493 (4.94)      17.5119 (1.10)      0.4322 (3.98)          7;9  55.8487 (0.89)         53           1
test_binary_ew_ops_numpy[mul-dtype2-100000000]              31.3741 (2.01)      34.2703 (1.98)      31.9154 (1.99)      0.6437 (3.35)      31.7127 (2.00)      0.2761 (2.54)          4;5  31.3328 (0.50)         32           1
test_binary_ew_ops_numpy[mul-dtype3-100000000]              31.5697 (2.02)      34.5859 (2.00)      32.1025 (2.01)      0.6879 (3.58)      31.8303 (2.01)      0.3655 (3.37)          4;4  31.1502 (0.50)         32           1
test_binary_ew_ops_numpy[mul-dtype4-100000000]              63.1086 (4.05)      67.5840 (3.91)      64.4673 (4.03)      1.4724 (7.66)      63.8397 (4.02)      1.9479 (17.94)         3;0  15.5117 (0.25)         16           1
test_binary_ew_ops_numpy[mul-dtype5-100000000]              62.4157 (4.00)      67.4516 (3.91)      63.9959 (4.00)      1.7472 (9.09)      63.0236 (3.97)      2.6434 (24.34)         3;0  15.6260 (0.25)         16           1
test_binary_ew_ops_numpy[mul-dtype6-100000000]             130.2870 (8.36)     139.3170 (8.07)     132.8091 (8.30)      3.0729 (15.98)    131.5830 (8.29)      3.3365 (30.72)         1;1   7.5296 (0.12)          8           1
test_binary_ew_ops_numpy[mul-dtype7-100000000]             129.8293 (8.33)     138.2732 (8.01)     134.0392 (8.37)      2.5360 (13.19)    134.5374 (8.48)      2.8147 (25.92)         2;0   7.4605 (0.12)          8           1
test_binary_ew_ops_numpy[mul-dtype8-100000000]              61.8674 (3.97)      65.4739 (3.79)      63.0521 (3.94)      1.1220 (5.84)      62.6025 (3.94)      1.0792 (9.94)          4;2  15.8599 (0.25)         15           1
test_binary_ew_ops_numpy[mul-dtype9-100000000]             125.2715 (8.03)     133.2712 (7.72)     128.4618 (8.02)      2.8458 (14.80)    127.1250 (8.01)      4.3670 (40.21)         2;0   7.7844 (0.12)          8           1
test_binary_ew_ops_numpy[ne-dtype0-100000000]               15.9781 (1.02)      17.5861 (1.02)      16.2680 (1.02)      0.3723 (1.94)      16.1409 (1.02)      0.1086 (1.0)           7;8  61.4703 (0.98)         61           1
test_binary_ew_ops_numpy[ne-dtype1-100000000]               15.9717 (1.02)      18.3684 (1.06)      16.4201 (1.03)      0.4996 (2.60)      16.2257 (1.02)      0.4391 (4.04)          9;5  60.9008 (0.97)         62           1
test_binary_ew_ops_numpy[ne-dtype2-100000000]               24.4305 (1.57)      27.1499 (1.57)      24.8914 (1.55)      0.5817 (3.03)      24.6755 (1.55)      0.3368 (3.10)          4;4  40.1745 (0.64)         40           1
test_binary_ew_ops_numpy[ne-dtype3-100000000]               24.3990 (1.56)      27.5134 (1.59)      24.8709 (1.55)      0.6258 (3.25)      24.6930 (1.56)      0.2335 (2.15)          3;4  40.2077 (0.64)         41           1
test_binary_ew_ops_numpy[ne-dtype4-100000000]               41.0486 (2.63)      44.0659 (2.55)      41.7549 (2.61)      0.7662 (3.98)      41.4483 (2.61)      0.8664 (7.98)          4;1  23.9493 (0.38)         24           1
test_binary_ew_ops_numpy[ne-dtype5-100000000]               40.9172 (2.62)      44.1818 (2.56)      41.9493 (2.62)      0.9122 (4.74)      41.5788 (2.62)      1.2615 (11.62)         5;0  23.8383 (0.38)         24           1
test_binary_ew_ops_numpy[ne-dtype6-100000000]               73.9266 (4.74)      77.2891 (4.48)      75.0365 (4.69)      1.0555 (5.49)      74.5767 (4.70)      1.0965 (10.10)         3;1  13.3268 (0.21)         14           1
test_binary_ew_ops_numpy[ne-dtype7-100000000]               74.0033 (4.75)      78.6052 (4.55)      75.0569 (4.69)      1.4574 (7.58)      74.3957 (4.69)      0.9836 (9.06)          2;2  13.3232 (0.21)         14           1
test_binary_ew_ops_numpy[ne-dtype8-100000000]               39.3015 (2.52)      42.6821 (2.47)      40.0946 (2.50)      0.7939 (4.13)      39.8975 (2.51)      0.6688 (6.16)          3;2  24.9410 (0.40)         25           1
test_binary_ew_ops_numpy[ne-dtype9-100000000]               69.5484 (4.46)      73.7198 (4.27)      70.6734 (4.41)      1.2592 (6.55)      70.1139 (4.42)      0.7599 (7.00)          2;2  14.1496 (0.23)         15           1
test_binary_ew_ops_numpy[sub-dtype0-100000000]              16.4733 (1.06)      19.1064 (1.11)      16.7585 (1.05)      0.4612 (2.40)      16.6221 (1.05)      0.1902 (1.75)          5;7  59.6714 (0.96)         60           1
test_binary_ew_ops_numpy[sub-dtype1-100000000]              16.4674 (1.06)      18.5324 (1.07)      16.7835 (1.05)      0.4499 (2.34)      16.6669 (1.05)      0.2729 (2.51)          6;6  59.5822 (0.95)         59           1
test_binary_ew_ops_numpy[sub-dtype2-100000000]              31.5230 (2.02)      34.3884 (1.99)      32.0264 (2.00)      0.6925 (3.60)      31.7622 (2.00)      0.2321 (2.14)          4;5  31.2242 (0.50)         32           1
test_binary_ew_ops_numpy[sub-dtype3-100000000]              31.5440 (2.02)      35.4464 (2.05)      32.0703 (2.00)      0.8329 (4.33)      31.7757 (2.00)      0.3627 (3.34)          3;4  31.1814 (0.50)         32           1
test_binary_ew_ops_numpy[sub-dtype4-100000000]              62.6771 (4.02)      68.3788 (3.96)      63.9234 (3.99)      1.4937 (7.77)      63.3004 (3.99)      1.7221 (15.86)         2;1  15.6437 (0.25)         16           1
test_binary_ew_ops_numpy[sub-dtype5-100000000]              62.5673 (4.01)      66.9199 (3.88)      63.5000 (3.97)      1.2650 (6.58)      63.0964 (3.97)      0.2753 (2.54)          2;2  15.7480 (0.25)         16           1
test_binary_ew_ops_numpy[sub-dtype6-100000000]             125.7188 (8.06)     130.3605 (7.55)     127.1297 (7.94)      1.8075 (9.40)     126.4216 (7.96)      2.4848 (22.88)         2;0   7.8660 (0.13)          8           1
test_binary_ew_ops_numpy[sub-dtype7-100000000]             125.4800 (8.05)     129.0168 (7.47)     127.1531 (7.94)      1.3575 (7.06)     126.7323 (7.98)      2.3876 (21.99)         3;0   7.8645 (0.13)          8           1
test_binary_ew_ops_numpy[sub-dtype8-100000000]              62.5425 (4.01)      67.1325 (3.89)      63.3583 (3.96)      1.3493 (7.02)      62.9277 (3.96)      0.3289 (3.03)          2;2  15.7832 (0.25)         16           1
test_binary_ew_ops_numpy[sub-dtype9-100000000]             125.1773 (8.03)     134.6215 (7.80)     128.6801 (8.04)      3.5645 (18.54)    127.5773 (8.04)      5.8408 (53.79)         2;0   7.7712 (0.12)          8           1
test_binary_ew_ops_numpy[truediv-dtype0-100000000]         146.3109 (9.38)     149.4872 (8.66)     147.6333 (9.22)      1.1677 (6.07)     147.1621 (9.27)      1.7690 (16.29)         2;0   6.7735 (0.11)          7           1
test_binary_ew_ops_numpy[truediv-dtype1-100000000]         145.6944 (9.34)     151.3228 (8.76)     148.1199 (9.25)      1.9676 (10.23)    148.1983 (9.34)      2.3098 (21.27)         2;0   6.7513 (0.11)          6           1
test_binary_ew_ops_numpy[truediv-dtype2-100000000]         145.8571 (9.35)     150.8264 (8.73)     149.1238 (9.31)      1.7832 (9.27)     149.2869 (9.40)      2.3644 (21.77)         1;0   6.7058 (0.11)          7           1
test_binary_ew_ops_numpy[truediv-dtype3-100000000]         149.1226 (9.56)     153.6927 (8.90)     151.2072 (9.45)      1.7331 (9.01)     150.7728 (9.50)      2.9390 (27.06)         3;0   6.6134 (0.11)          7           1
test_binary_ew_ops_numpy[truediv-dtype4-100000000]         157.1922 (10.08)    167.0096 (9.67)     160.4227 (10.02)     3.5000 (18.20)    160.8230 (10.13)     4.2234 (38.89)         1;0   6.2335 (0.10)          7           1
test_binary_ew_ops_numpy[truediv-dtype5-100000000]         170.3501 (10.93)    175.3673 (10.16)    172.5657 (10.78)     1.9517 (10.15)    171.8372 (10.83)     3.1061 (28.60)         3;0   5.7949 (0.09)          6           1
test_binary_ew_ops_numpy[truediv-dtype6-100000000]         201.0739 (12.90)    205.4297 (11.90)    202.6299 (12.66)     1.7948 (9.33)     201.8527 (12.72)     2.5556 (23.53)         1;0   4.9351 (0.08)          5           1
test_binary_ew_ops_numpy[truediv-dtype7-100000000]         221.9759 (14.24)    226.4631 (13.12)    224.1929 (14.00)     1.8393 (9.57)     224.9214 (14.17)     2.8409 (26.16)         2;0   4.4604 (0.07)          5           1
test_binary_ew_ops_numpy[truediv-dtype8-100000000]          62.7224 (4.02)      65.5518 (3.80)      63.4664 (3.96)      0.8304 (4.32)      63.2689 (3.99)      0.7262 (6.69)          2;2  15.7564 (0.25)         15           1
test_binary_ew_ops_numpy[truediv-dtype9-100000000]         127.4600 (8.17)     132.9562 (7.70)     128.9249 (8.05)      1.9381 (10.08)    128.0369 (8.07)      2.0263 (18.66)         1;1   7.7565 (0.12)          8           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
====================================================================================================== 260 passed in 676.99s (0:11:16) ======================================================================================================
```

</details>

<details>
<summary>UnaryEW</summary>

```
============================================================================================================ test session starts ============================================================================================================
platform linux -- Python 3.8.10, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
benchmark: 3.4.1 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /home/stotko/workspace/Open3D/python
plugins: anyio-3.1.0, benchmark-3.4.1
collected 216 items                                                                                                                                                                                                                         

../python/benchmarks/core/test_unary_ew.py .......................................................................................................................................................................................... [ 86%]
..............................                                                                                                                                                                                                        [100%]


----------------------------------------------------------------------------------------------------------- benchmark: 216 tests -----------------------------------------------------------------------------------------------------------
Name (time in ms)                                                Min                   Max                  Mean             StdDev                Median                IQR            Outliers           OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_float_unary_ew_ops[cos-dtype0-100000000]                68.5549 (>1000.0)     76.7596 (>1000.0)     70.6480 (>1000.0)   2.7129 (>1000.0)     69.4528 (>1000.0)   0.9164 (>1000.0)       3;3       14.1547 (0.00)         14           1
test_float_unary_ew_ops[cos-dtype1-100000000]               441.2352 (>1000.0)    464.8785 (>1000.0)    454.9096 (>1000.0)  10.9960 (>1000.0)    458.4684 (>1000.0)  20.3218 (>1000.0)       1;0        2.1982 (0.00)          5           1
test_float_unary_ew_ops[exp-dtype0-100000000]                63.9243 (>1000.0)     71.1588 (>1000.0)     65.5880 (>1000.0)   2.2377 (>1000.0)     65.1456 (>1000.0)   1.4122 (>1000.0)       2;2       15.2467 (0.00)         16           1
test_float_unary_ew_ops[exp-dtype1-100000000]               177.7633 (>1000.0)    185.2885 (>1000.0)    180.5521 (>1000.0)   3.4359 (>1000.0)    178.5820 (>1000.0)   6.1755 (>1000.0)       2;0        5.5386 (0.00)          6           1
test_float_unary_ew_ops[sin-dtype0-100000000]                66.8760 (>1000.0)     78.5995 (>1000.0)     69.7317 (>1000.0)   3.6971 (>1000.0)     67.7745 (>1000.0)   5.2642 (>1000.0)       4;0       14.3407 (0.00)         15           1
test_float_unary_ew_ops[sin-dtype1-100000000]               405.1437 (>1000.0)    427.6351 (>1000.0)    417.7741 (>1000.0)  11.2061 (>1000.0)    423.7121 (>1000.0)  20.8190 (>1000.0)       2;0        2.3936 (0.00)          5           1
test_float_unary_ew_ops[sqrt-dtype0-100000000]               49.6530 (>1000.0)     55.6020 (>1000.0)     50.9489 (>1000.0)   1.6005 (>1000.0)     50.3923 (>1000.0)   1.0277 (>1000.0)       3;3       19.6275 (0.00)         20           1
test_float_unary_ew_ops[sqrt-dtype1-100000000]               83.4326 (>1000.0)     88.4900 (>1000.0)     84.6049 (>1000.0)   1.5555 (>1000.0)     84.0198 (>1000.0)   1.1777 (>1000.0)       2;2       11.8196 (0.00)         12           1
test_float_unary_ew_ops_numpy[cos-dtype0-100000000]         130.2914 (>1000.0)    133.6165 (>1000.0)    131.3606 (>1000.0)   1.2454 (>1000.0)    130.7966 (>1000.0)   1.5508 (>1000.0)       2;0        7.6126 (0.00)          8           1
test_float_unary_ew_ops_numpy[cos-dtype1-100000000]       1,474.5237 (>1000.0)  1,478.0561 (>1000.0)  1,475.6288 (>1000.0)   1.4023 (>1000.0)  1,475.0215 (>1000.0)   1.2631 (>1000.0)       1;1        0.6777 (0.00)          5           1
test_float_unary_ew_ops_numpy[exp-dtype0-100000000]         109.2051 (>1000.0)    112.9823 (>1000.0)    110.5592 (>1000.0)   1.1059 (>1000.0)    110.2526 (>1000.0)   0.6322 (>1000.0)       3;2        9.0449 (0.00)         10           1
test_float_unary_ew_ops_numpy[exp-dtype1-100000000]         496.5468 (>1000.0)    499.0137 (>1000.0)    498.2026 (>1000.0)   1.0065 (>1000.0)    498.6247 (>1000.0)   1.2750 (>1000.0)       1;0        2.0072 (0.00)          5           1
test_float_unary_ew_ops_numpy[sin-dtype0-100000000]         128.4297 (>1000.0)    132.0381 (>1000.0)    129.7245 (>1000.0)   1.4892 (>1000.0)    128.9625 (>1000.0)   2.4700 (>1000.0)       2;0        7.7086 (0.00)          8           1
test_float_unary_ew_ops_numpy[sin-dtype1-100000000]       1,451.7876 (>1000.0)  1,456.5175 (>1000.0)  1,453.9590 (>1000.0)   1.8730 (>1000.0)  1,453.6379 (>1000.0)   2.9145 (>1000.0)       2;0        0.6878 (0.00)          5           1
test_float_unary_ew_ops_numpy[sqrt-dtype0-100000000]         52.0481 (>1000.0)     55.5271 (>1000.0)     52.8216 (>1000.0)   1.0154 (>1000.0)     52.3888 (>1000.0)   0.5027 (>1000.0)       3;3       18.9316 (0.00)         19           1
test_float_unary_ew_ops_numpy[sqrt-dtype1-100000000]        122.9515 (>1000.0)    127.8929 (>1000.0)    124.5095 (>1000.0)   2.1652 (>1000.0)    123.1707 (>1000.0)   3.7908 (>1000.0)       2;0        8.0315 (0.00)          9           1
test_unary_ew_ops[abs-dtype0-100000000]                      36.4710 (>1000.0)     40.7931 (>1000.0)     37.0520 (>1000.0)   0.8217 (>1000.0)     36.9581 (>1000.0)   0.3511 (>1000.0)       1;1       26.9891 (0.00)         25           1
test_unary_ew_ops[abs-dtype1-100000000]                      36.1967 (>1000.0)     41.1510 (>1000.0)     37.2259 (>1000.0)   1.0491 (>1000.0)     37.0081 (>1000.0)   0.3638 (>1000.0)       2;4       26.8630 (0.00)         28           1
test_unary_ew_ops[abs-dtype2-100000000]                      43.3397 (>1000.0)     45.5871 (>1000.0)     44.1699 (>1000.0)   0.5712 (>1000.0)     44.2280 (>1000.0)   0.8159 (>1000.0)       6;0       22.6399 (0.00)         21           1
test_unary_ew_ops[abs-dtype3-100000000]                      43.3237 (>1000.0)     49.9620 (>1000.0)     44.5137 (>1000.0)   1.4230 (>1000.0)     44.2192 (>1000.0)   1.0633 (>1000.0)       2;2       22.4650 (0.00)         23           1
test_unary_ew_ops[abs-dtype4-100000000]                      51.7902 (>1000.0)     55.5621 (>1000.0)     52.6016 (>1000.0)   0.9901 (>1000.0)     52.1232 (>1000.0)   1.1592 (>1000.0)       1;1       19.0108 (0.00)         16           1
test_unary_ew_ops[abs-dtype5-100000000]                      59.6405 (>1000.0)     67.9342 (>1000.0)     61.3580 (>1000.0)   2.3094 (>1000.0)     60.6459 (>1000.0)   0.9836 (>1000.0)       2;2       16.2978 (0.00)         17           1
test_unary_ew_ops[abs-dtype6-100000000]                      95.4664 (>1000.0)    101.8724 (>1000.0)     97.2188 (>1000.0)   1.7904 (>1000.0)     96.8165 (>1000.0)   1.1170 (>1000.0)       1;1       10.2861 (0.00)         11           1
test_unary_ew_ops[abs-dtype7-100000000]                     101.1724 (>1000.0)    108.0025 (>1000.0)    103.3684 (>1000.0)   2.4476 (>1000.0)    102.4863 (>1000.0)   0.7944 (>1000.0)       2;2        9.6741 (0.00)         10           1
test_unary_ew_ops[abs-dtype8-100000000]                      52.1354 (>1000.0)     58.3076 (>1000.0)     53.1894 (>1000.0)   1.3559 (>1000.0)     52.8767 (>1000.0)   1.0523 (>1000.0)       1;1       18.8007 (0.00)         19           1
test_unary_ew_ops[abs-dtype9-100000000]                      83.5681 (>1000.0)     93.4577 (>1000.0)     87.2690 (>1000.0)   2.7197 (>1000.0)     87.3109 (>1000.0)   3.6314 (>1000.0)       4;0       11.4588 (0.00)         12           1
test_unary_ew_ops[ceil-dtype0-100000000]                     36.5639 (>1000.0)     43.6312 (>1000.0)     37.5789 (>1000.0)   1.4821 (>1000.0)     37.2190 (>1000.0)   0.3416 (>1000.0)       2;3       26.6107 (0.00)         28           1
test_unary_ew_ops[ceil-dtype1-100000000]                     36.5898 (>1000.0)     41.1762 (>1000.0)     37.6609 (>1000.0)   1.3138 (>1000.0)     37.1433 (>1000.0)   0.5983 (>1000.0)       5;6       26.5527 (0.00)         28           1
test_unary_ew_ops[ceil-dtype2-100000000]                     43.9158 (>1000.0)     51.1244 (>1000.0)     45.3160 (>1000.0)   1.8308 (>1000.0)     44.8764 (>1000.0)   0.5416 (>1000.0)       3;3       22.0673 (0.00)         23           1
test_unary_ew_ops[ceil-dtype3-100000000]                     43.8359 (>1000.0)     47.8678 (>1000.0)     44.9233 (>1000.0)   0.8607 (>1000.0)     44.9125 (>1000.0)   0.6421 (>1000.0)       6;2       22.2602 (0.00)         23           1
test_unary_ew_ops[ceil-dtype4-100000000]                     52.0572 (>1000.0)     59.2085 (>1000.0)     53.6207 (>1000.0)   1.6287 (>1000.0)     53.3018 (>1000.0)   1.4673 (>1000.0)       2;1       18.6495 (0.00)         20           1
test_unary_ew_ops[ceil-dtype5-100000000]                     60.5211 (>1000.0)     67.5888 (>1000.0)     62.4342 (>1000.0)   2.0506 (>1000.0)     62.0702 (>1000.0)   1.0449 (>1000.0)       2;2       16.0169 (0.00)         16           1
test_unary_ew_ops[ceil-dtype6-100000000]                     97.5361 (>1000.0)    103.0022 (>1000.0)     98.6936 (>1000.0)   1.8076 (>1000.0)     98.0909 (>1000.0)   0.4726 (>1000.0)       2;2       10.1324 (0.00)         11           1
test_unary_ew_ops[ceil-dtype7-100000000]                    103.8025 (>1000.0)    123.0697 (>1000.0)    108.0489 (>1000.0)   6.8045 (>1000.0)    105.0870 (>1000.0)   4.9926 (>1000.0)       2;1        9.2551 (0.00)          9           1
test_unary_ew_ops[ceil-dtype8-100000000]                     52.4844 (>1000.0)     60.2070 (>1000.0)     55.8759 (>1000.0)   2.7963 (>1000.0)     56.6185 (>1000.0)   5.4237 (>1000.0)       4;0       17.8968 (0.00)         17           1
test_unary_ew_ops[ceil-dtype9-100000000]                     82.6783 (>1000.0)     88.8490 (>1000.0)     84.0580 (>1000.0)   2.0746 (>1000.0)     83.2053 (>1000.0)   0.9160 (>1000.0)       2;2       11.8965 (0.00)         12           1
test_unary_ew_ops[floor-dtype0-100000000]                    36.4495 (>1000.0)     41.8562 (>1000.0)     37.6478 (>1000.0)   1.3576 (>1000.0)     37.1831 (>1000.0)   0.3193 (>1000.0)       3;7       26.5620 (0.00)         28           1
test_unary_ew_ops[floor-dtype1-100000000]                    36.5439 (>1000.0)     42.9879 (>1000.0)     37.5654 (>1000.0)   1.3318 (>1000.0)     37.2304 (>1000.0)   0.4736 (>1000.0)       2;3       26.6202 (0.00)         27           1
test_unary_ew_ops[floor-dtype2-100000000]                    43.8219 (>1000.0)     48.3328 (>1000.0)     44.9651 (>1000.0)   1.0840 (>1000.0)     44.7987 (>1000.0)   0.4674 (>1000.0)       3;2       22.2395 (0.00)         23           1
test_unary_ew_ops[floor-dtype3-100000000]                    43.8364 (>1000.0)     48.7758 (>1000.0)     45.0158 (>1000.0)   1.0989 (>1000.0)     44.8443 (>1000.0)   0.3136 (>1000.0)       5;8       22.2144 (0.00)         23           1
test_unary_ew_ops[floor-dtype4-100000000]                    52.3553 (>1000.0)     56.4155 (>1000.0)     53.3551 (>1000.0)   0.9357 (>1000.0)     53.2532 (>1000.0)   1.0077 (>1000.0)       2;1       18.7424 (0.00)         17           1
test_unary_ew_ops[floor-dtype5-100000000]                    60.7616 (>1000.0)     67.2503 (>1000.0)     62.2423 (>1000.0)   1.9266 (>1000.0)     61.6217 (>1000.0)   1.0072 (>1000.0)       2;2       16.0663 (0.00)         17           1
test_unary_ew_ops[floor-dtype6-100000000]                    97.0911 (>1000.0)    111.3507 (>1000.0)     99.2262 (>1000.0)   4.0771 (>1000.0)     97.8950 (>1000.0)   0.5856 (>1000.0)       1;2       10.0780 (0.00)         11           1
test_unary_ew_ops[floor-dtype7-100000000]                   104.2810 (>1000.0)    116.2002 (>1000.0)    108.0907 (>1000.0)   4.1450 (>1000.0)    106.1787 (>1000.0)   6.9321 (>1000.0)       1;0        9.2515 (0.00)         10           1
test_unary_ew_ops[floor-dtype8-100000000]                    51.9799 (>1000.0)     59.3524 (>1000.0)     53.7723 (>1000.0)   1.7809 (>1000.0)     53.3353 (>1000.0)   0.5270 (>1000.0)       3;3       18.5970 (0.00)         19           1
test_unary_ew_ops[floor-dtype9-100000000]                    82.8553 (>1000.0)     88.2904 (>1000.0)     84.1428 (>1000.0)   1.5361 (>1000.0)     83.5499 (>1000.0)   1.2148 (>1000.0)       2;1       11.8846 (0.00)         13           1
test_unary_ew_ops[isfinite-dtype0-100000000]                 11.6169 (>1000.0)     17.9489 (629.32)      12.3928 (>1000.0)   0.9380 (>1000.0)     11.9797 (>1000.0)   1.1312 (>1000.0)       6;3       80.6918 (0.00)         85           1
test_unary_ew_ops[isfinite-dtype1-100000000]                 11.6505 (>1000.0)     17.8390 (625.47)      12.0386 (>1000.0)   0.8443 (>1000.0)     11.8422 (>1000.0)   0.1647 (>1000.0)       5;8       83.0659 (0.00)         84           1
test_unary_ew_ops[isfinite-dtype2-100000000]                 11.6599 (>1000.0)     16.3314 (572.61)      12.0569 (>1000.0)   0.7285 (>1000.0)     11.9177 (>1000.0)   0.1718 (>1000.0)       6;7       82.9400 (0.00)         85           1
test_unary_ew_ops[isfinite-dtype3-100000000]                 11.6579 (>1000.0)     16.1516 (566.31)      12.1057 (>1000.0)   0.8133 (>1000.0)     11.8990 (>1000.0)   0.1776 (>1000.0)      6;10       82.6056 (0.00)         84           1
test_unary_ew_ops[isfinite-dtype4-100000000]                 11.5060 (>1000.0)     17.8536 (625.98)      11.9732 (>1000.0)   0.8845 (>1000.0)     11.7889 (>1000.0)   0.1963 (>1000.0)       4;5       83.5196 (0.00)         84           1
test_unary_ew_ops[isfinite-dtype5-100000000]                 11.5088 (>1000.0)     16.0534 (562.86)      11.9652 (>1000.0)   0.7318 (>1000.0)     11.7881 (>1000.0)   0.1987 (>1000.0)       5;7       83.5755 (0.00)         86           1
test_unary_ew_ops[isfinite-dtype6-100000000]                 10.8962 (>1000.0)     15.7514 (552.27)      11.2845 (>1000.0)   0.7808 (>1000.0)     11.0866 (>1000.0)   0.1958 (>1000.0)       6;7       88.6175 (0.00)         89           1
test_unary_ew_ops[isfinite-dtype7-100000000]                 10.8924 (>1000.0)     15.0685 (528.33)      11.4009 (>1000.0)   0.7434 (>1000.0)     11.1261 (>1000.0)   0.5426 (>1000.0)      10;4       87.7121 (0.00)         91           1
test_unary_ew_ops[isfinite-dtype8-100000000]                 44.8347 (>1000.0)     61.1778 (>1000.0)     49.0017 (>1000.0)   3.7068 (>1000.0)     49.2175 (>1000.0)   4.5674 (>1000.0)       3;1       20.4075 (0.00)         22           1
test_unary_ew_ops[isfinite-dtype9-100000000]                 50.8696 (>1000.0)     58.6963 (>1000.0)     52.2520 (>1000.0)   2.1551 (>1000.0)     51.5535 (>1000.0)   0.4742 (>1000.0)       2;3       19.1380 (0.00)         20           1
test_unary_ew_ops[isinf-dtype0-100000000]                    11.6457 (>1000.0)     16.4595 (577.10)      11.9912 (>1000.0)   0.7229 (>1000.0)     11.8222 (>1000.0)   0.1987 (>1000.0)       3;5       83.3943 (0.00)         73           1
test_unary_ew_ops[isinf-dtype1-100000000]                    11.6616 (>1000.0)     16.3981 (574.95)      12.0859 (>1000.0)   0.7444 (>1000.0)     11.9305 (>1000.0)   0.1897 (>1000.0)       5;9       82.7409 (0.00)         83           1
test_unary_ew_ops[isinf-dtype2-100000000]                    11.6328 (>1000.0)     16.2204 (568.72)      12.0535 (>1000.0)   0.7755 (>1000.0)     11.8616 (>1000.0)   0.1678 (>1000.0)       6;8       82.9637 (0.00)         85           1
test_unary_ew_ops[isinf-dtype3-100000000]                    11.6641 (>1000.0)     16.5861 (581.54)      12.0447 (>1000.0)   0.8085 (>1000.0)     11.8698 (>1000.0)   0.1781 (>1000.0)       4;6       83.0238 (0.00)         84           1
test_unary_ew_ops[isinf-dtype4-100000000]                    11.5516 (>1000.0)     16.2886 (571.11)      11.9961 (>1000.0)   0.9106 (>1000.0)     11.7515 (>1000.0)   0.1823 (>1000.0)       6;8       83.3605 (0.00)         85           1
test_unary_ew_ops[isinf-dtype5-100000000]                    11.5374 (>1000.0)     16.3470 (573.16)      11.9673 (>1000.0)   0.7767 (>1000.0)     11.7879 (>1000.0)   0.1992 (>1000.0)       6;7       83.5608 (0.00)         84           1
test_unary_ew_ops[isinf-dtype6-100000000]                    10.8711 (>1000.0)     16.8745 (591.65)      11.5008 (>1000.0)   0.9544 (>1000.0)     11.1389 (>1000.0)   0.3392 (>1000.0)      8;20       86.9507 (0.00)         89           1
test_unary_ew_ops[isinf-dtype7-100000000]                    10.8718 (>1000.0)     16.4632 (577.23)      11.2745 (>1000.0)   0.8072 (>1000.0)     11.0684 (>1000.0)   0.1943 (>1000.0)       5;8       88.6954 (0.00)         92           1
test_unary_ew_ops[isinf-dtype8-100000000]                    46.0114 (>1000.0)     57.9014 (>1000.0)     48.6707 (>1000.0)   3.0812 (>1000.0)     47.1835 (>1000.0)   3.6610 (>1000.0)       3;1       20.5462 (0.00)         22           1
test_unary_ew_ops[isinf-dtype9-100000000]                    51.2816 (>1000.0)     59.6997 (>1000.0)     53.0038 (>1000.0)   2.4810 (>1000.0)     52.0868 (>1000.0)   0.6769 (>1000.0)       2;3       18.8666 (0.00)         16           1
test_unary_ew_ops[isnan-dtype0-100000000]                    11.6151 (>1000.0)     17.5732 (616.15)      12.1509 (>1000.0)   1.0420 (>1000.0)     11.8568 (>1000.0)   0.2036 (>1000.0)       7;8       82.2982 (0.00)         84           1
test_unary_ew_ops[isnan-dtype1-100000000]                    11.6707 (>1000.0)     16.4015 (575.07)      12.0465 (>1000.0)   0.7895 (>1000.0)     11.8629 (>1000.0)   0.1885 (>1000.0)       5;6       83.0119 (0.00)         81           1
test_unary_ew_ops[isnan-dtype2-100000000]                    11.6556 (>1000.0)     15.9895 (560.62)      12.0278 (>1000.0)   0.7245 (>1000.0)     11.8880 (>1000.0)   0.1632 (>1000.0)       4;5       83.1409 (0.00)         85           1
test_unary_ew_ops[isnan-dtype3-100000000]                    11.6347 (>1000.0)     16.3570 (573.51)      12.0517 (>1000.0)   0.7632 (>1000.0)     11.8777 (>1000.0)   0.1513 (>1000.0)       5;8       82.9756 (0.00)         86           1
test_unary_ew_ops[isnan-dtype4-100000000]                    11.5113 (>1000.0)     16.5739 (581.11)      11.8926 (>1000.0)   0.7366 (>1000.0)     11.7132 (>1000.0)   0.2135 (>1000.0)       5;5       84.0861 (0.00)         85           1
test_unary_ew_ops[isnan-dtype5-100000000]                    11.4982 (>1000.0)     16.7635 (587.76)      11.8974 (>1000.0)   0.8094 (>1000.0)     11.7149 (>1000.0)   0.1786 (>1000.0)       4;4       84.0522 (0.00)         72           1
test_unary_ew_ops[isnan-dtype6-100000000]                    10.8810 (>1000.0)     16.7883 (588.63)      11.2590 (>1000.0)   0.8051 (>1000.0)     11.0547 (>1000.0)   0.1600 (>1000.0)       5;8       88.8175 (0.00)         89           1
test_unary_ew_ops[isnan-dtype7-100000000]                    10.8766 (>1000.0)     18.6235 (652.97)      11.5968 (>1000.0)   1.2182 (>1000.0)     11.1561 (>1000.0)   0.5592 (>1000.0)      8;10       86.2310 (0.00)         90           1
test_unary_ew_ops[isnan-dtype8-100000000]                    30.4268 (>1000.0)     37.8106 (>1000.0)     32.8434 (>1000.0)   1.8663 (>1000.0)     33.0158 (>1000.0)   2.7181 (>1000.0)      10;0       30.4475 (0.00)         33           1
test_unary_ew_ops[isnan-dtype9-100000000]                    36.5680 (>1000.0)     42.4189 (>1000.0)     37.7426 (>1000.0)   1.4836 (>1000.0)     37.2051 (>1000.0)   1.3699 (>1000.0)       3;2       26.4952 (0.00)         26           1
test_unary_ew_ops[logical_not-dtype0-100000000]              31.1544 (>1000.0)     34.7817 (>1000.0)     32.1770 (>1000.0)   1.0316 (>1000.0)     31.8055 (>1000.0)   0.7984 (>1000.0)       6;4       31.0781 (0.00)         28           1
test_unary_ew_ops[logical_not-dtype1-100000000]              31.2782 (>1000.0)     38.3696 (>1000.0)     34.1330 (>1000.0)   1.8780 (>1000.0)     34.5033 (>1000.0)   3.5449 (>1000.0)      11;0       29.2971 (0.00)         32           1
test_unary_ew_ops[logical_not-dtype2-100000000]              30.9036 (>1000.0)     36.5573 (>1000.0)     31.9125 (>1000.0)   1.2479 (>1000.0)     31.5897 (>1000.0)   1.0048 (>1000.0)       2;2       31.3357 (0.00)         32           1
test_unary_ew_ops[logical_not-dtype3-100000000]              30.9503 (>1000.0)     35.3164 (>1000.0)     31.9272 (>1000.0)   1.0727 (>1000.0)     31.7692 (>1000.0)   0.9168 (>1000.0)       4;3       31.3213 (0.00)         32           1
test_unary_ew_ops[logical_not-dtype4-100000000]              30.3689 (>1000.0)     37.9808 (>1000.0)     31.3324 (>1000.0)   1.7240 (>1000.0)     30.9822 (>1000.0)   0.3490 (>1000.0)       2;2       31.9159 (0.00)         33           1
test_unary_ew_ops[logical_not-dtype5-100000000]              30.3887 (>1000.0)     36.4138 (>1000.0)     31.3081 (>1000.0)   1.3131 (>1000.0)     30.9464 (>1000.0)   0.4574 (>1000.0)       3;4       31.9406 (0.00)         33           1
test_unary_ew_ops[logical_not-dtype6-100000000]              35.0304 (>1000.0)     42.4819 (>1000.0)     36.0330 (>1000.0)   1.8164 (>1000.0)     35.3107 (>1000.0)   0.9559 (>1000.0)       2;2       27.7523 (0.00)         28           1
test_unary_ew_ops[logical_not-dtype7-100000000]              34.7761 (>1000.0)     42.0776 (>1000.0)     36.3469 (>1000.0)   1.7670 (>1000.0)     36.1868 (>1000.0)   1.3968 (>1000.0)       2;2       27.5127 (0.00)         28           1
test_unary_ew_ops[logical_not-dtype8-100000000]              30.2422 (>1000.0)     36.9424 (>1000.0)     31.1829 (>1000.0)   1.4536 (>1000.0)     30.8190 (>1000.0)   0.2518 (>1000.0)       2;5       32.0689 (0.00)         33           1
test_unary_ew_ops[logical_not-dtype9-100000000]              35.3419 (>1000.0)     40.0162 (>1000.0)     36.2638 (>1000.0)   1.1417 (>1000.0)     35.7323 (>1000.0)   0.8442 (>1000.0)       3;3       27.5757 (0.00)         28           1
test_unary_ew_ops[neg-dtype0-100000000]                      31.4498 (>1000.0)     36.4260 (>1000.0)     32.3192 (>1000.0)   1.0759 (>1000.0)     32.0530 (>1000.0)   0.7297 (>1000.0)       2;2       30.9414 (0.00)         32           1
test_unary_ew_ops[neg-dtype1-100000000]                      31.2124 (>1000.0)     36.1473 (>1000.0)     32.0876 (>1000.0)   1.0975 (>1000.0)     31.8853 (>1000.0)   0.8399 (>1000.0)       3;3       31.1647 (0.00)         32           1
test_unary_ew_ops[neg-dtype2-100000000]                      38.6869 (>1000.0)     45.9341 (>1000.0)     40.0308 (>1000.0)   1.7744 (>1000.0)     39.7172 (>1000.0)   0.8785 (>1000.0)       2;2       24.9808 (0.00)         26           1
test_unary_ew_ops[neg-dtype3-100000000]                      38.9017 (>1000.0)     44.5122 (>1000.0)     40.1221 (>1000.0)   1.2005 (>1000.0)     39.8998 (>1000.0)   0.6277 (>1000.0)       4;3       24.9239 (0.00)         26           1
test_unary_ew_ops[neg-dtype4-100000000]                      49.0358 (>1000.0)     54.7939 (>1000.0)     50.0981 (>1000.0)   1.5876 (>1000.0)     49.6137 (>1000.0)   0.5921 (>1000.0)       2;2       19.9608 (0.00)         20           1
test_unary_ew_ops[neg-dtype5-100000000]                      49.0630 (>1000.0)     53.1860 (>1000.0)     50.0262 (>1000.0)   0.9715 (>1000.0)     49.6922 (>1000.0)   0.5956 (>1000.0)       3;3       19.9895 (0.00)         19           1
test_unary_ew_ops[neg-dtype6-100000000]                      83.0415 (>1000.0)     89.9094 (>1000.0)     84.5578 (>1000.0)   2.1282 (>1000.0)     83.7673 (>1000.0)   0.9020 (>1000.0)       2;2       11.8262 (0.00)         12           1
test_unary_ew_ops[neg-dtype7-100000000]                      83.0920 (>1000.0)     88.4597 (>1000.0)     84.5537 (>1000.0)   1.5491 (>1000.0)     84.1252 (>1000.0)   1.9123 (>1000.0)       1;1       11.8268 (0.00)         12           1
test_unary_ew_ops[neg-dtype8-100000000]                      49.1847 (>1000.0)     56.8464 (>1000.0)     50.2609 (>1000.0)   1.8891 (>1000.0)     49.6700 (>1000.0)   0.4787 (>1000.0)       2;2       19.8962 (0.00)         21           1
test_unary_ew_ops[neg-dtype9-100000000]                      83.3382 (>1000.0)     90.1171 (>1000.0)     85.0948 (>1000.0)   2.3188 (>1000.0)     84.1640 (>1000.0)   1.4921 (>1000.0)       2;2       11.7516 (0.00)         12           1
test_unary_ew_ops[round-dtype0-100000000]                    36.8040 (>1000.0)     41.9397 (>1000.0)     38.3666 (>1000.0)   1.8441 (>1000.0)     37.2701 (>1000.0)   3.3979 (>1000.0)       7;0       26.0644 (0.00)         28           1
test_unary_ew_ops[round-dtype1-100000000]                    36.6356 (>1000.0)     41.9539 (>1000.0)     37.9185 (>1000.0)   1.3724 (>1000.0)     37.2076 (>1000.0)   2.2021 (>1000.0)       6;0       26.3723 (0.00)         26           1
test_unary_ew_ops[round-dtype2-100000000]                    43.7422 (>1000.0)     48.5576 (>1000.0)     44.7536 (>1000.0)   1.0341 (>1000.0)     44.5548 (>1000.0)   0.6059 (>1000.0)       3;3       22.3446 (0.00)         23           1
test_unary_ew_ops[round-dtype3-100000000]                    43.8423 (>1000.0)     48.6212 (>1000.0)     44.9463 (>1000.0)   1.2128 (>1000.0)     44.8901 (>1000.0)   0.7631 (>1000.0)       2;2       22.2488 (0.00)         23           1
test_unary_ew_ops[round-dtype4-100000000]                    52.3412 (>1000.0)     59.6603 (>1000.0)     53.9942 (>1000.0)   1.8928 (>1000.0)     53.5626 (>1000.0)   1.1486 (>1000.0)       2;2       18.5205 (0.00)         20           1
test_unary_ew_ops[round-dtype5-100000000]                    60.4488 (>1000.0)     67.0228 (>1000.0)     62.0965 (>1000.0)   1.9243 (>1000.0)     61.3782 (>1000.0)   1.0617 (>1000.0)       2;2       16.1040 (0.00)         17           1
test_unary_ew_ops[round-dtype6-100000000]                    97.3957 (>1000.0)    103.0598 (>1000.0)     99.0455 (>1000.0)   2.1635 (>1000.0)     98.1037 (>1000.0)   1.6052 (>1000.0)       2;2       10.0964 (0.00)         10           1
test_unary_ew_ops[round-dtype7-100000000]                   103.6234 (>1000.0)    115.1794 (>1000.0)    107.6604 (>1000.0)   4.1558 (>1000.0)    105.9147 (>1000.0)   5.5913 (>1000.0)       2;0        9.2885 (0.00)         10           1
test_unary_ew_ops[round-dtype8-100000000]                    52.4958 (>1000.0)     60.0220 (>1000.0)     54.0801 (>1000.0)   2.0061 (>1000.0)     53.5460 (>1000.0)   0.7867 (>1000.0)       2;2       18.4911 (0.00)         19           1
test_unary_ew_ops[round-dtype9-100000000]                    82.8371 (>1000.0)     87.8850 (>1000.0)     84.1916 (>1000.0)   1.5250 (>1000.0)     83.4634 (>1000.0)   1.4336 (>1000.0)       2;1       11.8777 (0.00)         13           1
test_unary_ew_ops[trunc-dtype0-100000000]                    24.2012 (>1000.0)     29.0794 (>1000.0)     24.8761 (>1000.0)   1.0828 (>1000.0)     24.5618 (>1000.0)   0.2273 (>1000.0)       4;4       40.1993 (0.00)         41           1
test_unary_ew_ops[trunc-dtype1-100000000]                    24.1091 (>1000.0)     30.3486 (>1000.0)     24.9386 (>1000.0)   1.3235 (>1000.0)     24.5363 (>1000.0)   0.3869 (>1000.0)       3;4       40.0985 (0.00)         41           1
test_unary_ew_ops[trunc-dtype2-100000000]                    32.2576 (>1000.0)     40.9801 (>1000.0)     33.1564 (>1000.0)   2.0653 (>1000.0)     32.6348 (>1000.0)   0.2342 (>1000.0)       2;3       30.1601 (0.00)         31           1
test_unary_ew_ops[trunc-dtype3-100000000]                    32.2782 (>1000.0)     37.5579 (>1000.0)     33.0462 (>1000.0)   1.2509 (>1000.0)     32.5981 (>1000.0)   0.3515 (>1000.0)       4;5       30.2606 (0.00)         30           1
test_unary_ew_ops[trunc-dtype4-100000000]                    47.8635 (>1000.0)     52.5654 (>1000.0)     49.5045 (>1000.0)   1.1701 (>1000.0)     49.2538 (>1000.0)   0.8636 (>1000.0)       7;3       20.2002 (0.00)         21           1
test_unary_ew_ops[trunc-dtype5-100000000]                    47.8908 (>1000.0)     55.6338 (>1000.0)     49.4345 (>1000.0)   1.7592 (>1000.0)     48.9546 (>1000.0)   1.3343 (>1000.0)       2;2       20.2288 (0.00)         21           1
test_unary_ew_ops[trunc-dtype6-100000000]                    91.4717 (>1000.0)     95.8105 (>1000.0)     93.1848 (>1000.0)   1.3632 (>1000.0)     93.1737 (>1000.0)   2.0783 (>1000.0)       4;0       10.7314 (0.00)         11           1
test_unary_ew_ops[trunc-dtype7-100000000]                   100.3658 (>1000.0)    111.1009 (>1000.0)    103.4587 (>1000.0)   3.9299 (>1000.0)    101.3074 (>1000.0)   5.1354 (>1000.0)       2;0        9.6657 (0.00)         10           1
test_unary_ew_ops[trunc-dtype8-100000000]                    49.4791 (>1000.0)     57.2347 (>1000.0)     50.7324 (>1000.0)   2.1786 (>1000.0)     50.0963 (>1000.0)   0.7886 (>1000.0)       2;2       19.7113 (0.00)         20           1
test_unary_ew_ops[trunc-dtype9-100000000]                    82.9746 (>1000.0)     89.4538 (>1000.0)     84.4106 (>1000.0)   2.3618 (>1000.0)     83.5159 (>1000.0)   0.5576 (>1000.0)       2;2       11.8469 (0.00)         12           1
test_unary_ew_ops_numpy[abs-dtype0-100000000]                31.6428 (>1000.0)     33.5491 (>1000.0)     32.1465 (>1000.0)   0.4585 (825.91)      31.9988 (>1000.0)   0.3402 (>1000.0)       6;4       31.1076 (0.00)         32           1
test_unary_ew_ops_numpy[abs-dtype1-100000000]                12.5306 (>1000.0)     14.3740 (503.98)      12.9043 (>1000.0)   0.3456 (622.65)      12.8263 (>1000.0)   0.1800 (>1000.0)      10;7       77.4935 (0.00)         76           1
test_unary_ew_ops_numpy[abs-dtype2-100000000]                35.9486 (>1000.0)     38.9344 (>1000.0)     36.3780 (>1000.0)   0.6590 (>1000.0)     36.1025 (>1000.0)   0.4155 (>1000.0)       2;2       27.4891 (0.00)         28           1
test_unary_ew_ops_numpy[abs-dtype3-100000000]                24.9256 (>1000.0)     28.0973 (985.15)      25.5177 (>1000.0)   0.6174 (>1000.0)     25.3507 (>1000.0)   0.2617 (>1000.0)       4;5       39.1885 (0.00)         40           1
test_unary_ew_ops_numpy[abs-dtype4-100000000]                53.9679 (>1000.0)     57.5744 (>1000.0)     54.9172 (>1000.0)   1.0981 (>1000.0)     54.4430 (>1000.0)   0.5946 (>1000.0)       3;3       18.2092 (0.00)         19           1
test_unary_ew_ops_numpy[abs-dtype5-100000000]                50.8911 (>1000.0)     54.7726 (>1000.0)     51.7163 (>1000.0)   1.0187 (>1000.0)     51.3146 (>1000.0)   0.7190 (>1000.0)       3;3       19.3363 (0.00)         20           1
test_unary_ew_ops_numpy[abs-dtype6-100000000]               121.6564 (>1000.0)    125.5578 (>1000.0)    122.7150 (>1000.0)   1.4382 (>1000.0)    122.0938 (>1000.0)   1.2262 (>1000.0)       2;1        8.1490 (0.00)          9           1
test_unary_ew_ops_numpy[abs-dtype7-100000000]               100.6715 (>1000.0)    105.6474 (>1000.0)    102.0194 (>1000.0)   1.6394 (>1000.0)    101.5784 (>1000.0)   1.4163 (>1000.0)       2;1        9.8021 (0.00)         10           1
test_unary_ew_ops_numpy[abs-dtype8-100000000]                51.0894 (>1000.0)     54.6458 (>1000.0)     52.0625 (>1000.0)   1.0426 (>1000.0)     51.7340 (>1000.0)   0.9172 (>1000.0)       3;3       19.2077 (0.00)         19           1
test_unary_ew_ops_numpy[abs-dtype9-100000000]               102.0327 (>1000.0)    106.7242 (>1000.0)    103.6868 (>1000.0)   1.6726 (>1000.0)    103.0324 (>1000.0)   3.1821 (>1000.0)       3;0        9.6444 (0.00)         10           1
test_unary_ew_ops_numpy[ceil-dtype0-100000000]              949.1488 (>1000.0)    952.5303 (>1000.0)    950.4683 (>1000.0)   1.2512 (>1000.0)    950.2726 (>1000.0)   1.1470 (>1000.0)       2;0        1.0521 (0.00)          5           1
test_unary_ew_ops_numpy[ceil-dtype1-100000000]              965.3768 (>1000.0)    970.1344 (>1000.0)    967.6983 (>1000.0)   1.9036 (>1000.0)    968.0790 (>1000.0)   2.9969 (>1000.0)       2;0        1.0334 (0.00)          5           1
test_unary_ew_ops_numpy[ceil-dtype2-100000000]               53.6459 (>1000.0)     56.6998 (>1000.0)     54.8052 (>1000.0)   0.8460 (>1000.0)     54.4860 (>1000.0)   1.0219 (>1000.0)       4;1       18.2464 (0.00)         19           1
test_unary_ew_ops_numpy[ceil-dtype3-100000000]               53.0789 (>1000.0)     57.1279 (>1000.0)     53.9432 (>1000.0)   0.9790 (>1000.0)     53.6682 (>1000.0)   0.6175 (>1000.0)       2;2       18.5380 (0.00)         18           1
test_unary_ew_ops_numpy[ceil-dtype4-100000000]              106.3903 (>1000.0)    109.8003 (>1000.0)    107.4514 (>1000.0)   1.2632 (>1000.0)    106.9903 (>1000.0)   0.9323 (>1000.0)       2;2        9.3065 (0.00)         10           1
test_unary_ew_ops_numpy[ceil-dtype5-100000000]              113.4925 (>1000.0)    116.6215 (>1000.0)    114.4578 (>1000.0)   1.1557 (>1000.0)    114.0580 (>1000.0)   0.9437 (>1000.0)       2;2        8.7368 (0.00)          9           1
test_unary_ew_ops_numpy[ceil-dtype6-100000000]              131.9005 (>1000.0)    136.7950 (>1000.0)    133.1183 (>1000.0)   1.7033 (>1000.0)    132.3490 (>1000.0)   1.4770 (>1000.0)       1;1        7.5121 (0.00)          8           1
test_unary_ew_ops_numpy[ceil-dtype7-100000000]              141.8925 (>1000.0)    146.4846 (>1000.0)    143.5445 (>1000.0)   1.4878 (>1000.0)    143.4298 (>1000.0)   1.7929 (>1000.0)       2;0        6.9665 (0.00)          8           1
test_unary_ew_ops_numpy[ceil-dtype8-100000000]               51.4392 (>1000.0)     55.0510 (>1000.0)     52.3609 (>1000.0)   0.9852 (>1000.0)     52.1189 (>1000.0)   0.6716 (>1000.0)       2;2       19.0982 (0.00)         20           1
test_unary_ew_ops_numpy[ceil-dtype9-100000000]              102.9005 (>1000.0)    106.6988 (>1000.0)    103.8891 (>1000.0)   1.2395 (>1000.0)    103.2618 (>1000.0)   1.4387 (>1000.0)       2;1        9.6257 (0.00)         10           1
test_unary_ew_ops_numpy[floor-dtype0-100000000]             998.6144 (>1000.0)  1,019.9952 (>1000.0)  1,009.6404 (>1000.0)   8.0293 (>1000.0)  1,009.0437 (>1000.0)  10.9504 (>1000.0)       2;0        0.9905 (0.00)          5           1
test_unary_ew_ops_numpy[floor-dtype1-100000000]             994.6539 (>1000.0)  1,001.3607 (>1000.0)    998.1661 (>1000.0)   2.7459 (>1000.0)    999.0711 (>1000.0)   4.4069 (>1000.0)       2;0        1.0018 (0.00)          5           1
test_unary_ew_ops_numpy[floor-dtype2-100000000]              53.5847 (>1000.0)     57.3383 (>1000.0)     54.7426 (>1000.0)   1.0727 (>1000.0)     54.3916 (>1000.0)   0.6858 (>1000.0)       4;3       18.2673 (0.00)         19           1
test_unary_ew_ops_numpy[floor-dtype3-100000000]              53.0100 (>1000.0)     56.4130 (>1000.0)     53.7854 (>1000.0)   0.9544 (>1000.0)     53.4687 (>1000.0)   0.4728 (>1000.0)       3;3       18.5924 (0.00)         18           1
test_unary_ew_ops_numpy[floor-dtype4-100000000]             105.9741 (>1000.0)    109.4179 (>1000.0)    107.0033 (>1000.0)   1.0553 (>1000.0)    106.6924 (>1000.0)   1.2699 (>1000.0)       1;1        9.3455 (0.00)         10           1
test_unary_ew_ops_numpy[floor-dtype5-100000000]             112.1341 (>1000.0)    115.3481 (>1000.0)    113.7104 (>1000.0)   1.2224 (>1000.0)    113.4889 (>1000.0)   2.2269 (>1000.0)       5;0        8.7943 (0.00)          9           1
test_unary_ew_ops_numpy[floor-dtype6-100000000]             129.8410 (>1000.0)    133.5688 (>1000.0)    131.1501 (>1000.0)   1.5103 (>1000.0)    130.3452 (>1000.0)   2.6272 (>1000.0)       2;0        7.6249 (0.00)          8           1
test_unary_ew_ops_numpy[floor-dtype7-100000000]             148.2688 (>1000.0)    152.5496 (>1000.0)    150.0947 (>1000.0)   1.9114 (>1000.0)    149.2675 (>1000.0)   3.5997 (>1000.0)       2;0        6.6625 (0.00)          7           1
test_unary_ew_ops_numpy[floor-dtype8-100000000]              51.3987 (>1000.0)     55.7634 (>1000.0)     52.3615 (>1000.0)   1.0814 (>1000.0)     52.0118 (>1000.0)   0.5629 (>1000.0)       2;3       19.0980 (0.00)         19           1
test_unary_ew_ops_numpy[floor-dtype9-100000000]             102.6270 (>1000.0)    107.4848 (>1000.0)    104.3247 (>1000.0)   1.9661 (>1000.0)    103.3696 (>1000.0)   3.4195 (>1000.0)       3;0        9.5855 (0.00)         10           1
test_unary_ew_ops_numpy[isfinite-dtype0-100000000]            8.0633 (>1000.0)      9.7042 (340.25)       8.3396 (>1000.0)   0.2382 (429.04)       8.2921 (>1000.0)   0.2077 (>1000.0)      18;7      119.9100 (0.00)        120           1
test_unary_ew_ops_numpy[isfinite-dtype1-100000000]            8.0745 (>1000.0)      9.8749 (346.23)       8.3137 (>1000.0)   0.2546 (458.66)       8.2514 (>1000.0)   0.1618 (>1000.0)       8;8      120.2838 (0.00)        115           1
test_unary_ew_ops_numpy[isfinite-dtype2-100000000]            8.0602 (>1000.0)      9.5814 (335.94)       8.3186 (>1000.0)   0.2254 (406.00)       8.2707 (>1000.0)   0.1958 (>1000.0)      19;7      120.2125 (0.00)        120           1
test_unary_ew_ops_numpy[isfinite-dtype3-100000000]            8.0819 (>1000.0)      9.2929 (325.83)       8.3661 (>1000.0)   0.2402 (432.78)       8.3104 (>1000.0)   0.2450 (>1000.0)      23;8      119.5298 (0.00)        120           1
test_unary_ew_ops_numpy[isfinite-dtype4-100000000]            8.0531 (>1000.0)      9.5005 (333.11)       8.3074 (>1000.0)   0.2309 (416.05)       8.2846 (>1000.0)   0.2120 (>1000.0)      16;6      120.3748 (0.00)        108           1
test_unary_ew_ops_numpy[isfinite-dtype5-100000000]            8.0799 (>1000.0)      9.2826 (325.47)       8.3356 (>1000.0)   0.2430 (437.77)       8.2754 (>1000.0)   0.2204 (>1000.0)      15;9      119.9678 (0.00)        119           1
test_unary_ew_ops_numpy[isfinite-dtype6-100000000]            8.0703 (>1000.0)      9.1577 (321.09)       8.2869 (>1000.0)   0.2179 (392.50)       8.2390 (>1000.0)   0.2150 (>1000.0)     12;11      120.6726 (0.00)        121           1
test_unary_ew_ops_numpy[isfinite-dtype7-100000000]            8.0748 (>1000.0)     10.0400 (352.02)       8.4813 (>1000.0)   0.4004 (721.35)       8.3784 (>1000.0)   0.3196 (>1000.0)      12;9      117.9064 (0.00)        108           1
test_unary_ew_ops_numpy[isfinite-dtype8-100000000]           30.1357 (>1000.0)     34.0176 (>1000.0)     30.7145 (>1000.0)   0.7963 (>1000.0)     30.4070 (>1000.0)   0.3847 (>1000.0)       4;5       32.5579 (0.00)         33           1
test_unary_ew_ops_numpy[isfinite-dtype9-100000000]           52.3990 (>1000.0)     56.1547 (>1000.0)     53.6643 (>1000.0)   1.1861 (>1000.0)     53.1375 (>1000.0)   1.7427 (>1000.0)       6;0       18.6344 (0.00)         19           1
test_unary_ew_ops_numpy[isinf-dtype0-100000000]               8.0424 (>1000.0)      9.3389 (327.44)       8.3265 (>1000.0)   0.2396 (431.58)       8.2762 (>1000.0)   0.2474 (>1000.0)      26;7      120.0981 (0.00)        118           1
test_unary_ew_ops_numpy[isinf-dtype1-100000000]               8.0682 (>1000.0)      9.6340 (337.79)       8.3680 (>1000.0)   0.2826 (509.14)       8.2785 (>1000.0)   0.2005 (>1000.0)     16;14      119.5028 (0.00)        118           1
test_unary_ew_ops_numpy[isinf-dtype2-100000000]               8.0628 (>1000.0)      9.2347 (323.79)       8.3210 (>1000.0)   0.2148 (386.88)       8.2902 (>1000.0)   0.1681 (>1000.0)      24;9      120.1780 (0.00)        118           1
test_unary_ew_ops_numpy[isinf-dtype3-100000000]               8.0864 (>1000.0)      9.3101 (326.43)       8.3528 (>1000.0)   0.2252 (405.76)       8.3260 (>1000.0)   0.2592 (>1000.0)      30;6      119.7199 (0.00)        120           1
test_unary_ew_ops_numpy[isinf-dtype4-100000000]               8.0462 (>1000.0)      9.2515 (324.37)       8.3707 (>1000.0)   0.2673 (481.49)       8.3274 (>1000.0)   0.2536 (>1000.0)      27;9      119.4638 (0.00)        117           1
test_unary_ew_ops_numpy[isinf-dtype5-100000000]               8.0829 (>1000.0)      9.3936 (329.36)       8.3041 (>1000.0)   0.2226 (401.08)       8.2597 (>1000.0)   0.1890 (>1000.0)      11;8      120.4230 (0.00)        119           1
test_unary_ew_ops_numpy[isinf-dtype6-100000000]               8.0266 (>1000.0)      9.3311 (327.17)       8.2852 (>1000.0)   0.2474 (445.70)       8.2448 (>1000.0)   0.2496 (>1000.0)      11;8      120.6968 (0.00)        121           1
test_unary_ew_ops_numpy[isinf-dtype7-100000000]               8.0698 (>1000.0)      9.2327 (323.72)       8.3253 (>1000.0)   0.2433 (438.26)       8.2646 (>1000.0)   0.2178 (>1000.0)      15;9      120.1160 (0.00)        120           1
test_unary_ew_ops_numpy[isinf-dtype8-100000000]              30.4443 (>1000.0)     34.0919 (>1000.0)     31.0879 (>1000.0)   0.8365 (>1000.0)     30.8424 (>1000.0)   0.3266 (>1000.0)       3;5       32.1669 (0.00)         33           1
test_unary_ew_ops_numpy[isinf-dtype9-100000000]              53.9351 (>1000.0)     58.0016 (>1000.0)     54.9561 (>1000.0)   1.1378 (>1000.0)     54.3900 (>1000.0)   0.8909 (>1000.0)       3;3       18.1963 (0.00)         19           1
test_unary_ew_ops_numpy[isnan-dtype0-100000000]               8.0407 (>1000.0)      9.3737 (328.66)       8.3166 (>1000.0)   0.2337 (420.96)       8.2737 (>1000.0)   0.1759 (>1000.0)     24;10      120.2415 (0.00)        117           1
test_unary_ew_ops_numpy[isnan-dtype1-100000000]               8.0679 (>1000.0)      9.4360 (330.84)       8.3585 (>1000.0)   0.2342 (421.97)       8.3084 (>1000.0)   0.1995 (>1000.0)      18;9      119.6391 (0.00)        120           1
test_unary_ew_ops_numpy[isnan-dtype2-100000000]               8.0475 (>1000.0)      9.1655 (321.36)       8.3115 (>1000.0)   0.2241 (403.79)       8.2543 (>1000.0)   0.2871 (>1000.0)      27;5      120.3153 (0.00)        112           1
test_unary_ew_ops_numpy[isnan-dtype3-100000000]               8.0653 (>1000.0)      9.5044 (333.24)       8.3616 (>1000.0)   0.2493 (449.16)       8.3189 (>1000.0)   0.2332 (>1000.0)      16;7      119.5936 (0.00)        120           1
test_unary_ew_ops_numpy[isnan-dtype4-100000000]               8.0459 (>1000.0)      9.2718 (325.09)       8.3277 (>1000.0)   0.2541 (457.84)       8.2907 (>1000.0)   0.2462 (>1000.0)     27;10      120.0819 (0.00)        113           1
test_unary_ew_ops_numpy[isnan-dtype5-100000000]               8.0868 (>1000.0)      9.2500 (324.32)       8.3596 (>1000.0)   0.2317 (417.40)       8.3119 (>1000.0)   0.2228 (>1000.0)      28;9      119.6223 (0.00)        120           1
test_unary_ew_ops_numpy[isnan-dtype6-100000000]               8.0384 (>1000.0)      9.4621 (331.76)       8.3765 (>1000.0)   0.2971 (535.28)       8.2836 (>1000.0)   0.2890 (>1000.0)      24;7      119.3818 (0.00)        116           1
test_unary_ew_ops_numpy[isnan-dtype7-100000000]               8.0803 (>1000.0)      9.6410 (338.03)       8.3562 (>1000.0)   0.2520 (454.02)       8.3026 (>1000.0)   0.2463 (>1000.0)      16;8      119.6711 (0.00)        118           1
test_unary_ew_ops_numpy[isnan-dtype8-100000000]              27.1037 (>1000.0)     30.3477 (>1000.0)     27.6577 (>1000.0)   0.7066 (>1000.0)     27.4412 (>1000.0)   0.3435 (>1000.0)       3;3       36.1564 (0.00)         36           1
test_unary_ew_ops_numpy[isnan-dtype9-100000000]              47.0612 (>1000.0)     51.3442 (>1000.0)     48.0232 (>1000.0)   1.0906 (>1000.0)     47.6743 (>1000.0)   0.4095 (>1000.0)       3;4       20.8233 (0.00)         21           1
test_unary_ew_ops_numpy[logical_not-dtype0-100000000]        12.8343 (>1000.0)     14.8568 (520.91)      13.1495 (>1000.0)   0.3796 (683.77)      13.0148 (>1000.0)   0.2066 (>1000.0)       6;7       76.0485 (0.00)         76           1
test_unary_ew_ops_numpy[logical_not-dtype1-100000000]        12.8213 (>1000.0)     14.8320 (520.04)      13.1594 (>1000.0)   0.3425 (617.07)      13.0475 (>1000.0)   0.2873 (>1000.0)       8;6       75.9915 (0.00)         76           1
test_unary_ew_ops_numpy[logical_not-dtype2-100000000]        18.3402 (>1000.0)     20.7369 (727.07)      18.7375 (>1000.0)   0.4844 (872.60)      18.6031 (>1000.0)   0.2724 (>1000.0)       5;5       53.3689 (0.00)         53           1
test_unary_ew_ops_numpy[logical_not-dtype3-100000000]        18.4121 (>1000.0)     20.4142 (715.76)      18.7401 (>1000.0)   0.4671 (841.56)      18.5961 (>1000.0)   0.2748 (>1000.0)       6;6       53.3614 (0.00)         53           1
test_unary_ew_ops_numpy[logical_not-dtype4-100000000]        28.7642 (>1000.0)     32.5419 (>1000.0)     29.2672 (>1000.0)   0.7539 (>1000.0)     29.0325 (>1000.0)   0.4505 (>1000.0)       3;3       34.1680 (0.00)         35           1
test_unary_ew_ops_numpy[logical_not-dtype5-100000000]        28.6739 (>1000.0)     31.0428 (>1000.0)     29.2698 (>1000.0)   0.6467 (>1000.0)     29.0225 (>1000.0)   0.3650 (>1000.0)       5;5       34.1649 (0.00)         34           1
test_unary_ew_ops_numpy[logical_not-dtype6-100000000]        48.9204 (>1000.0)     53.6256 (>1000.0)     49.6715 (>1000.0)   1.1892 (>1000.0)     49.3107 (>1000.0)   0.5710 (>1000.0)       2;2       20.1323 (0.00)         21           1
test_unary_ew_ops_numpy[logical_not-dtype7-100000000]        48.7729 (>1000.0)     53.7975 (>1000.0)     49.7333 (>1000.0)   1.3860 (>1000.0)     49.1484 (>1000.0)   0.5797 (>1000.0)       3;3       20.1073 (0.00)         21           1
test_unary_ew_ops_numpy[logical_not-dtype8-100000000]        71.1351 (>1000.0)     73.0361 (>1000.0)     71.6235 (>1000.0)   0.6119 (>1000.0)     71.4345 (>1000.0)   0.4997 (>1000.0)       2;2       13.9619 (0.00)         15           1
test_unary_ew_ops_numpy[logical_not-dtype9-100000000]        79.2917 (>1000.0)     83.4476 (>1000.0)     80.2461 (>1000.0)   1.3283 (>1000.0)     79.7185 (>1000.0)   0.5936 (>1000.0)       2;2       12.4617 (0.00)         13           1
test_unary_ew_ops_numpy[neg-dtype0-100000000]                12.5183 (>1000.0)     14.0209 (491.60)      12.9092 (>1000.0)   0.3363 (605.83)      12.8067 (>1000.0)   0.2287 (>1000.0)      11;8       77.4638 (0.00)         76           1
test_unary_ew_ops_numpy[neg-dtype1-100000000]                12.6000 (>1000.0)     14.7037 (515.54)      12.9562 (>1000.0)   0.3866 (696.42)      12.8456 (>1000.0)   0.2516 (>1000.0)       7;5       77.1834 (0.00)         77           1
test_unary_ew_ops_numpy[neg-dtype2-100000000]                25.1915 (>1000.0)     27.7919 (974.44)      25.6570 (>1000.0)   0.5864 (>1000.0)     25.4324 (>1000.0)   0.3742 (>1000.0)       5;5       38.9758 (0.00)         37           1
test_unary_ew_ops_numpy[neg-dtype3-100000000]                25.1518 (>1000.0)     29.0276 (>1000.0)     25.6447 (>1000.0)   0.7162 (>1000.0)     25.4058 (>1000.0)   0.4263 (>1000.0)       4;4       38.9945 (0.00)         40           1
test_unary_ew_ops_numpy[neg-dtype4-100000000]                51.0306 (>1000.0)     54.5504 (>1000.0)     51.8532 (>1000.0)   1.0919 (>1000.0)     51.4290 (>1000.0)   0.6345 (>1000.0)       3;3       19.2852 (0.00)         20           1
test_unary_ew_ops_numpy[neg-dtype5-100000000]                50.8730 (>1000.0)     55.2784 (>1000.0)     51.6479 (>1000.0)   1.0003 (>1000.0)     51.2162 (>1000.0)   0.6919 (>1000.0)       2;1       19.3619 (0.00)         20           1
test_unary_ew_ops_numpy[neg-dtype6-100000000]               102.0945 (>1000.0)    109.9837 (>1000.0)    104.1127 (>1000.0)   2.3840 (>1000.0)    103.5152 (>1000.0)   2.3476 (>1000.0)       1;1        9.6050 (0.00)         10           1
test_unary_ew_ops_numpy[neg-dtype7-100000000]               101.9838 (>1000.0)    105.8165 (>1000.0)    103.1658 (>1000.0)   1.3253 (>1000.0)    102.6701 (>1000.0)   1.1174 (>1000.0)       2;2        9.6931 (0.00)         10           1
test_unary_ew_ops_numpy[neg-dtype8-100000000]                51.1969 (>1000.0)     54.3105 (>1000.0)     51.8869 (>1000.0)   0.8048 (>1000.0)     51.5700 (>1000.0)   0.7064 (>1000.0)       2;2       19.2727 (0.00)         20           1
test_unary_ew_ops_numpy[neg-dtype9-100000000]               101.9141 (>1000.0)    105.8364 (>1000.0)    103.0536 (>1000.0)   1.4323 (>1000.0)    102.3844 (>1000.0)   1.4782 (>1000.0)       2;1        9.7037 (0.00)         10           1
test_unary_ew_ops_numpy[round-dtype0-100000000]               0.0010 (1.0)          0.0285 (1.0)          0.0012 (1.02)      0.0007 (1.35)         0.0011 (1.0)       0.0000 (1.04)    1307;6973  865,170.3655 (0.98)      66033           1
test_unary_ew_ops_numpy[round-dtype1-100000000]               0.0011 (1.02)         0.0359 (1.26)         0.0012 (1.03)      0.0006 (1.01)         0.0012 (1.05)      0.0000 (1.92)      127;333  856,404.5091 (0.97)      92277           1
test_unary_ew_ops_numpy[round-dtype2-100000000]               0.0011 (1.03)         0.0294 (1.03)         0.0011 (1.0)       0.0006 (1.0)          0.0011 (1.01)      0.0000 (1.0)      135;3970  878,573.9426 (1.0)       96778           1
test_unary_ew_ops_numpy[round-dtype3-100000000]               0.0011 (1.02)         0.0321 (1.13)         0.0012 (1.03)      0.0007 (1.24)         0.0011 (1.04)      0.0001 (2.92)      201;324  856,029.9648 (0.97)      99592           1
test_unary_ew_ops_numpy[round-dtype4-100000000]               0.0011 (1.03)         0.0640 (2.24)         0.0011 (1.01)      0.0006 (1.13)         0.0011 (1.02)      0.0000 (1.44)     160;3912  870,485.7618 (0.99)      95511           1
test_unary_ew_ops_numpy[round-dtype5-100000000]               0.0011 (1.02)         0.0321 (1.13)         0.0012 (1.02)      0.0007 (1.21)         0.0011 (1.02)      0.0001 (2.60)      188;345  861,017.7672 (0.98)      91291           1
test_unary_ew_ops_numpy[round-dtype6-100000000]               0.0011 (1.03)         0.0648 (2.27)         0.0012 (1.02)      0.0008 (1.50)         0.0011 (1.02)      0.0000 (1.00)     224;5471  862,085.5363 (0.98)      92251           1
test_unary_ew_ops_numpy[round-dtype7-100000000]               0.0011 (1.02)         0.0313 (1.10)         0.0011 (1.00)      0.0006 (1.08)         0.0011 (1.01)      0.0000 (1.12)     172;3930  876,095.0557 (1.00)      95049           1
test_unary_ew_ops_numpy[round-dtype8-100000000]              51.9346 (>1000.0)     55.3641 (>1000.0)     52.6030 (>1000.0)   1.0255 (>1000.0)     52.1878 (>1000.0)   0.3318 (>1000.0)       2;4       19.0103 (0.00)         20           1
test_unary_ew_ops_numpy[round-dtype9-100000000]             102.8550 (>1000.0)    106.4171 (>1000.0)    103.9383 (>1000.0)   1.3421 (>1000.0)    103.3801 (>1000.0)   1.3768 (>1000.0)       2;1        9.6211 (0.00)         10           1
test_unary_ew_ops_numpy[trunc-dtype0-100000000]             946.4069 (>1000.0)    948.5548 (>1000.0)    947.5895 (>1000.0)   0.8391 (>1000.0)    947.5479 (>1000.0)   1.2487 (>1000.0)       2;0        1.0553 (0.00)          5           1
test_unary_ew_ops_numpy[trunc-dtype1-100000000]             949.5361 (>1000.0)    954.7472 (>1000.0)    952.5346 (>1000.0)   1.9690 (>1000.0)    952.9485 (>1000.0)   2.5494 (>1000.0)       2;0        1.0498 (0.00)          5           1
test_unary_ew_ops_numpy[trunc-dtype2-100000000]              54.0420 (>1000.0)     57.3113 (>1000.0)     54.7909 (>1000.0)   0.9411 (>1000.0)     54.4285 (>1000.0)   0.5763 (>1000.0)       2;2       18.2512 (0.00)         19           1
test_unary_ew_ops_numpy[trunc-dtype3-100000000]              56.9898 (>1000.0)     59.7286 (>1000.0)     57.5790 (>1000.0)   0.7557 (>1000.0)     57.3460 (>1000.0)   0.4405 (>1000.0)       3;3       17.3674 (0.00)         18           1
test_unary_ew_ops_numpy[trunc-dtype4-100000000]             108.1338 (>1000.0)    112.1832 (>1000.0)    109.4460 (>1000.0)   1.5156 (>1000.0)    108.6217 (>1000.0)   2.1446 (>1000.0)       2;0        9.1369 (0.00)          9           1
test_unary_ew_ops_numpy[trunc-dtype5-100000000]             114.8019 (>1000.0)    118.4822 (>1000.0)    115.8142 (>1000.0)   1.3101 (>1000.0)    115.2196 (>1000.0)   1.4913 (>1000.0)       2;0        8.6345 (0.00)          9           1
test_unary_ew_ops_numpy[trunc-dtype6-100000000]             132.1214 (>1000.0)    138.6124 (>1000.0)    134.4954 (>1000.0)   2.5069 (>1000.0)    133.3639 (>1000.0)   4.2004 (>1000.0)       2;0        7.4352 (0.00)          8           1
test_unary_ew_ops_numpy[trunc-dtype7-100000000]             149.4853 (>1000.0)    153.5155 (>1000.0)    151.0060 (>1000.0)   1.8297 (>1000.0)    149.7212 (>1000.0)   3.1959 (>1000.0)       1;0        6.6223 (0.00)          7           1
test_unary_ew_ops_numpy[trunc-dtype8-100000000]              52.0216 (>1000.0)     55.9734 (>1000.0)     52.8173 (>1000.0)   1.0062 (>1000.0)     52.4166 (>1000.0)   0.5999 (>1000.0)       3;3       18.9332 (0.00)         19           1
test_unary_ew_ops_numpy[trunc-dtype9-100000000]             102.5434 (>1000.0)    107.1712 (>1000.0)    103.8015 (>1000.0)   1.6937 (>1000.0)    103.0370 (>1000.0)   0.7960 (>1000.0)       2;2        9.6338 (0.00)         10           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
====================================================================================================== 216 passed in 454.85s (0:07:34) ======================================================================================================
```

</details>

Notes:
- The enumerated `dtype`s are in the following order
    - All types:
    ```
    o3c.int8,
    o3c.uint8,
    o3c.int16,
    o3c.uint16,
    o3c.int32,
    o3c.uint32,
    o3c.int64,
    o3c.uint64,
    o3c.float32,
    o3c.float64,
    ```
    - Float types:
    ```
    o3c.float32,
    o3c.float64,
    ```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4117)
<!-- Reviewable:end -->
