### PR TITLE
Add flatten operation to Tensor

### DIFF
--- a/cpp/open3d/core/Tensor.cpp
+++ b/cpp/open3d/core/Tensor.cpp
@@ -656,18 +656,20 @@ Tensor Tensor::Reshape(const SizeVector& dst_shape) const {
     }
 }
 
-Tensor Tensor::Flatten(int64_t start_dim,
-                       int64_t end_dim) const {
+Tensor Tensor::Flatten(int64_t start_dim, int64_t end_dim) const {
     core::SizeVector shape = GetShape();
     core::SizeVector dst_shape;
-    if (start_dim < -(int64_t)shape.size() || start_dim >= (int64_t)shape.size())
+    if (start_dim < -(int64_t)shape.size() ||
+        start_dim >= (int64_t)shape.size())
         utility::LogError(
                 "Dimension out of range (expected to be in range of [{}, {}], "
-                "but got {})", -(int64_t)shape.size(), (int64_t)shape.size()-1, start_dim);
+                "but got {})",
+                -(int64_t)shape.size(), (int64_t)shape.size() - 1, start_dim);
     if (end_dim < -(int64_t)shape.size() || end_dim >= (int64_t)shape.size())
         utility::LogError(
                 "Dimension out of range (expected to be in range of [{}, {}], "
-                "but got {})", -(int64_t)shape.size(), (int64_t)shape.size()-1, end_dim);
+                "but got {})",
+                -(int64_t)shape.size(), (int64_t)shape.size() - 1, end_dim);
     if (end_dim < 0) end_dim += (int64_t)shape.size();
     if (start_dim < 0) start_dim += (int64_t)shape.size();
     if (end_dim < start_dim)
@@ -678,9 +680,8 @@ Tensor Tensor::Flatten(int64_t start_dim,
     for (int64_t dim = 0; dim < (int64_t)shape.size(); dim++) {
         if (dim >= start_dim && dim <= end_dim) {
             flat_dimension_size *= shape[dim];
-            if (dim == end_dim) 
-                dst_shape.push_back(flat_dimension_size);
-        } else 
+            if (dim == end_dim) dst_shape.push_back(flat_dimension_size);
+        } else
             dst_shape.push_back(shape[dim]);
     }
     return Reshape(dst_shape);

