### PR TITLE
Join Identical Vertices [Fixing #3799]

### DIFF
--- a/cpp/open3d/io/file_format/FileASSIMP.cpp
+++ b/cpp/open3d/io/file_format/FileASSIMP.cpp
@@ -55,10 +55,13 @@ FileGeometry ReadFileGeometryTypeFBX(const std::string& path) {
     return FileGeometry(CONTAINS_TRIANGLES | CONTAINS_POINTS);
 }
 
-const unsigned int kPostProcessFlags =
-        aiProcess_GenNormals | aiProcess_RemoveRedundantMaterials |
-        aiProcess_Triangulate | aiProcess_GenUVCoords | aiProcess_SortByPType |
-        aiProcess_OptimizeMeshes | aiProcess_PreTransformVertices;
+const unsigned int kPostProcessFlags_compulsory =
+        aiProcess_JoinIdenticalVertices;
+
+const unsigned int kPostProcessFlags_fast =
+        aiProcessPreset_TargetRealtime_Fast |
+        aiProcess_RemoveRedundantMaterials | aiProcess_OptimizeMeshes |
+        aiProcess_PreTransformVertices;
 
 struct TextureImages {
     std::shared_ptr<geometry::Image> albedo;
@@ -143,10 +146,10 @@ bool ReadTriangleMeshUsingASSIMP(
         const ReadTriangleMeshOptions& params /*={}*/) {
     Assimp::Importer importer;
 
-    unsigned int post_process_flags = 0;
+    unsigned int post_process_flags = kPostProcessFlags_compulsory;
 
     if (params.enable_post_processing) {
-        post_process_flags = kPostProcessFlags;
+        post_process_flags = kPostProcessFlags_fast;
     }
 
     const auto* scene = importer.ReadFile(filename.c_str(), post_process_flags);
@@ -305,7 +308,8 @@ bool ReadModelUsingAssimp(const std::string& filename,
     // is silent on this salient point).
     importer.SetProgressHandler(
             new AssimpProgress(params, readfile_total / progress_total));
-    const auto* scene = importer.ReadFile(filename.c_str(), kPostProcessFlags);
+    const auto* scene =
+            importer.ReadFile(filename.c_str(), kPostProcessFlags_fast);
     if (!scene) {
         utility::LogWarning("Unable to load file {} with ASSIMP", filename);
         return false;

--- a/cpp/tests/t/io/TriangleMeshIO.cpp
+++ b/cpp/tests/t/io/TriangleMeshIO.cpp
@@ -59,41 +59,39 @@ TEST(TriangleMeshIO, ReadWriteTriangleMeshOBJ) {
     EXPECT_TRUE(t::io::ReadTriangleMesh(
             utility::GetDataPathDownload("tests/cube.obj"), mesh));
 
-    core::Tensor triangles = core::Tensor::Init<int64_t>({{0, 1, 2},
-                                                          {3, 4, 5},
-                                                          {6, 7, 8},
-                                                          {9, 10, 11},
-                                                          {12, 13, 14},
-                                                          {15, 16, 17},
-                                                          {18, 19, 20},
-                                                          {21, 22, 23},
-                                                          {24, 25, 26},
-                                                          {27, 28, 29},
-                                                          {30, 31, 32},
-                                                          {33, 34, 35}});
     core::Tensor vertices = core::Tensor::Init<float>(
             {{0.0, 0.0, 0.0}, {1.0, 1.0, 0.0}, {1.0, 0.0, 0.0},
-             {0.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {1.0, 1.0, 0.0},
-             {0.0, 0.0, 0.0}, {0.0, 1.0, 1.0}, {0.0, 1.0, 0.0},
-             {0.0, 0.0, 0.0}, {0.0, 0.0, 1.0}, {0.0, 1.0, 1.0},
-             {0.0, 1.0, 0.0}, {1.0, 1.0, 1.0}, {1.0, 1.0, 0.0},
-             {0.0, 1.0, 0.0}, {0.0, 1.0, 1.0}, {1.0, 1.0, 1.0},
+             {0.0, 1.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 1.0, 1.0},
+             {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}, {0.0, 1.0, 0.0},
+             {1.0, 1.0, 1.0}, {1.0, 1.0, 0.0}, {0.0, 1.0, 1.0},
              {1.0, 0.0, 0.0}, {1.0, 1.0, 0.0}, {1.0, 1.0, 1.0},
-             {1.0, 0.0, 0.0}, {1.0, 1.0, 1.0}, {1.0, 0.0, 1.0},
-             {0.0, 0.0, 0.0}, {1.0, 0.0, 0.0}, {1.0, 0.0, 1.0},
-             {0.0, 0.0, 0.0}, {1.0, 0.0, 1.0}, {0.0, 0.0, 1.0},
-             {0.0, 0.0, 1.0}, {1.0, 0.0, 1.0}, {1.0, 1.0, 1.0},
-             {0.0, 0.0, 1.0}, {1.0, 1.0, 1.0}, {0.0, 1.0, 1.0}});
-    EXPECT_TRUE(mesh.GetTriangleIndices().AllClose(triangles));
+             {1.0, 0.0, 1.0}, {0.0, 0.0, 0.0}, {1.0, 0.0, 0.0},
+             {1.0, 0.0, 1.0}, {0.0, 0.0, 1.0}, {0.0, 0.0, 1.0},
+             {1.0, 0.0, 1.0}, {1.0, 1.0, 1.0}, {0.0, 1.0, 1.0}});
     EXPECT_TRUE(mesh.GetVertexPositions().AllClose(vertices));
+
+    core::Tensor triangles = core::Tensor::Init<int64_t>({{0, 1, 2},
+                                                          {0, 3, 1},
+                                                          {4, 5, 6},
+                                                          {4, 7, 5},
+                                                          {8, 9, 10},
+                                                          {8, 11, 9},
+                                                          {12, 13, 14},
+                                                          {12, 14, 15},
+                                                          {16, 17, 18},
+                                                          {16, 18, 19},
+                                                          {20, 21, 22},
+                                                          {20, 22, 23}});
+    EXPECT_TRUE(mesh.GetTriangleIndices().AllClose(triangles));
 
     std::string file_name = utility::GetDataPathCommon("test_mesh.obj");
     EXPECT_TRUE(t::io::WriteTriangleMesh(file_name, mesh));
     EXPECT_TRUE(t::io::ReadTriangleMesh(file_name, mesh_read));
     EXPECT_TRUE(
-            mesh.GetTriangleIndices().AllClose(mesh_read.GetTriangleIndices()));
-    EXPECT_TRUE(
             mesh.GetVertexPositions().AllClose(mesh_read.GetVertexPositions()));
+    EXPECT_TRUE(
+            mesh.GetTriangleIndices().AllClose(mesh_read.GetTriangleIndices()));
+
     std::remove(file_name.c_str());
 }
 
@@ -103,9 +101,9 @@ TEST(TriangleMeshIO, TriangleMeshLegecyCompatibility) {
     t::geometry::TriangleMesh mesh_tensor, mesh_tensor_read;
     geometry::TriangleMesh mesh_legacy, mesh_legacy_read;
     EXPECT_TRUE(t::io::ReadTriangleMesh(
-            utility::GetDataPathCommon("monkey/monkey.obj"), mesh_tensor));
+            utility::GetDataPathDownload("tests/cube.obj"), mesh_tensor));
     EXPECT_TRUE(io::ReadTriangleMesh(
-            utility::GetDataPathCommon("monkey/monkey.obj"), mesh_legacy));
+            utility::GetDataPathDownload("tests/cube.obj"), mesh_legacy));
 
     EXPECT_EQ(mesh_tensor.GetTriangleIndices().GetLength(),
               static_cast<int64_t>(mesh_legacy.triangles_.size()));


### PR DESCRIPTION
Issue: https://github.com/isl-org/Open3D/issues/3799

`ASSIMP`: Face normals are shared between all points of a single face, so a single point can have multiple normals, which forces the library to duplicate vertices in some cases.

`aiProcess_JoinIdenticalVertices` Identifies and joins identical vertex data sets within all imported meshes.

- `aiProcessPreset_TargetRealtime_Fast` includes the removed flags.

#### Please note: We may still have duplicated vertices sometimes added by the `ASSIMP loader`. 

Refactored unit test: In test `TriangleMeshLegecyCompatibility`, using `cube` instead of `monkey`, because of the following issue:
- Reading `monkey` is fine, Writing `monkey` to a file and then reading in `legacy` and `tensor` is giving a slightly different number of vertices. Suspected reason: While `tensor -> eigen` there might be some precision loss, which leads to some vertices getting very close, which are then removed by the `JoinIdenticalVertices` step.

  

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4119)
<!-- Reviewable:end -->
