### PR TITLE
Add missing pybinds for View class

### DIFF
--- a/cpp/open3d/visualization/rendering/filament/FilamentView.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentView.cpp
@@ -167,11 +167,14 @@ std::array<int, 4> FilamentView::GetViewport() const {
 }
 
 void FilamentView::SetPostProcessing(bool enabled) {
+    post_processing_enabled_ = enabled;
     view_->setPostProcessingEnabled(enabled);
 }
 
 void FilamentView::SetAmbientOcclusion(bool enabled,
                                        bool ssct_enabled /* = false */) {
+    ao_enabled_ = enabled;
+    ao_ssct_enabled_ = ssct_enabled;
     filament::View::AmbientOcclusionOptions options;
     options.enabled = enabled;
     options.ssct.enabled = ssct_enabled;
@@ -179,6 +182,8 @@ void FilamentView::SetAmbientOcclusion(bool enabled,
 }
 
 void FilamentView::SetAntiAliasing(bool enabled, bool temporal /* = false */) {
+    aa_enabled_ = enabled;
+    aa_temporal_ = temporal;
     if (enabled) {
         filament::View::TemporalAntiAliasingOptions options;
         options.enabled = temporal;
@@ -190,6 +195,8 @@ void FilamentView::SetAntiAliasing(bool enabled, bool temporal /* = false */) {
 }
 
 void FilamentView::SetShadowing(bool enabled, ShadowType type) {
+    shadowing_enabled_ = enabled;
+    shadowing_type_ = type;
     if (enabled) {
         filament::View::ShadowType stype =
                 (type == ShadowType::kPCF) ? filament::View::ShadowType::PCF
@@ -351,6 +358,20 @@ void FilamentView::CopySettingsFrom(const FilamentView& other) {
     if (other.configured_for_picking_) {
         ConfigureForColorPicking();
     }
+    if (other.color_grading_) {
+        view_->setColorGrading(other.color_grading_);
+    }
+    post_processing_enabled_ = other.post_processing_enabled_;
+    ao_enabled_ = other.ao_enabled_;
+    ao_ssct_enabled_ = other.ao_ssct_enabled_;
+    aa_enabled_ = other.aa_enabled_;
+    aa_temporal_ = other.aa_temporal_;
+    shadowing_enabled_ = other.shadowing_enabled_;
+    shadowing_type_ = other.shadowing_type_;
+    SetShadowing(shadowing_enabled_, shadowing_type_);
+    SetAntiAliasing(aa_enabled_, aa_temporal_);
+    SetAmbientOcclusion(ao_enabled_, ao_ssct_enabled_);
+    SetPostProcessing(post_processing_enabled_);
 }
 
 void FilamentView::SetScene(FilamentScene& scene) {

--- a/cpp/open3d/visualization/rendering/filament/FilamentView.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentView.cpp
@@ -167,14 +167,11 @@ std::array<int, 4> FilamentView::GetViewport() const {
 }
 
 void FilamentView::SetPostProcessing(bool enabled) {
-    post_processing_enabled_ = enabled;
     view_->setPostProcessingEnabled(enabled);
 }
 
 void FilamentView::SetAmbientOcclusion(bool enabled,
                                        bool ssct_enabled /* = false */) {
-    ao_enabled_ = enabled;
-    ao_ssct_enabled_ = ssct_enabled;
     filament::View::AmbientOcclusionOptions options;
     options.enabled = enabled;
     options.ssct.enabled = ssct_enabled;
@@ -182,8 +179,6 @@ void FilamentView::SetAmbientOcclusion(bool enabled,
 }
 
 void FilamentView::SetAntiAliasing(bool enabled, bool temporal /* = false */) {
-    aa_enabled_ = enabled;
-    aa_temporal_ = temporal;
     if (enabled) {
         filament::View::TemporalAntiAliasingOptions options;
         options.enabled = temporal;
@@ -195,8 +190,6 @@ void FilamentView::SetAntiAliasing(bool enabled, bool temporal /* = false */) {
 }
 
 void FilamentView::SetShadowing(bool enabled, ShadowType type) {
-    shadowing_enabled_ = enabled;
-    shadowing_type_ = type;
     if (enabled) {
         filament::View::ShadowType stype =
                 (type == ShadowType::kPCF) ? filament::View::ShadowType::PCF
@@ -361,17 +354,14 @@ void FilamentView::CopySettingsFrom(const FilamentView& other) {
     if (other.color_grading_) {
         view_->setColorGrading(other.color_grading_);
     }
-    post_processing_enabled_ = other.post_processing_enabled_;
-    ao_enabled_ = other.ao_enabled_;
-    ao_ssct_enabled_ = other.ao_ssct_enabled_;
-    aa_enabled_ = other.aa_enabled_;
-    aa_temporal_ = other.aa_temporal_;
-    shadowing_enabled_ = other.shadowing_enabled_;
-    shadowing_type_ = other.shadowing_type_;
-    SetShadowing(shadowing_enabled_, shadowing_type_);
-    SetAntiAliasing(aa_enabled_, aa_temporal_);
-    SetAmbientOcclusion(ao_enabled_, ao_ssct_enabled_);
-    SetPostProcessing(post_processing_enabled_);
+    auto ao_options = other.view_->getAmbientOcclusionOptions();
+    view_->setAmbientOcclusionOptions(ao_options);
+    auto aa_mode = other.view_->getAntiAliasing();
+    auto temporal_options = other.view_->getTemporalAntiAliasingOptions();
+    view_->setAntiAliasing(aa_mode);
+    view_->setTemporalAntiAliasingOptions(temporal_options);
+    view_->setShadowingEnabled(other.view_->isShadowingEnabled());
+    view_->setPostProcessingEnabled(other.view_->isPostProcessingEnabled());
 }
 
 void FilamentView::SetScene(FilamentScene& scene) {

--- a/cpp/open3d/visualization/rendering/filament/FilamentView.h
+++ b/cpp/open3d/visualization/rendering/filament/FilamentView.h
@@ -112,16 +112,6 @@ private:
     TextureHandle depth_buffer_;
     RenderTargetHandle render_target_;
 
-    // Parameters that must be stored to properly copy a View. Typically used
-    // when offscreen rendering
-    bool post_processing_enabled_ = true;
-    bool ao_enabled_ = true;
-    bool ao_ssct_enabled_ = false;
-    bool aa_enabled_ = true;
-    bool aa_temporal_ = false;
-    bool shadowing_enabled_ = true;
-    ShadowType shadowing_type_ = ShadowType::kPCF;
-
     filament::Engine& engine_;
     FilamentScene* scene_ = nullptr;
     FilamentResourceManager& resource_mgr_;

--- a/cpp/open3d/visualization/rendering/filament/FilamentView.h
+++ b/cpp/open3d/visualization/rendering/filament/FilamentView.h
@@ -112,6 +112,16 @@ private:
     TextureHandle depth_buffer_;
     RenderTargetHandle render_target_;
 
+    // Parameters that must be stored to properly copy a View. Typically used
+    // when offscreen rendering
+    bool post_processing_enabled_ = true;
+    bool ao_enabled_ = true;
+    bool ao_ssct_enabled_ = false;
+    bool aa_enabled_ = true;
+    bool aa_temporal_ = false;
+    bool shadowing_enabled_ = true;
+    ShadowType shadowing_type_ = ShadowType::kPCF;
+
     filament::Engine& engine_;
     FilamentScene* scene_ = nullptr;
     FilamentResourceManager& resource_mgr_;

--- a/cpp/pybind/visualization/rendering/rendering.cpp
+++ b/cpp/pybind/visualization/rendering/rendering.cpp
@@ -460,8 +460,42 @@ void pybind_rendering_classes(py::module &m) {
     // ---- View ----
     py::class_<View, UnownedPointer<View>> view(m, "View",
                                                 "Low-level view class");
+    // ---- Shadow Types ----
+    py::enum_<View::ShadowType> shadow_type(
+            view, "ShadowType", "Available shadow mapping algorithm options");
+    shadow_type.value("PCF", View::ShadowType::kPCF)
+            .value("VSM", View::ShadowType::kVSM);
+
     view.def("set_color_grading", &View::SetColorGrading,
-             "Sets the parameters to be used for the color grading algorithms");
+             "Sets the parameters to be used for the color grading algorithms")
+            .def("set_post_processing", &View::SetPostProcessing,
+                 "True to enable, False to disable post processing. Post "
+                 "processing effects include: color grading, ambient occlusion "
+                 "(and other screen space effects), and anti-aliasing.")
+            .def("set_ambient_occlusion", &View::SetAmbientOcclusion,
+                 "enabled"_a, "ssct_enabled"_a = false,
+                 "True to enable, False to disable ambient occlusion. "
+                 "Optionally, screen-space cone tracing may be enabled with "
+                 "ssct_enabled=True.")
+            .def("set_antialiasing", &View::SetAntiAliasing, "enabled"_a,
+                 "temporal"_a = false,
+                 "True to enable, False to disable anti-aliasing. Note that "
+                 "this only impacts anti-aliasing post-processing. MSAA is "
+                 "controlled separately by `set_sample_count`. Temporal "
+                 "anti-aliasing may be optionally enabled with temporal=True.")
+            .def("set_sample_count", &View::SetSampleCount,
+                 "Sets the sample count for MSAA. Set to 1 to disable MSAA. "
+                 "Typical values are 2, 4 or 8. The maximum possible value "
+                 "depends on the underlying GPU and OpenGL driver.")
+            .def("set_shadowing", &View::SetShadowing, "enabled"_a,
+                 "type"_a = View::ShadowType::kPCF,
+                 "True to enable, false to enable all shadow mapping when "
+                 "rendering this View. When enabling shadow mapping you may "
+                 "also specify one of two shadow mapping algorithms: PCF "
+                 "(default) or VSM. Note: shadowing is enabled by default with "
+                 "PCF shadow mapping.")
+            .def("get_camera", &View::GetCamera,
+                 "Returns the Camera associated with this View.");
 
     // ---- Scene ----
     py::class_<Scene, UnownedPointer<Scene>> scene(m, "Scene",


### PR DESCRIPTION
Addresses #2946 . Allows users to disable post-processing effects that may be detrimental to data visualization.

```
import open3d as o3d
import numpy as np

# Create three random point clouds
rng = np.random.default_rng()
pts1 = rng.random((10000, 3), dtype=np.float32)
t1 = o3d.core.Tensor(pts1)
pcd1 = o3d.t.geometry.PointCloud(t1)
pcd1.point['colors'] = t1
mat = o3d.visualization.rendering.MaterialRecord()
mat.shader = "defaultUnlit"
mat.point_size = 5

render = o3d.visualization.rendering.OffscreenRenderer(800,600)
render.scene.add_geometry("pcd", pcd1, mat)
render.setup_camera(45.0, [0.5, 0.5, 0.5], [0.5, 2, 0.5], [0, 0, 1])

img = render.render_to_image()
o3d.io.write_image("/tmp/default_render.png", img)

# Disable post processing
render.scene.view.set_post_processing(False)
img = render.render_to_image()
o3d.io.write_image("/tmp/no_post_processing.png", img)
```
Default Rendering:
![default_render](https://user-images.githubusercontent.com/3722407/146431272-5487f813-7531-4d1d-9a8b-7b49cdaccbc8.png)

No Post Processing:
![no_post_processing](https://user-images.githubusercontent.com/3722407/146431336-6a6f4b26-70f3-48ca-8aee-53ba4c2efb57.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4441)
<!-- Reviewable:end -->
