### PR TITLE
expose API for Fast Global Registration given correspondences

### DIFF
--- a/cpp/open3d/pipelines/registration/FastGlobalRegistration.h
+++ b/cpp/open3d/pipelines/registration/FastGlobalRegistration.h
@@ -31,6 +31,7 @@
 #include <tuple>
 #include <vector>
 
+#include "open3d/pipelines/registration/TransformationEstimation.h"
 #include "open3d/utility/Optional.h"
 
 namespace open3d {
@@ -105,7 +106,26 @@ public:
     utility::optional<unsigned int> seed_;
 };
 
-RegistrationResult FastGlobalRegistration(
+/// \brief Fast Global Registration based on a given set of correspondences.
+///
+/// \param source The source point cloud.
+/// \param target The target point cloud.
+/// \param corres Correspondence indices between source and target point clouds.
+/// \param option FGR options
+RegistrationResult FastGlobalRegistrationBasedOnCorrespondence(
+        const geometry::PointCloud &source,
+        const geometry::PointCloud &target,
+        const CorrespondenceSet &corres,
+        const FastGlobalRegistrationOption &option =
+                FastGlobalRegistrationOption());
+
+/// \brief Fast Global Registration based on a given set of FPFH features.
+///
+/// \param source The source point cloud.
+/// \param target The target point cloud.
+/// \param corres Correspondence indices between source and target point clouds.
+/// \param option FGR options
+RegistrationResult FastGlobalRegistrationBasedOnFeatureMatching(
         const geometry::PointCloud &source,
         const geometry::PointCloud &target,
         const Feature &source_feature,

--- a/cpp/open3d/pipelines/registration/FastGlobalRegistration.h
+++ b/cpp/open3d/pipelines/registration/FastGlobalRegistration.h
@@ -64,6 +64,8 @@ public:
     /// \param iteration_number Maximum number of iterations.
     /// \param tuple_scale Similarity measure used for tuples of feature points.
     /// \param maximum_tuple_count Maximum numer of tuples.
+    /// \param tuple_test Set to `true` to perform geometric compatibility tests
+    /// on initial set of correspondences.
     /// \param seed Random seed.
     FastGlobalRegistrationOption(
             double division_factor = 1.4,
@@ -73,6 +75,7 @@ public:
             int iteration_number = 64,
             double tuple_scale = 0.95,
             int maximum_tuple_count = 1000,
+            bool tuple_test = true,
             utility::optional<unsigned int> seed = utility::nullopt)
         : division_factor_(division_factor),
           use_absolute_scale_(use_absolute_scale),
@@ -81,6 +84,7 @@ public:
           iteration_number_(iteration_number),
           tuple_scale_(tuple_scale),
           maximum_tuple_count_(maximum_tuple_count),
+          tuple_test_(tuple_test),
           seed_(seed) {}
     ~FastGlobalRegistrationOption() {}
 
@@ -102,6 +106,9 @@ public:
     double tuple_scale_;
     /// Maximum number of tuples..
     int maximum_tuple_count_;
+    /// Set to `true` to perform geometric compatibility tests on initial set of
+    /// correspondences.
+    bool tuple_test_;
     /// Random seed
     utility::optional<unsigned int> seed_;
 };

--- a/cpp/pybind/pipelines/registration/registration.cpp
+++ b/cpp/pybind/pipelines/registration/registration.cpp
@@ -473,18 +473,20 @@ must hold true for all edges.)");
                              bool decrease_mu,
                              double maximum_correspondence_distance,
                              int iteration_number, double tuple_scale,
-                             int maximum_tuple_count,
+                             int maximum_tuple_count, bool tuple_test,
                              utility::optional<unsigned int> seed) {
                      return new FastGlobalRegistrationOption(
                              division_factor, use_absolute_scale, decrease_mu,
                              maximum_correspondence_distance, iteration_number,
-                             tuple_scale, maximum_tuple_count, seed);
+                             tuple_scale, maximum_tuple_count, tuple_test,
+                             seed);
                  }),
                  "division_factor"_a = 1.4, "use_absolute_scale"_a = false,
                  "decrease_mu"_a = false,
                  "maximum_correspondence_distance"_a = 0.025,
                  "iteration_number"_a = 64, "tuple_scale"_a = 0.95,
-                 "maximum_tuple_count"_a = 1000, "seed"_a = py::none())
+                 "maximum_tuple_count"_a = 1000, "tuple_test"_a = true,
+                 "seed"_a = py::none())
             .def_readwrite(
                     "division_factor",
                     &FastGlobalRegistrationOption::division_factor_,
@@ -512,6 +514,10 @@ must hold true for all edges.)");
             .def_readwrite("maximum_tuple_count",
                            &FastGlobalRegistrationOption::maximum_tuple_count_,
                            "float: Maximum tuple numbers.")
