### PR TITLE
fix call to AdvancedMatching in FGR

### DIFF
--- a/cpp/open3d/pipelines/registration/FastGlobalRegistration.cpp
+++ b/cpp/open3d/pipelines/registration/FastGlobalRegistration.cpp
@@ -316,13 +316,7 @@ RegistrationResult FastGlobalRegistrationBasedOnCorrespondence(
     }
 
     if (option.tuple_test_) {
-        // for AdvancedMatching ensure the first point cloud is the larger one
-        if (source.points_.size() > target.points_.size()) {
-            corresvec = AdvancedMatching(source, target, corresvec, option);
-        } else {
-            corresvec = AdvancedMatching(target, source, corresvec, option);
-            for (auto& p : corresvec) std::swap(p.first, p.second);
-        }
+        corresvec = AdvancedMatching(source, target, corresvec, option);
     }
 
     Eigen::Matrix4d transformation;
@@ -359,8 +353,8 @@ RegistrationResult FastGlobalRegistrationBasedOnFeatureMatching(
 
     std::vector<std::pair<int, int>> corres;
     if (option.tuple_test_) {
-        // for AdvancedMatching ensure the first point cloud is the larger one
-        if (source.points_.size() > target.points_.size()) {
+        // use the smaller point cloud as the query during knn search
+        if (source.points_.size() >= target.points_.size()) {
             corres = AdvancedMatching(
                     source, target,
                     InitialMatching(source_feature, target_feature), option);


### PR DESCRIPTION
the `FastGlobalRegisrationBasedOnCorrespondence` function from https://github.com/isl-org/Open3D/pull/4188 has a bug in it (does not affect the original `FastGlobalRegistrationBasedOnFeatureMatching`)

the check on if `source` or `target` has more points (which was copied from `FastGlobalRegistrationBasedOnFeatureMatching`)  is useful so that the smaller set of points is used as the query in `InitialMatching`. This check was copied into the new `FastGlobalRegisrationBasedOnCorrespondence` function, but does not use `InitialMatching` -- i.e., the initial matches come from  the user. In this case, it does not make sense to swap the source/target based on number of points and in fact by swapping them but not swapping the "columns" of `corresvec` results in incorrect initial matches.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4479)
<!-- Reviewable:end -->
