### PR TITLE
fix text editor eats last char sometimes due to insufficient buffer size

### DIFF
--- a/cpp/open3d/visualization/gui/TextEdit.cpp
+++ b/cpp/open3d/visualization/gui/TextEdit.cpp
@@ -127,7 +127,7 @@ Widget::DrawResult TextEdit::Draw(const DrawContext &context) {
     if (ImGui::InputTextWithHint(impl_->id_.c_str(),
                                  impl_->placeholder_.c_str(),
                                  const_cast<char *>(impl_->text_.c_str()),
-                                 impl_->text_.capacity()+1, text_flags,
+                                 impl_->text_.capacity() + 1, text_flags,
                                  InputTextCallback, &impl_->text_)) {
         if (impl_->on_text_changed_) {
             impl_->on_text_changed_(impl_->text_.c_str());

--- a/cpp/open3d/visualization/gui/TextEdit.cpp
+++ b/cpp/open3d/visualization/gui/TextEdit.cpp
@@ -127,7 +127,7 @@ Widget::DrawResult TextEdit::Draw(const DrawContext &context) {
     if (ImGui::InputTextWithHint(impl_->id_.c_str(),
                                  impl_->placeholder_.c_str(),
                                  const_cast<char *>(impl_->text_.c_str()),
-                                 impl_->text_.capacity(), text_flags,
+                                 impl_->text_.capacity()+1, text_flags,
                                  InputTextCallback, &impl_->text_)) {
         if (impl_->on_text_changed_) {
             impl_->on_text_changed_(impl_->text_.c_str());


### PR DESCRIPTION
Sometimes text editor will eat last char while being focused like this:
![bad](https://user-images.githubusercontent.com/18083216/143408774-7b1cfd86-7994-46e8-a47a-8e6f7d0edc74.gif)

This is caused by insufficient buffer size passing to `ImGui::InputTextEx`
```
// Edit a string of text
// - buf_size account for the zero-terminator, so a buf_size of 6 can hold "Hello" but not "Hello!".
bool ImGui::InputTextEx(const char* label, const char* hint, char* buf, int buf_size, const ImVec2& size_arg, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* callback_user_data)
```

Here TextEditor passes `impl_->text_.capacity()` as `buf_size`. Note that `capacity()` does not necessary contain null-terminal of string. That means if string length is 6, the `capacity()` could be 6, but we need a buffer size including null-terminal char, which should be 7. And because `string.capacity() >= string.length()`, so it happens sometimes, not always.

So we need add 1 to `capacity()` for null-terminal for buffer size to `InputTextEx`, this is how it works now:
![good](https://user-images.githubusercontent.com/18083216/143409673-04354c9f-fa31-4c10-b6dc-65977c0aa010.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4344)
<!-- Reviewable:end -->