--- a/cpp/open3d/core/Tensor.cpp
+++ b/cpp/open3d/core/Tensor.cpp
@@ -679,7 +679,9 @@ Tensor Tensor::Flatten(int64_t start_dim /*= 0*/,
     for (int64_t dim = 0; dim < num_dims; dim++) {
         if (dim >= start_dim && dim <= end_dim) {
             flat_dimension_size *= shape[dim];
-            if (dim == end_dim) dst_shape.push_back(flat_dimension_size);
+            if (dim == end_dim) {
+                dst_shape.push_back(flat_dimension_size);
+            }
         } else {
             dst_shape.push_back(shape[dim]);
         }

--- a/cpp/open3d/core/Tensor.cpp
+++ b/cpp/open3d/core/Tensor.cpp
@@ -661,6 +661,12 @@ Tensor Tensor::Flatten(int64_t start_dim /*= 0*/,
     core::SizeVector shape = GetShape();
     core::SizeVector dst_shape;
     int64_t num_dims = NumDims();
+    if (num_dims == 0) {
+        // Wrap here only to check for validity of input dimensions
+        start_dim = shape_util::WrapDim(start_dim, 1, false);
+        end_dim = shape_util::WrapDim(end_dim, 1, false);
+        return Broadcast({1});
+    }
     start_dim = shape_util::WrapDim(start_dim, num_dims, false);
     end_dim = shape_util::WrapDim(end_dim, num_dims, false);
     if (end_dim < start_dim) {

--- a/cpp/open3d/core/Tensor.cpp
+++ b/cpp/open3d/core/Tensor.cpp
@@ -657,34 +657,26 @@ Tensor Tensor::Reshape(const SizeVector& dst_shape) const {
 }
 
 Tensor Tensor::Flatten(int64_t start_dim /*= 0*/,
-                       int64_t end_dim /*= false*/) const {
+                       int64_t end_dim /*= -1*/) const {
     core::SizeVector shape = GetShape();
     core::SizeVector dst_shape;
-    if (start_dim < -(int64_t)shape.size() ||
-        start_dim >= (int64_t)shape.size())
-        utility::LogError(
-                "Dimension out of range (expected to be in range of [{}, {}], "
-                "but got {})",
-                -(int64_t)shape.size(), (int64_t)shape.size() - 1, start_dim);
-    if (end_dim < -(int64_t)shape.size() || end_dim >= (int64_t)shape.size())
-        utility::LogError(
-                "Dimension out of range (expected to be in range of [{}, {}], "
-                "but got {})",
-                -(int64_t)shape.size(), (int64_t)shape.size() - 1, end_dim);
-    if (end_dim < 0) end_dim += (int64_t)shape.size();
-    if (start_dim < 0) start_dim += (int64_t)shape.size();
-    if (end_dim < start_dim)
+    int64_t num_dims = NumDims();
+    start_dim = shape_util::WrapDim(start_dim, num_dims, false);
+    end_dim = shape_util::WrapDim(end_dim, num_dims, false);
+    if (end_dim < start_dim) {
         utility::LogError(
                 "Flatten() has invalid args: start_dim cannot come after "
                 "end_dim");
+    }
     // Multiply the flattened dimensions together
     int64_t flat_dimension_size = 1;
-    for (int64_t dim = 0; dim < (int64_t)shape.size(); dim++) {
+    for (int64_t dim = 0; dim < num_dims; dim++) {
         if (dim >= start_dim && dim <= end_dim) {
             flat_dimension_size *= shape[dim];
             if (dim == end_dim) dst_shape.push_back(flat_dimension_size);
-        } else
+        } else {
             dst_shape.push_back(shape[dim]);
+        }
     }
     return Reshape(dst_shape);
 }

--- a/cpp/open3d/core/Tensor.cpp
+++ b/cpp/open3d/core/Tensor.cpp
@@ -656,7 +656,8 @@ Tensor Tensor::Reshape(const SizeVector& dst_shape) const {
     }
 }
 
-Tensor Tensor::Flatten(int64_t start_dim, int64_t end_dim) const {
+Tensor Tensor::Flatten(int64_t start_dim /*= 0*/,
+                       int64_t end_dim /*= false*/) const {
     core::SizeVector shape = GetShape();
     core::SizeVector dst_shape;
     if (start_dim < -(int64_t)shape.size() ||
@@ -676,6 +677,7 @@ Tensor Tensor::Flatten(int64_t start_dim, int64_t end_dim) const {
         utility::LogError(
                 "Flatten() has invalid args: start_dim cannot come after "
                 "end_dim");
+    // Multiply the flattened dimensions together
     int64_t flat_dimension_size = 1;
     for (int64_t dim = 0; dim < (int64_t)shape.size(); dim++) {
         if (dim >= start_dim && dim <= end_dim) {

--- a/cpp/open3d/core/Tensor.cpp
+++ b/cpp/open3d/core/Tensor.cpp
@@ -658,23 +658,26 @@ Tensor Tensor::Reshape(const SizeVector& dst_shape) const {
 
 Tensor Tensor::Flatten(int64_t start_dim /*= 0*/,
                        int64_t end_dim /*= -1*/) const {
-    core::SizeVector shape = GetShape();
-    core::SizeVector dst_shape;
     int64_t num_dims = NumDims();
     if (num_dims == 0) {
-        // Wrap here only to check for validity of input dimensions
-        start_dim = shape_util::WrapDim(start_dim, 1, false);
-        end_dim = shape_util::WrapDim(end_dim, 1, false);
-        return Broadcast({1});
+        // Flattening a 0-d tensor is equivalent to flattening the tensor
+        // reshaped to 1-d. Technically, we cannot have a start_dim or end_dim,
+        // since a 0-d tensor cannot be indexed, e.g. np.array(100)[0] is not
+        // valid. But start_dim = 0 and end_dim = -1 are the default parameter
+        // values so we make an exception case for 0-d. We reshape it to 1-d for
+        // boundary checks of start_dim and end_dim.
+        return Reshape({1}).Flatten(start_dim, end_dim);
     }
+    core::SizeVector shape = GetShape();
+    core::SizeVector dst_shape;
     start_dim = shape_util::WrapDim(start_dim, num_dims, false);
     end_dim = shape_util::WrapDim(end_dim, num_dims, false);
     if (end_dim < start_dim) {
         utility::LogError(
-                "Flatten() has invalid args: start_dim cannot come after "
-                "end_dim");
+                "start_dim {} must be smaller or equal to end_dim {}.",
+                start_dim, end_dim);
     }
-    // Multiply the flattened dimensions together
+    // Multiply the flattened dimensions together.
     int64_t flat_dimension_size = 1;
     for (int64_t dim = 0; dim < num_dims; dim++) {
         if (dim >= start_dim && dim <= end_dim) {

--- a/cpp/open3d/core/Tensor.cpp
+++ b/cpp/open3d/core/Tensor.cpp
@@ -656,6 +656,36 @@ Tensor Tensor::Reshape(const SizeVector& dst_shape) const {
     }
 }
 
+Tensor Tensor::Flatten(int64_t start_dim,
+                       int64_t end_dim) const {
+    core::SizeVector shape = GetShape();
+    core::SizeVector dst_shape;
+    if (start_dim < -(int64_t)shape.size() || start_dim >= (int64_t)shape.size())
+        utility::LogError(
+                "Dimension out of range (expected to be in range of [{}, {}], "
+                "but got {})", -(int64_t)shape.size(), (int64_t)shape.size()-1, start_dim);
+    if (end_dim < -(int64_t)shape.size() || end_dim >= (int64_t)shape.size())
+        utility::LogError(
+                "Dimension out of range (expected to be in range of [{}, {}], "
+                "but got {})", -(int64_t)shape.size(), (int64_t)shape.size()-1, end_dim);
+    if (end_dim < 0) end_dim += (int64_t)shape.size();
+    if (start_dim < 0) start_dim += (int64_t)shape.size();
+    if (end_dim < start_dim)
+        utility::LogError(
+                "Flatten() has invalid args: start_dim cannot come after "
+                "end_dim");
+    int64_t flat_dimension_size = 1;
+    for (int64_t dim = 0; dim < (int64_t)shape.size(); dim++) {
+        if (dim >= start_dim && dim <= end_dim) {
+            flat_dimension_size *= shape[dim];
+            if (dim == end_dim) 
+                dst_shape.push_back(flat_dimension_size);
+        } else 
+            dst_shape.push_back(shape[dim]);
+    }
+    return Reshape(dst_shape);
+}
+
 Tensor Tensor::View(const SizeVector& dst_shape) const {
     SizeVector inferred_dst_shape =
             shape_util::InferShape(dst_shape, NumElements());

--- a/cpp/open3d/core/Tensor.h
+++ b/cpp/open3d/core/Tensor.h
@@ -415,6 +415,10 @@ public:
     /// - https://pytorch.org/docs/stable/tensors.html
     /// - aten/src/ATen/native/TensorShape.cpp
     /// - aten/src/ATen/TensorUtils.cpp
+    ///
+    /// \param start_dim The first dimension to flatten (exclusive).
+    /// \param end_dim The last dimension to flatten, starting from \p start_dim
+    /// (exclusive).
     Tensor Flatten(int64_t start_dim = 0, int64_t end_dim = -1) const;
 
     /// Returns a new tensor view with the same data but of a different shape.

--- a/cpp/open3d/core/Tensor.h
+++ b/cpp/open3d/core/Tensor.h
@@ -415,7 +415,7 @@ public:
     /// - https://pytorch.org/docs/stable/tensors.html
     /// - aten/src/ATen/native/TensorShape.cpp
     /// - aten/src/ATen/TensorUtils.cpp
-    Tensor Flatten(int64_t start_dim=0, int64_t end_dim=-1) const;
+    Tensor Flatten(int64_t start_dim = 0, int64_t end_dim = -1) const;
 
     /// Returns a new tensor view with the same data but of a different shape.
     ///

--- a/cpp/open3d/core/Tensor.h
+++ b/cpp/open3d/core/Tensor.h
@@ -416,9 +416,9 @@ public:
     /// - aten/src/ATen/native/TensorShape.cpp
     /// - aten/src/ATen/TensorUtils.cpp
     ///
-    /// \param start_dim The first dimension to flatten (exclusive).
+    /// \param start_dim The first dimension to flatten (inclusive).
     /// \param end_dim The last dimension to flatten, starting from \p start_dim
-    /// (exclusive).
+    /// (inclusive).
     Tensor Flatten(int64_t start_dim = 0, int64_t end_dim = -1) const;
 
     /// Returns a new tensor view with the same data but of a different shape.

--- a/cpp/open3d/core/Tensor.h
+++ b/cpp/open3d/core/Tensor.h
@@ -399,6 +399,24 @@ public:
     /// - aten/src/ATen/TensorUtils.cpp
     Tensor Reshape(const SizeVector& dst_shape) const;
 
+    /// Flattens input by reshaping it into a one-dimensional tensor. If
+    /// start_dim or end_dim are passed, only dimensions starting with start_dim
+    /// and ending with end_dim are flattened. The order of elements in input is
+    /// unchanged.
+    ///
+    /// Unlike NumPy’s flatten, which always copies input’s data, this function
+    /// may return the original object, a view, or copy. If no dimensions are
+    /// flattened, then the original object input is returned. Otherwise, if
+    /// input can be viewed as the flattened shape, then that view is returned.
+    /// Finally, only if the input cannot be viewed as the flattened shape is
+    /// input’s data copied.
+    ///
+    /// Ref:
+    /// - https://pytorch.org/docs/stable/tensors.html
+    /// - aten/src/ATen/native/TensorShape.cpp
+    /// - aten/src/ATen/TensorUtils.cpp
+    Tensor Flatten(int64_t start_dim=0, int64_t end_dim=-1) const;
+
     /// Returns a new tensor view with the same data but of a different shape.
     ///
     /// The returned tensor shares the same data and must have the same number

--- a/cpp/pybind/core/tensor.cpp
+++ b/cpp/pybind/core/tensor.cpp
@@ -686,6 +686,25 @@ Ref:
                "underlying memory will be used.");
     tensor.def("is_contiguous", &Tensor::IsContiguous,
                "Returns True if the underlying memory buffer is contiguous.");
+    tensor.def(
+            "flatten", &Tensor::Flatten,
+            R"(Flattens input by reshaping it into a one-dimensional tensor. If
+start_dim or end_dim are passed, only dimensions starting with start_dim
+and ending with end_dim are flattened. The order of elements in input is
+unchanged.
+
+Unlike NumPy’s flatten, which always copies input’s data, this function
+may return the original object, a view, or copy. If no dimensions are
+flattened, then the original object input is returned. Otherwise, if
+input can be viewed as the flattened shape, then that view is returned.
+Finally, only if the input cannot be viewed as the flattened shape is
+input’s data copied.
+
+Ref:
+- https://pytorch.org/docs/stable/tensors.html
+- aten/src/ATen/native/TensorShape.cpp
+- aten/src/ATen/TensorUtils.cpp)",
+            "start_dim"_a = 0, "end_dim"_a = -1);
 
     // See "emulating numeric types" section for Python built-in numeric ops.
     // https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types

--- a/cpp/pybind/core/tensor.cpp
+++ b/cpp/pybind/core/tensor.cpp
@@ -707,10 +707,10 @@ Ref:
             "start_dim"_a = 0, "end_dim"_a = -1);
     docstring::ClassMethodDocInject(
             m, "Tensor", "flatten",
-            {{"start_dim", "The first dimension to flatten (exclusive)"},
+            {{"start_dim", "The first dimension to flatten (inclusive)."},
              {"end_dim",
               "The last dimension to flatten, starting from start_dim "
-              "(exclusive)"}});
+              "(inclusive)."}});
 
     // See "emulating numeric types" section for Python built-in numeric ops.
     // https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types

--- a/cpp/pybind/core/tensor.cpp
+++ b/cpp/pybind/core/tensor.cpp
@@ -705,6 +705,12 @@ Ref:
 - aten/src/ATen/native/TensorShape.cpp
 - aten/src/ATen/TensorUtils.cpp)",
             "start_dim"_a = 0, "end_dim"_a = -1);
+    docstring::ClassMethodDocInject(
+            m, "Tensor", "flatten",
+            {{"start_dim", "The first dimension to flatten (exclusive)"},
+             {"end_dim",
+              "The last dimension to flatten, starting from start_dim "
+              "(exclusive)"}});
 
     // See "emulating numeric types" section for Python built-in numeric ops.
     // https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types

--- a/cpp/tests/core/Tensor.cpp
+++ b/cpp/tests/core/Tensor.cpp
@@ -417,7 +417,7 @@ TEST_P(TensorPermuteDevices, Flatten) {
     // Flatten 0-D Tensor
     core::Tensor src_t = core::Tensor::Init<float>(3, device);
     core::Tensor dst_t = core::Tensor::Init<float>({3}, device);
-    
+
     EXPECT_TRUE((dst_t == src_t.Flatten()).All());
     EXPECT_TRUE((dst_t == src_t.Flatten(0)).All());
     EXPECT_TRUE((dst_t == src_t.Flatten(-1)).All());
@@ -435,7 +435,7 @@ TEST_P(TensorPermuteDevices, Flatten) {
     // Flatten 1-D Tensor
     src_t = core::Tensor::Init<float>({1, 2, 3}, device);
     dst_t = core::Tensor::Init<float>({1, 2, 3}, device);
-    
+
     EXPECT_TRUE((dst_t == src_t.Flatten()).All());
     EXPECT_TRUE((dst_t == src_t.Flatten(0)).All());
     EXPECT_TRUE((dst_t == src_t.Flatten(-1)).All());
@@ -472,7 +472,7 @@ TEST_P(TensorPermuteDevices, Flatten) {
     for (int64_t dim : {-2, -1, 0, 1}) {
         EXPECT_TRUE((dst_t_unchanged == src_t.Flatten(dim, dim)).All());
     }
-    
+
     // Out of bounds dimensions
     EXPECT_ANY_THROW(src_t.Flatten(0, 2));
     EXPECT_ANY_THROW(src_t.Flatten(0, -3));
@@ -492,9 +492,9 @@ TEST_P(TensorPermuteDevices, Flatten) {
             {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}, device);
     dst_t_unchanged = core::Tensor::Init<float>(
             {{{1, 2, 3}, {4, 5, 6}}, {{7, 8, 9}, {10, 11, 12}}}, device);
-    core::Tensor dst_t_unflat_last = core::Tensor::Init<float>(
+    core::Tensor dst_t_first_two_flat = core::Tensor::Init<float>(
             {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}}, device);
-    core::Tensor dst_t_unflat_first = core::Tensor::Init<float>(
+    core::Tensor dst_t_last_two_flat = core::Tensor::Init<float>(
             {{1, 2, 3, 4, 5, 6}, {7, 8, 9, 10, 11, 12}}, device);
 
     EXPECT_TRUE((dst_t_flat == src_t.Flatten()).All());
@@ -506,15 +506,15 @@ TEST_P(TensorPermuteDevices, Flatten) {
     EXPECT_TRUE((dst_t_flat == src_t.Flatten(0, -1)).All());
     EXPECT_TRUE((dst_t_flat == src_t.Flatten(-3, -1)).All());
 
-    EXPECT_TRUE((dst_t_unflat_last == src_t.Flatten(0, 1)).All());
-    EXPECT_TRUE((dst_t_unflat_last == src_t.Flatten(0, -2)).All());
-    EXPECT_TRUE((dst_t_unflat_last == src_t.Flatten(-3, 1)).All());
-    EXPECT_TRUE((dst_t_unflat_last == src_t.Flatten(-3, -2)).All());
+    EXPECT_TRUE((dst_t_first_two_flat == src_t.Flatten(0, 1)).All());
+    EXPECT_TRUE((dst_t_first_two_flat == src_t.Flatten(0, -2)).All());
+    EXPECT_TRUE((dst_t_first_two_flat == src_t.Flatten(-3, 1)).All());
+    EXPECT_TRUE((dst_t_first_two_flat == src_t.Flatten(-3, -2)).All());
 
-    EXPECT_TRUE((dst_t_unflat_first == src_t.Flatten(1, 2)).All());
-    EXPECT_TRUE((dst_t_unflat_first == src_t.Flatten(1, -1)).All());
-    EXPECT_TRUE((dst_t_unflat_first == src_t.Flatten(-2, 2)).All());
-    EXPECT_TRUE((dst_t_unflat_first == src_t.Flatten(-2, -1)).All());
+    EXPECT_TRUE((dst_t_last_two_flat == src_t.Flatten(1, 2)).All());
+    EXPECT_TRUE((dst_t_last_two_flat == src_t.Flatten(1, -1)).All());
+    EXPECT_TRUE((dst_t_last_two_flat == src_t.Flatten(-2, 2)).All());
+    EXPECT_TRUE((dst_t_last_two_flat == src_t.Flatten(-2, -1)).All());
 
     for (int64_t dim : {-3, -2, -1, 0, 1, 2}) {
         EXPECT_TRUE((dst_t_unchanged == src_t.Flatten(dim, dim)).All());

--- a/cpp/tests/core/Tensor.cpp
+++ b/cpp/tests/core/Tensor.cpp
@@ -414,23 +414,122 @@ TEST_P(TensorPermuteDevices, Expand) {
 TEST_P(TensorPermuteDevices, Flatten) {
     core::Device device = GetParam();
 
-    core::Tensor src_t = core::Tensor::Init<float>(
-            {{{0, 1, 2, 3}, {4, 5, 6, 7}, {8, 9, 10, 11}},
-             {{12, 13, 14, 15}, {16, 17, 18, 19}, {20, 21, 22, 23}}},
-            device);
+    // Flatten 0-D Tensor
+    core::Tensor src_t = core::Tensor::Init<float>(3, device);
+    core::Tensor dst_t = core::Tensor::Init<float>({3}, device);
+    
+    EXPECT_TRUE((dst_t == src_t.Flatten()).All());
+    EXPECT_TRUE((dst_t == src_t.Flatten(0)).All());
+    EXPECT_TRUE((dst_t == src_t.Flatten(-1)).All());
 
-    core::Tensor dst_t_no_param = core::Tensor::Init<float>(
-            {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
-             12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23},
-            device);
+    EXPECT_TRUE((dst_t == src_t.Flatten(0, 0)).All());
+    EXPECT_TRUE((dst_t == src_t.Flatten(0, -1)).All());
+    EXPECT_TRUE((dst_t == src_t.Flatten(-1, 0)).All());
+    EXPECT_TRUE((dst_t == src_t.Flatten(-1, -1)).All());
 
-    core::Tensor dst_t_with_param = core::Tensor::Init<float>(
-            {{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
-             {12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23}},
-            device);
+    EXPECT_ANY_THROW(src_t.Flatten(-2));
+    EXPECT_ANY_THROW(src_t.Flatten(1));
+    EXPECT_ANY_THROW(src_t.Flatten(0, -2));
+    EXPECT_ANY_THROW(src_t.Flatten(0, 1));
 
-    EXPECT_TRUE((dst_t_no_param == src_t.Flatten()).All());
-    EXPECT_TRUE((dst_t_with_param == src_t.Flatten(1)).All());
+    // Flatten 1-D Tensor
+    src_t = core::Tensor::Init<float>({1, 2, 3}, device);
+    dst_t = core::Tensor::Init<float>({1, 2, 3}, device);
+    
+    EXPECT_TRUE((dst_t == src_t.Flatten()).All());
+    EXPECT_TRUE((dst_t == src_t.Flatten(0)).All());
+    EXPECT_TRUE((dst_t == src_t.Flatten(-1)).All());
+
+    EXPECT_TRUE((dst_t == src_t.Flatten(0, 0)).All());
+    EXPECT_TRUE((dst_t == src_t.Flatten(0, -1)).All());
+    EXPECT_TRUE((dst_t == src_t.Flatten(-1, 0)).All());
+    EXPECT_TRUE((dst_t == src_t.Flatten(-1, -1)).All());
+
+    EXPECT_ANY_THROW(src_t.Flatten(-2));
+    EXPECT_ANY_THROW(src_t.Flatten(1));
+    EXPECT_ANY_THROW(src_t.Flatten(0, -2));
+    EXPECT_ANY_THROW(src_t.Flatten(0, 1));
+
+    // Flatten 2-D Tensor
+    src_t = core::Tensor::Init<float>({{1, 2, 3}, {4, 5, 6}}, device);
+    core::Tensor dst_t_flat =
+            core::Tensor::Init<float>({1, 2, 3, 4, 5, 6}, device);
+    core::Tensor dst_t_unchanged =
+            core::Tensor::Init<float>({{1, 2, 3}, {4, 5, 6}}, device);
+
+    EXPECT_TRUE((dst_t_flat == src_t.Flatten()).All());
+    EXPECT_TRUE((dst_t_flat == src_t.Flatten(0)).All());
+    EXPECT_TRUE((dst_t_flat == src_t.Flatten(-2)).All());
+
+    EXPECT_TRUE((dst_t_flat == src_t.Flatten(0, 1)).All());
+    EXPECT_TRUE((dst_t_flat == src_t.Flatten(-2, 1)).All());
+    EXPECT_TRUE((dst_t_flat == src_t.Flatten(0, -1)).All());
+    EXPECT_TRUE((dst_t_flat == src_t.Flatten(-2, -1)).All());
+
+    EXPECT_TRUE((dst_t_unchanged == src_t.Flatten(1)).All());
+    EXPECT_TRUE((dst_t_unchanged == src_t.Flatten(-1)).All());
+
+    for (int64_t dim : {-2, -1, 0, 1}) {
+        EXPECT_TRUE((dst_t_unchanged == src_t.Flatten(dim, dim)).All());
+    }
+    
+    // Out of bounds dimensions
+    EXPECT_ANY_THROW(src_t.Flatten(0, 2));
+    EXPECT_ANY_THROW(src_t.Flatten(0, -3));
+    EXPECT_ANY_THROW(src_t.Flatten(-3, 0));
+    EXPECT_ANY_THROW(src_t.Flatten(2, 0));
+
+    // end_dim is greater than start_dim
+    EXPECT_ANY_THROW(src_t.Flatten(1, 0));
+    EXPECT_ANY_THROW(src_t.Flatten(-1, 0));
+    EXPECT_ANY_THROW(src_t.Flatten(1, -2));
+    EXPECT_ANY_THROW(src_t.Flatten(-1, -2));
+
+    // Flatten 3-D Tensor
+    src_t = core::Tensor::Init<float>(
+            {{{1, 2, 3}, {4, 5, 6}}, {{7, 8, 9}, {10, 11, 12}}}, device);
+    dst_t_flat = core::Tensor::Init<float>(
+            {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}, device);
+    dst_t_unchanged = core::Tensor::Init<float>(
+            {{{1, 2, 3}, {4, 5, 6}}, {{7, 8, 9}, {10, 11, 12}}}, device);
+    core::Tensor dst_t_unflat_last = core::Tensor::Init<float>(
+            {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}}, device);
+    core::Tensor dst_t_unflat_first = core::Tensor::Init<float>(
+            {{1, 2, 3, 4, 5, 6}, {7, 8, 9, 10, 11, 12}}, device);
+
+    EXPECT_TRUE((dst_t_flat == src_t.Flatten()).All());
+    EXPECT_TRUE((dst_t_flat == src_t.Flatten(0)).All());
+    EXPECT_TRUE((dst_t_flat == src_t.Flatten(-3)).All());
+
+    EXPECT_TRUE((dst_t_flat == src_t.Flatten(0, 2)).All());
+    EXPECT_TRUE((dst_t_flat == src_t.Flatten(-3, 2)).All());
+    EXPECT_TRUE((dst_t_flat == src_t.Flatten(0, -1)).All());
+    EXPECT_TRUE((dst_t_flat == src_t.Flatten(-3, -1)).All());
+
+    EXPECT_TRUE((dst_t_unflat_last == src_t.Flatten(0, 1)).All());
+    EXPECT_TRUE((dst_t_unflat_last == src_t.Flatten(0, -2)).All());
+    EXPECT_TRUE((dst_t_unflat_last == src_t.Flatten(-3, 1)).All());
+    EXPECT_TRUE((dst_t_unflat_last == src_t.Flatten(-3, -2)).All());
+
+    EXPECT_TRUE((dst_t_unflat_first == src_t.Flatten(1, 2)).All());
+    EXPECT_TRUE((dst_t_unflat_first == src_t.Flatten(1, -1)).All());
+    EXPECT_TRUE((dst_t_unflat_first == src_t.Flatten(-2, 2)).All());
+    EXPECT_TRUE((dst_t_unflat_first == src_t.Flatten(-2, -1)).All());
+
+    for (int64_t dim : {-3, -2, -1, 0, 1, 2}) {
+        EXPECT_TRUE((dst_t_unchanged == src_t.Flatten(dim, dim)).All());
+    }
+
+    // Out of bounds dimensions
+    EXPECT_ANY_THROW(src_t.Flatten(0, 3));
+    EXPECT_ANY_THROW(src_t.Flatten(0, -4));
+    EXPECT_ANY_THROW(src_t.Flatten(-4, 0));
+    EXPECT_ANY_THROW(src_t.Flatten(3, 0));
+
+    // end_dim is greater than start_dim
+    EXPECT_ANY_THROW(src_t.Flatten(1, 0));
+    EXPECT_ANY_THROW(src_t.Flatten(2, 0));
+    EXPECT_ANY_THROW(src_t.Flatten(2, 1));
 }
 
 TEST_P(TensorPermuteDevices, DefaultStrides) {

--- a/cpp/tests/core/Tensor.cpp
+++ b/cpp/tests/core/Tensor.cpp
@@ -418,14 +418,14 @@ TEST_P(TensorPermuteDevices, Flatten) {
     core::Tensor src_t = core::Tensor::Init<float>(3, device);
     core::Tensor dst_t = core::Tensor::Init<float>({3}, device);
 
-    EXPECT_TRUE((dst_t == src_t.Flatten()).All());
-    EXPECT_TRUE((dst_t == src_t.Flatten(0)).All());
-    EXPECT_TRUE((dst_t == src_t.Flatten(-1)).All());
+    EXPECT_TRUE(dst_t.AllEqual(src_t.Flatten()));
+    EXPECT_TRUE(dst_t.AllEqual(src_t.Flatten(0)));
+    EXPECT_TRUE(dst_t.AllEqual(src_t.Flatten(-1)));
 
-    EXPECT_TRUE((dst_t == src_t.Flatten(0, 0)).All());
-    EXPECT_TRUE((dst_t == src_t.Flatten(0, -1)).All());
-    EXPECT_TRUE((dst_t == src_t.Flatten(-1, 0)).All());
-    EXPECT_TRUE((dst_t == src_t.Flatten(-1, -1)).All());
+    EXPECT_TRUE(dst_t.AllEqual(src_t.Flatten(0, 0)));
+    EXPECT_TRUE(dst_t.AllEqual(src_t.Flatten(0, -1)));
+    EXPECT_TRUE(dst_t.AllEqual(src_t.Flatten(-1, 0)));
+    EXPECT_TRUE(dst_t.AllEqual(src_t.Flatten(-1, -1)));
 
     EXPECT_ANY_THROW(src_t.Flatten(-2));
     EXPECT_ANY_THROW(src_t.Flatten(1));
@@ -436,14 +436,14 @@ TEST_P(TensorPermuteDevices, Flatten) {
     src_t = core::Tensor::Init<float>({1, 2, 3}, device);
     dst_t = core::Tensor::Init<float>({1, 2, 3}, device);
 
-    EXPECT_TRUE((dst_t == src_t.Flatten()).All());
-    EXPECT_TRUE((dst_t == src_t.Flatten(0)).All());
-    EXPECT_TRUE((dst_t == src_t.Flatten(-1)).All());
+    EXPECT_TRUE(dst_t.AllEqual(src_t.Flatten()));
+    EXPECT_TRUE(dst_t.AllEqual(src_t.Flatten(0)));
+    EXPECT_TRUE(dst_t.AllEqual(src_t.Flatten(-1)));
 
-    EXPECT_TRUE((dst_t == src_t.Flatten(0, 0)).All());
-    EXPECT_TRUE((dst_t == src_t.Flatten(0, -1)).All());
-    EXPECT_TRUE((dst_t == src_t.Flatten(-1, 0)).All());
-    EXPECT_TRUE((dst_t == src_t.Flatten(-1, -1)).All());
+    EXPECT_TRUE(dst_t.AllEqual(src_t.Flatten(0, 0)));
+    EXPECT_TRUE(dst_t.AllEqual(src_t.Flatten(0, -1)));
+    EXPECT_TRUE(dst_t.AllEqual(src_t.Flatten(-1, 0)));
+    EXPECT_TRUE(dst_t.AllEqual(src_t.Flatten(-1, -1)));
 
     EXPECT_ANY_THROW(src_t.Flatten(-2));
     EXPECT_ANY_THROW(src_t.Flatten(1));
@@ -457,20 +457,20 @@ TEST_P(TensorPermuteDevices, Flatten) {
     core::Tensor dst_t_unchanged =
             core::Tensor::Init<float>({{1, 2, 3}, {4, 5, 6}}, device);
 
-    EXPECT_TRUE((dst_t_flat == src_t.Flatten()).All());
-    EXPECT_TRUE((dst_t_flat == src_t.Flatten(0)).All());
-    EXPECT_TRUE((dst_t_flat == src_t.Flatten(-2)).All());
+    EXPECT_TRUE(dst_t_flat.AllEqual(src_t.Flatten()));
+    EXPECT_TRUE(dst_t_flat.AllEqual(src_t.Flatten(0)));
+    EXPECT_TRUE(dst_t_flat.AllEqual(src_t.Flatten(-2)));
 
-    EXPECT_TRUE((dst_t_flat == src_t.Flatten(0, 1)).All());
-    EXPECT_TRUE((dst_t_flat == src_t.Flatten(-2, 1)).All());
-    EXPECT_TRUE((dst_t_flat == src_t.Flatten(0, -1)).All());
-    EXPECT_TRUE((dst_t_flat == src_t.Flatten(-2, -1)).All());
+    EXPECT_TRUE(dst_t_flat.AllEqual(src_t.Flatten(0, 1)));
+    EXPECT_TRUE(dst_t_flat.AllEqual(src_t.Flatten(-2, 1)));
+    EXPECT_TRUE(dst_t_flat.AllEqual(src_t.Flatten(0, -1)));
+    EXPECT_TRUE(dst_t_flat.AllEqual(src_t.Flatten(-2, -1)));
 
-    EXPECT_TRUE((dst_t_unchanged == src_t.Flatten(1)).All());
-    EXPECT_TRUE((dst_t_unchanged == src_t.Flatten(-1)).All());
+    EXPECT_TRUE(dst_t_unchanged.AllEqual(src_t.Flatten(1)));
+    EXPECT_TRUE(dst_t_unchanged.AllEqual(src_t.Flatten(-1)));
 
     for (int64_t dim : {-2, -1, 0, 1}) {
-        EXPECT_TRUE((dst_t_unchanged == src_t.Flatten(dim, dim)).All());
+        EXPECT_TRUE(dst_t_unchanged.AllEqual(src_t.Flatten(dim, dim)));
     }
 
     // Out of bounds dimensions
@@ -497,27 +497,27 @@ TEST_P(TensorPermuteDevices, Flatten) {
     core::Tensor dst_t_last_two_flat = core::Tensor::Init<float>(
             {{1, 2, 3, 4, 5, 6}, {7, 8, 9, 10, 11, 12}}, device);
 
-    EXPECT_TRUE((dst_t_flat == src_t.Flatten()).All());
-    EXPECT_TRUE((dst_t_flat == src_t.Flatten(0)).All());
-    EXPECT_TRUE((dst_t_flat == src_t.Flatten(-3)).All());
+    EXPECT_TRUE(dst_t_flat.AllEqual(src_t.Flatten()));
+    EXPECT_TRUE(dst_t_flat.AllEqual(src_t.Flatten(0)));
+    EXPECT_TRUE(dst_t_flat.AllEqual(src_t.Flatten(-3)));
 
-    EXPECT_TRUE((dst_t_flat == src_t.Flatten(0, 2)).All());
-    EXPECT_TRUE((dst_t_flat == src_t.Flatten(-3, 2)).All());
-    EXPECT_TRUE((dst_t_flat == src_t.Flatten(0, -1)).All());
-    EXPECT_TRUE((dst_t_flat == src_t.Flatten(-3, -1)).All());
+    EXPECT_TRUE(dst_t_flat.AllEqual(src_t.Flatten(0, 2)));
+    EXPECT_TRUE(dst_t_flat.AllEqual(src_t.Flatten(-3, 2)));
+    EXPECT_TRUE(dst_t_flat.AllEqual(src_t.Flatten(0, -1)));
+    EXPECT_TRUE(dst_t_flat.AllEqual(src_t.Flatten(-3, -1)));
 
-    EXPECT_TRUE((dst_t_first_two_flat == src_t.Flatten(0, 1)).All());
-    EXPECT_TRUE((dst_t_first_two_flat == src_t.Flatten(0, -2)).All());
-    EXPECT_TRUE((dst_t_first_two_flat == src_t.Flatten(-3, 1)).All());
-    EXPECT_TRUE((dst_t_first_two_flat == src_t.Flatten(-3, -2)).All());
+    EXPECT_TRUE(dst_t_first_two_flat.AllEqual(src_t.Flatten(0, 1)));
+    EXPECT_TRUE(dst_t_first_two_flat.AllEqual(src_t.Flatten(0, -2)));
+    EXPECT_TRUE(dst_t_first_two_flat.AllEqual(src_t.Flatten(-3, 1)));
+    EXPECT_TRUE(dst_t_first_two_flat.AllEqual(src_t.Flatten(-3, -2)));
 
-    EXPECT_TRUE((dst_t_last_two_flat == src_t.Flatten(1, 2)).All());
-    EXPECT_TRUE((dst_t_last_two_flat == src_t.Flatten(1, -1)).All());
-    EXPECT_TRUE((dst_t_last_two_flat == src_t.Flatten(-2, 2)).All());
-    EXPECT_TRUE((dst_t_last_two_flat == src_t.Flatten(-2, -1)).All());
+    EXPECT_TRUE(dst_t_last_two_flat.AllEqual(src_t.Flatten(1, 2)));
+    EXPECT_TRUE(dst_t_last_two_flat.AllEqual(src_t.Flatten(1, -1)));
+    EXPECT_TRUE(dst_t_last_two_flat.AllEqual(src_t.Flatten(-2, 2)));
+    EXPECT_TRUE(dst_t_last_two_flat.AllEqual(src_t.Flatten(-2, -1)));
 
     for (int64_t dim : {-3, -2, -1, 0, 1, 2}) {
-        EXPECT_TRUE((dst_t_unchanged == src_t.Flatten(dim, dim)).All());
+        EXPECT_TRUE(dst_t_unchanged.AllEqual(src_t.Flatten(dim, dim)));
     }
 
     // Out of bounds dimensions

--- a/cpp/tests/core/Tensor.cpp
+++ b/cpp/tests/core/Tensor.cpp
@@ -414,7 +414,7 @@ TEST_P(TensorPermuteDevices, Expand) {
 TEST_P(TensorPermuteDevices, Flatten) {
     core::Device device = GetParam();
 
-    // Flatten 0-D Tensor
+    // Flatten 0-D Tensor.
     core::Tensor src_t = core::Tensor::Init<float>(3, device);
     core::Tensor dst_t = core::Tensor::Init<float>({3}, device);
 
@@ -432,7 +432,7 @@ TEST_P(TensorPermuteDevices, Flatten) {
     EXPECT_ANY_THROW(src_t.Flatten(0, -2));
     EXPECT_ANY_THROW(src_t.Flatten(0, 1));
 
-    // Flatten 1-D Tensor
+    // Flatten 1-D Tensor.
     src_t = core::Tensor::Init<float>({1, 2, 3}, device);
     dst_t = core::Tensor::Init<float>({1, 2, 3}, device);
 
@@ -450,7 +450,7 @@ TEST_P(TensorPermuteDevices, Flatten) {
     EXPECT_ANY_THROW(src_t.Flatten(0, -2));
     EXPECT_ANY_THROW(src_t.Flatten(0, 1));
 
-    // Flatten 2-D Tensor
+    // Flatten 2-D Tensor.
     src_t = core::Tensor::Init<float>({{1, 2, 3}, {4, 5, 6}}, device);
     core::Tensor dst_t_flat =
             core::Tensor::Init<float>({1, 2, 3, 4, 5, 6}, device);
@@ -473,19 +473,19 @@ TEST_P(TensorPermuteDevices, Flatten) {
         EXPECT_TRUE(dst_t_unchanged.AllEqual(src_t.Flatten(dim, dim)));
     }
 
-    // Out of bounds dimensions
+    // Out of bounds dimensions.
     EXPECT_ANY_THROW(src_t.Flatten(0, 2));
     EXPECT_ANY_THROW(src_t.Flatten(0, -3));
     EXPECT_ANY_THROW(src_t.Flatten(-3, 0));
     EXPECT_ANY_THROW(src_t.Flatten(2, 0));
 
-    // end_dim is greater than start_dim
+    // end_dim is greater than start_dim.
     EXPECT_ANY_THROW(src_t.Flatten(1, 0));
     EXPECT_ANY_THROW(src_t.Flatten(-1, 0));
     EXPECT_ANY_THROW(src_t.Flatten(1, -2));
     EXPECT_ANY_THROW(src_t.Flatten(-1, -2));
 
-    // Flatten 3-D Tensor
+    // Flatten 3-D Tensor.
     src_t = core::Tensor::Init<float>(
             {{{1, 2, 3}, {4, 5, 6}}, {{7, 8, 9}, {10, 11, 12}}}, device);
     dst_t_flat = core::Tensor::Init<float>(
@@ -520,13 +520,13 @@ TEST_P(TensorPermuteDevices, Flatten) {
         EXPECT_TRUE(dst_t_unchanged.AllEqual(src_t.Flatten(dim, dim)));
     }
 
-    // Out of bounds dimensions
+    // Out of bounds dimensions.
     EXPECT_ANY_THROW(src_t.Flatten(0, 3));
     EXPECT_ANY_THROW(src_t.Flatten(0, -4));
     EXPECT_ANY_THROW(src_t.Flatten(-4, 0));
     EXPECT_ANY_THROW(src_t.Flatten(3, 0));
 
-    // end_dim is greater than start_dim
+    // end_dim is greater than start_dim.
     EXPECT_ANY_THROW(src_t.Flatten(1, 0));
     EXPECT_ANY_THROW(src_t.Flatten(2, 0));
     EXPECT_ANY_THROW(src_t.Flatten(2, 1));

--- a/cpp/tests/core/Tensor.cpp
+++ b/cpp/tests/core/Tensor.cpp
@@ -411,6 +411,28 @@ TEST_P(TensorPermuteDevices, Expand) {
     EXPECT_EQ(dst_t.GetDataPtr(), src_t.GetDataPtr());
 }
 
+TEST_P(TensorPermuteDevices, Flatten) {
+    core::Device device = GetParam();
+
+    core::Tensor src_t = core::Tensor::Init<float>(
+            {{{0, 1, 2, 3}, {4, 5, 6, 7}, {8, 9, 10, 11}},
+             {{12, 13, 14, 15}, {16, 17, 18, 19}, {20, 21, 22, 23}}},
+            device);
+
+    core::Tensor dst_t_no_param = core::Tensor::Init<float>(
+            {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
+             12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23},
+            device);
+
+    core::Tensor dst_t_with_param = core::Tensor::Init<float>(
+            {{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
+             {12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23}},
+            device);
+
+    EXPECT_TRUE((dst_t_no_param == src_t.Flatten()).All());
+    EXPECT_TRUE((dst_t_with_param == src_t.Flatten(1)).All());
+}
+
 TEST_P(TensorPermuteDevices, DefaultStrides) {
     core::Device device = GetParam();
 

--- a/python/test/core/test_core.py
+++ b/python/test/core/test_core.py
@@ -242,19 +242,25 @@ def test_arange(device):
     assert o3_t.dtype == o3c.int64
     np.testing.assert_equal(np_t, o3_t.cpu().numpy())
 
+
 @pytest.mark.parametrize("device", list_devices())
 def test_arange(device):
     src_t = o3c.Tensor([[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]],
-             [[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]]]).to(device)
-    
-    dst_t_no_param = o3c.Tensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
-             12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]).to(device)
-    
-    dst_t_with_param = o3c.Tensor([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
-             [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]]).to(device)
- 
-    assert((dst_t_no_param == src_t.flatten()).all())
-    assert((dst_t_with_param == src_t.flatten(1)).all())
+                        [[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22,
+                                                              23]]]).to(device)
+
+    dst_t_no_param = o3c.Tensor([
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+        20, 21, 22, 23
+    ]).to(device)
+
+    dst_t_with_param = o3c.Tensor(
+        [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+         [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]]).to(device)
+
+    assert ((dst_t_no_param == src_t.flatten()).all())
+    assert ((dst_t_with_param == src_t.flatten(1)).all())
+
 
 @pytest.mark.parametrize("dtype", list_non_bool_dtypes())
 @pytest.mark.parametrize("device", list_devices())

--- a/python/test/core/test_core.py
+++ b/python/test/core/test_core.py
@@ -258,15 +258,19 @@ def test_flatten(device):
     assert ((dst_t == src_t.flatten(-1, 0)).all())
     assert ((dst_t == src_t.flatten(-1, -1)).all())
 
-    with pytest.raises(RuntimeError): src_t.flatten(-2)
-    with pytest.raises(RuntimeError): src_t.flatten(1)
-    with pytest.raises(RuntimeError): src_t.flatten(0, -2)
-    with pytest.raises(RuntimeError): src_t.flatten(0, 1)
+    with pytest.raises(RuntimeError):
+        src_t.flatten(-2)
+    with pytest.raises(RuntimeError):
+        src_t.flatten(1)
+    with pytest.raises(RuntimeError):
+        src_t.flatten(0, -2)
+    with pytest.raises(RuntimeError):
+        src_t.flatten(0, 1)
 
     # Flatten 1-D tensor
     src_t = o3c.Tensor([1, 2, 3]).to(device)
     dst_t = o3c.Tensor([1, 2, 3]).to(device)
-    
+
     assert ((dst_t == src_t.flatten()).all())
     assert ((dst_t == src_t.flatten(0)).all())
     assert ((dst_t == src_t.flatten(-1)).all())
@@ -276,82 +280,106 @@ def test_flatten(device):
     assert ((dst_t == src_t.flatten(-1, 0)).all())
     assert ((dst_t == src_t.flatten(-1, -1)).all())
 
-    with pytest.raises(RuntimeError): src_t.flatten(-2)
-    with pytest.raises(RuntimeError): src_t.flatten(1)
-    with pytest.raises(RuntimeError): src_t.flatten(0, -2)
-    with pytest.raises(RuntimeError): src_t.flatten(0, 1)
+    with pytest.raises(RuntimeError):
+        src_t.flatten(-2)
+    with pytest.raises(RuntimeError):
+        src_t.flatten(1)
+    with pytest.raises(RuntimeError):
+        src_t.flatten(0, -2)
+    with pytest.raises(RuntimeError):
+        src_t.flatten(0, 1)
 
     # Flatten 2-D tensor
     src_t = o3c.Tensor([[1, 2, 3], [4, 5, 6]]).to(device)
     dst_t_flat = o3c.Tensor([1, 2, 3, 4, 5, 6]).to(device)
     dst_t_unchanged = o3c.Tensor([[1, 2, 3], [4, 5, 6]]).to(device)
-    
-    assert((dst_t_flat == src_t.flatten()).all())
-    assert((dst_t_flat == src_t.flatten(0)).all())
-    assert((dst_t_flat == src_t.flatten(-2)).all())
 
-    assert((dst_t_flat == src_t.flatten(0, 1)).all())
-    assert((dst_t_flat == src_t.flatten(-2, 1)).all())
-    assert((dst_t_flat == src_t.flatten(0, -1)).all())
-    assert((dst_t_flat == src_t.flatten(-2, -1)).all())
+    assert ((dst_t_flat == src_t.flatten()).all())
+    assert ((dst_t_flat == src_t.flatten(0)).all())
+    assert ((dst_t_flat == src_t.flatten(-2)).all())
 
-    assert((dst_t_unchanged == src_t.flatten(1)).all())
-    assert((dst_t_unchanged == src_t.flatten(-1)).all())
+    assert ((dst_t_flat == src_t.flatten(0, 1)).all())
+    assert ((dst_t_flat == src_t.flatten(-2, 1)).all())
+    assert ((dst_t_flat == src_t.flatten(0, -1)).all())
+    assert ((dst_t_flat == src_t.flatten(-2, -1)).all())
+
+    assert ((dst_t_unchanged == src_t.flatten(1)).all())
+    assert ((dst_t_unchanged == src_t.flatten(-1)).all())
 
     for dim in range(-2, 2):
-        assert((dst_t_unchanged == src_t.flatten(dim, dim)).all())
+        assert ((dst_t_unchanged == src_t.flatten(dim, dim)).all())
 
     # Out of bounds dimensions
-    with pytest.raises(RuntimeError): src_t.flatten(0, 2)
-    with pytest.raises(RuntimeError): src_t.flatten(0, -3)
-    with pytest.raises(RuntimeError): src_t.flatten(-3, 0)
-    with pytest.raises(RuntimeError): src_t.flatten(2, 0)
+    with pytest.raises(RuntimeError):
+        src_t.flatten(0, 2)
+    with pytest.raises(RuntimeError):
+        src_t.flatten(0, -3)
+    with pytest.raises(RuntimeError):
+        src_t.flatten(-3, 0)
+    with pytest.raises(RuntimeError):
+        src_t.flatten(2, 0)
 
     # end_dim is greater than start_dim
-    with pytest.raises(RuntimeError): src_t.flatten(1, 0)
-    with pytest.raises(RuntimeError): src_t.flatten(-1, 0)
-    with pytest.raises(RuntimeError): src_t.flatten(1, -2)
-    with pytest.raises(RuntimeError): src_t.flatten(-1, -2)
+    with pytest.raises(RuntimeError):
+        src_t.flatten(1, 0)
+    with pytest.raises(RuntimeError):
+        src_t.flatten(-1, 0)
+    with pytest.raises(RuntimeError):
+        src_t.flatten(1, -2)
+    with pytest.raises(RuntimeError):
+        src_t.flatten(-1, -2)
 
     # Flatten 3-D tensor
-    src_t = o3c.Tensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]).to(device)
+    src_t = o3c.Tensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11,
+                                                             12]]]).to(device)
     dst_t_flat = o3c.Tensor([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]).to(device)
-    dst_t_unchanged = o3c.Tensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]).to(device)
-    dst_t_first_two_flat = o3c.Tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]).to(device)
-    dst_t_last_two_flat = o3c.Tensor([[1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12]]).to(device)
+    dst_t_unchanged = o3c.Tensor([[[1, 2, 3], [4, 5, 6]],
+                                  [[7, 8, 9], [10, 11, 12]]]).to(device)
+    dst_t_first_two_flat = o3c.Tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9],
+                                       [10, 11, 12]]).to(device)
+    dst_t_last_two_flat = o3c.Tensor([[1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11,
+                                                           12]]).to(device)
 
-    assert((dst_t_flat == src_t.flatten()).all())
-    assert((dst_t_flat == src_t.flatten(0)).all())
-    assert((dst_t_flat == src_t.flatten(-3)).all())
+    assert ((dst_t_flat == src_t.flatten()).all())
+    assert ((dst_t_flat == src_t.flatten(0)).all())
+    assert ((dst_t_flat == src_t.flatten(-3)).all())
 
-    assert((dst_t_flat == src_t.flatten(0, 2)).all())
-    assert((dst_t_flat == src_t.flatten(-3, 2)).all())
-    assert((dst_t_flat == src_t.flatten(0, -1)).all())
-    assert((dst_t_flat == src_t.flatten(-3, -1)).all())
+    assert ((dst_t_flat == src_t.flatten(0, 2)).all())
+    assert ((dst_t_flat == src_t.flatten(-3, 2)).all())
+    assert ((dst_t_flat == src_t.flatten(0, -1)).all())
+    assert ((dst_t_flat == src_t.flatten(-3, -1)).all())
 
-    assert((dst_t_first_two_flat == src_t.flatten(0, 1)).all())
-    assert((dst_t_first_two_flat == src_t.flatten(0, -2)).all())
-    assert((dst_t_first_two_flat == src_t.flatten(-3, 1)).all())
-    assert((dst_t_first_two_flat == src_t.flatten(-3, -2)).all())
+    assert ((dst_t_first_two_flat == src_t.flatten(0, 1)).all())
+    assert ((dst_t_first_two_flat == src_t.flatten(0, -2)).all())
+    assert ((dst_t_first_two_flat == src_t.flatten(-3, 1)).all())
+    assert ((dst_t_first_two_flat == src_t.flatten(-3, -2)).all())
 
-    assert((dst_t_last_two_flat == src_t.flatten(1, 2)).all())
-    assert((dst_t_last_two_flat == src_t.flatten(1, -1)).all())
-    assert((dst_t_last_two_flat == src_t.flatten(-2, 2)).all())
-    assert((dst_t_last_two_flat == src_t.flatten(-2, -1)).all())
+    assert ((dst_t_last_two_flat == src_t.flatten(1, 2)).all())
+    assert ((dst_t_last_two_flat == src_t.flatten(1, -1)).all())
+    assert ((dst_t_last_two_flat == src_t.flatten(-2, 2)).all())
+    assert ((dst_t_last_two_flat == src_t.flatten(-2, -1)).all())
 
     for dim in range(-3, 3):
-        assert((dst_t_unchanged == src_t.flatten(dim, dim)).all())
+        assert ((dst_t_unchanged == src_t.flatten(dim, dim)).all())
 
     # Out of bounds dimensions
-    with pytest.raises(RuntimeError): src_t.flatten(0, 3)
-    with pytest.raises(RuntimeError): src_t.flatten(0, -4)
-    with pytest.raises(RuntimeError): src_t.flatten(-4, 0)
-    with pytest.raises(RuntimeError): src_t.flatten(3, 0)
+    with pytest.raises(RuntimeError):
+        src_t.flatten(0, 3)
+    with pytest.raises(RuntimeError):
+        src_t.flatten(0, -4)
+    with pytest.raises(RuntimeError):
+        src_t.flatten(-4, 0)
+    with pytest.raises(RuntimeError):
+        src_t.flatten(3, 0)
 
     # end_dim is greater than start_dim
-    with pytest.raises(RuntimeError): src_t.flatten(1, 0)
-    with pytest.raises(RuntimeError): src_t.flatten(2, 0)
-    with pytest.raises(RuntimeError): src_t.flatten(2, 0)
+    with pytest.raises(RuntimeError):
+        src_t.flatten(1, 0)
+    with pytest.raises(RuntimeError):
+        src_t.flatten(2, 0)
+    with pytest.raises(RuntimeError):
+        src_t.flatten(2, 0)
+
 
 @pytest.mark.parametrize("dtype", list_non_bool_dtypes())
 @pytest.mark.parametrize("device", list_devices())

--- a/python/test/core/test_core.py
+++ b/python/test/core/test_core.py
@@ -245,22 +245,113 @@ def test_arange(device):
 
 @pytest.mark.parametrize("device", list_devices())
 def test_flatten(device):
-    src_t = o3c.Tensor([[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]],
-                        [[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22,
-                                                              23]]]).to(device)
 
-    dst_t_no_param = o3c.Tensor([
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-        20, 21, 22, 23
-    ]).to(device)
+    # Flatten 0-D tensor
+    src_t = o3c.Tensor(3).to(device)
+    dst_t = o3c.Tensor([3]).to(device)
+    assert ((dst_t == src_t.flatten()).all())
+    assert ((dst_t == src_t.flatten(0)).all())
+    assert ((dst_t == src_t.flatten(-1)).all())
 
-    dst_t_with_param = o3c.Tensor(
-        [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
-         [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]]).to(device)
+    assert ((dst_t == src_t.flatten(0, 0)).all())
+    assert ((dst_t == src_t.flatten(0, -1)).all())
+    assert ((dst_t == src_t.flatten(-1, 0)).all())
+    assert ((dst_t == src_t.flatten(-1, -1)).all())
 
-    assert ((dst_t_no_param == src_t.flatten()).all())
-    assert ((dst_t_with_param == src_t.flatten(1)).all())
+    with pytest.raises(RuntimeError): src_t.flatten(-2)
+    with pytest.raises(RuntimeError): src_t.flatten(1)
+    with pytest.raises(RuntimeError): src_t.flatten(0, -2)
+    with pytest.raises(RuntimeError): src_t.flatten(0, 1)
 
+    # Flatten 1-D tensor
+    src_t = o3c.Tensor([1, 2, 3]).to(device)
+    dst_t = o3c.Tensor([1, 2, 3]).to(device)
+    
+    assert ((dst_t == src_t.flatten()).all())
+    assert ((dst_t == src_t.flatten(0)).all())
+    assert ((dst_t == src_t.flatten(-1)).all())
+
+    assert ((dst_t == src_t.flatten(0, 0)).all())
+    assert ((dst_t == src_t.flatten(0, -1)).all())
+    assert ((dst_t == src_t.flatten(-1, 0)).all())
+    assert ((dst_t == src_t.flatten(-1, -1)).all())
+
+    with pytest.raises(RuntimeError): src_t.flatten(-2)
+    with pytest.raises(RuntimeError): src_t.flatten(1)
+    with pytest.raises(RuntimeError): src_t.flatten(0, -2)
+    with pytest.raises(RuntimeError): src_t.flatten(0, 1)
+
+    # Flatten 2-D tensor
+    src_t = o3c.Tensor([[1, 2, 3], [4, 5, 6]]).to(device)
+    dst_t_flat = o3c.Tensor([1, 2, 3, 4, 5, 6]).to(device)
+    dst_t_unchanged = o3c.Tensor([[1, 2, 3], [4, 5, 6]]).to(device)
+    
+    assert((dst_t_flat == src_t.flatten()).all())
+    assert((dst_t_flat == src_t.flatten(0)).all())
+    assert((dst_t_flat == src_t.flatten(-2)).all())
+
+    assert((dst_t_flat == src_t.flatten(0, 1)).all())
+    assert((dst_t_flat == src_t.flatten(-2, 1)).all())
+    assert((dst_t_flat == src_t.flatten(0, -1)).all())
+    assert((dst_t_flat == src_t.flatten(-2, -1)).all())
+
+    assert((dst_t_unchanged == src_t.flatten(1)).all())
+    assert((dst_t_unchanged == src_t.flatten(-1)).all())
+
+    for dim in range(-2, 2):
+        assert((dst_t_unchanged == src_t.flatten(dim, dim)).all())
+
+    # Out of bounds dimensions
+    with pytest.raises(RuntimeError): src_t.flatten(0, 2)
+    with pytest.raises(RuntimeError): src_t.flatten(0, -3)
+    with pytest.raises(RuntimeError): src_t.flatten(-3, 0)
+    with pytest.raises(RuntimeError): src_t.flatten(2, 0)
+
+    # end_dim is greater than start_dim
+    with pytest.raises(RuntimeError): src_t.flatten(1, 0)
+    with pytest.raises(RuntimeError): src_t.flatten(-1, 0)
+    with pytest.raises(RuntimeError): src_t.flatten(1, -2)
+    with pytest.raises(RuntimeError): src_t.flatten(-1, -2)
+
+    # Flatten 3-D tensor
+    src_t = o3c.Tensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]).to(device)
+    dst_t_flat = o3c.Tensor([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]).to(device)
+    dst_t_unchanged = o3c.Tensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]).to(device)
+    dst_t_first_two_flat = o3c.Tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]).to(device)
+    dst_t_last_two_flat = o3c.Tensor([[1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12]]).to(device)
+
+    assert((dst_t_flat == src_t.flatten()).all())
+    assert((dst_t_flat == src_t.flatten(0)).all())
+    assert((dst_t_flat == src_t.flatten(-3)).all())
+
+    assert((dst_t_flat == src_t.flatten(0, 2)).all())
+    assert((dst_t_flat == src_t.flatten(-3, 2)).all())
+    assert((dst_t_flat == src_t.flatten(0, -1)).all())
+    assert((dst_t_flat == src_t.flatten(-3, -1)).all())
+
+    assert((dst_t_first_two_flat == src_t.flatten(0, 1)).all())
+    assert((dst_t_first_two_flat == src_t.flatten(0, -2)).all())
+    assert((dst_t_first_two_flat == src_t.flatten(-3, 1)).all())
+    assert((dst_t_first_two_flat == src_t.flatten(-3, -2)).all())
+
+    assert((dst_t_last_two_flat == src_t.flatten(1, 2)).all())
+    assert((dst_t_last_two_flat == src_t.flatten(1, -1)).all())
+    assert((dst_t_last_two_flat == src_t.flatten(-2, 2)).all())
+    assert((dst_t_last_two_flat == src_t.flatten(-2, -1)).all())
+
+    for dim in range(-3, 3):
+        assert((dst_t_unchanged == src_t.flatten(dim, dim)).all())
+
+    # Out of bounds dimensions
+    with pytest.raises(RuntimeError): src_t.flatten(0, 3)
+    with pytest.raises(RuntimeError): src_t.flatten(0, -4)
+    with pytest.raises(RuntimeError): src_t.flatten(-4, 0)
+    with pytest.raises(RuntimeError): src_t.flatten(3, 0)
+
+    # end_dim is greater than start_dim
+    with pytest.raises(RuntimeError): src_t.flatten(1, 0)
+    with pytest.raises(RuntimeError): src_t.flatten(2, 0)
+    with pytest.raises(RuntimeError): src_t.flatten(2, 0)
 
 @pytest.mark.parametrize("dtype", list_non_bool_dtypes())
 @pytest.mark.parametrize("device", list_devices())

