### PR TITLE
support FileDialog::Mode::OPEN_DIR for selecting a directory

### DIFF
--- a/cpp/open3d/visualization/gui/FileDialog.cpp
+++ b/cpp/open3d/visualization/gui/FileDialog.cpp
@@ -159,21 +159,26 @@ struct FileDialog::Impl {
             auto d = utility::filesystem::GetFileNameWithoutDirectory(dir);
             entries_.emplace_back(d, DirEntry::Type::DIR);
         }
-        std::unordered_set<std::string> filter;
-        auto it = filter_idx_2_filter.find(filter_->GetSelectedIndex());
-        if (it != filter_idx_2_filter.end()) {
-            filter = it->second;
-        }
-        for (auto &file : raw_files) {
-            auto f = utility::filesystem::GetFileNameWithoutDirectory(file);
-            auto ext = utility::filesystem::GetFileExtensionInLowerCase(f);
-            if (!ext.empty()) {
-                ext = std::string(".") + ext;
+
+        // append file filters only for file modes
+        if (mode_ != Mode::OPEN_DIR) {
+            std::unordered_set<std::string> filter;
+            auto it = filter_idx_2_filter.find(filter_->GetSelectedIndex());
+            if (it != filter_idx_2_filter.end()) {
+                filter = it->second;
             }
-            if (filter.empty() || filter.find(ext) != filter.end()) {
-                entries_.emplace_back(f, DirEntry::Type::FILE);
+            for (auto &file : raw_files) {
+                auto f = utility::filesystem::GetFileNameWithoutDirectory(file);
+                auto ext = utility::filesystem::GetFileExtensionInLowerCase(f);
+                if (!ext.empty()) {
+                    ext = std::string(".") + ext;
+                }
+                if (filter.empty() || filter.find(ext) != filter.end()) {
+                    entries_.emplace_back(f, DirEntry::Type::FILE);
+                }
             }
         }
+
         std::sort(entries_.begin(), entries_.end());
 
         // Include an entry for ".." for convenience on Linux.
@@ -223,7 +228,8 @@ struct FileDialog::Impl {
     }
 
     void UpdateOk() {
-        ok_->SetEnabled(std::string(filename_->GetText()) != "");
+        ok_->SetEnabled(mode_ == Mode::OPEN_DIR ||
+                        std::string(filename_->GetText()) != "");
     }
 };
 
@@ -253,7 +259,7 @@ FileDialog::FileDialog(Mode mode, const char *title, const Theme &theme)
     layout->AddChild(impl_->filelist_);
 
     impl_->cancel_ = std::make_shared<Button>("Cancel");
-    if (mode == Mode::OPEN) {
+    if (mode == Mode::OPEN || mode == Mode::OPEN_DIR) {
         impl_->ok_ = std::make_shared<Button>("Open");
     } else if (mode == Mode::SAVE) {
         impl_->ok_ = std::make_shared<Button>("Save");
@@ -405,8 +411,14 @@ void FileDialog::OnDone() {
                 }
             }
         }
-        utility::LogInfo("[o3d] name: {}.", name);
-        this->impl_->on_done_((dir + "/" + name).c_str());
+        std::string path;
+        if (!name.empty()) {
+            utility::LogInfo("[o3d] name: {}.", name);
+            path = dir + "/" + name;
+        } else {
+            path = dir;
+        }
+        this->impl_->on_done_(path.c_str());
     } else {
         utility::LogError("FileDialog: need to call SetOnDone()");
     }

--- a/cpp/open3d/visualization/gui/FileDialog.h
+++ b/cpp/open3d/visualization/gui/FileDialog.h
@@ -42,7 +42,7 @@ class FileDialog : public Dialog {
     using Super = Dialog;
 
 public:
-    enum class Mode { OPEN, SAVE };
+    enum class Mode { OPEN, SAVE, OPEN_DIR };
 
     FileDialog(Mode type, const char *title, const Theme &theme);
     virtual ~FileDialog();

--- a/cpp/pybind/visualization/gui/gui.cpp
+++ b/cpp/pybind/visualization/gui/gui.cpp
@@ -1663,6 +1663,7 @@ void pybind_gui_classes(py::module &m) {
             py::none(), py::none(), "");
     filedlg_mode.value("OPEN", FileDialog::Mode::OPEN)
             .value("SAVE", FileDialog::Mode::SAVE)
+            .value("OPEN_DIR", FileDialog::Mode::OPEN_DIR)
             .export_values();
     filedlg.def(py::init<FileDialog::Mode, const char *, const Theme &>(),
                 "Creates either an open or save file dialog. The first "


### PR DESCRIPTION
add OPEN_DIR besides OPEN and SAVE for FileDialog mode definition to select a directory in cpp as long as python.

Currently OPEN and SAVE mode of FileDialog select a file path like /path/to/file.json, there is no way to select a directory path like /path/to/dir/path. OPEN_DIR mode is used to select an existing directory path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4272)
<!-- Reviewable:end -->
