### PR TITLE
Add simplified path to update geometry in O3DVisualizer

### DIFF
--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
@@ -1013,6 +1013,23 @@ struct O3DVisualizer::Impl {
         scene_->ForceRedraw();
     }
 
+    void UpdateGeometry(const std::string &name,
+                        std::shared_ptr<t::geometry::Geometry> tgeom,
+                        uint32_t update_flags) {
+        auto t_cloud =
+                std::dynamic_pointer_cast<t::geometry::PointCloud>(tgeom);
+        if (!t_cloud) {
+            utility::LogWarning(
+                    "Only TGeometry PointClouds can currently be updated using "
+                    "UpdateGeometry. Try removing the geometry that needs to "
+                    "be updated then adding the update geometry.");
+            return;
+        }
+        scene_->GetScene()->GetScene()->UpdateGeometry(name, *t_cloud,
+                                                       update_flags);
+        scene_->ForceRedraw();
+    }
+
     void RemoveGeometry(const std::string &name) {
         std::string group;
         for (size_t i = 0; i < objects_.size(); ++i) {
@@ -1978,6 +1995,12 @@ void O3DVisualizer::Add3DLabel(const Eigen::Vector3f &pos, const char *text) {
 }
 
 void O3DVisualizer::Clear3DLabels() { impl_->Clear3DLabels(); }
+
+void O3DVisualizer::UpdateGeometry(const std::string &name,
+                                   std::shared_ptr<t::geometry::Geometry> tgeom,
+                                   uint32_t update_flags) {
+    impl_->UpdateGeometry(name, tgeom, update_flags);
+}
 
 void O3DVisualizer::RemoveGeometry(const std::string &name) {
     return impl_->RemoveGeometry(name);

--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.h
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.h
@@ -138,6 +138,10 @@ public:
 
     void RemoveGeometry(const std::string& name);
 
+    void UpdateGeometry(const std::string& name,
+                        std::shared_ptr<t::geometry::Geometry> tgeom,
+                        uint32_t update_flags);
+
     void ShowGeometry(const std::string& name, bool show);
 
     DrawObject GetGeometry(const std::string& name) const;

--- a/cpp/pybind/visualization/o3dvisualizer.cpp
+++ b/cpp/pybind/visualization/o3dvisualizer.cpp
@@ -259,6 +259,11 @@ void pybind_o3dvisualizer(py::module& m) {
             .def("remove_geometry", &O3DVisualizer::RemoveGeometry,
                  "remove_geometry(name): removes the geometry with the "
                  "name.")
+            .def("update_geometry", &O3DVisualizer::UpdateGeometry,
+                 "update_geometry(name, tpoint_cloud, update_flags): updates "
+                 "the attributes of the named geometry specified by "
+                 "update_flags with tpoint_cloud. Note: Currently this "
+                 "function only works with T Geometry Point Clouds.")
             .def("show_geometry", &O3DVisualizer::ShowGeometry,
                  "Checks or unchecks the named geometry in the list. Note that "
                  "even if show_geometry(name, True) is called, the object may "


### PR DESCRIPTION
Adds `update_geometry` function to O3DVisualizer so geometry can be updated using a higher level call that takes care of internal book keeping instead of having to use the low level `O3DVisualizer.scene.update_geometry` function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4202)
<!-- Reviewable:end -->