--- a/python/test/core/test_core.py
+++ b/python/test/core/test_core.py
@@ -242,6 +242,19 @@ def test_arange(device):
     assert o3_t.dtype == o3c.int64
     np.testing.assert_equal(np_t, o3_t.cpu().numpy())
 
+@pytest.mark.parametrize("device", list_devices())
+def test_arange(device):
+    src_t = o3c.Tensor([[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]],
+             [[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]]]).to(device)
+    
+    dst_t_no_param = o3c.Tensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+             12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]).to(device)
+    
+    dst_t_with_param = o3c.Tensor([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+             [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]]).to(device)
+ 
+    assert((dst_t_no_param == src_t.flatten()).all())
+    assert((dst_t_with_param == src_t.flatten(1)).all())
 
 @pytest.mark.parametrize("dtype", list_non_bool_dtypes())
 @pytest.mark.parametrize("device", list_devices())

--- a/python/test/core/test_core.py
+++ b/python/test/core/test_core.py
@@ -244,7 +244,7 @@ def test_arange(device):
 
 
 @pytest.mark.parametrize("device", list_devices())
-def test_arange(device):
+def test_flatten(device):
     src_t = o3c.Tensor([[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]],
                         [[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22,
                                                               23]]]).to(device)

--- a/python/test/core/test_core.py
+++ b/python/test/core/test_core.py
@@ -249,14 +249,14 @@ def test_flatten(device):
     # Flatten 0-D tensor
     src_t = o3c.Tensor(3, dtype=o3c.Dtype.Int64).to(device)
     dst_t = o3c.Tensor([3], dtype=o3c.Dtype.Int64).to(device)
