### PR TITLE
Remove `Assign` op from Tensor

### DIFF
--- a/cpp/open3d/core/EigenConverter.h
+++ b/cpp/open3d/core/EigenConverter.h
@@ -32,7 +32,6 @@
 #include "open3d/core/Device.h"
 #include "open3d/core/Dtype.h"
 #include "open3d/core/Tensor.h"
-#include "open3d/core/TensorList.h"
 
 namespace open3d {
 namespace core {

--- a/cpp/open3d/core/Tensor.cpp
+++ b/cpp/open3d/core/Tensor.cpp
@@ -591,17 +591,6 @@ Tensor Tensor::SetItem(const std::vector<TensorKey>& tks, const Tensor& value) {
     return *this;
 }
 
-/// Assign (copy) values from another Tensor, shape, dtype, device may change.
-void Tensor::Assign(const Tensor& other) {
-    shape_ = other.shape_;
-    strides_ = shape_util::DefaultStrides(shape_);
-    dtype_ = other.dtype_;
-    blob_ = std::make_shared<Blob>(shape_.NumElements() * dtype_.ByteSize(),
-                                   other.GetDevice());
-    data_ptr_ = blob_->GetDataPtr();
-    kernel::Copy(other, *this);
-}
-
 /// Broadcast Tensor to a new broadcastable shape
 Tensor Tensor::Broadcast(const SizeVector& dst_shape) const {
     if (!shape_util::CanBeBrocastedToShape(shape_, dst_shape)) {

--- a/cpp/open3d/core/Tensor.h
+++ b/cpp/open3d/core/Tensor.h
@@ -342,11 +342,6 @@ public:
     /// ```
     Tensor SetItem(const std::vector<TensorKey>& tks, const Tensor& value);
 
-    /// Assign (copy) values from another Tensor, shape, dtype, device may
-    /// change. Slices of the original Tensor still keeps the original memory.
-    /// After assignment, the Tensor will be contiguous.
-    void Assign(const Tensor& other);
-
     /// Broadcast Tensor to a new broadcastable shape.
     Tensor Broadcast(const SizeVector& dst_shape) const;
 

--- a/cpp/tests/t/geometry/Image.cpp
+++ b/cpp/tests/t/geometry/Image.cpp
@@ -29,7 +29,6 @@
 #include <gmock/gmock.h>
 
 #include "core/CoreTest.h"
-#include "open3d/core/TensorList.h"
 #include "open3d/io/ImageIO.h"
 #include "open3d/io/PinholeCameraTrajectoryIO.h"
 #include "open3d/t/io/ImageIO.h"

--- a/cpp/tests/t/geometry/LineSet.cpp
+++ b/cpp/tests/t/geometry/LineSet.cpp
@@ -30,7 +30,6 @@
 
 #include "core/CoreTest.h"
 #include "open3d/core/TensorCheck.h"
-#include "open3d/core/TensorList.h"
 #include "tests/Tests.h"
 
 namespace open3d {

--- a/cpp/tests/t/geometry/TriangleMesh.cpp
+++ b/cpp/tests/t/geometry/TriangleMesh.cpp
@@ -28,7 +28,6 @@
 
 #include "core/CoreTest.h"
 #include "open3d/core/TensorCheck.h"
-#include "open3d/core/TensorList.h"
 #include "tests/Tests.h"
 
 namespace open3d {

--- a/cpp/tests/t/io/ImageIO.cpp
+++ b/cpp/tests/t/io/ImageIO.cpp
@@ -32,7 +32,6 @@
 #include "open3d/core/Dtype.h"
 #include "open3d/core/SizeVector.h"
 #include "open3d/core/Tensor.h"
-#include "open3d/core/TensorList.h"
 #include "open3d/t/geometry/Image.h"
 #include "tests/Tests.h"
 

--- a/cpp/tests/t/io/PointCloudIO.cpp
+++ b/cpp/tests/t/io/PointCloudIO.cpp
@@ -33,7 +33,6 @@
 #include "open3d/core/Dtype.h"
 #include "open3d/core/SizeVector.h"
 #include "open3d/core/Tensor.h"
-#include "open3d/core/TensorList.h"
 #include "open3d/t/geometry/PointCloud.h"
 #include "tests/Tests.h"
 


### PR DESCRIPTION
- Removed `Assign` op from Tensor.
- Removed `TensorList.h` header from files not using it.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4134)
<!-- Reviewable:end -->
