### PR TITLE
Fixed build error on Fedora(assimp).

### DIFF
--- a/3rdparty/assimp/assimp.cmake
+++ b/3rdparty/assimp/assimp.cmake
@@ -40,5 +40,5 @@ ExternalProject_Add(
 
 ExternalProject_Get_Property(ext_assimp INSTALL_DIR)
 set(ASSIMP_INCLUDE_DIR ${INSTALL_DIR}/include/)
-set(ASSIMP_LIB_DIR ${INSTALL_DIR}/lib)
+set(ASSIMP_LIB_DIR ${INSTALL_DIR}/${Open3D_INSTALL_LIB_DIR})
 set(ASSIMP_LIBRARIES ${lib_name})


### PR DESCRIPTION
On Fedora, the installation directory is `lib64`, so the build will fail.  
Use `${Open3D_INSTALL_LIB_DIR}` to fix the build error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4491)
<!-- Reviewable:end -->