-    assert (dst_t.allclose(src_t.flatten()))
-    assert (dst_t.allclose(src_t.flatten(0)))
-    assert (dst_t.allclose(src_t.flatten(-1)))
+    assert dst_t.allclose(src_t.flatten())
+    assert dst_t.allclose(src_t.flatten(0))
+    assert dst_t.allclose(src_t.flatten(-1))
 
-    assert (dst_t.allclose(src_t.flatten(0, 0)))
-    assert (dst_t.allclose(src_t.flatten(0, -1)))
-    assert (dst_t.allclose(src_t.flatten(-1, 0)))
-    assert (dst_t.allclose(src_t.flatten(-1, -1)))
+    assert dst_t.allclose(src_t.flatten(0, 0))
+    assert dst_t.allclose(src_t.flatten(0, -1))
+    assert dst_t.allclose(src_t.flatten(-1, 0))
+    assert dst_t.allclose(src_t.flatten(-1, -1))
 
     with pytest.raises(RuntimeError):
         src_t.flatten(-2)
@@ -271,14 +271,14 @@ def test_flatten(device):
     src_t = o3c.Tensor([1, 2, 3], dtype=o3c.Dtype.Int64).to(device)
     dst_t = o3c.Tensor([1, 2, 3], dtype=o3c.Dtype.Int64).to(device)
 
