### PR TITLE
Fix 3578 and 4439

### DIFF
--- a/cpp/open3d/io/file_format/FileJPG.cpp
+++ b/cpp/open3d/io/file_format/FileJPG.cpp
@@ -31,8 +31,8 @@
 // clang-format on
 
 #include "open3d/io/ImageIO.h"
-#include "open3d/utility/Logging.h"
 #include "open3d/utility/FileSystem.h"
+#include "open3d/utility/Logging.h"
 
 namespace open3d {
 namespace io {

--- a/cpp/open3d/t/geometry/kernel/PointCloudCPU.cpp
+++ b/cpp/open3d/t/geometry/kernel/PointCloudCPU.cpp
@@ -32,6 +32,8 @@ namespace geometry {
 namespace kernel {
 namespace pointcloud {
 
+using std::round;
+
 void ProjectCPU(
         core::Tensor& depth,
         utility::optional<std::reference_wrapper<core::Tensor>> image_colors,
@@ -68,6 +70,8 @@ void ProjectCPU(
 
         // coordinate in image (in pixel)
         transform_indexer.Project(xc, yc, zc, &u, &v);
+        u = round(u);
+        v = round(v);
         if (!depth_indexer.InBoundary(u, v) || zc <= 0 || zc > depth_max) {
             return;
         }

--- a/cpp/open3d/t/geometry/kernel/PointCloudCUDA.cu
+++ b/cpp/open3d/t/geometry/kernel/PointCloudCUDA.cu
@@ -65,6 +65,8 @@ void ProjectCUDA(
 
                 // coordinate in image (in pixel)
                 transform_indexer.Project(xc, yc, zc, &u, &v);
+                u = round(u);
+                v = round(v);
                 if (!depth_indexer.InBoundary(u, v) || zc <= 0 ||
                     zc > depth_max) {
                     return;

--- a/cpp/open3d/t/io/file_format/FileJPG.cpp
+++ b/cpp/open3d/t/io/file_format/FileJPG.cpp
@@ -31,8 +31,8 @@
 // clang-format on
 
 #include "open3d/t/io/ImageIO.h"
-#include "open3d/utility/Logging.h"
 #include "open3d/utility/FileSystem.h"
+#include "open3d/utility/Logging.h"
 
 namespace open3d {
 namespace t {

--- a/cpp/pybind/t/geometry/pointcloud.cpp
+++ b/cpp/pybind/t/geometry/pointcloud.cpp
@@ -235,6 +235,18 @@ The attributes of the point cloud have different levels::
             "from_legacy", &PointCloud::FromLegacy, "pcd_legacy"_a,
             "dtype"_a = core::Float32, "device"_a = core::Device("CPU:0"),
             "Create a PointCloud from a legacy Open3D PointCloud.");
+    pointcloud.def("project_to_depth_image", &PointCloud::ProjectToDepthImage,
+                   "width"_a, "height"_a, "intrinsics"_a,
+                   "extrinsics"_a = core::Tensor::Eye(4, core::Float32,
+                                                      core::Device("CPU:0")),
+                   "depth_scale"_a = 1000.0, "depth_max"_a = 3.0,
+                   "Project a point cloud to a depth image.");
+    pointcloud.def("project_to_rgbd_image", &PointCloud::ProjectToRGBDImage,
+                   "width"_a, "height"_a, "intrinsics"_a,
+                   "extrinsics"_a = core::Tensor::Eye(4, core::Float32,
+                                                      core::Device("CPU:0")),
+                   "depth_scale"_a = 1000.0, "depth_max"_a = 3.0,
+                   "Project a colored point cloud to a RGBD image.");
     pointcloud.def("to_legacy", &PointCloud::ToLegacy,
                    "Convert to a legacy Open3D PointCloud.");
 


### PR DESCRIPTION
Provide projection functionality in python.
- [x] support #4439 (also mentioned in #4442)
- [x] fix issue in #3578  

## Depth
```python
import open3d as o3d

import numpy as np
import matplotlib.pyplot as plt

import argparse

if __name__ == '__main__':
    parser = argparse.ArgumentParser()
    parser.add_argument('path')
    args = parser.parse_args()

    depth = o3d.t.io.read_image(args.path)
    intrinsic = o3d.core.Tensor([[535.4, 0, 320.1], [0, 539.2, 247.6],
                                 [0, 0, 1]])

    pcd = o3d.t.geometry.PointCloud.create_from_depth_image(depth,
                                                            intrinsic,
                                                            depth_scale=5000.0,
                                                            depth_max=10.0)
    o3d.visualization.draw([pcd])
    depth_reproj = pcd.project_to_depth_image(640,
                                              480,
                                              intrinsic,
                                              depth_scale=5000.0,
                                              depth_max=10.0)

    fig, axs = plt.subplots(1, 2)
    axs[0].imshow(np.asarray(depth.to_legacy()))
    axs[1].imshow(np.asarray(depth_reproj.to_legacy()))
    plt.show()
```
![image](https://user-images.githubusercontent.com/6127282/146646905-cc16ce95-6c45-497f-a10f-585dc704249f.png)

## RGBD
```python
import open3d as o3d

import numpy as np
import matplotlib.pyplot as plt

import argparse

if __name__ == '__main__':
    parser = argparse.ArgumentParser()
    parser.add_argument('depth')
    parser.add_argument('color')

    args = parser.parse_args()

    device = o3d.core.Device('CPU:0')
    depth = o3d.t.io.read_image(args.depth).to(device)
    color = o3d.t.io.read_image(args.color).to(device)

    intrinsic = o3d.core.Tensor([[535.4, 0, 320.1], [0, 539.2, 247.6],
                                 [0, 0, 1]])
    rgbd = o3d.t.geometry.RGBDImage(color, depth)

    pcd = o3d.t.geometry.PointCloud.create_from_rgbd_image(rgbd,
                                                           intrinsic,
                                                           depth_scale=5000.0,
                                                           depth_max=10.0)
    o3d.visualization.draw([pcd])
    rgbd_reproj = pcd.project_to_rgbd_image(640,
                                            480,
                                            intrinsic,
                                            depth_scale=5000.0,
                                            depth_max=10.0)

    fig, axs = plt.subplots(1, 2)
    axs[0].imshow(np.asarray(rgbd_reproj.color.to_legacy()))
    axs[1].imshow(np.asarray(rgbd_reproj.depth.to_legacy()))
    plt.show()
```

![image](https://user-images.githubusercontent.com/6127282/146647616-155feb2d-d517-43c2-ba14-6ab3910b8e0f.png)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4464)
<!-- Reviewable:end -->
