### PR TITLE
avoid deadlock while PostToMainThread is called inside a Posted

### DIFF
--- a/cpp/open3d/visualization/gui/Application.cpp
+++ b/cpp/open3d/visualization/gui/Application.cpp
@@ -607,6 +607,9 @@ Application::RunStatus Application::ProcessQueuedEvents(EnvUnlocker &unlocker) {
     }
 
     // Run any posted functions
+    // To avoid deadlock while PostToMainThread is called in Posted, the
+    // posted_lock_ should not be locked in its invoking.
+    decltype(impl_->posted_) posted;
     {
         // The only other place posted_lock_ is used is PostToMainThread.
         // If pybind is posting a Python function, it acquires posted_lock_,
@@ -615,34 +618,34 @@ Application::RunStatus Application::ProcessQueuedEvents(EnvUnlocker &unlocker) {
         unlocker.unlock();
         std::lock_guard<std::mutex> lock(impl_->posted_lock_);
         unlocker.relock();
+        posted = std::move(impl_->posted_);
+    }
 
-        for (auto &p : impl_->posted_) {
-            // Make sure this window still exists. Unfortunately, p.window
-            // is a pointer but impl_->windows_ is a shared_ptr, so we can't
-            // use find.
-            if (p.window) {
-                bool found = false;
-                for (auto w : impl_->windows_) {
-                    if (w.get() == p.window) {
-                        found = true;
-                    }
-                }
-                if (!found) {
-                    continue;
+    for (auto &p : posted) {
+        // Make sure this window still exists. Unfortunately, p.window
+        // is a pointer but impl_->windows_ is a shared_ptr, so we can't
+        // use find.
+        if (p.window) {
+            bool found = false;
+            for (auto w : impl_->windows_) {
+                if (w.get() == p.window) {
+                    found = true;
                 }
             }
-
-            void *old = nullptr;
-            if (p.window) {
-                old = p.window->MakeDrawContextCurrent();
-            }
-            p.f();
-            if (p.window) {
-                p.window->RestoreDrawContext(old);
-                p.window->PostRedraw();
+            if (!found) {
+                continue;
             }
         }
-        impl_->posted_.clear();
+
+        void *old = nullptr;
+        if (p.window) {
+            old = p.window->MakeDrawContextCurrent();
+        }
+        p.f();
+        if (p.window) {
+            p.window->RestoreDrawContext(old);
+            p.window->PostRedraw();
+        }
     }
 
     // Clear any tasks that have finished


### PR DESCRIPTION
If PostToMainThread is called inside Posted, the posted_lock_ will cause a deadlock for mutex multiple locking. To avoid this, we should limit the locking range of posted_lock_ to minimum. Here it protects the moving from posted_ to a local variable(which is thread safe), and release the mutex before any Posted is called.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4448)
<!-- Reviewable:end -->
