### PR TITLE
fix issue 4409

### DIFF
--- a/cpp/open3d/geometry/PointCloudSegmentation.cpp
+++ b/cpp/open3d/geometry/PointCloudSegmentation.cpp
@@ -182,7 +182,8 @@ std::tuple<Eigen::Vector4d, std::vector<size_t>> PointCloud::SegmentPlane(
         // inliers.
         if (ransac_n == 3) {
             plane_model = TriangleMesh::ComputeTrianglePlane(
-                    points_[inliers[0]], points_[inliers[1]], points_[inliers[2]]);
+                    points_[inliers[0]], points_[inliers[1]],
+                    points_[inliers[2]]);
         } else {
             plane_model = GetPlaneFromPoints(points_, inliers);
         }

--- a/cpp/open3d/geometry/PointCloudSegmentation.cpp
+++ b/cpp/open3d/geometry/PointCloudSegmentation.cpp
@@ -180,8 +180,13 @@ std::tuple<Eigen::Vector4d, std::vector<size_t>> PointCloud::SegmentPlane(
 
         // Fit model to num_model_parameters randomly selected points among the
         // inliers.
-        plane_model = TriangleMesh::ComputeTrianglePlane(
-                points_[inliers[0]], points_[inliers[1]], points_[inliers[2]]);
+        if (ransac_n == 3) {
+            plane_model = TriangleMesh::ComputeTrianglePlane(
+                    points_[inliers[0]], points_[inliers[1]], points_[inliers[2]]);
+        } else {
+            plane_model = GetPlaneFromPoints(points_, inliers);
+        }
+
         if (plane_model.isZero(0)) {
             continue;
         }

--- a/cpp/tests/geometry/PointCloud.cpp
+++ b/cpp/tests/geometry/PointCloud.cpp
@@ -1212,6 +1212,9 @@ TEST(PointCloud, SegmentPlane) {
 
     // TODO: seed the ransac
     ExpectEQ(plane_model, Eigen::Vector4d(-0.06, -0.10, 0.99, -1.06), 0.1);
+
+    std::tie(plane_model, inliers) = pcd.SegmentPlane(0.01, 10, 1000);
+    ExpectEQ(plane_model, Eigen::Vector4d(-0.06, -0.10, 0.99, -1.06), 0.1);
 }
 
 TEST(PointCloud, SegmentPlaneKnownPlane) {
@@ -1226,6 +1229,9 @@ TEST(PointCloud, SegmentPlaneKnownPlane) {
     Eigen::Vector4d plane_model;
     std::vector<size_t> inliers;
     std::tie(plane_model, inliers) = pcd.SegmentPlane(0.01, 3, 10);
+    ExpectEQ(pcd.SelectByIndex(inliers)->points_, ref);
+
+    std::tie(plane_model, inliers) = pcd.SegmentPlane(0.01, 4, 10);
     ExpectEQ(pcd.SelectByIndex(inliers)->points_, ref);
 }
 


### PR DESCRIPTION
Fixes #4409.
As the doc say, ransac_n is the inliers to initial plane.
But in current implement, only 3 point used.
So I make this change, and also passed unit test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4418)
<!-- Reviewable:end -->
