### PR TITLE
Correct unproject behavior to match documentation

### DIFF
--- a/cpp/open3d/visualization/gui/SceneWidget.cpp
+++ b/cpp/open3d/visualization/gui/SceneWidget.cpp
@@ -488,8 +488,7 @@ private:
         if (win_z < far_z) {
             auto vp = scene_->GetView()->GetViewport();
             auto point = scene_->GetCamera()->Unproject(
-                    float(x), float(vp[3] - y), win_z, float(vp[2]),
-                    float(vp[3]));
+                    float(x), float(y), win_z, float(vp[2]), float(vp[3]));
             SetCenterOfRotation(point);
             interactor_->Rotate(0, 0);  // update now
         }

--- a/cpp/open3d/visualization/rendering/Camera.h
+++ b/cpp/open3d/visualization/rendering/Camera.h
@@ -114,6 +114,9 @@ public:
     virtual ProjectionMatrix GetProjectionMatrix() const = 0;
     virtual Transform GetCullingProjectionMatrix() const = 0;
 
+    /// Returns world space coordinates given an x,y position in screen
+    /// coordinates relative to upper left, the screen dimensions, and z is the
+    /// depth value (0.0 - 1.0)
     virtual Eigen::Vector3f Unproject(float x,
                                       float y,
                                       float z,

--- a/cpp/open3d/visualization/rendering/filament/FilamentCamera.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentCamera.cpp
@@ -347,7 +347,8 @@ void FilamentCamera::SetModelMatrix(const Transform& view) {
 Eigen::Vector3f FilamentCamera::Unproject(
         float x, float y, float z, float view_width, float view_height) const {
     Eigen::Vector4f gl_pt(2.0f * x / view_width - 1.0f,
-                          2.0f * y / view_height - 1.0f, 2.0f * z - 1.0f, 1.0f);
+                          2.0f * (view_height - y) / view_height - 1.0f,
+                          2.0f * z - 1.0f, 1.0f);
 
     auto proj = GetProjectionMatrix();
     Eigen::Vector4f obj_pt = (proj * GetViewMatrix()).inverse() * gl_pt;


### PR DESCRIPTION
Addresses issues #4244 and #4382. The documentation indicate that inputs to `Camera::Unproject` and `visualization.rendering.Camera.unproject` expect `x,y` in screen coordinates relative to upper-left of screen but the implementation expected lower-right origin.

The following modified version of the `mouse-and-point-coord.py` demo provided by the authors of both referenced issues can be used to test:

```
import numpy as np
import open3d as o3d
import open3d.visualization.gui as gui
import open3d.visualization.rendering as rendering
import os

SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))


# This example displays a point cloud and if you Ctrl-click on a point
# (Cmd-click on macOS) it will show the coordinates of the point.
# This example illustrates:
# - custom mouse handling on SceneWidget
# - getting a the depth value of a point (OpenGL depth)
# - converting from a window point + OpenGL depth to world coordinate
class ExampleApp:

    def __init__(self, cloud):
        # We will create a SceneWidget that fills the entire window, and then
        # a label in the lower left on top of the SceneWidget to display the
        # coordinate.
        app = gui.Application.instance
        self.window = app.create_window("Open3D - GetCoord Example", 1024, 768)
        # Since we want the label on top of the scene, we cannot use a layout,
        # so we need to manually layout the window's children.
        self.window.set_on_layout(self._on_layout)
        self.widget3d = gui.SceneWidget()
        self.window.add_child(self.widget3d)
        self.info = gui.Label("")
        self.info.visible = False
        self.window.add_child(self.info)

        self.widget3d.scene = rendering.Open3DScene(self.window.renderer)

        mat = rendering.MaterialRecord()
        mat.shader = "defaultLit"
        # Point size is in native pixels, but "pixel" means different things to
        # different platforms (macOS, in particular), so multiply by Window scale
        # factor.
        mat.point_size = 3 * self.window.scaling
        self.widget3d.scene.add_geometry("Point Cloud", cloud, mat)

        bounds = self.widget3d.scene.bounding_box
        center = bounds.get_center()
        self.widget3d.setup_camera(60, bounds, center)
        self.widget3d.look_at(center, center - [0, 0, 12], [0, -1, 0])
        self.widget3d.set_on_mouse(self._on_mouse_widget3d)
        self.picked_points = []

    def _on_layout(self, layout_context):
        r = self.window.content_rect
        self.widget3d.frame = r
        pref = self.info.calc_preferred_size(layout_context,
                                             gui.Widget.Constraints())
        self.info.frame = gui.Rect(r.x,
                                   r.get_bottom() - pref.height, pref.width,
                                   pref.height)

    def _on_mouse_widget3d(self, event):
        # We could override BUTTON_DOWN without a modifier, but that would
        # interfere with manipulating the scene.
        if event.type == gui.MouseEvent.Type.BUTTON_DOWN and event.is_modifier_down(
                gui.KeyModifier.CTRL):

            def depth_callback(depth_image):
                # Coordinates are expressed in absolute coordinates of the
                # window, but to dereference the image correctly we need them
                # relative to the origin of the widget. Note that even if the
                # scene widget is the only thing in the window, if a menubar
                # exists it also takes up space in the window (except on macOS).
                x = event.x - self.widget3d.frame.x
                y = event.y - self.widget3d.frame.y
                # Note that np.asarray() reverses the axes.
                depth = np.asarray(depth_image)[y, x]

                if depth == 1.0:  # clicked on nothing (i.e. the far plane)
                    world = [0, 0, 0]
                    text = ""
                else:
                    world = self.widget3d.scene.camera.unproject(
                        event.x, event.y, depth, self.widget3d.frame.width,
                        self.widget3d.frame.height)
                    text = "({:.3f}, {:.3f}, {:.3f})".format(
                        world[0], world[1], world[2])
                self.picked_points.append(world)

                # This is not called on the main thread, so we need to
                # post to the main thread to safely access UI items.
                def update_label():
                    self.info.text = text
                    self.info.visible = (text != "")
                    # We are sizing the info label to be exactly the right size,
                    # so since the text likely changed width, we need to
                    # re-layout to set the new frame.
                    self.window.set_needs_layout()

                    mat = o3d.visualization.rendering.MaterialRecord()
                    mat.shader = "defaultLit"
                    # NOTE: USE 0.01 IF TESTING WITH POINT CLOUD
                    sphere = o3d.geometry.TriangleMesh.create_sphere(radius=0.1)
                    sphere.paint_uniform_color([0.1, 0.1, 0.7])
                    sphere.compute_vertex_normals()
                    sphere.translate(world)
                    self.widget3d.scene.add_geometry(f"point {len(self.picked_points)}", sphere, mat)

                gui.Application.instance.post_to_main_thread(
                    self.window, update_label)

            self.widget3d.scene.scene.render_to_depth_image(depth_callback)
            return gui.Widget.EventCallbackResult.HANDLED
        return gui.Widget.EventCallbackResult.IGNORED

def main():
    app = gui.Application.instance
    app.initialize()

    # This example will also work with a triangle mesh, or any 3D object.
    # If you use a triangle mesh you will probably want to set the material
    # shader to "defaultLit" instead of "defaultUnlit".

    # TEST WITH SPHERE...
    cloud = o3d.geometry.TriangleMesh.create_sphere(5.0)
    cloud.compute_vertex_normals()

    # OR POINTCLOUD...
    # cloud = o3d.io.read_point_cloud("examples/test_data/ICP/cloud_bin_0.pcd")

    ex = ExampleApp(cloud)

    app.run()


if __name__ == "__main__":
    main()
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4431)
<!-- Reviewable:end -->
