### PR TITLE
:book: recommends release build type for user

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,8 +100,8 @@ endif()
 # https://blog.kitware.com/cmake-and-the-default-build-type/
 if(NOT CMAKE_CONFIGURATION_TYPES)
     if(NOT CMAKE_BUILD_TYPE)
-        message(STATUS "Setting build type to RelWithDebInfo as none was specified.")
-        set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Choose the type of build." FORCE)
+        message(STATUS "Setting build type to Release as none was specified.")
+        set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
         # Set the possible values of build type for cmake-gui.
         set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
                     "Debug" "Release" "MinSizeRel" "RelWithDebInfo")

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -84,12 +84,15 @@ If Python binding is not needed, you can turn it off by ``-DBUILD_PYTHON_MODULE=
 
     mkdir build
     cd build
-    cmake -DCMAKE_INSTALL_PREFIX=<open3d_install_directory> ..
+    cmake ..
 
-The ``CMAKE_INSTALL_PREFIX`` argument is optional and can be used to install
-Open3D to a user location. In the absence of this argument Open3D will be
-installed to a system location where ``sudo`` is required) For more
-options of the build, see :ref:`compilation_options`.
+You can specify ``-DCMAKE_INSTALL_PREFIX=$HOME/open3d_install`` to control the
+installation directory of ``make install``. In the absence of
+``CMAKE_INSTALL_PREFIX``, Open3D will be installed to a system location where
+``sudo`` may be required.
+
+For more build options, see :ref:`compilation_options` and the root
+``CMakeLists.txt``.
 
 .. _compilation_unix_build:
 

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -84,7 +84,7 @@ If Python binding is not needed, you can turn it off by ``-DBUILD_PYTHON_MODULE=
 
     mkdir build
     cd build
-    cmake -DCMAKE_BUILD_TYPE=Release ..
+    cmake ..
 
 You can specify ``-DCMAKE_INSTALL_PREFIX=$HOME/open3d_install`` to control the
 installation directory of ``make install``. In the absence of

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -84,7 +84,7 @@ If Python binding is not needed, you can turn it off by ``-DBUILD_PYTHON_MODULE=
 
     mkdir build
     cd build
-    cmake ..
+    cmake -DCMAKE_BUILD_TYPE=Release ..
 
 You can specify ``-DCMAKE_INSTALL_PREFIX=$HOME/open3d_install`` to control the
 installation directory of ``make install``. In the absence of


### PR DESCRIPTION
Fixes #4207

@ssheorey , shall we recommend the `Release` build in the documentation. Or, shall make `Release` build the default build type in CMake (currently `RelWithDebInfo` is the default for single-config generators)? 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4221)
<!-- Reviewable:end -->
