### PR TITLE
Typo In Common.py in the New Reconstruction System Python Example Means That Script Can Not Save Reconstruction as Point Cloud

### DIFF
--- a/examples/python/new_reconstruction_system/common.py
+++ b/examples/python/new_reconstruction_system/common.py
@@ -175,7 +175,7 @@ def extract_pointcloud(volume, config, file_name=None):
             o3d.io.write_point_cloud(file_name, pcd)
 
     elif config.engine == 'tensor':
-        pcd = volume.extract_point_clound(
+        pcd = volume.extract_point_cloud(
             weight_threshold=config.surface_weight_thr)
 
         if file_name is not None:


### PR DESCRIPTION
In the common.py script in the new reconstruction system, python example, extract_point_cloud is misspelled extract_point_clound. 
Sorry if I should have reported this bug somewhere else or in some other method, and hopefully it's worth creating a pull request over.
Sorry if I didn't format it right, it's my first pull request for any public github project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4155)
<!-- Reviewable:end -->
