### PR TITLE
Robust oriented bounding box computation and fixed reflection

### DIFF
--- a/cpp/open3d/geometry/BoundingVolume.cpp
+++ b/cpp/open3d/geometry/BoundingVolume.cpp
@@ -226,7 +226,8 @@ AxisAlignedBoundingBox AxisAlignedBoundingBox::GetAxisAlignedBoundingBox()
     return *this;
 }
 
-OrientedBoundingBox AxisAlignedBoundingBox::GetOrientedBoundingBox(bool) const {
+OrientedBoundingBox AxisAlignedBoundingBox::GetOrientedBoundingBox(
+        bool robust) const {
     return OrientedBoundingBox::CreateFromAxisAlignedBoundingBox(*this);
 }
 

--- a/cpp/open3d/geometry/BoundingVolume.cpp
+++ b/cpp/open3d/geometry/BoundingVolume.cpp
@@ -63,7 +63,7 @@ AxisAlignedBoundingBox OrientedBoundingBox::GetAxisAlignedBoundingBox() const {
     return AxisAlignedBoundingBox::CreateFromPoints(GetBoxPoints());
 }
 
-OrientedBoundingBox OrientedBoundingBox::GetOrientedBoundingBox() const {
+OrientedBoundingBox OrientedBoundingBox::GetOrientedBoundingBox(bool) const {
     return *this;
 }
 
@@ -146,9 +146,15 @@ OrientedBoundingBox OrientedBoundingBox::CreateFromAxisAlignedBoundingBox(
 }
 
 OrientedBoundingBox OrientedBoundingBox::CreateFromPoints(
-        const std::vector<Eigen::Vector3d>& points) {
+        const std::vector<Eigen::Vector3d>& points, bool robust) {
     PointCloud hull_pcd;
-    hull_pcd.points_ = std::get<0>(Qhull::ComputeConvexHull(points))->vertices_;
+    std::vector<size_t> hull_point_indices;
+    {
+        std::shared_ptr<TriangleMesh> mesh;
+        std::tie(mesh, hull_point_indices) =
+                Qhull::ComputeConvexHull(points, robust);
+        hull_pcd.points_ = mesh->vertices_;
+    }
 
     Eigen::Vector3d mean;
     Eigen::Matrix3d cov;
@@ -157,9 +163,6 @@ OrientedBoundingBox OrientedBoundingBox::CreateFromPoints(
     Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> es(cov);
     Eigen::Vector3d evals = es.eigenvalues();
     Eigen::Matrix3d R = es.eigenvectors();
-    R.col(0) /= R.col(0).norm();
-    R.col(1) /= R.col(1).norm();
-    R.col(2) /= R.col(2).norm();
 
     if (evals(1) > evals(0)) {
         std::swap(evals(1), evals(0));
@@ -179,10 +182,15 @@ OrientedBoundingBox OrientedBoundingBox::CreateFromPoints(
         R.col(2) = R.col(1);
         R.col(1) = tmp;
     }
+    R.col(0) /= R.col(0).norm();
+    R.col(1) /= R.col(1).norm();
+    R.col(2) = R.col(0).cross(R.col(1));
 
-    for (auto& pt : hull_pcd.points_) {
-        pt = R.transpose() * (pt - mean);
+    for (size_t i = 0; i < hull_point_indices.size(); ++i) {
+        hull_pcd.points_[i] =
+                R.transpose() * (points[hull_point_indices[i]] - mean);
     }
+
     const auto aabox = hull_pcd.GetAxisAlignedBoundingBox();
 
     OrientedBoundingBox obox;
@@ -218,7 +226,7 @@ AxisAlignedBoundingBox AxisAlignedBoundingBox::GetAxisAlignedBoundingBox()
     return *this;
 }
 
-OrientedBoundingBox AxisAlignedBoundingBox::GetOrientedBoundingBox() const {
+OrientedBoundingBox AxisAlignedBoundingBox::GetOrientedBoundingBox(bool) const {
     return OrientedBoundingBox::CreateFromAxisAlignedBoundingBox(*this);
 }
 

--- a/cpp/open3d/geometry/BoundingVolume.h
+++ b/cpp/open3d/geometry/BoundingVolume.h
@@ -181,7 +181,8 @@ public:
     virtual Eigen::Vector3d GetMaxBound() const override;
     virtual Eigen::Vector3d GetCenter() const override;
     virtual AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
-    virtual OrientedBoundingBox GetOrientedBoundingBox(bool) const override;
+    virtual OrientedBoundingBox GetOrientedBoundingBox(
+            bool robust = false) const override;
     virtual AxisAlignedBoundingBox& Transform(
             const Eigen::Matrix4d& transformation) override;
     virtual AxisAlignedBoundingBox& Translate(

--- a/cpp/open3d/geometry/BoundingVolume.h
+++ b/cpp/open3d/geometry/BoundingVolume.h
@@ -74,7 +74,8 @@ public:
     virtual Eigen::Vector3d GetMaxBound() const override;
     virtual Eigen::Vector3d GetCenter() const override;
     virtual AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
-    virtual OrientedBoundingBox GetOrientedBoundingBox() const override;
+    virtual OrientedBoundingBox GetOrientedBoundingBox(
+            bool robust) const override;
     virtual OrientedBoundingBox& Transform(
             const Eigen::Matrix4d& transformation) override;
     virtual OrientedBoundingBox& Translate(const Eigen::Vector3d& translation,
@@ -125,8 +126,12 @@ public:
     /// bounding box that could be computed for example with O'Rourke's
     /// algorithm (cf. http://cs.smith.edu/~jorourke/Papers/MinVolBox.pdf,
     /// https://www.geometrictools.com/Documentation/MinimumVolumeBox.pdf)
+    /// \param points The input points
+    /// \param robust If set to true uses a more robust method which works
+    ///               in degenerate cases but introduces noise to the points
+    ///               coordinates.
     static OrientedBoundingBox CreateFromPoints(
-            const std::vector<Eigen::Vector3d>& points);
+            const std::vector<Eigen::Vector3d>& points, bool robust = false);
 
 public:
     /// The center point of the bounding box.
@@ -176,7 +181,7 @@ public:
     virtual Eigen::Vector3d GetMaxBound() const override;
     virtual Eigen::Vector3d GetCenter() const override;
     virtual AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
-    virtual OrientedBoundingBox GetOrientedBoundingBox() const override;
+    virtual OrientedBoundingBox GetOrientedBoundingBox(bool) const override;
     virtual AxisAlignedBoundingBox& Transform(
             const Eigen::Matrix4d& transformation) override;
     virtual AxisAlignedBoundingBox& Translate(

--- a/cpp/open3d/geometry/Geometry3D.h
+++ b/cpp/open3d/geometry/Geometry3D.h
@@ -65,8 +65,14 @@ public:
     virtual Eigen::Vector3d GetCenter() const = 0;
     /// Returns an axis-aligned bounding box of the geometry.
     virtual AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const = 0;
-    /// Returns an oriented bounding box of the geometry.
-    virtual OrientedBoundingBox GetOrientedBoundingBox() const = 0;
+
+    /// Computes the oriented bounding box based on the PCA of the convex hull.
+    /// The returned bounding box is an approximation to the minimal bounding
+    /// box.
+    /// \param robust If set to true uses a more robust method which works
+    ///               in degenerate cases but introduces noise to the points
+    ///               coordinates.
+    virtual OrientedBoundingBox GetOrientedBoundingBox(bool robust) const = 0;
     /// \brief Apply transformation (4x4 matrix) to the geometry coordinates.
     virtual Geometry3D& Transform(const Eigen::Matrix4d& transformation) = 0;
 

--- a/cpp/open3d/geometry/Geometry3D.h
+++ b/cpp/open3d/geometry/Geometry3D.h
@@ -72,7 +72,8 @@ public:
     /// \param robust If set to true uses a more robust method which works
     ///               in degenerate cases but introduces noise to the points
     ///               coordinates.
-    virtual OrientedBoundingBox GetOrientedBoundingBox(bool robust) const = 0;
+    virtual OrientedBoundingBox GetOrientedBoundingBox(
+            bool robust = false) const = 0;
     /// \brief Apply transformation (4x4 matrix) to the geometry coordinates.
     virtual Geometry3D& Transform(const Eigen::Matrix4d& transformation) = 0;
 

--- a/cpp/open3d/geometry/LineSet.cpp
+++ b/cpp/open3d/geometry/LineSet.cpp
@@ -56,8 +56,8 @@ AxisAlignedBoundingBox LineSet::GetAxisAlignedBoundingBox() const {
     return AxisAlignedBoundingBox::CreateFromPoints(points_);
 }
 
-OrientedBoundingBox LineSet::GetOrientedBoundingBox() const {
-    return OrientedBoundingBox::CreateFromPoints(points_);
+OrientedBoundingBox LineSet::GetOrientedBoundingBox(bool robust) const {
+    return OrientedBoundingBox::CreateFromPoints(points_, robust);
 }
 
 LineSet &LineSet::Transform(const Eigen::Matrix4d &transformation) {

--- a/cpp/open3d/geometry/LineSet.h
+++ b/cpp/open3d/geometry/LineSet.h
@@ -69,7 +69,8 @@ public:
     Eigen::Vector3d GetMaxBound() const override;
     Eigen::Vector3d GetCenter() const override;
     AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
-    OrientedBoundingBox GetOrientedBoundingBox() const override;
+    OrientedBoundingBox GetOrientedBoundingBox(
+            bool robust = false) const override;
     LineSet &Transform(const Eigen::Matrix4d &transformation) override;
     LineSet &Translate(const Eigen::Vector3d &translation,
                        bool relative = true) override;

--- a/cpp/open3d/geometry/MeshBase.cpp
+++ b/cpp/open3d/geometry/MeshBase.cpp
@@ -66,8 +66,8 @@ AxisAlignedBoundingBox MeshBase::GetAxisAlignedBoundingBox() const {
     return AxisAlignedBoundingBox::CreateFromPoints(vertices_);
 }
 
-OrientedBoundingBox MeshBase::GetOrientedBoundingBox() const {
-    return OrientedBoundingBox::CreateFromPoints(vertices_);
+OrientedBoundingBox MeshBase::GetOrientedBoundingBox(bool robust) const {
+    return OrientedBoundingBox::CreateFromPoints(vertices_, robust);
 }
 
 MeshBase &MeshBase::Transform(const Eigen::Matrix4d &transformation) {

--- a/cpp/open3d/geometry/MeshBase.h
+++ b/cpp/open3d/geometry/MeshBase.h
@@ -86,7 +86,8 @@ public:
     virtual Eigen::Vector3d GetMaxBound() const override;
     virtual Eigen::Vector3d GetCenter() const override;
     virtual AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
-    virtual OrientedBoundingBox GetOrientedBoundingBox() const override;
+    virtual OrientedBoundingBox GetOrientedBoundingBox(
+            bool robust = false) const override;
     virtual MeshBase &Transform(const Eigen::Matrix4d &transformation) override;
     virtual MeshBase &Translate(const Eigen::Vector3d &translation,
                                 bool relative = true) override;

--- a/cpp/open3d/geometry/Octree.cpp
+++ b/cpp/open3d/geometry/Octree.cpp
@@ -529,7 +529,7 @@ AxisAlignedBoundingBox Octree::GetAxisAlignedBoundingBox() const {
     return box;
 }
 
-OrientedBoundingBox Octree::GetOrientedBoundingBox(bool) const {
+OrientedBoundingBox Octree::GetOrientedBoundingBox(bool robust) const {
     return OrientedBoundingBox::CreateFromAxisAlignedBoundingBox(
             GetAxisAlignedBoundingBox());
 }

--- a/cpp/open3d/geometry/Octree.cpp
+++ b/cpp/open3d/geometry/Octree.cpp
@@ -529,7 +529,7 @@ AxisAlignedBoundingBox Octree::GetAxisAlignedBoundingBox() const {
     return box;
 }
 
-OrientedBoundingBox Octree::GetOrientedBoundingBox() const {
+OrientedBoundingBox Octree::GetOrientedBoundingBox(bool) const {
     return OrientedBoundingBox::CreateFromAxisAlignedBoundingBox(
             GetAxisAlignedBoundingBox());
 }

--- a/cpp/open3d/geometry/Octree.h
+++ b/cpp/open3d/geometry/Octree.h
@@ -298,7 +298,8 @@ public:
     Eigen::Vector3d GetMaxBound() const override;
     Eigen::Vector3d GetCenter() const override;
     AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
-    OrientedBoundingBox GetOrientedBoundingBox() const override;
+    OrientedBoundingBox GetOrientedBoundingBox(
+            bool robust = false) const override;
     Octree& Transform(const Eigen::Matrix4d& transformation) override;
     Octree& Translate(const Eigen::Vector3d& translation,
                       bool relative = true) override;

--- a/cpp/open3d/geometry/PointCloud.cpp
+++ b/cpp/open3d/geometry/PointCloud.cpp
@@ -67,8 +67,8 @@ AxisAlignedBoundingBox PointCloud::GetAxisAlignedBoundingBox() const {
     return AxisAlignedBoundingBox::CreateFromPoints(points_);
 }
 
-OrientedBoundingBox PointCloud::GetOrientedBoundingBox() const {
-    return OrientedBoundingBox::CreateFromPoints(points_);
+OrientedBoundingBox PointCloud::GetOrientedBoundingBox(bool robust) const {
+    return OrientedBoundingBox::CreateFromPoints(points_, robust);
 }
 
 PointCloud &PointCloud::Transform(const Eigen::Matrix4d &transformation) {

--- a/cpp/open3d/geometry/PointCloud.h
+++ b/cpp/open3d/geometry/PointCloud.h
@@ -70,7 +70,8 @@ public:
     Eigen::Vector3d GetMaxBound() const override;
     Eigen::Vector3d GetCenter() const override;
     AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
-    OrientedBoundingBox GetOrientedBoundingBox() const override;
+    OrientedBoundingBox GetOrientedBoundingBox(
+            bool robust = false) const override;
     PointCloud &Transform(const Eigen::Matrix4d &transformation) override;
     PointCloud &Translate(const Eigen::Vector3d &translation,
                           bool relative = true) override;

--- a/cpp/open3d/geometry/VoxelGrid.cpp
+++ b/cpp/open3d/geometry/VoxelGrid.cpp
@@ -104,7 +104,7 @@ AxisAlignedBoundingBox VoxelGrid::GetAxisAlignedBoundingBox() const {
     return box;
 }
 
-OrientedBoundingBox VoxelGrid::GetOrientedBoundingBox() const {
+OrientedBoundingBox VoxelGrid::GetOrientedBoundingBox(bool) const {
     return OrientedBoundingBox::CreateFromAxisAlignedBoundingBox(
             GetAxisAlignedBoundingBox());
 }

--- a/cpp/open3d/geometry/VoxelGrid.h
+++ b/cpp/open3d/geometry/VoxelGrid.h
@@ -91,7 +91,8 @@ public:
     Eigen::Vector3d GetMaxBound() const override;
     Eigen::Vector3d GetCenter() const override;
     AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
-    OrientedBoundingBox GetOrientedBoundingBox() const override;
+    OrientedBoundingBox GetOrientedBoundingBox(
+            bool robust = false) const override;
     VoxelGrid &Transform(const Eigen::Matrix4d &transformation) override;
     VoxelGrid &Translate(const Eigen::Vector3d &translation,
                          bool relative = true) override;

--- a/cpp/open3d/visualization/utility/PointCloudPicker.cpp
+++ b/cpp/open3d/visualization/utility/PointCloudPicker.cpp
@@ -76,10 +76,12 @@ geometry::AxisAlignedBoundingBox PointCloudPicker::GetAxisAlignedBoundingBox()
     }
 }
 
-geometry::OrientedBoundingBox PointCloudPicker::GetOrientedBoundingBox() const {
+geometry::OrientedBoundingBox PointCloudPicker::GetOrientedBoundingBox(
+        bool robust) const {
     if (pointcloud_ptr_) {
         return geometry::OrientedBoundingBox::CreateFromPoints(
-                ((const geometry::PointCloud&)(*pointcloud_ptr_)).points_);
+                ((const geometry::PointCloud&)(*pointcloud_ptr_)).points_,
+                robust);
     } else {
         return geometry::OrientedBoundingBox();
     }

--- a/cpp/open3d/visualization/utility/PointCloudPicker.h
+++ b/cpp/open3d/visualization/utility/PointCloudPicker.h
@@ -53,7 +53,8 @@ public:
     Eigen::Vector3d GetMaxBound() const final;
     Eigen::Vector3d GetCenter() const final;
     geometry::AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const final;
-    geometry::OrientedBoundingBox GetOrientedBoundingBox(bool) const final;
+    geometry::OrientedBoundingBox GetOrientedBoundingBox(
+            bool robust = false) const final;
     PointCloudPicker& Transform(const Eigen::Matrix4d& transformation) override;
     PointCloudPicker& Translate(const Eigen::Vector3d& translation,
                                 bool relative = true) override;

--- a/cpp/open3d/visualization/utility/PointCloudPicker.h
+++ b/cpp/open3d/visualization/utility/PointCloudPicker.h
@@ -53,7 +53,7 @@ public:
     Eigen::Vector3d GetMaxBound() const final;
     Eigen::Vector3d GetCenter() const final;
     geometry::AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const final;
-    geometry::OrientedBoundingBox GetOrientedBoundingBox() const final;
+    geometry::OrientedBoundingBox GetOrientedBoundingBox(bool) const final;
     PointCloudPicker& Transform(const Eigen::Matrix4d& transformation) override;
     PointCloudPicker& Translate(const Eigen::Vector3d& translation,
                                 bool relative = true) override;

--- a/cpp/pybind/geometry/boundingvolume.cpp
+++ b/cpp/pybind/geometry/boundingvolume.cpp
@@ -70,11 +70,25 @@ void pybind_boundingvolume(py::module &m) {
                         "Returns an oriented bounding box from the "
                         "AxisAlignedBoundingBox.",
                         "aabox"_a)
-            .def_static(
-                    "create_from_points",
-                    &OrientedBoundingBox::CreateFromPoints,
-                    "Creates the bounding box that encloses the set of points.",
-                    "points"_a)
+            .def_static("create_from_points",
+                        &OrientedBoundingBox::CreateFromPoints, "points"_a,
+                        "robust"_a = false,
+                        R"doc(
+Creates the oriented bounding box that encloses the set of points.
+
+Computes the oriented bounding box based on the PCA of the convex hull.
+The returned bounding box is an approximation to the minimal bounding box.
+
+Args:
+     points (open3d.utility.Vector3dVector): Input points.
+     robust (bool): If set to true uses a more robust method which works in 
+          degenerate cases but introduces noise to the points coordinates.
+
+Returns:
+     open3d.geometry.OrientedBoundingBox: The oriented bounding box. The
+     bounding box is oriented such that the axes are ordered with respect to
+     the principal components.
+)doc")
             .def("volume", &OrientedBoundingBox::Volume,
                  "Returns the volume of the bounding box.")
             .def("get_box_points", &OrientedBoundingBox::GetBoxPoints,
@@ -97,9 +111,6 @@ void pybind_boundingvolume(py::module &m) {
             {{"aabox",
               "AxisAlignedBoundingBox object from which OrientedBoundingBox is "
               "created."}});
-    docstring::ClassMethodDocInject(m, "OrientedBoundingBox",
-                                    "create_from_points",
-                                    {{"points", "A list of points."}});
 
     py::class_<AxisAlignedBoundingBox, PyGeometry3D<AxisAlignedBoundingBox>,
                std::shared_ptr<AxisAlignedBoundingBox>, Geometry3D>

--- a/cpp/pybind/geometry/geometry.cpp
+++ b/cpp/pybind/geometry/geometry.cpp
@@ -105,8 +105,22 @@ void pybind_geometry_classes(py::module &m) {
                  &Geometry3D::GetAxisAlignedBoundingBox,
                  "Returns an axis-aligned bounding box of the geometry.")
             .def("get_oriented_bounding_box",
-                 &Geometry3D::GetOrientedBoundingBox,
-                 "Returns an oriented bounding box of the geometry.")
+                 &Geometry3D::GetOrientedBoundingBox, "robust"_a = false,
+                 R"doc(
+Returns the oriented bounding box for the geometry.
+
+Computes the oriented bounding box based on the PCA of the convex hull.
+The returned bounding box is an approximation to the minimal bounding box.
+
+Args:
+     robust (bool): If set to true uses a more robust method which works in 
+          degenerate cases but introduces noise to the points coordinates.
+
+Returns:
+     open3d.geometry.OrientedBoundingBox: The oriented bounding box. The
+     bounding box is oriented such that the axes are ordered with respect to
+     the principal components.
+)doc")
             .def("transform", &Geometry3D::Transform,
                  "Apply transformation (4x4 matrix) to the geometry "
                  "coordinates.")
@@ -156,8 +170,6 @@ void pybind_geometry_classes(py::module &m) {
     docstring::ClassMethodDocInject(m, "Geometry3D", "get_center");
     docstring::ClassMethodDocInject(m, "Geometry3D",
                                     "get_axis_aligned_bounding_box");
-    docstring::ClassMethodDocInject(m, "Geometry3D",
-                                    "get_oriented_bounding_box");
     docstring::ClassMethodDocInject(m, "Geometry3D", "transform");
     docstring::ClassMethodDocInject(
             m, "Geometry3D", "translate",

--- a/cpp/pybind/geometry/geometry_trampoline.h
+++ b/cpp/pybind/geometry/geometry_trampoline.h
@@ -66,7 +66,7 @@ public:
     AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override {
         PYBIND11_OVERLOAD_PURE(AxisAlignedBoundingBox, Geometry3DBase, );
     }
-    OrientedBoundingBox GetOrientedBoundingBox() const override {
+    OrientedBoundingBox GetOrientedBoundingBox(bool) const override {
         PYBIND11_OVERLOAD_PURE(OrientedBoundingBox, Geometry3DBase, );
     }
     Geometry3DBase& Transform(const Eigen::Matrix4d& transformation) override {

--- a/cpp/pybind/geometry/geometry_trampoline.h
+++ b/cpp/pybind/geometry/geometry_trampoline.h
@@ -66,8 +66,9 @@ public:
     AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override {
         PYBIND11_OVERLOAD_PURE(AxisAlignedBoundingBox, Geometry3DBase, );
     }
-    OrientedBoundingBox GetOrientedBoundingBox(bool) const override {
-        PYBIND11_OVERLOAD_PURE(OrientedBoundingBox, Geometry3DBase, );
+    OrientedBoundingBox GetOrientedBoundingBox(
+            bool robust = false) const override {
+        PYBIND11_OVERLOAD_PURE(OrientedBoundingBox, Geometry3DBase, robust);
     }
     Geometry3DBase& Transform(const Eigen::Matrix4d& transformation) override {
         PYBIND11_OVERLOAD_PURE(Geometry3DBase&, Geometry3DBase, transformation);

--- a/cpp/tests/geometry/PointCloud.cpp
+++ b/cpp/tests/geometry/PointCloud.cpp
@@ -160,16 +160,19 @@ TEST(PointCloud, GetOrientedBoundingBox) {
     EXPECT_ANY_THROW(pcd.GetOrientedBoundingBox());
     pcd = geometry::PointCloud({{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}});
     EXPECT_ANY_THROW(pcd.GetOrientedBoundingBox());
+    EXPECT_NO_THROW(pcd.GetOrientedBoundingBox(true));
 
     // Line
     pcd = geometry::PointCloud({{0, 0, 0}, {1, 1, 1}});
     EXPECT_ANY_THROW(pcd.GetOrientedBoundingBox());
     pcd = geometry::PointCloud({{0, 0, 0}, {1, 1, 1}, {2, 2, 2}, {3, 3, 3}});
     EXPECT_ANY_THROW(pcd.GetOrientedBoundingBox());
+    EXPECT_NO_THROW(pcd.GetOrientedBoundingBox(true));
 
     // Plane
     pcd = geometry::PointCloud({{0, 0, 0}, {0, 0, 1}, {0, 1, 0}, {0, 1, 1}});
     EXPECT_ANY_THROW(pcd.GetOrientedBoundingBox());
+    EXPECT_NO_THROW(pcd.GetOrientedBoundingBox(true));
 
     // Valid 4 points
     pcd = geometry::PointCloud({{0, 0, 0}, {0, 0, 1}, {0, 1, 0}, {1, 1, 1}});
@@ -198,6 +201,12 @@ TEST(PointCloud, GetOrientedBoundingBox) {
                                                 {3, 0, 1},
                                                 {3, 2, 0},
                                                 {3, 2, 1}})));
+
+    // Check for a bug where the OBB rotation contained a reflection for this
+    // example.
+    pcd = geometry::PointCloud({{0, 2, 4}, {7, 9, 1}, {5, 2, 0}, {3, 8, 7}});
+    obb = pcd.GetOrientedBoundingBox();
+    EXPECT_GT(obb.R_.determinant(), 0.999);
 }
 
 TEST(PointCloud, Transform) {


### PR DESCRIPTION
This PR
- adds the `robust` parameter to allow computing the OBB for degenerate cases 
  - #2571
  - #3916 
- fixes a problem with the rotation matrix of the obb containing a reflection 
  - #2206
  - #4006
- improves docstrings

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4452)
<!-- Reviewable:end -->