+            .def_readwrite(
+                    "tuple_test", &FastGlobalRegistrationOption::tuple_test_,
+                    "bool: Set to `true` to perform geometric compatibility "
+                    "tests on initial set of correspondences.")
             .def_readwrite("seed", &FastGlobalRegistrationOption::seed_,
                            "unsigned int: Random seed.")
             .def("__repr__", [](const FastGlobalRegistrationOption &c) {
@@ -525,10 +531,10 @@ must hold true for all edges.)");
                         "\niteration_number={}"
                         "\ntuple_scale={}"
                         "\nmaximum_tuple_count={}",
-                        "\nseed={}", c.division_factor_, c.use_absolute_scale_,
-                        c.decrease_mu_, c.maximum_correspondence_distance_,
-                        c.iteration_number_, c.tuple_scale_,
-                        c.maximum_tuple_count_,
+                        "\ntuple_test={}", "\nseed={}", c.division_factor_,
+                        c.use_absolute_scale_, c.decrease_mu_,
+                        c.maximum_correspondence_distance_, c.iteration_number_,
+                        c.tuple_scale_, c.maximum_tuple_count_, c.tuple_test_,
                         c.seed_.has_value() ? std::to_string(c.seed_.value())
                                             : "None");
             });

--- a/cpp/pybind/pipelines/registration/registration.cpp
+++ b/cpp/pybind/pipelines/registration/registration.cpp
@@ -682,13 +682,24 @@ void pybind_registration_methods(py::module &m) {
             m, "registration_ransac_based_on_feature_matching",
             map_shared_argument_docstrings);
 
-    m.def("registration_fast_based_on_feature_matching",
-          &FastGlobalRegistration, py::call_guard<py::gil_scoped_release>(),
+    m.def("registration_fgr_based_on_correspondence",
+          &FastGlobalRegistrationBasedOnCorrespondence,
+          py::call_guard<py::gil_scoped_release>(),
+          "Function for fast global registration based on a set of "
+          "correspondences",
+          "source"_a, "target"_a, "corres"_a,
+          "option"_a = FastGlobalRegistrationOption());
+    docstring::FunctionDocInject(m, "registration_fgr_based_on_correspondence",
+                                 map_shared_argument_docstrings);
+
+    m.def("registration_fgr_based_on_feature_matching",
+          &FastGlobalRegistrationBasedOnFeatureMatching,
+          py::call_guard<py::gil_scoped_release>(),
           "Function for fast global registration based on feature matching",
           "source"_a, "target"_a, "source_feature"_a, "target_feature"_a,
           "option"_a = FastGlobalRegistrationOption());
     docstring::FunctionDocInject(m,
-                                 "registration_fast_based_on_feature_matching",
+                                 "registration_fgr_based_on_feature_matching",
                                  map_shared_argument_docstrings);
 
     m.def("get_information_matrix_from_point_clouds",

--- a/examples/python/pipelines/global_registration.ipynb
+++ b/examples/python/pipelines/global_registration.ipynb
@@ -304,7 +304,7 @@
     "    distance_threshold = voxel_size * 0.5\n",
     "    print(\":: Apply fast global registration with distance threshold %.3f\" \\\n",
     "            % distance_threshold)\n",
-    "    result = o3d.pipelines.registration.registration_fast_based_on_feature_matching(\n",
+    "    result = o3d.pipelines.registration.registration_fgr_based_on_feature_matching(\n",
     "        source_down, target_down, source_fpfh, target_fpfh,\n",
     "        o3d.pipelines.registration.FastGlobalRegistrationOption(\n",
     "            maximum_correspondence_distance=distance_threshold))\n",

--- a/examples/python/pipelines/global_registration.ipynb
+++ b/examples/python/pipelines/global_registration.ipynb
@@ -334,6 +334,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition to FPFH-feature-based FGR, global registration can be performed with correspondence-based FGR via `registration_fgr_based_on_correspondence`. This method is useful if your correspondence frontend is different than FPFH, but you would still like to use FGR given a set of putative correspondences. It can be called with\n",
+    "\n",
+    "```python\n",
+    "o3d.pipelines.registration.registration_fgr_based_on_correspondence(\n",
+    "        source_down, target_down, correspondence_set,\n",
+    "        o3d.pipelines.registration.FastGlobalRegistrationOption())\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -344,7 +357,7 @@
  "metadata": {
   "celltoolbar": "Edit Metadata",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -358,7 +371,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/examples/python/reconstruction_system/register_fragments.py
+++ b/examples/python/reconstruction_system/register_fragments.py
@@ -53,7 +53,7 @@ def preprocess_point_cloud(pcd, config):
 def register_point_cloud_fpfh(source, target, source_fpfh, target_fpfh, config):
     distance_threshold = config["voxel_size"] * 1.4
     if config["global_registration"] == "fgr":
-        result = o3d.pipelines.registration.registration_fast_based_on_feature_matching(
+        result = o3d.pipelines.registration.registration_fgr_based_on_feature_matching(
             source, target, source_fpfh, target_fpfh,
             o3d.pipelines.registration.FastGlobalRegistrationOption(
                 maximum_correspondence_distance=distance_threshold))


### PR DESCRIPTION
- make FGR API more explicit and parallel the RANSAC registration API by:
	- renaming in c++ `FastGlobalRegistration` --> `FastGlobalRegistrationBasedOnFeatureMatching`
	- adding c++ `FastGlobalRegistrationBasedOnCorrespondence`, python `registration_fgr_based_on_correspondence`
- rename existing python API to be more explicit: `registration_fast_based_on_feature_matching` --> `registration_fgr_based_on_feature_matching`
- add function documentation in c++
- updates in `global_registration.ipynb` and `examples/python/reconstruction_system/register_fragments.py` for renamed `registration_fgr_based_on_feature_matching`

I felt `registration_fgr_*` was more descriptive than `registration_fast_*`, but happy to revert that change if we don't want to change the API

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4188)
<!-- Reviewable:end -->