-    assert (dst_t.allclose(src_t.flatten()))
-    assert (dst_t.allclose(src_t.flatten(0)))
-    assert (dst_t.allclose(src_t.flatten(-1)))
+    assert dst_t.allclose(src_t.flatten())
+    assert dst_t.allclose(src_t.flatten(0))
+    assert dst_t.allclose(src_t.flatten(-1))
 
-    assert (dst_t.allclose(src_t.flatten(0, 0)))
-    assert (dst_t.allclose(src_t.flatten(0, -1)))
-    assert (dst_t.allclose(src_t.flatten(-1, 0)))
-    assert (dst_t.allclose(src_t.flatten(-1, -1)))
+    assert dst_t.allclose(src_t.flatten(0, 0))
+    assert dst_t.allclose(src_t.flatten(0, -1))
+    assert dst_t.allclose(src_t.flatten(-1, 0))
+    assert dst_t.allclose(src_t.flatten(-1, -1))
 
     with pytest.raises(RuntimeError):
         src_t.flatten(-2)
@@ -296,20 +296,20 @@ def test_flatten(device):
     dst_t_unchanged = o3c.Tensor([[1, 2, 3], [4, 5, 6]],
                                  dtype=o3c.Dtype.Int64).to(device)
 
-    assert (dst_t_flat.allclose(src_t.flatten()))
-    assert (dst_t_flat.allclose(src_t.flatten(0)))
-    assert (dst_t_flat.allclose(src_t.flatten(-2)))
+    assert dst_t_flat.allclose(src_t.flatten())
+    assert dst_t_flat.allclose(src_t.flatten(0))
+    assert dst_t_flat.allclose(src_t.flatten(-2))
 
