### PR TITLE
Add Holes filling algorithm for CPU TSDF Pipelines.

### DIFF
--- a/cpp/open3d/pipelines/integration/ScalableTSDFVolume.cpp
+++ b/cpp/open3d/pipelines/integration/ScalableTSDFVolume.cpp
@@ -221,8 +221,8 @@ std::shared_ptr<geometry::PointCloud> ScalableTSDFVolume::ExtractPointCloud() {
     return pointcloud;
 }
 
-std::shared_ptr<geometry::TriangleMesh>
-ScalableTSDFVolume::ExtractTriangleMesh() {
+std::shared_ptr<geometry::TriangleMesh> ScalableTSDFVolume::ExtractTriangleMesh(
+        bool fill_holes /* = false*/) {
     // implementation of marching cubes, based on
     // http://paulbourke.net/geometry/polygonise/
     auto mesh = std::make_shared<geometry::TriangleMesh>();
@@ -298,7 +298,7 @@ ScalableTSDFVolume::ExtractTriangleMesh() {
                                                        .color_.cast<double>();
                                 }
                             }
-                            if (w[i] == 0.0f) {
+                            if (w[i] == 0.0f && !fill_holes) {
                                 cube_index = 0;
                                 break;
                             } else {

--- a/cpp/open3d/pipelines/integration/ScalableTSDFVolume.h
+++ b/cpp/open3d/pipelines/integration/ScalableTSDFVolume.h
@@ -81,7 +81,8 @@ public:
                    const camera::PinholeCameraIntrinsic &intrinsic,
                    const Eigen::Matrix4d &extrinsic) override;
     std::shared_ptr<geometry::PointCloud> ExtractPointCloud() override;
-    std::shared_ptr<geometry::TriangleMesh> ExtractTriangleMesh() override;
+    std::shared_ptr<geometry::TriangleMesh> ExtractTriangleMesh(
+            bool fill_holes = false) override;
     /// Debug function to extract the voxel data into a point cloud.
     std::shared_ptr<geometry::PointCloud> ExtractVoxelPointCloud();
 

--- a/cpp/open3d/pipelines/integration/TSDFVolume.h
+++ b/cpp/open3d/pipelines/integration/TSDFVolume.h
@@ -87,7 +87,10 @@ public:
 
     /// \brief Function to extract a triangle mesh, using the marching cubes
     /// algorithm. (https://en.wikipedia.org/wiki/Marching_cubes)
-    virtual std::shared_ptr<geometry::TriangleMesh> ExtractTriangleMesh() = 0;
+    /// \param fill_holes Use the Hole filling algorithm describded in section 4
+    /// of the Curless and Levoy paper.
+    virtual std::shared_ptr<geometry::TriangleMesh> ExtractTriangleMesh(
+            bool fill_holes = false) = 0;
 
 public:
     /// Length of the voxel in meters.

--- a/cpp/open3d/pipelines/integration/UniformTSDFVolume.cpp
+++ b/cpp/open3d/pipelines/integration/UniformTSDFVolume.cpp
@@ -158,8 +158,8 @@ std::shared_ptr<geometry::PointCloud> UniformTSDFVolume::ExtractPointCloud() {
     return pointcloud;
 }
 
-std::shared_ptr<geometry::TriangleMesh>
-UniformTSDFVolume::ExtractTriangleMesh() {
+std::shared_ptr<geometry::TriangleMesh> UniformTSDFVolume::ExtractTriangleMesh(
+        bool fill_holes /* = false*/) {
     // implementation of marching cubes, based on
     // http://paulbourke.net/geometry/polygonise/
     auto mesh = std::make_shared<geometry::TriangleMesh>();
@@ -180,7 +180,7 @@ UniformTSDFVolume::ExtractTriangleMesh() {
                 for (int i = 0; i < 8; i++) {
                     Eigen::Vector3i idx = Eigen::Vector3i(x, y, z) + shift[i];
 
-                    if (voxels_[IndexOf(idx)].weight_ == 0.0f) {
+                    if (voxels_[IndexOf(idx)].weight_ == 0.0f && !fill_holes) {
                         cube_index = 0;
                         break;
                     } else {

--- a/cpp/open3d/pipelines/integration/UniformTSDFVolume.h
+++ b/cpp/open3d/pipelines/integration/UniformTSDFVolume.h
@@ -70,7 +70,8 @@ public:
                    const camera::PinholeCameraIntrinsic &intrinsic,
                    const Eigen::Matrix4d &extrinsic) override;
     std::shared_ptr<geometry::PointCloud> ExtractPointCloud() override;
-    std::shared_ptr<geometry::TriangleMesh> ExtractTriangleMesh() override;
+    std::shared_ptr<geometry::TriangleMesh> ExtractTriangleMesh(
+            bool fill_holes = false) override;
 
     /// Debug function to extract the voxel data into a VoxelGrid
     std::shared_ptr<geometry::PointCloud> ExtractVoxelPointCloud() const;

--- a/cpp/pybind/pipelines/integration/integration.cpp
+++ b/cpp/pybind/pipelines/integration/integration.cpp
@@ -51,7 +51,8 @@ public:
         PYBIND11_OVERLOAD_PURE(std::shared_ptr<geometry::PointCloud>,
                                TSDFVolumeBase, );
     }
-    std::shared_ptr<geometry::TriangleMesh> ExtractTriangleMesh() override {
+    std::shared_ptr<geometry::TriangleMesh> ExtractTriangleMesh(
+            bool fill_holes = false) override {
         PYBIND11_OVERLOAD_PURE(std::shared_ptr<geometry::TriangleMesh>,
                                TSDFVolumeBase, );
     }
@@ -93,7 +94,10 @@ In SIGGRAPH, 1996)");
             .def("extract_point_cloud", &TSDFVolume::ExtractPointCloud,
                  "Function to extract a point cloud with normals")
             .def("extract_triangle_mesh", &TSDFVolume::ExtractTriangleMesh,
-                 "Function to extract a triangle mesh")
+                 "fill_holes"_a = false,
+                 "Function to extract a triangle mesh, specify fill_holes=True "
+                 "to use the Hole filling algorithm describded in the original "
+                 "paper.")
             .def_readwrite("voxel_length", &TSDFVolume::voxel_length_,
                            "float: Length of the voxel in meters.")
             .def_readwrite("sdf_trunc", &TSDFVolume::sdf_trunc_,

--- a/examples/python/pipelines/rgbd_integration.ipynb
+++ b/examples/python/pipelines/rgbd_integration.ipynb
@@ -155,7 +155,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"Extract a triangle mesh, from the volume(using the hole filling algorithm) and visualize it.\")\n",
+    "print(\n",
+    "    \"Extract a triangle mesh, from the volume(using the hole filling algorithm) and visualize it.\"\n",
+    ")\n",
     "mesh = volume.extract_triangle_mesh(fill_holes=True)\n",
     "mesh.compute_vertex_normals()\n",
     "o3d.visualization.draw_geometries([mesh],\n",

--- a/examples/python/pipelines/rgbd_integration.ipynb
+++ b/examples/python/pipelines/rgbd_integration.ipynb
@@ -130,7 +130,7 @@
    "metadata": {},
    "source": [
     "## Extract a mesh\n",
-    "Mesh extraction uses the marching cubes algorithm [\\[LorensenAndCline1987\\]](../reference.html#lorensenandcline1987)."
+    "Mesh extraction uses the marching cubes algorithm [\\[LorensenAndCline1987\\]](../reference.html#lorensenandcline1987). You can also specify the mesh extraction algorithm to fill some holes, as described in section _\"4 Hole Filling\"_ in [\\[Curless1996\\]](../reference.html#curless1996)."
    ]
   },
   {
@@ -141,6 +141,22 @@
    "source": [
     "print(\"Extract a triangle mesh from the volume and visualize it.\")\n",
     "mesh = volume.extract_triangle_mesh()\n",
+    "mesh.compute_vertex_normals()\n",
+    "o3d.visualization.draw_geometries([mesh],\n",
+    "                                  front=[0.5297, -0.1873, -0.8272],\n",
+    "                                  lookat=[2.0712, 2.0312, 1.7251],\n",
+    "                                  up=[-0.0558, -0.9809, 0.1864],\n",
+    "                                  zoom=0.47)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Extract a triangle mesh, from the volume(using the hole filling algorithm) and visualize it.\")\n",
+    "mesh = volume.extract_triangle_mesh(fill_holes=True)\n",
     "mesh.compute_vertex_normals()\n",
     "o3d.visualization.draw_geometries([mesh],\n",
     "                                  front=[0.5297, -0.1873, -0.8272],\n",


### PR DESCRIPTION
# Description

This is as described in Section 4 of the original paper. Note: This
change has been made intentionally backward compatible, so no
`extract_triangle_mesh` calls change the behavior.

This simple fix is usually missing on most TSDF implementations, and
depending on the application it might be the desired behavior(mostly when
reconstructing "objects" and not scenes).

## Reference

Section 4 of the original [paper](https://graphics.stanford.edu/papers/volrange/volrange.pdf)
![image](https://user-images.githubusercontent.com/21349875/140752482-da7bd071-a606-4a9b-834d-52e2d51f1291.png)


## Results

### Before (and now without specifying the `fill_holes = True` flag):
![image](https://user-images.githubusercontent.com/21349875/140752561-1f6b1340-0cc3-4767-9cc5-57b2d88540a9.png)

### After (when explicitly saying to fill_holes):

![image](https://user-images.githubusercontent.com/21349875/140752622-8787dba8-7079-435f-ac81-7b8196ad9914.png)

Closeup:

![ScreenCapture_2021-11-08-14-45-18](https://user-images.githubusercontent.com/21349875/140752796-c2c87a4d-281b-475f-9f76-7783876fcf18.png)

## Note

The "fill_holes" might be a bit misleading, this is **NOT** a mesh-repair pipeline. Just the original hole-filling idea described in the Curless and Levoy paper.

## ToDo

- [ ] I quickly checked the new Tensor API but I'm still unfamiliar with it, so not sure if to add this change there are not, or how to test it.
- [ ]  Look for an example application (Bunny-reconstruction for example) where this hole filling shine :star:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4262)
<!-- Reviewable:end -->
