### PR TITLE
Add joggle_inputs option to convex hull functions

### DIFF
--- a/cpp/open3d/geometry/PointCloud.cpp
+++ b/cpp/open3d/geometry/PointCloud.cpp
@@ -673,8 +673,8 @@ std::vector<double> PointCloud::ComputeNearestNeighborDistance() const {
 }
 
 std::tuple<std::shared_ptr<TriangleMesh>, std::vector<size_t>>
-PointCloud::ComputeConvexHull() const {
-    return Qhull::ComputeConvexHull(points_);
+PointCloud::ComputeConvexHull(bool joggle_inputs) const {
+    return Qhull::ComputeConvexHull(points_, joggle_inputs);
 }
 
 std::tuple<std::shared_ptr<TriangleMesh>, std::vector<size_t>>

--- a/cpp/open3d/geometry/PointCloud.h
+++ b/cpp/open3d/geometry/PointCloud.h
@@ -299,8 +299,13 @@ public:
     std::vector<double> ComputeNearestNeighborDistance() const;
 
     /// Function that computes the convex hull of the point cloud using qhull
+    /// \param joggle_inputs If true allows the algorithm to add random noise
+    ///        to the points to work around degenerate inputs. This adds the
+    ///        'QJ' option to the qhull command.
+    /// \returns The triangle mesh of the convex hull and the list of point
+    ///          indices that are part of the convex hull.
     std::tuple<std::shared_ptr<TriangleMesh>, std::vector<size_t>>
-    ComputeConvexHull() const;
+    ComputeConvexHull(bool joggle_inputs = false) const;
 
     /// \brief This is an implementation of the Hidden Point Removal operator
     /// described in Katz et. al. 'Direct Visibility of Point Sets', 2007.

--- a/cpp/open3d/geometry/Qhull.cpp
+++ b/cpp/open3d/geometry/Qhull.cpp
@@ -39,7 +39,8 @@ namespace open3d {
 namespace geometry {
 
 std::tuple<std::shared_ptr<TriangleMesh>, std::vector<size_t>>
-Qhull::ComputeConvexHull(const std::vector<Eigen::Vector3d>& points) {
+Qhull::ComputeConvexHull(const std::vector<Eigen::Vector3d>& points,
+                         bool joggle_inputs) {
     auto convex_hull = std::make_shared<TriangleMesh>();
     std::vector<size_t> pt_map;
 
@@ -55,8 +56,13 @@ Qhull::ComputeConvexHull(const std::vector<Eigen::Vector3d>& points) {
     qhull_points.append(qhull_points_data);
 
     orgQhull::Qhull qhull;
+    std::string options = "Qt";
+    if (joggle_inputs) {
+        options += " QJ";
+    }
     qhull.runQhull(qhull_points.comment().c_str(), qhull_points.dimension(),
-                   qhull_points.count(), qhull_points.coordinates(), "Qt");
+                   qhull_points.count(), qhull_points.coordinates(),
+                   options.c_str());
 
     orgQhull::QhullFacetList facets = qhull.facetList();
     convex_hull->triangles_.resize(facets.count());

--- a/cpp/open3d/geometry/Qhull.h
+++ b/cpp/open3d/geometry/Qhull.h
@@ -38,8 +38,16 @@ class TetraMesh;
 
 class Qhull {
 public:
+    /// Computes the convex hull
+    /// \param points Input points.
+    /// \param joggle_inputs If true allows the algorithm to add random noise
+    ///        to the points to work around degenerate inputs. This adds the
+    ///        'QJ' option to the qhull command.
+    /// \returns The triangle mesh of the convex hull and the list of point
+    ///          indices that are part of the convex hull.
     static std::tuple<std::shared_ptr<TriangleMesh>, std::vector<size_t>>
-    ComputeConvexHull(const std::vector<Eigen::Vector3d>& points);
+    ComputeConvexHull(const std::vector<Eigen::Vector3d>& points,
+                      bool joggle_inputs = false);
 
     static std::tuple<std::shared_ptr<TetraMesh>, std::vector<size_t>>
     ComputeDelaunayTetrahedralization(

--- a/cpp/pybind/geometry/pointcloud.cpp
+++ b/cpp/pybind/geometry/pointcloud.cpp
@@ -172,7 +172,18 @@ void pybind_pointcloud(py::module &m) {
                  "Function to compute the distance from a point to its nearest "
                  "neighbor in the point cloud")
             .def("compute_convex_hull", &PointCloud::ComputeConvexHull,
-                 "Computes the convex hull of the point cloud.")
+                 "joggle_inputs"_a = false, R"doc(
+Computes the convex hull of the point cloud.
+
+Args:
+     joggle_inputs (bool): If True allows the algorithm to add random noise to
+          the points to work around degenerate inputs. This adds the 'QJ' 
+          option to the qhull command.
+
+Returns:
+     tuple(open3d.geometry.TriangleMesh, list): The triangle mesh of the convex
+     hull and the list of point indices that are part of the convex hull.
+)doc")
             .def("hidden_point_removal", &PointCloud::HiddenPointRemoval,
                  "Removes hidden points from a point cloud and returns a mesh "
                  "of the remaining points. Based on Katz et al. 'Direct "
@@ -320,8 +331,6 @@ camera. Given depth value d at (u, v) image coordinate, the corresponding 3d poi
                                     "compute_mahalanobis_distance");
     docstring::ClassMethodDocInject(m, "PointCloud",
                                     "compute_nearest_neighbor_distance");
-    docstring::ClassMethodDocInject(m, "PointCloud", "compute_convex_hull",
-                                    {{"input", "The input point cloud."}});
     docstring::ClassMethodDocInject(
             m, "PointCloud", "hidden_point_removal",
             {{"input", "The input point cloud."},

--- a/cpp/tests/geometry/PointCloud.cpp
+++ b/cpp/tests/geometry/PointCloud.cpp
@@ -1147,7 +1147,7 @@ TEST(PointCloud, ComputeConvexHull) {
     // Degenerate input
     pcd.points_ = {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}};
     EXPECT_ANY_THROW(pcd.ComputeConvexHull());
-    // allow adding random noise to fix the degenerate input
+    // Allow adding random noise to fix the degenerate input
     EXPECT_NO_THROW(pcd.ComputeConvexHull(true));
 
     // Hard-coded test

--- a/cpp/tests/geometry/PointCloud.cpp
+++ b/cpp/tests/geometry/PointCloud.cpp
@@ -1144,6 +1144,12 @@ TEST(PointCloud, ComputeConvexHull) {
     pcd.points_ = {{0, 0, 0}, {0, 0, 1}, {0, 1, 0}};
     EXPECT_ANY_THROW(pcd.ComputeConvexHull());
 
+    // Degenerate input
+    pcd.points_ = {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}};
+    EXPECT_ANY_THROW(pcd.ComputeConvexHull());
+    // allow adding random noise to fix the degenerate input
+    EXPECT_NO_THROW(pcd.ComputeConvexHull(true));
+
     // Hard-coded test
     pcd.points_ = {{0, 0, 0}, {0, 0, 1}, {0, 1, 0}, {1, 0, 0}};
     std::tie(mesh, pt_map) = pcd.ComputeConvexHull();


### PR DESCRIPTION
This PR adds an option to `ComputeConvexHull()` to work around degenerate inputs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4447)
<!-- Reviewable:end -->
