### PR TITLE
Setup custom (intrinsic) projection matrix with infinite far plane

### DIFF
--- a/cpp/open3d/visualization/rendering/Renderer.cpp
+++ b/cpp/open3d/visualization/rendering/Renderer.cpp
@@ -146,7 +146,7 @@ void Renderer::RenderToDepthImage(
                         if (pixels[i] == 0.f) {
                             pixels[i] = std::numeric_limits<float>::infinity();
                         } else {
-                            pixels[i] = -z_near / pixels[i];
+                            pixels[i] = z_near / pixels[i];
                         }
                     }
                 } else {

--- a/cpp/open3d/visualization/rendering/filament/FilamentCamera.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentCamera.cpp
@@ -168,6 +168,7 @@ void FilamentCamera::SetProjection(const Eigen::Matrix3d& intrinsics,
                                    double width,
                                    double height) {
     filament::math::mat4 custom_proj;
+    filament::math::mat4 culling_proj;
     custom_proj[0][0] = 2.0 * intrinsics(0, 0) / width;
     custom_proj[0][1] = 0.0;
     custom_proj[0][2] = 0.0;
@@ -180,15 +181,19 @@ void FilamentCamera::SetProjection(const Eigen::Matrix3d& intrinsics,
 
     custom_proj[2][0] = 1.0 - 2.0 * intrinsics(0, 2) / width;
     custom_proj[2][1] = -1.0 + 2.0 * intrinsics(1, 2) / height;
-    custom_proj[2][2] = (-far - near) / (far - near);
+    custom_proj[2][2] = -1.0;
     custom_proj[2][3] = -1.0;
 
     custom_proj[3][0] = 0.0;
     custom_proj[3][1] = 0.0;
-    custom_proj[3][2] = -2.0 * far * near / (far - near);
+    custom_proj[3][2] = -2.0 * near;
     custom_proj[3][3] = 0.0;
 
-    camera_->setCustomProjection(custom_proj, near, far);
+    culling_proj = custom_proj;
+    culling_proj[2][2] = (-far - near) / (far - near);
+    culling_proj[3][2] = -2.0 * far * near / (far - near);
+
+    camera_->setCustomProjection(custom_proj, culling_proj, near, far);
 
     projection_.is_intrinsic = true;
     projection_.is_ortho = false;

--- a/cpp/open3d/visualization/rendering/filament/FilamentCamera.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentCamera.cpp
@@ -193,7 +193,11 @@ void FilamentCamera::SetProjection(const Eigen::Matrix3d& intrinsics,
     culling_proj[2][2] = (-far - near) / (far - near);
     culling_proj[3][2] = -2.0 * far * near / (far - near);
 
+#ifdef WIN32
+    camera_->setCustomProjection(custom_proj, near, far);
+#else
     camera_->setCustomProjection(custom_proj, culling_proj, near, far);
+#endif
 
     projection_.is_intrinsic = true;
     projection_.is_ortho = false;


### PR DESCRIPTION
The following script should show almost identical z values both when setting up the camera with intrinsics/extrinsics and with fov/camera pose.

```
import open3d as o3d
import numpy as np

vis = o3d.visualization.rendering.OffscreenRenderer(800,600,)

sphere = o3d.geometry.TriangleMesh.create_sphere(create_uv_map=True, radius=1.0)
sphere.compute_vertex_normals()
sphere.paint_uniform_color((0, 1, 0))

mat = o3d.visualization.rendering.MaterialRecord()
mat.shader = 'defaultLit'

vis.scene.add_geometry('mysphere', sphere, mat)

# test with intrinsics
w, h = 800, 600
f = 1000
cx, cy = 400, 300
cam_intrinsics = o3d.camera.PinholeCameraIntrinsic(w,h,f,f,cx,cy)
cam_extrinsics = np.eye(4)
cam_extrinsics[0:3,3] = [0,0,3]
vis.setup_camera(cam_intrinsics, cam_extrinsics)
img = vis.render_to_image()
o3d.io.write_image("/tmp/test_intrinsic.png", img, 9)
depth_intrinsic = np.asarray(vis.render_to_depth_image(True))
print(depth_intrinsic[300,400])

# test with 'regular' camera setup
vis.setup_camera(30.0, [0, 0, 0], [0, -3, 0], [1, 0, 0])
img = vis.render_to_image()
o3d.io.write_image("/tmp/test_regular.png", img, 9)
depth_regular = np.asarray(vis.render_to_depth_image(True))
print(depth_regular[300,400])
```
Output:
```
2.0001116
2.0001402
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4415)
<!-- Reviewable:end -->
