### PR TITLE
rm -rf folder, std::experimental::filesystem, macOS 10.15+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION 3.19.2)
 # - use first-class language support for ISPC (3.19.2 patch release required)
 
 if (APPLE)
-set (CMAKE_OSX_DEPLOYMENT_TARGET "10.14" CACHE STRING
+set (CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING
     "Minimum OS X deployment version" FORCE)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For more, please visit the [Open3D documentation](http://www.open3d.org/docs).
 
 ## Python quick start
 
-Pre-built pip and conda packages support Ubuntu 18.04+, macOS 10.14+ and
+Pre-built pip and conda packages support Ubuntu 18.04+, macOS 10.15+ and
 Windows 10 (64-bit) with Python 3.6-3.9.
 
 ```bash

--- a/cmake/Open3DSetGlobalProperties.cmake
+++ b/cmake/Open3DSetGlobalProperties.cmake
@@ -6,6 +6,23 @@ function(open3d_set_global_properties target)
     target_compile_features(${target} PUBLIC cxx_std_14)
 
     # std::filesystem (C++17) or std::experimental::filesystem (C++14)
+    #
+    # Ref: https://en.cppreference.com/w/cpp/filesystem:
+    #      Using this library may require additional compiler/linker options.
+    #      GNU implementation prior to 9.1 requires linking with -lstdc++fs and
+    #      LLVM implementation prior to LLVM 9.0 requires linking with -lc++fs.
+    # Ref: https://gitlab.kitware.com/cmake/cmake/-/issues/17834
+    #      It's non-trivial to determine the link flags for CMake.
+    #
+    # The linkage can be "-lstdc++fs" or "-lc++fs" or ""(empty). In our
+    # experiments, the behaviour doesn't quite match the specifications.
+    #
+    # - On Ubuntu 20.04:
+    #   - "-lstdc++fs" works with with GCC 7/10 and Clang 7/12
+    #   - "" does not work with GCC 7/10 and Clang 7/12
+    #
+    # - On latest macOS/Windows with the default compiler:
+    #   - "" works.
     if(UNIX AND NOT APPLE)
         target_link_libraries(${target} PRIVATE stdc++fs)
     endif()

--- a/cmake/Open3DSetGlobalProperties.cmake
+++ b/cmake/Open3DSetGlobalProperties.cmake
@@ -5,6 +5,11 @@ function(open3d_set_global_properties target)
     # Tell CMake we want a compiler that supports C++14 features
     target_compile_features(${target} PUBLIC cxx_std_14)
 
+    # std::filesystem (C++17) or std::experimental::filesystem (C++14)
+    if(UNIX AND NOT APPLE)
+        target_link_libraries(${target} PRIVATE stdc++fs)
+    endif()
+
     # Colorize GCC/Clang terminal outputs
     if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-fdiagnostics-color=always>)

--- a/cpp/open3d/utility/FileSystem.cpp
+++ b/cpp/open3d/utility/FileSystem.cpp
@@ -55,6 +55,7 @@
 #define _LIBCPP_NO_EXPERIMENTAL_DEPRECATION_WARNING_FILESYSTEM
 #endif
 #include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
 
 #include "open3d/utility/Logging.h"
 
@@ -267,8 +268,7 @@ bool MakeDirectoryHierarchy(const std::string &directory) {
 
 bool DeleteDirectory(const std::string &directory) {
     std::error_code error;
-    if (std::experimental::filesystem::remove_all(directory, error) ==
-        static_cast<std::uintmax_t>(-1)) {
+    if (fs::remove_all(directory, error) == static_cast<std::uintmax_t>(-1)) {
         utility::LogWarning("Failed to remove directory {}: {}.", directory,
                             error.message());
         return false;

--- a/cpp/tests/utility/FileSystem.cpp
+++ b/cpp/tests/utility/FileSystem.cpp
@@ -353,11 +353,18 @@ TEST(FileSystem, DeleteDirectory) {
     status = utility::filesystem::MakeDirectory(path);
     EXPECT_TRUE(status);
 
+    status = utility::filesystem::MakeDirectory(path + "/sub_dir");
+    EXPECT_TRUE(status);
+    FILE *file = utility::filesystem::FOpen(path + "/file_name.txt", "w");
+    fclose(file);
+
     status = utility::filesystem::DeleteDirectory(path);
     EXPECT_TRUE(status);
 
+    // std::filesystem::remove_all() won't throw error if the directory doesn't
+    // exist.
     status = utility::filesystem::DeleteDirectory(path);
-    EXPECT_FALSE(status);
+    EXPECT_TRUE(status);
 }
 
 TEST(FileSystem, File_Exists_Remove) {

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -11,7 +11,7 @@ System requirements
 * C++14 compiler:
 
   * Ubuntu 18.04+: GCC 5+, Clang 7+
-  * macOS 10.14+: XCode 8.0+
+  * macOS 10.15+: XCode 8.0+
   * Windows 10 (64-bit): Visual Studio 2019+
 
 * CMake: 3.19+

--- a/docs/getting_started.rst.in
+++ b/docs/getting_started.rst.in
@@ -22,7 +22,7 @@ Supported Python versions:
 Supported operating systems:
 
 * Ubuntu 18.04+
-* macOS 10.14+
+* macOS 10.15+
 * Windows 10 (64-bit)
 
 If you have other Python versions (e.g. Python 2) or operating systems, please


### PR DESCRIPTION
- Allow `DeleteDirectory()` to remove directory with its contents.
- Uses `std::experimental::filesystem`, can be changed to `std::filesystem` after C++17 is enabled.
- Requires macOS 10.15+ (Initial release date: October 7, 2019).



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4462)
<!-- Reviewable:end -->
