### PR TITLE
made set/get geomety transform available in python

### DIFF
--- a/cpp/open3d/visualization/rendering/Open3DScene.cpp
+++ b/cpp/open3d/visualization/rendering/Open3DScene.cpp
@@ -342,6 +342,33 @@ void Open3DScene::RemoveGeometry(const std::string& name) {
     }
 }
 
+bool Open3DScene::GeometryIsVisible(const std::string& name) {
+    auto scene = renderer_.GetScene(scene_);
+    return scene->GeometryIsVisible(name);
+}
+
+void Open3DScene::SetGeometryTransform(const std::string& name,
+                                       const Eigen::Matrix4d& transform) {
+    auto scene = renderer_.GetScene(scene_);
+    auto g = geometries_.find(name);
+    if (g != geometries_.end()) {
+        const Eigen::Transform<float, 3, Eigen::Affine> t(
+                transform.cast<float>());
+        scene->SetGeometryTransform(name, t);
+        if (!g->second.fast_name.empty()) {
+            scene->SetGeometryTransform(g->second.fast_name, t);
+        }
+        if (!g->second.low_name.empty()) {
+            scene->SetGeometryTransform(g->second.low_name, t);
+        }
+    }
+}
+
+Eigen::Matrix4d Open3DScene::GetGeometryTransform(const std::string& name) {
+    auto scene = renderer_.GetScene(scene_);
+    return scene->GetGeometryTransform(name).matrix().cast<double>();
+}
+
 void Open3DScene::ModifyGeometryMaterial(const std::string& name,
                                          const MaterialRecord& mat) {
     auto scene = renderer_.GetScene(scene_);

--- a/cpp/open3d/visualization/rendering/Open3DScene.h
+++ b/cpp/open3d/visualization/rendering/Open3DScene.h
@@ -108,6 +108,11 @@ public:
     void RemoveGeometry(const std::string& name);
     /// Shows or hides the geometry with the specified name.
     void ShowGeometry(const std::string& name, bool show);
+    bool GeometryIsVisible(const std::string& name);
+    void SetGeometryTransform(const std::string& name,
+                              const Eigen::Matrix4d& transform);
+    Eigen::Matrix4d GetGeometryTransform(const std::string& name);
+
     void ModifyGeometryMaterial(const std::string& name,
                                 const MaterialRecord& mat);
     void AddModel(const std::string& name, const TriangleMeshModel& model);

--- a/cpp/pybind/visualization/rendering/rendering.cpp
+++ b/cpp/pybind/visualization/rendering/rendering.cpp
@@ -619,6 +619,15 @@ void pybind_rendering_classes(py::module &m) {
                  "added to the scene, False otherwise")
             .def("remove_geometry", &Open3DScene::RemoveGeometry,
                  "Removes the geometry with the given name")
+            .def("geometry_is_visible", &Open3DScene::GeometryIsVisible,
+                 "geometry_is_visible(name): returns True if the geometry name "
+                 "is visible")
+            .def("set_geometry_transform", &Open3DScene::SetGeometryTransform,
+                 "set_geometry_transform(name, transform): sets the pose of the"
+                 " geometry name to transform")
+            .def("get_geometry_transform", &Open3DScene::GetGeometryTransform,
+                 "get_geometry_transform(name): returns the pose of the "
+                 "geometry name in the scene")
             .def("modify_geometry_material",
                  &Open3DScene::ModifyGeometryMaterial,
                  "modify_geometry_material(name, material). Modifies the "


### PR DESCRIPTION
this PR exposes SetGeometryTransform, GetGeometryTransform and GeometryIsVisible to the python API which allows us to show animations in the open3d.visualization.gui.SceneWidget

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4366)
<!-- Reviewable:end -->