-    assert (dst_t_flat.allclose(src_t.flatten(0, 1)))
-    assert (dst_t_flat.allclose(src_t.flatten(-2, 1)))
-    assert (dst_t_flat.allclose(src_t.flatten(0, -1)))
-    assert (dst_t_flat.allclose(src_t.flatten(-2, -1)))
+    assert dst_t_flat.allclose(src_t.flatten(0, 1))
+    assert dst_t_flat.allclose(src_t.flatten(-2, 1))
+    assert dst_t_flat.allclose(src_t.flatten(0, -1))
+    assert dst_t_flat.allclose(src_t.flatten(-2, -1))
 
-    assert (dst_t_unchanged.allclose(src_t.flatten(1)))
-    assert (dst_t_unchanged.allclose(src_t.flatten(-1)))
+    assert dst_t_unchanged.allclose(src_t.flatten(1))
+    assert dst_t_unchanged.allclose(src_t.flatten(-1))
 
     for dim in range(-2, 2):
-        assert (dst_t_unchanged.allclose(src_t.flatten(dim, dim)))
+        assert dst_t_unchanged.allclose(src_t.flatten(dim, dim))
 
     # Out of bounds dimensions
     with pytest.raises(RuntimeError):
@@ -346,27 +346,27 @@ def test_flatten(device):
         [[1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12]],
         dtype=o3c.Dtype.Int64).to(device)
 
