### PR TITLE
Change IBL/Lighting defaults for O3DVisualizer

### DIFF
--- a/cpp/open3d/visualization/rendering/Open3DScene.cpp
+++ b/cpp/open3d/visualization/rendering/Open3DScene.cpp
@@ -210,25 +210,25 @@ void Open3DScene::SetLighting(LightingProfile profile,
         case LightingProfile::DARK_SHADOWS:
             scene->EnableIndirectLight(true);
             scene->EnableSunLight(true);
-            scene->SetIndirectLightIntensity(5000);
+            scene->SetIndirectLightIntensity(7500);
             scene->SetSunLight(sun_dir, sun_color, 85000);
             break;
         default:
         case LightingProfile::MED_SHADOWS:
             scene->EnableIndirectLight(true);
             scene->EnableSunLight(true);
-            scene->SetIndirectLightIntensity(7500);
+            scene->SetIndirectLightIntensity(20000);
             scene->SetSunLight(sun_dir, sun_color, 70000);
             break;
         case LightingProfile::SOFT_SHADOWS:
             scene->EnableIndirectLight(true);
             scene->EnableSunLight(true);
-            scene->SetIndirectLightIntensity(15000);
-            scene->SetSunLight(sun_dir, sun_color, 35000);
+            scene->SetIndirectLightIntensity(37500);
+            scene->SetSunLight(sun_dir, sun_color, 70000);
             break;
         case LightingProfile::NO_SHADOWS:
             scene->EnableIndirectLight(true);
-            scene->SetIndirectLightIntensity(20000);
+            scene->SetIndirectLightIntensity(37500);
             scene->EnableSunLight(false);
             break;
     }

--- a/cpp/open3d/visualization/rendering/Open3DScene.cpp
+++ b/cpp/open3d/visualization/rendering/Open3DScene.cpp
@@ -210,7 +210,7 @@ void Open3DScene::SetLighting(LightingProfile profile,
         case LightingProfile::DARK_SHADOWS:
             scene->EnableIndirectLight(true);
             scene->EnableSunLight(true);
-            scene->SetIndirectLightIntensity(7500);
+            scene->SetIndirectLightIntensity(10000);
             scene->SetSunLight(sun_dir, sun_color, 85000);
             break;
         default:
@@ -218,13 +218,13 @@ void Open3DScene::SetLighting(LightingProfile profile,
             scene->EnableIndirectLight(true);
             scene->EnableSunLight(true);
             scene->SetIndirectLightIntensity(20000);
-            scene->SetSunLight(sun_dir, sun_color, 70000);
+            scene->SetSunLight(sun_dir, sun_color, 80000);
             break;
         case LightingProfile::SOFT_SHADOWS:
             scene->EnableIndirectLight(true);
             scene->EnableSunLight(true);
             scene->SetIndirectLightIntensity(37500);
-            scene->SetSunLight(sun_dir, sun_color, 70000);
+            scene->SetSunLight(sun_dir, sun_color, 75000);
             break;
         case LightingProfile::NO_SHADOWS:
             scene->EnableIndirectLight(true);

--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
@@ -290,7 +290,6 @@ struct LightingProfile {
 
 static const char *kCustomName = "Custom";
 static const std::vector<LightingProfile> gLightingProfiles = {
-        {"Hard shadows", Open3DScene::LightingProfile::HARD_SHADOWS},
         {"Dark shadows", Open3DScene::LightingProfile::DARK_SHADOWS},
         {"Medium shadows", Open3DScene::LightingProfile::MED_SHADOWS},
         {"Soft shadows", Open3DScene::LightingProfile::SOFT_SHADOWS},
@@ -413,7 +412,7 @@ struct O3DVisualizer::Impl {
 
         MakeSettingsUI();
         SetMouseMode(SceneWidget::Controls::ROTATE_CAMERA);
-        SetLightingProfile(gLightingProfiles[3]);  // soft shadows
+        SetLightingProfile(gLightingProfiles[2]);  // soft shadows
         SetPointSize(ui_state_.point_size);  // sync selections_' point size
     }
 

--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
@@ -413,7 +413,7 @@ struct O3DVisualizer::Impl {
 
         MakeSettingsUI();
         SetMouseMode(SceneWidget::Controls::ROTATE_CAMERA);
-        SetLightingProfile(gLightingProfiles[2]);  // med shadows
+        SetLightingProfile(gLightingProfiles[3]);  // soft shadows
         SetPointSize(ui_state_.point_size);  // sync selections_' point size
     }
 
@@ -710,7 +710,7 @@ struct O3DVisualizer::Impl {
 
         settings.sun_intensity = new Slider(Slider::INT);
         settings.sun_intensity->SetLimits(0.0, 150000.0);
-        settings.sun_intensity->SetValue(ui_state_.ibl_intensity);
+        settings.sun_intensity->SetValue(ui_state_.sun_intensity);
         settings.sun_intensity->SetOnValueChanged([this](double new_value) {
             this->ui_state_.sun_intensity = int(new_value);
             this->SetUIState(ui_state_);

--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.h
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.h
@@ -79,7 +79,7 @@ public:
                 gui::SceneWidget::Controls::ROTATE_CAMERA;
         Shader scene_shader = Shader::STANDARD;
         bool show_settings = false;
-        bool show_skybox = false;
+        bool show_skybox = true;
         bool show_axes = false;
         bool show_ground = false;
         rendering::Scene::GroundPlane ground_plane =

--- a/cpp/pybind/visualization/o3dvisualizer.cpp
+++ b/cpp/pybind/visualization/o3dvisualizer.cpp
@@ -352,6 +352,8 @@ void pybind_o3dvisualizer(py::module& m) {
             .def("set_ibl_intensity", &O3DVisualizer::SetIBLIntensity,
                  "set_ibl_intensity(intensity): Sets the intensity of the "
                  "current IBL")
+            .def("show_skybox", &O3DVisualizer::ShowSkybox,
+                 "Show/Hide the skybox")
             .def_property(
                     "show_settings",
                     [](const O3DVisualizer& dv) {

--- a/examples/python/gui/demo-scene.py
+++ b/examples/python/gui/demo-scene.py
@@ -190,6 +190,4 @@ if __name__ == "__main__":
              bg_color=(0.8, 0.9, 0.9, 1.0),
              show_ui=True,
              width=1920,
-             height=1080,
-             ibl="default",
-             ibl_intensity=37500)
+             height=1080)

--- a/python/open3d/visualization/draw.py
+++ b/python/open3d/visualization/draw.py
@@ -41,6 +41,7 @@ def draw(geometry=None,
          bg_image=None,
          ibl=None,
          ibl_intensity=None,
+         show_skybox=None,
          show_ui=None,
          point_size=None,
          animation_time_step=1.0,
@@ -91,6 +92,9 @@ def draw(geometry=None,
 
     if ibl_intensity is not None:
         w.set_ibl_intensity(ibl_intensity)
+
+    if show_skybox is not None:
+        w.show_skybox(show_skybox)
 
     if rpc_interface:
         w.start_rpc_interface(address="tcp://127.0.0.1:51454", timeout=10000)


### PR DESCRIPTION
Settings for built-in lighting profiles updated to make environment lighting more prominent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4263)
<!-- Reviewable:end -->
