### PR TITLE
Add keywords to draw to allow IBL and its intensity to be set

### DIFF
--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
@@ -1274,16 +1274,17 @@ struct O3DVisualizer::Impl {
     }
 
     void SetIBL(std::string path) {
-        utility::LogWarning("Setting IBL to {}", path);
         std::string ibl_path;
         if (path == "") {
             // Set IBL back to default
-            ibl_path = std::string(Application::GetInstance().GetResourcePath()) +
-                   std::string("/") + std::string(kDefaultIBL);
+            ibl_path =
+                    std::string(Application::GetInstance().GetResourcePath()) +
+                    std::string("/") + std::string(kDefaultIBL);
         } else if (utility::filesystem::FileExists(path + "_ibl.ktx")) {
-            // 
+            // Set IBL to named IBL - probably came from selecting in UI
             ibl_path = path;
         } else if (utility::filesystem::FileExists(path)) {
+            // User specified full path to IBL file
             if (path.find("_ibl.ktx") == path.size() - 8) {
                 ibl_path = path.substr(0, path.size() - 8);
             } else {
@@ -1293,15 +1294,22 @@ struct O3DVisualizer::Impl {
                 return;
             }
         } else {
-            ibl_path = std::string(Application::GetInstance().GetResourcePath()) +
-                   std::string("/") + path;
-            if (!utility::filesystem::FileExists(ibl_path)) {
+            // User specified the IBL 'stem' without the full path
+            ibl_path =
+                    std::string(Application::GetInstance().GetResourcePath()) +
+                    "/" + path;
+            if (!utility::filesystem::FileExists(ibl_path + "_ibl.ktx")) {
                 return;
             }
         }
         ui_state_.ibl_path = ibl_path;
         scene_->GetScene()->GetScene()->SetIndirectLight(ibl_path);
         scene_->ForceRedraw();
+    }
+
+    void SetIBLIntensity(float intensity) {
+        ui_state_.ibl_intensity = intensity;
+        SetUIState(ui_state_);
     }
 
     void SetLightingProfile(const LightingProfile &profile) {
@@ -1993,8 +2001,10 @@ void O3DVisualizer::ShowSettings(bool show) { impl_->ShowSettings(show); }
 
 void O3DVisualizer::ShowSkybox(bool show) { impl_->ShowSkybox(show); }
 
-void O3DVisualizer::SetIBL(const std::string &path, float intensity) {
-    impl_->SetIBL(path);
+void O3DVisualizer::SetIBL(const std::string &path) { impl_->SetIBL(path); }
+
+void O3DVisualizer::SetIBLIntensity(float intensity) {
+    impl_->SetIBLIntensity(intensity);
 }
 
 void O3DVisualizer::ShowAxes(bool show) { impl_->ShowAxes(show); }

--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.h
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.h
@@ -160,7 +160,8 @@ public:
 
     void ShowSettings(bool show);
     void ShowSkybox(bool show);
-    void SetIBL(const std::string& path, float intensity);
+    void SetIBL(const std::string& path);
+    void SetIBLIntensity(float intensity);
     void ShowAxes(bool show);
     void ShowGround(bool show);
     void SetGroundPlane(rendering::Scene::GroundPlane plane);

--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.h
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.h
@@ -160,6 +160,7 @@ public:
 
     void ShowSettings(bool show);
     void ShowSkybox(bool show);
+    void SetIBL(const std::string& path, float intensity);
     void ShowAxes(bool show);
     void ShowGround(bool show);
     void SetGroundPlane(rendering::Scene::GroundPlane plane);

--- a/cpp/pybind/visualization/o3dvisualizer.cpp
+++ b/cpp/pybind/visualization/o3dvisualizer.cpp
@@ -331,7 +331,10 @@ void pybind_o3dvisualizer(py::module& m) {
                  "and, optionally, the background image. Passing None for the "
                  "background image will clear any image already there.")
             .def("set_ibl", &O3DVisualizer::SetIBL,
-                 "set_ibl(path, intensity): Sets the IBL and its intensity")
+                 "set_ibl(path): Sets the IBL from its stem name or full path")
+            .def("set_ibl_intensity", &O3DVisualizer::SetIBLIntensity,
+                 "set_ibl_intensity(intensity): Sets the intensity of the "
+                 "current IBL")
             .def_property(
                     "show_settings",
                     [](const O3DVisualizer& dv) {

--- a/cpp/pybind/visualization/o3dvisualizer.cpp
+++ b/cpp/pybind/visualization/o3dvisualizer.cpp
@@ -330,6 +330,8 @@ void pybind_o3dvisualizer(py::module& m) {
                  "set_background(color, image=None): Sets the background color "
                  "and, optionally, the background image. Passing None for the "
                  "background image will clear any image already there.")
+            .def("set_ibl", &O3DVisualizer::SetIBL,
+                 "set_ibl(path, intensity): Sets the IBL and its intensity")
             .def_property(
                     "show_settings",
                     [](const O3DVisualizer& dv) {

--- a/cpp/pybind/visualization/o3dvisualizer.cpp
+++ b/cpp/pybind/visualization/o3dvisualizer.cpp
@@ -331,7 +331,10 @@ void pybind_o3dvisualizer(py::module& m) {
                  "and, optionally, the background image. Passing None for the "
                  "background image will clear any image already there.")
             .def("set_ibl", &O3DVisualizer::SetIBL,
-                 "set_ibl(path): Sets the IBL from its stem name or full path")
+                 "set_ibl(ibl_name): Sets the IBL and its matching skybox. If "
+                 "ibl_name_ibl.ktx is found in the default resource directory "
+                 "then it is used. Otherwise, ibl_name is assumt to be a path "
+                 "to the ibl KTX file.")
             .def("set_ibl_intensity", &O3DVisualizer::SetIBLIntensity,
                  "set_ibl_intensity(intensity): Sets the intensity of the "
                  "current IBL")

--- a/python/open3d/visualization/draw.py
+++ b/python/open3d/visualization/draw.py
@@ -39,6 +39,7 @@ def draw(geometry=None,
          field_of_view=60.0,
          bg_color=(1.0, 1.0, 1.0, 1.0),
          bg_image=None,
+         ibl=None,
          show_ui=None,
          point_size=None,
          animation_time_step=1.0,
@@ -83,6 +84,9 @@ def draw(geometry=None,
 
     if show_ui is not None:
         w.show_settings = show_ui
+
+    if ibl is not None:
+        w.set_ibl(ibl, 40000.0)
 
     if rpc_interface:
         w.start_rpc_interface(address="tcp://127.0.0.1:51454", timeout=10000)

--- a/python/open3d/visualization/draw.py
+++ b/python/open3d/visualization/draw.py
@@ -40,6 +40,7 @@ def draw(geometry=None,
          bg_color=(1.0, 1.0, 1.0, 1.0),
          bg_image=None,
          ibl=None,
+         ibl_intensity=None,
          show_ui=None,
          point_size=None,
          animation_time_step=1.0,
@@ -86,7 +87,10 @@ def draw(geometry=None,
         w.show_settings = show_ui
 
     if ibl is not None:
-        w.set_ibl(ibl, 40000.0)
+        w.set_ibl(ibl)
+
+    if ibl_intensity is not None:
+        w.set_ibl_intensity(ibl_intensity)
 
     if rpc_interface:
         w.start_rpc_interface(address="tcp://127.0.0.1:51454", timeout=10000)


### PR DESCRIPTION
Prior to this PR you could only change the IBL by using the `O3DVisualizers` user interface. It is now possible to specify the IBL and its intensity as part of the `draw` call:

```
vis.draw(sphere, ibl="photo_studio", ibl_intensity=40000.0)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4190)
<!-- Reviewable:end -->