-    assert (dst_t_flat.allclose(src_t.flatten()))
-    assert (dst_t_flat.allclose(src_t.flatten(0)))
-    assert (dst_t_flat.allclose(src_t.flatten(-3)))
+    assert dst_t_flat.allclose(src_t.flatten())
+    assert dst_t_flat.allclose(src_t.flatten(0))
+    assert dst_t_flat.allclose(src_t.flatten(-3))
 
-    assert (dst_t_flat.allclose(src_t.flatten(0, 2)))
-    assert (dst_t_flat.allclose(src_t.flatten(-3, 2)))
-    assert (dst_t_flat.allclose(src_t.flatten(0, -1)))
-    assert (dst_t_flat.allclose(src_t.flatten(-3, -1)))
+    assert dst_t_flat.allclose(src_t.flatten(0, 2))
+    assert dst_t_flat.allclose(src_t.flatten(-3, 2))
+    assert dst_t_flat.allclose(src_t.flatten(0, -1))
+    assert dst_t_flat.allclose(src_t.flatten(-3, -1))
 
-    assert (dst_t_first_two_flat.allclose(src_t.flatten(0, 1)))
-    assert (dst_t_first_two_flat.allclose(src_t.flatten(0, -2)))
-    assert (dst_t_first_two_flat.allclose(src_t.flatten(-3, 1)))
-    assert (dst_t_first_two_flat.allclose(src_t.flatten(-3, -2)))
+    assert dst_t_first_two_flat.allclose(src_t.flatten(0, 1))
+    assert dst_t_first_two_flat.allclose(src_t.flatten(0, -2))
+    assert dst_t_first_two_flat.allclose(src_t.flatten(-3, 1))
+    assert dst_t_first_two_flat.allclose(src_t.flatten(-3, -2))
 
-    assert (dst_t_last_two_flat.allclose(src_t.flatten(1, 2)))
-    assert (dst_t_last_two_flat.allclose(src_t.flatten(1, -1)))
-    assert (dst_t_last_two_flat.allclose(src_t.flatten(-2, 2)))
-    assert (dst_t_last_two_flat.allclose(src_t.flatten(-2, -1)))
+    assert dst_t_last_two_flat.allclose(src_t.flatten(1, 2))
+    assert dst_t_last_two_flat.allclose(src_t.flatten(1, -1))
+    assert dst_t_last_two_flat.allclose(src_t.flatten(-2, 2))
+    assert dst_t_last_two_flat.allclose(src_t.flatten(-2, -1))
 
     for dim in range(-3, 3):
-        assert (dst_t_unchanged.allclose(src_t.flatten(dim, dim)))
+        assert dst_t_unchanged.allclose(src_t.flatten(dim, dim))
 
     # Out of bounds dimensions
     with pytest.raises(RuntimeError):

--- a/python/test/core/test_core.py
+++ b/python/test/core/test_core.py
@@ -247,8 +247,8 @@ def test_arange(device):
 def test_flatten(device):
 
     # Flatten 0-D tensor
-    src_t = o3c.Tensor(3).to(device)
-    dst_t = o3c.Tensor([3]).to(device)
+    src_t = o3c.Tensor(3, dtype=o3c.Dtype.Int64).to(device)
+    dst_t = o3c.Tensor([3], dtype=o3c.Dtype.Int64).to(device)
     assert ((dst_t == src_t.flatten()).all())
     assert ((dst_t == src_t.flatten(0)).all())
     assert ((dst_t == src_t.flatten(-1)).all())
@@ -268,8 +268,8 @@ def test_flatten(device):
         src_t.flatten(0, 1)
 
     # Flatten 1-D tensor
