### PR TITLE
Fixed build error on Fedora(curl).

### DIFF
--- a/3rdparty/curl/curl.cmake
+++ b/3rdparty/curl/curl.cmake
@@ -73,7 +73,7 @@ else()
 
     ExternalProject_Get_Property(ext_curl SOURCE_DIR)
     set(CURL_INCLUDE_DIRS ${SOURCE_DIR}/include/) # "/" is critical.
-    set(CURL_LIB_DIR ${SOURCE_DIR}/${Open3D_INSTALL_LIB_DIR})
+    set(CURL_LIB_DIR ${SOURCE_DIR}/lib)
     set(CURL_LIBRARIES ${curl_lib_name})
 endif()
 


### PR DESCRIPTION
The `libdir` for curl is `${CMAKE_INSTALL_PREFIX}/lib`. This will result in a build error on Fedora.
- https://github.com/curl/curl/blob/d4492b6d125d31ef5c74e4deb6786896606b70cc/CMakeLists.txt#L1504

Change `${Open3D_INSTALL_LIB_DIR}` to `lib`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4495)
<!-- Reviewable:end -->
