### PR TITLE
Explicitly set line set/bounding volume color

### DIFF
--- a/examples/cpp/Draw.cpp
+++ b/examples/cpp/Draw.cpp
@@ -78,12 +78,14 @@ void MultiObjects() {
     auto big_bbox = std::make_shared<geometry::AxisAlignedBoundingBox>(
             Eigen::Vector3d{-pc_rad, -3, -pc_rad},
             Eigen::Vector3d{6.0 + r, 1.0 + r, pc_rad});
+    big_bbox->color_ = {0.0, 0.0, 0.0};
     auto bbox = sphere_unlit->GetAxisAlignedBoundingBox();
     auto sphere_bbox = std::make_shared<geometry::AxisAlignedBoundingBox>(
             bbox.min_bound_, bbox.max_bound_);
     sphere_bbox->color_ = {1.0, 0.5, 0.0};
     auto lines = geometry::LineSet::CreateFromAxisAlignedBoundingBox(
             sphere_lit->GetAxisAlignedBoundingBox());
+    lines->PaintUniformColor({0.0, 1.0, 0.0});
     auto lines_colored = geometry::LineSet::CreateFromAxisAlignedBoundingBox(
             sphere_colored_lit->GetAxisAlignedBoundingBox());
     lines_colored->PaintUniformColor({0.0, 0.0, 1.0});

--- a/examples/python/gui/draw.py
+++ b/examples/python/gui/draw.py
@@ -78,10 +78,12 @@ def multi_objects():
     sphere_colored_lit.translate((6, 1, 0))
     big_bbox = o3d.geometry.AxisAlignedBoundingBox((-pc_rad, -3, -pc_rad),
                                                    (6.0 + r, 1.0 + r, pc_rad))
+    big_bbox.color = (0.0, 0.0, 0.0)
     sphere_bbox = sphere_unlit.get_axis_aligned_bounding_box()
     sphere_bbox.color = (1.0, 0.5, 0.0)
     lines = o3d.geometry.LineSet.create_from_axis_aligned_bounding_box(
         sphere_lit.get_axis_aligned_bounding_box())
+    lines.paint_uniform_color((0.0, 1.0, 0.0))
     lines_colored = o3d.geometry.LineSet.create_from_axis_aligned_bounding_box(
         sphere_colored_lit.get_axis_aligned_bounding_box())
     lines_colored.paint_uniform_color((0.0, 0.0, 1.0))


### PR DESCRIPTION
* Internal change to default bounding volume color caused unexpected colors in example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4274)
<!-- Reviewable:end -->
