### PR TITLE
Add higher level interfaces to avoid UI issues

### DIFF
--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
@@ -1112,6 +1112,26 @@ struct O3DVisualizer::Impl {
         return DrawObject();
     }
 
+    MaterialRecord GetGeometryMaterial(const std::string &name) {
+        for (auto &o : objects_) {
+            if (o.name == name) {
+                return o.material;
+            }
+        }
+        return MaterialRecord();
+    }
+
+    void ModifyGeometryMaterial(const std::string &name,
+                                const MaterialRecord *material) {
+        for (auto &o : objects_) {
+            if (o.name == name) {
+                o.material = *material;
+                scene_->GetScene()->ModifyGeometryMaterial(name, *material);
+                break;
+            }
+        }
+    }
+
     void Add3DLabel(const Eigen::Vector3f &pos, const char *text) {
         scene_->AddLabel(pos, text);
     }
@@ -1268,10 +1288,11 @@ struct O3DVisualizer::Impl {
                           const MaterialRecord &original_material,
                           O3DVisualizer::Shader shader) {
         bool is_lines = (original_material.shader == "unlitLine");
+        bool is_gradient = (original_material.shader == "unlitGradient");
         auto scene = scene_->GetScene();
         // Lines are already unlit, so keep using the original shader when in
         // unlit mode so that we can keep the wide lines.
-        if (shader == Shader::STANDARD ||
+        if (shader == Shader::STANDARD || is_gradient ||
             (shader == Shader::UNLIT && is_lines)) {
             scene->ModifyGeometryMaterial(name, original_material);
         } else {
@@ -2031,6 +2052,16 @@ void O3DVisualizer::ShowGeometry(const std::string &name, bool show) {
 O3DVisualizer::DrawObject O3DVisualizer::GetGeometry(
         const std::string &name) const {
     return impl_->GetGeometry(name);
+}
+
+MaterialRecord O3DVisualizer::GetGeometryMaterial(
+        const std::string &name) const {
+    return impl_->GetGeometryMaterial(name);
+}
+
+void O3DVisualizer::ModifyGeometryMaterial(
+        const std::string &name, const rendering::MaterialRecord *material) {
+    impl_->ModifyGeometryMaterial(name, material);
 }
 
 void O3DVisualizer::ShowSettings(bool show) { impl_->ShowSettings(show); }

--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.h
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.h
@@ -145,6 +145,11 @@ public:
     void ShowGeometry(const std::string& name, bool show);
 
     DrawObject GetGeometry(const std::string& name) const;
+    rendering::MaterialRecord GetGeometryMaterial(
+            const std::string& name) const;
+
+    void ModifyGeometryMaterial(const std::string& name,
+                                const rendering::MaterialRecord* material);
 
     void Add3DLabel(const Eigen::Vector3f& pos, const char* text);
     void Clear3DLabels();

--- a/cpp/pybind/visualization/o3dvisualizer.cpp
+++ b/cpp/pybind/visualization/o3dvisualizer.cpp
@@ -274,6 +274,15 @@ void pybind_o3dvisualizer(py::module& m) {
                  "the name. This should be treated as read-only. Modify "
                  "visibility with show_geometry(), and other values by "
                  "removing the object and re-adding it with the new values")
+            .def("get_geometry_material", &O3DVisualizer::GetGeometryMaterial,
+                 "get_geometry_material(name): Returns the MaterialRecord "
+                 "corresponding to the name. The returned material is a copy, "
+                 "therefore modifying it directly will not change the "
+                 "visualization.")
+            .def("modify_geometry_material",
+                 &O3DVisualizer::ModifyGeometryMaterial,
+                 "modify_geometry_material(name,material): Updates the named "
+                 "geometry to use the new provided material.")
             .def("add_3d_label", &O3DVisualizer::Add3DLabel,
                  "add_3d_label([x,y,z], text): displays text anchored at the "
                  "3D coordinate specified")


### PR DESCRIPTION
* Adds `get_geometry_material` and `modify_geometry_material` to help keep script originated material changes and UI synchronized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4236)
<!-- Reviewable:end -->
