### PR TITLE
Hide refracted materials when rendering to depth image

### DIFF
--- a/cpp/open3d/visualization/rendering/filament/FilamentRenderToBuffer.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentRenderToBuffer.cpp
@@ -119,7 +119,7 @@ void FilamentRenderToBuffer::Configure(const View* view,
 
     // Create a proper copy of the View with scen attached
     CopySettings(view);
-    auto* downcast_scene = dynamic_cast<FilamentScene*>(scene);
+    auto* downcast_scene = static_cast<FilamentScene*>(scene);
     if (downcast_scene) {
         view_->SetScene(*downcast_scene);
         scene_ = downcast_scene;
@@ -154,7 +154,7 @@ void FilamentRenderToBuffer::SetDimensions(const std::uint32_t width,
 
 void FilamentRenderToBuffer::CopySettings(const View* view) {
     view_ = new FilamentView(engine_, EngineInstance::GetResourceManager());
-    auto* downcast = dynamic_cast<const FilamentView*>(view);
+    auto* downcast = static_cast<const FilamentView*>(view);
     if (downcast) {
         view_->CopySettingsFrom(*downcast);
     }

--- a/cpp/open3d/visualization/rendering/filament/FilamentRenderToBuffer.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentRenderToBuffer.cpp
@@ -122,6 +122,7 @@ void FilamentRenderToBuffer::Configure(const View* view,
     auto* downcast_scene = dynamic_cast<FilamentScene*>(scene);
     if (downcast_scene) {
         view_->SetScene(*downcast_scene);
+        scene_ = downcast_scene;
     }
     SetDimensions(width, height);
 }
@@ -189,6 +190,7 @@ void FilamentRenderToBuffer::ReadPixelsCallback(void*, size_t, void* user) {
 
 void FilamentRenderToBuffer::Render() {
     frame_done_ = false;
+    scene_->HideRefractedMaterials();
     if (renderer_->beginFrame(swapchain_)) {
         renderer_->render(view_->GetNativeView());
 
@@ -212,6 +214,7 @@ void FilamentRenderToBuffer::Render() {
 
         renderer_->endFrame();
     }
+    scene_->HideRefractedMaterials(false);
 
     pending_ = false;
 }

--- a/cpp/open3d/visualization/rendering/filament/FilamentRenderToBuffer.h
+++ b/cpp/open3d/visualization/rendering/filament/FilamentRenderToBuffer.h
@@ -76,6 +76,7 @@ private:
     filament::Renderer* renderer_ = nullptr;
     filament::SwapChain* swapchain_ = nullptr;
     FilamentView* view_ = nullptr;
+    FilamentScene* scene_ = nullptr;
 
     std::size_t width_ = 0;
     std::size_t height_ = 0;

--- a/cpp/open3d/visualization/rendering/filament/FilamentScene.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentScene.cpp
@@ -498,6 +498,7 @@ bool FilamentScene::CreateAndAddFilamentEntity(
                 object_name,
                 RenderableGeometry{object_name,
                                    true,
+                                   false,
                                    true,
                                    true,
                                    true,
@@ -1900,7 +1901,17 @@ void FilamentScene::Draw(filament::Renderer& renderer) {
 void FilamentScene::HideRefractedMaterials(bool hide) {
     for (auto geom : geometries_) {
         if (geom.second.mat.properties.shader == "defaultLitSSR") {
-            ShowGeometry(geom.first, !hide);
+            if (hide) {
+                if (!geom.second.visible) {
+                    geom.second.was_hidden_before_picking = true;
+                } else {
+                    ShowGeometry(geom.first, false);
+                }
+            } else {
+                if (!geom.second.was_hidden_before_picking) {
+                    ShowGeometry(geom.first, true);
+                }
+            }
         }
     }
 }

--- a/cpp/open3d/visualization/rendering/filament/FilamentScene.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentScene.cpp
@@ -1897,6 +1897,14 @@ void FilamentScene::Draw(filament::Renderer& renderer) {
     }
 }
 
+void FilamentScene::HideRefractedMaterials(bool hide) {
+    for (auto geom : geometries_) {
+        if (geom.second.mat.properties.shader == "defaultLitSSR") {
+            ShowGeometry(geom.first, !hide);
+        }
+    }
+}
+
 }  // namespace rendering
 }  // namespace visualization
 }  // namespace open3d

--- a/cpp/open3d/visualization/rendering/filament/FilamentScene.h
+++ b/cpp/open3d/visualization/rendering/filament/FilamentScene.h
@@ -229,6 +229,12 @@ public:
 
     void Draw(filament::Renderer& renderer);
 
+    // NOTE: This method is to work around Filament limitation when rendering to
+    // depth buffer. Materials with SSR require multiple passes which causes a
+    // crash with render to depth since we must disable multiple passes (i.e.,
+    // post-processing) in order to get back valid, un-modified depth values.
+    void HideRefractedMaterials(bool hide = true);
+
     // NOTE: Can GetNativeScene be removed?
     filament::Scene* GetNativeScene() const { return scene_; }
 

--- a/cpp/open3d/visualization/rendering/filament/FilamentScene.h
+++ b/cpp/open3d/visualization/rendering/filament/FilamentScene.h
@@ -284,6 +284,7 @@ private:
     struct RenderableGeometry {
         std::string name;
         bool visible = true;
+        bool was_hidden_before_picking = false;
         bool cast_shadows = true;
         bool receive_shadows = true;
         bool culling_enabled = true;


### PR DESCRIPTION
This PR solves crash when trying to double click in `O3DVisualizer` window when there are objects with "defaultLitSSR" materials.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4291)
<!-- Reviewable:end -->
