### PR TITLE
Support Wide Lines For T Geometry Line Sets

### DIFF
--- a/cpp/open3d/visualization/rendering/filament/FilamentGeometryBuffersBuilder.h
+++ b/cpp/open3d/visualization/rendering/filament/FilamentGeometryBuffersBuilder.h
@@ -206,8 +206,16 @@ public:
     filament::Box ComputeAABB() override;
 
 private:
-    Buffers ConstructThinLines();
-
+    void ConstructThinLines(uint32_t& n_vertices,
+                            float** vertex_data,
+                            uint32_t& n_indices,
+                            uint32_t& indices_bytes,
+                            uint32_t** line_indices);
+    void ConstructWideLines(uint32_t& n_vertices,
+                            float** vertex_data,
+                            uint32_t& n_indices,
+                            uint32_t& indices_bytes,
+                            uint32_t** line_indices);
     t::geometry::LineSet geometry_;
 };
 

--- a/cpp/open3d/visualization/rendering/filament/FilamentGeometryBuffersBuilder.h
+++ b/cpp/open3d/visualization/rendering/filament/FilamentGeometryBuffersBuilder.h
@@ -206,11 +206,15 @@ public:
     filament::Box ComputeAABB() override;
 
 private:
+    /// Utility function for building GPU assets needed for rendering lines as
+    /// lines. Used for 'thin' lines.
     void ConstructThinLines(uint32_t& n_vertices,
                             float** vertex_data,
                             uint32_t& n_indices,
                             uint32_t& indices_bytes,
                             uint32_t** line_indices);
+    /// Utility method for building GPU assets needed for rendering wide lines
+    /// which are rendered as pairs of triangles per line
     void ConstructWideLines(uint32_t& n_vertices,
                             float** vertex_data,
                             uint32_t& n_indices,

--- a/cpp/open3d/visualization/rendering/filament/FilamentScene.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentScene.cpp
@@ -393,6 +393,10 @@ bool FilamentScene::AddGeometry(const std::string& object_name,
         buffer_builder->SetDownsampleThreshold(downsample_threshold);
     }
     buffer_builder->SetAdjustColorsForSRGBToneMapping(material.sRGB_color);
+    if (material.shader == "unlitLine") {
+        buffer_builder->SetWideLines();
+    }
+
     auto buffers = buffer_builder->ConstructBuffers();
     auto vb = std::get<0>(buffers);
     auto ib = std::get<1>(buffers);

--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
@@ -901,7 +901,7 @@ struct O3DVisualizer::Impl {
 
             mat.base_color = CalcDefaultUnlitColor();
             mat.shader = kShaderUnlit;
-            if (lines || obb || aabb) {
+            if (lines || obb || aabb || t_lines) {
                 mat.shader = kShaderUnlitLines;
                 mat.line_width = ui_state_.line_width * window_->GetScaling();
             }

--- a/python/open3d/visualization/draw.py
+++ b/python/open3d/visualization/draw.py
@@ -44,6 +44,7 @@ def draw(geometry=None,
          show_skybox=None,
          show_ui=None,
          point_size=None,
+         line_width=None,
          animation_time_step=1.0,
          animation_duration=None,
          rpc_interface=False,
@@ -61,6 +62,9 @@ def draw(geometry=None,
 
     if point_size is not None:
         w.point_size = point_size
+
+    if line_width is not None:
+        w.line_width = line_width
 
     def add(g, n):
         if isinstance(g, dict):


### PR DESCRIPTION
Before line sets render as thin, pixel-width lines. Default view:
![2021-11-13-130512_1024x768_scrot](https://user-images.githubusercontent.com/3722407/141704007-babc6526-3c09-40d6-8d74-651f98630849.png)

Default view with this PR:
![2021-11-14-182408_1024x768_scrot](https://user-images.githubusercontent.com/3722407/141704011-1a11033d-63ea-46d1-ad26-26520750ff5a.png)

Colored, wider lines:
![2021-11-14-184540_1024x768_scrot](https://user-images.githubusercontent.com/3722407/141704033-ed7c3c7f-fd99-4d89-9e5b-0c7887c0b35c.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4293)
<!-- Reviewable:end -->