-    src_t = o3c.Tensor([1, 2, 3]).to(device)
-    dst_t = o3c.Tensor([1, 2, 3]).to(device)
+    src_t = o3c.Tensor([1, 2, 3], dtype=o3c.Dtype.Int64).to(device)
+    dst_t = o3c.Tensor([1, 2, 3], dtype=o3c.Dtype.Int64).to(device)
 
     assert ((dst_t == src_t.flatten()).all())
     assert ((dst_t == src_t.flatten(0)).all())
@@ -290,9 +290,11 @@ def test_flatten(device):
         src_t.flatten(0, 1)
 
     # Flatten 2-D tensor
-    src_t = o3c.Tensor([[1, 2, 3], [4, 5, 6]]).to(device)
-    dst_t_flat = o3c.Tensor([1, 2, 3, 4, 5, 6]).to(device)
-    dst_t_unchanged = o3c.Tensor([[1, 2, 3], [4, 5, 6]]).to(device)
+    src_t = o3c.Tensor([[1, 2, 3], [4, 5, 6]], dtype=o3c.Dtype.Int64).to(device)
+    dst_t_flat = o3c.Tensor([1, 2, 3, 4, 5, 6],
+                            dtype=o3c.Dtype.Int64).to(device)
+    dst_t_unchanged = o3c.Tensor([[1, 2, 3], [4, 5, 6]],
+                                 dtype=o3c.Dtype.Int64).to(device)
 
     assert ((dst_t_flat == src_t.flatten()).all())
     assert ((dst_t_flat == src_t.flatten(0)).all())
@@ -330,15 +332,19 @@ def test_flatten(device):
         src_t.flatten(-1, -2)
 
     # Flatten 3-D tensor
-    src_t = o3c.Tensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11,
-                                                             12]]]).to(device)
-    dst_t_flat = o3c.Tensor([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]).to(device)
-    dst_t_unchanged = o3c.Tensor([[[1, 2, 3], [4, 5, 6]],
-                                  [[7, 8, 9], [10, 11, 12]]]).to(device)
-    dst_t_first_two_flat = o3c.Tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9],
-                                       [10, 11, 12]]).to(device)
-    dst_t_last_two_flat = o3c.Tensor([[1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11,
-                                                           12]]).to(device)
+    src_t = o3c.Tensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]],
+                       dtype=o3c.Dtype.Int64).to(device)
+    dst_t_flat = o3c.Tensor([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                            dtype=o3c.Dtype.Int64).to(device)
+    dst_t_unchanged = o3c.Tensor(
+        [[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]],
+        dtype=o3c.Dtype.Int64).to(device)
+    dst_t_first_two_flat = o3c.Tensor(
+        [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]],
+        dtype=o3c.Dtype.Int64).to(device)
+    dst_t_last_two_flat = o3c.Tensor(
+        [[1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12]],
+        dtype=o3c.Dtype.Int64).to(device)
 
     assert ((dst_t_flat == src_t.flatten()).all())
     assert ((dst_t_flat == src_t.flatten(0)).all())

--- a/python/test/core/test_core.py
+++ b/python/test/core/test_core.py
@@ -249,14 +249,14 @@ def test_flatten(device):
     # Flatten 0-D tensor
     src_t = o3c.Tensor(3, dtype=o3c.Dtype.Int64).to(device)
     dst_t = o3c.Tensor([3], dtype=o3c.Dtype.Int64).to(device)
-    assert ((dst_t == src_t.flatten()).all())
-    assert ((dst_t == src_t.flatten(0)).all())
-    assert ((dst_t == src_t.flatten(-1)).all())
+    assert (dst_t.allclose(src_t.flatten()))
+    assert (dst_t.allclose(src_t.flatten(0)))
+    assert (dst_t.allclose(src_t.flatten(-1)))
 
-    assert ((dst_t == src_t.flatten(0, 0)).all())
-    assert ((dst_t == src_t.flatten(0, -1)).all())
-    assert ((dst_t == src_t.flatten(-1, 0)).all())
-    assert ((dst_t == src_t.flatten(-1, -1)).all())
+    assert (dst_t.allclose(src_t.flatten(0, 0)))
+    assert (dst_t.allclose(src_t.flatten(0, -1)))
+    assert (dst_t.allclose(src_t.flatten(-1, 0)))
+    assert (dst_t.allclose(src_t.flatten(-1, -1)))
 
     with pytest.raises(RuntimeError):
         src_t.flatten(-2)
@@ -271,14 +271,14 @@ def test_flatten(device):
     src_t = o3c.Tensor([1, 2, 3], dtype=o3c.Dtype.Int64).to(device)
     dst_t = o3c.Tensor([1, 2, 3], dtype=o3c.Dtype.Int64).to(device)
 
-    assert ((dst_t == src_t.flatten()).all())
-    assert ((dst_t == src_t.flatten(0)).all())
-    assert ((dst_t == src_t.flatten(-1)).all())
+    assert (dst_t.allclose(src_t.flatten()))
+    assert (dst_t.allclose(src_t.flatten(0)))
+    assert (dst_t.allclose(src_t.flatten(-1)))
 
-    assert ((dst_t == src_t.flatten(0, 0)).all())
-    assert ((dst_t == src_t.flatten(0, -1)).all())
-    assert ((dst_t == src_t.flatten(-1, 0)).all())
-    assert ((dst_t == src_t.flatten(-1, -1)).all())
+    assert (dst_t.allclose(src_t.flatten(0, 0)))
+    assert (dst_t.allclose(src_t.flatten(0, -1)))
+    assert (dst_t.allclose(src_t.flatten(-1, 0)))
+    assert (dst_t.allclose(src_t.flatten(-1, -1)))
 
     with pytest.raises(RuntimeError):
         src_t.flatten(-2)
@@ -296,20 +296,20 @@ def test_flatten(device):
     dst_t_unchanged = o3c.Tensor([[1, 2, 3], [4, 5, 6]],
                                  dtype=o3c.Dtype.Int64).to(device)
 
-    assert ((dst_t_flat == src_t.flatten()).all())
-    assert ((dst_t_flat == src_t.flatten(0)).all())
-    assert ((dst_t_flat == src_t.flatten(-2)).all())
+    assert (dst_t_flat.allclose(src_t.flatten()))
+    assert (dst_t_flat.allclose(src_t.flatten(0)))
+    assert (dst_t_flat.allclose(src_t.flatten(-2)))
 
-    assert ((dst_t_flat == src_t.flatten(0, 1)).all())
-    assert ((dst_t_flat == src_t.flatten(-2, 1)).all())
-    assert ((dst_t_flat == src_t.flatten(0, -1)).all())
-    assert ((dst_t_flat == src_t.flatten(-2, -1)).all())
+    assert (dst_t_flat.allclose(src_t.flatten(0, 1)))
+    assert (dst_t_flat.allclose(src_t.flatten(-2, 1)))
+    assert (dst_t_flat.allclose(src_t.flatten(0, -1)))
+    assert (dst_t_flat.allclose(src_t.flatten(-2, -1)))
 
-    assert ((dst_t_unchanged == src_t.flatten(1)).all())
-    assert ((dst_t_unchanged == src_t.flatten(-1)).all())
+    assert (dst_t_unchanged.allclose(src_t.flatten(1)))
+    assert (dst_t_unchanged.allclose(src_t.flatten(-1)))
 
     for dim in range(-2, 2):
-        assert ((dst_t_unchanged == src_t.flatten(dim, dim)).all())
+        assert (dst_t_unchanged.allclose(src_t.flatten(dim, dim)))
 
     # Out of bounds dimensions
     with pytest.raises(RuntimeError):
@@ -346,27 +346,27 @@ def test_flatten(device):
         [[1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12]],
         dtype=o3c.Dtype.Int64).to(device)
 
-    assert ((dst_t_flat == src_t.flatten()).all())
-    assert ((dst_t_flat == src_t.flatten(0)).all())
-    assert ((dst_t_flat == src_t.flatten(-3)).all())
+    assert (dst_t_flat.allclose(src_t.flatten()))
+    assert (dst_t_flat.allclose(src_t.flatten(0)))
+    assert (dst_t_flat.allclose(src_t.flatten(-3)))
 
-    assert ((dst_t_flat == src_t.flatten(0, 2)).all())
-    assert ((dst_t_flat == src_t.flatten(-3, 2)).all())
-    assert ((dst_t_flat == src_t.flatten(0, -1)).all())
-    assert ((dst_t_flat == src_t.flatten(-3, -1)).all())
+    assert (dst_t_flat.allclose(src_t.flatten(0, 2)))
+    assert (dst_t_flat.allclose(src_t.flatten(-3, 2)))
+    assert (dst_t_flat.allclose(src_t.flatten(0, -1)))
+    assert (dst_t_flat.allclose(src_t.flatten(-3, -1)))
 
-    assert ((dst_t_first_two_flat == src_t.flatten(0, 1)).all())
-    assert ((dst_t_first_two_flat == src_t.flatten(0, -2)).all())
-    assert ((dst_t_first_two_flat == src_t.flatten(-3, 1)).all())
-    assert ((dst_t_first_two_flat == src_t.flatten(-3, -2)).all())
+    assert (dst_t_first_two_flat.allclose(src_t.flatten(0, 1)))
+    assert (dst_t_first_two_flat.allclose(src_t.flatten(0, -2)))
+    assert (dst_t_first_two_flat.allclose(src_t.flatten(-3, 1)))
+    assert (dst_t_first_two_flat.allclose(src_t.flatten(-3, -2)))
 
-    assert ((dst_t_last_two_flat == src_t.flatten(1, 2)).all())
-    assert ((dst_t_last_two_flat == src_t.flatten(1, -1)).all())
-    assert ((dst_t_last_two_flat == src_t.flatten(-2, 2)).all())
-    assert ((dst_t_last_two_flat == src_t.flatten(-2, -1)).all())
+    assert (dst_t_last_two_flat.allclose(src_t.flatten(1, 2)))
+    assert (dst_t_last_two_flat.allclose(src_t.flatten(1, -1)))
+    assert (dst_t_last_two_flat.allclose(src_t.flatten(-2, 2)))
+    assert (dst_t_last_two_flat.allclose(src_t.flatten(-2, -1)))
 
     for dim in range(-3, 3):
-        assert ((dst_t_unchanged == src_t.flatten(dim, dim)).all())
+        assert (dst_t_unchanged.allclose(src_t.flatten(dim, dim)))
 
     # Out of bounds dimensions
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
The flatten operation is based on flatten from pytorch, as pytorch and numpy had inconsistent flatten functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4305)
<!-- Reviewable:end -->
