### PR TITLE
SegmentPlane function force ransac_n equal 3

### DIFF
--- a/cpp/open3d/geometry/PointCloudSegmentation.cpp
+++ b/cpp/open3d/geometry/PointCloudSegmentation.cpp
@@ -136,6 +136,8 @@ std::tuple<Eigen::Vector4d, std::vector<size_t>> PointCloud::SegmentPlane(
         const double distance_threshold /* = 0.01 */,
         const int ransac_n /* = 3 */,
         const int num_iterations /* = 100 */) const {
+    ransac_n = 3;
+    
     RANSACResult result;
     double error = 0;
 


### PR DESCRIPTION
Hello, thanks for your work.
I doubt the second parameter of `SegmentPlane` function is useless, but I don't want to do a break change.
in this code block
https://github.com/isl-org/Open3D/blob/3147bd1baea27590bf708f8129aad6d7e77e967c/cpp/open3d/geometry/PointCloudSegmentation.cpp#L168-L186
the useable elements is only the first three in `inliers` variable.
And if user use this function wrong, and maybe set `ransac_n` too big, it may cause useless performance consumption.
Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4215)
<!-- Reviewable:end -->
