### PR TITLE
Fix a compare that would be broken on Python 4

### DIFF
--- a/util/check_style.py
+++ b/util/check_style.py
@@ -36,7 +36,7 @@ import time
 import sys
 
 # Yapf requires python 3.6+
-if not (sys.version_info.major == 3 and sys.version_info.minor >= 6):
+if sys.version_info < (3, 6):
     raise RuntimeError(
         "Requires Python 3.6+, currently using Python {}.{}.".format(
             sys.version_info.major, sys.version_info.minor))


### PR DESCRIPTION
 % `flake8 . --count --select=E9,F63,F7,F82,Y --show-source --statistics`
```
./Open3D/util/check_style.py:39:41: YTT204 `sys.version_info.minor` compared to integer (python4), compare `sys.version_info` to tuple
if not (sys.version_info.major == 3 and sys.version_info.minor >= 6):
                                        ^
./Open3D/examples/python/t_reconstruction_system/common.py:80:38: F821 undefined name 'depth_folder'
              len(depth_file_names), depth_folder, color_folder, extensions))
                                     ^
./Open3D/python/open3d/ml/tf/python/ops/gradients.py:294:18: F821 undefined name 'ml_ops'
    grad_input = ml_ops.trilinear_devoxelize_grad(grad_out, inds, wgts, r)
                 ^
2     F821 undefined name 'depth_folder'
1     YTT204 `sys.version_info.minor` compared to integer (python4), compare `sys.version_info` to tuple
3
```
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4249)
<!-- Reviewable:end -->
