### PR TITLE
Improve consistency in use of pixel size parameter

### DIFF
--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
@@ -1259,7 +1259,6 @@ struct O3DVisualizer::Impl {
         UpdateSelectionPointSize(px);
 
         px = int(ConvertToScaledPixels(px));
-        utility::LogWarning("Point size in set: {}", px);
         for (auto &o : objects_) {
             o.material.point_size = float(px);
             OverrideMaterial(o.name, o.material, ui_state_.scene_shader);

--- a/python/open3d/visualization/draw.py
+++ b/python/open3d/visualization/draw.py
@@ -60,12 +60,6 @@ def draw(geometry=None,
         for a in actions:
             w.add_action(a[0], a[1])
 
-    if point_size is not None:
-        w.point_size = point_size
-
-    if line_width is not None:
-        w.line_width = line_width
-
     def add(g, n):
         if isinstance(g, dict):
             w.add_geometry(g)
@@ -99,6 +93,12 @@ def draw(geometry=None,
 
     if show_skybox is not None:
         w.show_skybox(show_skybox)
+
+    if point_size is not None:
+        w.point_size = point_size
+
+    if line_width is not None:
+        w.line_width = line_width
 
     if rpc_interface:
         w.start_rpc_interface(address="tcp://127.0.0.1:51454", timeout=10000)


### PR DESCRIPTION
The following behaviors change with this PR:

- If `point_size` is set in `draw` call then all point clouds will have their point sizes set to `point_size` regardless of the `point_size` specified in the material properties.
- If `point_size` is _not_ set in `draw` call then point clouds will be rendered with the `point_size` set in their respective material properties. Note: prior to this PR _all_ point clouds would have their point size set to the point size of the last point cloud geometry listed in the `draw` call.
- The point size slider in the User Interface will not be updated to match the point size of a point cloud's material settings. Instead, it works as a global override.

The following script demonstrates the new behavior:
```
import open3d as o3d
from open3d.core import Tensor, concatenate
from open3d.visualization import rendering, draw
from open3d.ml.vis import Colormap

# Create a helix point cloud. We will use the Z values to assign colors.
values = Tensor.arange(start=0.0, stop=1.0, step=0.001,
                       dtype=o3d.core.float32).reshape((-1, 1))
values2 = Tensor.arange(start=1.0, stop=2.0, step=0.001,
                       dtype=o3d.core.float32).reshape((-1, 1))
period = 0.2
xyz = concatenate(
    ((6.28 / period * values).sin(), (6.28 / period * values).cos(), values), 1)
xyz2 = concatenate(
    ((6.28 / period * values).sin(), (6.28 / period * values).cos(), values2), 1)

pcd = o3d.t.geometry.PointCloud(xyz)
pcd2 = o3d.t.geometry.PointCloud(xyz2)

# Use a special point property to specify colormap lookup values for the point
# cloud.
pcd.point['__visualization_scalar'] = values
pcd2.point['__visualization_scalar'] = values2

# Use a default rainbow colormap
colormap = Colormap.make_rainbow()

# Add alpha channel and convert to Gradient Points
colormap = list(
    rendering.Gradient.Point(pt.value, pt.color + [1.0])
    for pt in colormap.points)

# Now create the materials - each point cloud will have a different point size
material = rendering.MaterialRecord()
material.shader = "unlitGradient"
material.gradient = rendering.Gradient(colormap)
material.gradient.mode = rendering.Gradient.GRADIENT
material.scalar_min = 0.0
material.scalar_max = 1.0
material.point_size = 9.0
material2 = rendering.MaterialRecord()
material2.shader = "unlitGradient"
material2.gradient = rendering.Gradient(colormap)
material2.gradient.mode = rendering.Gradient.GRADIENT
material2.scalar_min = 1.0
material2.scalar_max = 2.0
material2.point_size = 3.0

# Draw two stacked helixes with different point sizes
draw([{
    'name': 'helix',
    'geometry': pcd,
    'material': material},
    { 'name': 'helix2',
      'geometry' : pcd2,
      'material': material2}],
show_skybox=False)

# Draw two stacked helixes overriding material point sizes.
draw([{
    'name': 'helix',
    'geometry': pcd,
    'material': material},
    { 'name': 'helix2',
      'geometry' : pcd2,
      'material': material2}],
point_size=9,
show_skybox=False)
```
![2021-12-12-120035_1024x768_scrot](https://user-images.githubusercontent.com/3722407/145721825-96cb12ce-081d-4c5f-ae79-e43a6fb5f4ef.png)

![2021-12-12-120046_1024x768_scrot](https://user-images.githubusercontent.com/3722407/145721837-e1ed97fc-cb7e-45de-a322-646b5144f556.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4413)
<!-- Reviewable:end -->
