### PR TITLE
Viewer app links 3rd-party libraires (with apple frameworks)

### DIFF
--- a/cpp/apps/CMakeLists.txt
+++ b/cpp/apps/CMakeLists.txt
@@ -49,6 +49,7 @@ macro(open3d_add_app SRC_DIR APP_NAME TARGET_NAME)
     set_target_properties(${TARGET_NAME} PROPERTIES FOLDER "apps")
     open3d_show_and_abort_on_warning(${TARGET_NAME})
     open3d_set_global_properties(${TARGET_NAME})
+    open3d_link_3rdparty_libraries(${TARGET_NAME})
 
     # Copy the resource files. This needs to be done as a post-build step
     # because on macOS, we don't know the bundle directory until build time


### PR DESCRIPTION
On some macOS systems, the Viewer app may fail to link when `-DBUILD_SHARED_LIBS=ON`.
```bash
cmake -DBUILD_SHARED_LIBS=ON ..
make Open3DViewer -j10
```

```
[100%] Linking CXX executable ../../bin/Open3D.app/Contents/MacOS/Open3D
Undefined symbols for architecture x86_64:
  "___CFConstantStringClassReference", referenced from:
      CFString in Open3DViewer_mac.mm.o
      CFString in Open3DViewer_mac.mm.o
      CFString in Open3DViewer_mac.mm.o
      CFString in Open3DViewer_mac.mm.o
      CFString in Open3DViewer_mac.mm.o
      CFString in Open3DViewer_mac.mm.o
      CFString in Open3DViewer_mac.mm.o
      ...
  "_OBJC_CLASS_$_NSApplication", referenced from:
      objc-class-ref in Open3DViewer_mac.mm.o
  "_OBJC_METACLASS_$_NSObject", referenced from:
      _OBJC_METACLASS_$_AppDelegate in Open3DViewer_mac.mm.o
  "_OBJC_CLASS_$_NSObject", referenced from:
      _OBJC_CLASS_$_AppDelegate in Open3DViewer_mac.mm.o
  "_objc_setProperty_atomic", referenced from:
      -[AppDelegate setTimer:] in Open3DViewer_mac.mm.o
  "_LSSetDefaultRoleHandlerForContentType", referenced from:
      Open3DVisualizer::OnMenuItemSelected(int)::'lambda0'()::operator()() const in Open3DViewer_mac.mm.o
  "_NSHomeDirectory", referenced from:
      _main in Open3DViewer_mac.mm.o
  "__objc_empty_cache", referenced from:
      _OBJC_CLASS_$_AppDelegate in Open3DViewer_mac.mm.o
      _OBJC_METACLASS_$_AppDelegate in Open3DViewer_mac.mm.o
  "_objc_alloc", referenced from:
      _main in Open3DViewer_mac.mm.o
  "_NSApp", referenced from:
      _main in Open3DViewer_mac.mm.o
     (maybe you meant: __OBJC_PROTOCOL_$_NSApplicationDelegate, __OBJC_LABEL_PROTOCOL_$_NSApplicationDelegate )
  "_objc_getProperty", referenced from:
      -[AppDelegate timer] in Open3DViewer_mac.mm.o
  "_objc_msgSend", referenced from:
      -[AppDelegate application:openFile:] in Open3DViewer_mac.mm.o
      _main in Open3DViewer_mac.mm.o
  "_objc_msgSendSuper2", referenced from:
      -[AppDelegate init] in Open3DViewer_mac.mm.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[3]: *** [bin/Open3D.app/Contents/MacOS/Open3D] Error 1
make[2]: *** [cpp/apps/CMakeFiles/Open3DViewer.dir/all] Error 2
make[1]: *** [cpp/apps/CMakeFiles/Open3DViewer.dir/rule] Error 2
make: *** [Open3DViewer] Error 2
```

The missing Apple frameworks library can be provided by:
https://github.com/isl-org/Open3D/blob/5a7f3922dea60e821840d953161b1340cb864115/3rdparty/find_dependencies.cmake#L628-L634

When building `-DBUILD_SHARED_LIBS=ON`, `libOpen3D.so` will have the correct link flags for the Apple framework. However, these link flags will not propagate to `Open3DViewer`, unless we explicitly link the 3rd-party libraries again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4445)
<!-- Reviewable:end -->
