### PR TITLE
use latest nvidia driver in base vm image

### DIFF
--- a/.github/workflows/create_gcloud_vm.sh
+++ b/.github/workflows/create_gcloud_vm.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Use this script to create the base Google Cloud VM image for Ubuntu CUDA CI.
+# This script only needs to be run once. It is recommended to run this script
+# section by section, as it will prompt you for the necessary information.
+#
+# When we update the Google Cloud VM, change ubuntu-cuda.yml such that the
+# "--image-family" points to the new image.
+#
+# List of packages installed:
+# - Nvidia driver
+# - Nvidia docker
+
+set -euo pipefail
+
+INSTANCE_NAME="open3d-ci-base-image-vm"
+INSTANCE_ZONE="us-west1-a"
+CUSTOM_IMAGE_NAME="ubuntu-os-docker-gpu-2004-20211116"
+
+# Create VM.
+gcloud compute instances create "${INSTANCE_NAME}" \
+    --zone="${INSTANCE_ZONE}" \
+    --service-account="open3d-ci-sa-gpu@open3d-dev.iam.gserviceaccount.com" \
+    --accelerator="count=2,type=nvidia-tesla-t4" \
+    --maintenance-policy="TERMINATE" \
+    --machine-type="n1-standard-8" \
+    --image-project="ubuntu-os-cloud" \
+    --image-family="ubuntu-2004-lts" \
+    --boot-disk-size="128GB" \
+    --boot-disk-type="pd-ssd"
+sleep 30
+
+# Install latest nvidia-driver. This will not install CUDA toolkits and nvcc.
+# Ref: https://cloud.google.com/compute/docs/gpus/install-drivers-gpu
+# This script may restart the macine. Run it twice.
+gcloud compute ssh "${INSTANCE_NAME}" \
+    --zone "${INSTANCE_ZONE}" \
+    --command "curl https://raw.githubusercontent.com/GoogleCloudPlatform/compute-gpu-installation/main/linux/install_gpu_driver.py --output install_gpu_driver.py \
+            && sudo python3 install_gpu_driver.py"
+gcloud compute ssh "${INSTANCE_NAME}" \
+    --zone "${INSTANCE_ZONE}" \
+    --command "curl https://raw.githubusercontent.com/GoogleCloudPlatform/compute-gpu-installation/main/linux/install_gpu_driver.py --output install_gpu_driver.py \
+            && sudo python3 install_gpu_driver.py"
+
+# Check that nvidia-smi is working.
+gcloud compute ssh "${INSTANCE_NAME}" \
+    --zone "${INSTANCE_ZONE}" \
+    --command "nvidia-smi"
+
+# Install docker.
+gcloud compute ssh "${INSTANCE_NAME}" \
+    --zone "${INSTANCE_ZONE}" \
+    --command "curl https://get.docker.com | sh \
+            && sudo systemctl --now enable docker"
+
+# Install nvidia-docker.
+gcloud compute ssh "${INSTANCE_NAME}" \
+    --zone "${INSTANCE_ZONE}" \
+    --command "curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add - \
+            && curl -s -L https://nvidia.github.io/nvidia-docker/ubuntu20.04/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list \
+            && sudo apt-get update \
+            && sudo apt-get install -y nvidia-docker2 \
+            && sudo systemctl restart docker \
+            && sudo docker run --rm --gpus all nvidia/cuda:11.0-base nvidia-smi"
+
+# Turn off VM.
+gcloud compute instances stop "${INSTANCE_NAME}" \
+    --zone "${INSTANCE_ZONE}"
+
+# Save image.
+gcloud compute images create "${INSTANCE_NAME}" \
+    --source-disk="${INSTANCE_NAME}" \
+    --source-disk-zone="${INSTANCE_ZONE}" \
+    --family="${CUSTOM_IMAGE_NAME}" \
+    --storage-location=us
+
+# Delete VM.
+gcloud compute instances delete "${INSTANCE_NAME}" --zone="${INSTANCE_ZONE}"

--- a/.github/workflows/ubuntu-cuda.yml
+++ b/.github/workflows/ubuntu-cuda.yml
@@ -91,14 +91,14 @@ jobs:
           # GCE only supports GPU on n1-standard (2020/07)
           ZONE_ID=0
           until ((ZONE_ID >= ${#INSTANCE_ZONES[@]})) ||
-            gcloud compute instances create "$INSTANCE_NAME" \
+            gcloud compute instances create "${INSTANCE_NAME}" \
               --zone="${INSTANCE_ZONES[$ZONE_ID]}" \
               --accelerator="count=2,type=nvidia-tesla-t4" \
               --maintenance-policy="TERMINATE" \
               --machine-type=n1-standard-8 \
               --boot-disk-size="128GB" \
               --boot-disk-type="pd-ssd" \
-              --image-family="ubuntu-os-docker-gpu-2004-lts" \
+              --image-family="ubuntu-os-docker-gpu-2004-20211116" \
               --scopes "https://www.googleapis.com/auth/devstorage.full_control" \
               --service-account="$GCE_GPU_CI_SA"; do
               ((ZONE_ID = ZONE_ID + 1))

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Trigger
+
 <p align="center">
 <img src="https://raw.githubusercontent.com/isl-org/Open3D/master/docs/_static/open3d_logo_horizontal.png" width="320" />
 </p>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-Trigger
-
 <p align="center">
 <img src="https://raw.githubusercontent.com/isl-org/Open3D/master/docs/_static/open3d_logo_horizontal.png" width="320" />
 </p>


### PR DESCRIPTION
Another attempt to fix: https://github.com/isl-org/Open3D/runs/4219104903?check_suite_focus=true

```
pytest is randomized, add --randomly-seed=SEED to repeat the test sequence.
docker: Error response from daemon: OCI runtime create failed: container_linux.go:380: starting container process caused: process_linux.go:545: container init caused: Running hook #0:: error running hook: exit status 1, stdout: , stderr: nvidia-container-cli: initialization error: nvml error: driver/library version mismatch: unknown.
```

This issue occurs randomly. Hopefully, the latest CUDA driver (11.5) can help with this.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4302)
<!-- Reviewable:end -->
