### PR TITLE
Revert example to its original camera setup

### DIFF
--- a/examples/python/gui/render-to-image.py
+++ b/examples/python/gui/render-to-image.py
@@ -75,7 +75,7 @@ def main():
     img = render.render_to_image()
     o3d.io.write_image("/tmp/test.png", img, 9)
 
-    render.setup_camera(60.0, [0, 0, 0], [0, 10, 0], [0, 0, 1])
+    render.setup_camera(60.0, [0, 0, 0], [-10, 0, 0], [0, 0, 1])
     img = render.render_to_image()
     o3d.io.write_image("/tmp/test2.png", img, 9)
 


### PR DESCRIPTION
The `render-to-image.py` example is supposed to render two images from two different points of view. At some point the second view was accidentally changed so it's identical to the first. This PR restores the example to its original state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4440)
<!-- Reviewable:end -->
