### PR TITLE
Widget proxy

### DIFF
--- a/cpp/open3d/visualization/gui/CMakeLists.txt
+++ b/cpp/open3d/visualization/gui/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(GUI PRIVATE
     Util.cpp
     VectorEdit.cpp
     Widget.cpp
+    WidgetProxy.cpp
     Window.cpp
 )
 

--- a/cpp/open3d/visualization/gui/Widget.cpp
+++ b/cpp/open3d/visualization/gui/Widget.cpp
@@ -119,7 +119,7 @@ Widget::DrawResult Widget::Draw(const DrawContext& context) {
             auto r = child->Draw(context);
             // The mouse can only be over one item, so there should never
             // be multiple items returning non-NONE.
-            if (r != DrawResult::NONE) {
+            if (r > result) {
                 result = r;
             }
         }

--- a/cpp/open3d/visualization/gui/Widget.h
+++ b/cpp/open3d/visualization/gui/Widget.h
@@ -73,11 +73,11 @@ public:
     explicit Widget(const std::vector<std::shared_ptr<Widget>>& children);
     virtual ~Widget();
 
-    void AddChild(std::shared_ptr<Widget> child);
-    const std::vector<std::shared_ptr<Widget>> GetChildren() const;
+    virtual void AddChild(std::shared_ptr<Widget> child);
+    virtual const std::vector<std::shared_ptr<Widget>> GetChildren() const;
 
     /// Returns the frame size in pixels.
-    const Rect& GetFrame() const;
+    virtual const Rect& GetFrame() const;
     /// The frame is in pixels. The size of a pixel varies on different
     /// and operatings sytems now frequently scale text sizes on high DPI
     /// monitors. Prefer using a Layout to using this function, but if you
@@ -86,18 +86,18 @@ public:
     /// according to the scaling factor of the window.
     virtual void SetFrame(const Rect& f);
 
-    const Color& GetBackgroundColor() const;
-    bool IsDefaultBackgroundColor() const;
-    void SetBackgroundColor(const Color& color);
+    virtual const Color& GetBackgroundColor() const;
+    virtual bool IsDefaultBackgroundColor() const;
+    virtual void SetBackgroundColor(const Color& color);
 
-    bool IsVisible() const;
+    virtual bool IsVisible() const;
     virtual void SetVisible(bool vis);
 
-    bool IsEnabled() const;
+    virtual bool IsEnabled() const;
     virtual void SetEnabled(bool enabled);
 
-    void SetTooltip(const char* text);
-    const char* GetTooltip() const;
+    virtual void SetTooltip(const char* text);
+    virtual const char* GetTooltip() const;
 
     static constexpr int DIM_GROW = 10000;
     struct Constraints {

--- a/cpp/open3d/visualization/gui/WidgetProxy.cpp
+++ b/cpp/open3d/visualization/gui/WidgetProxy.cpp
@@ -1,0 +1,228 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "WidgetProxy.h"
+
+#include "open3d/visualization/gui/Color.h"
+#include "open3d/visualization/gui/Events.h"
+
+namespace open3d {
+namespace visualization {
+namespace gui {
+struct WidgetProxy::Impl {
+    std::shared_ptr<Widget> widget_;
+    bool need_layout_ = false;
+};
+
+WidgetProxy::WidgetProxy() : impl_(new WidgetProxy::Impl()) {}
+WidgetProxy::~WidgetProxy() {}
+
+std::shared_ptr<Widget> WidgetProxy::GetActiveWidget() const {
+    return impl_->widget_;
+}
+void WidgetProxy::SetWidget(std::shared_ptr<Widget> widget) {
+    impl_->widget_ = widget;
+    impl_->need_layout_ = true;
+}
+std::shared_ptr<Widget> WidgetProxy::GetWidget() {
+    return GetActiveWidget();
+}
+void WidgetProxy::AddChild(std::shared_ptr<Widget> child) {
+    auto widget = GetActiveWidget();
+    if (widget) {
+        widget->AddChild(child);
+    }
+}
+
+const std::vector<std::shared_ptr<Widget>> WidgetProxy::GetChildren() const {
+    auto widget = GetActiveWidget();
+    if (widget) {
+        return widget->GetChildren();
+    }
+    return Widget::GetChildren();
+}
+
+const Rect& WidgetProxy::GetFrame() const {
+    auto widget = GetActiveWidget();
+    if (widget) {
+        return widget->GetFrame();
+    }
+    return Widget::GetFrame();
+}
+
+void WidgetProxy::SetFrame(const Rect& f) {
+    auto widget = GetActiveWidget();
+    if (widget) {
+        widget->SetFrame(f);
+    }
+    Widget::SetFrame(f);
+}
+
+const Color& WidgetProxy::GetBackgroundColor() const {
+    auto widget = GetActiveWidget();
+    if (widget) {
+        return widget->GetBackgroundColor();
+    }
+    return Widget::GetBackgroundColor();
+}
+
+bool WidgetProxy::IsDefaultBackgroundColor() const {
+    auto widget = GetActiveWidget();
+    if (widget) {
+        return widget->IsDefaultBackgroundColor();
+    }
+    return Widget::IsDefaultBackgroundColor();
+}
+
+void WidgetProxy::SetBackgroundColor(const Color& color) {
+    auto widget = GetActiveWidget();
+    if (widget) {
+        widget->SetBackgroundColor(color);
+    }
+    Widget::SetBackgroundColor(color);
+}
+
+bool WidgetProxy::IsVisible() const {
+    auto widget = GetActiveWidget();
+    if (widget) {
+        return Widget::IsVisible() && widget->IsVisible();
+    }
+    return false;
+}
+
+void WidgetProxy::SetVisible(bool vis) {
+    auto widget = GetActiveWidget();
+    if (widget) {
+        widget->SetVisible(vis);
+    }
+}
+
+bool WidgetProxy::IsEnabled() const {
+    auto widget = GetActiveWidget();
+    if (widget) {
+        return Widget::IsEnabled() && widget->IsEnabled();
+    }
+    return false;
+}
+
+void WidgetProxy::SetEnabled(bool enabled) {
+    auto widget = GetActiveWidget();
+    if (widget) {
+        widget->SetEnabled(enabled);
+    }
+}
+
+void WidgetProxy::SetTooltip(const char* text) {
+    auto widget = GetActiveWidget();
+    if (widget) {
+        widget->SetTooltip(text);
+    }
+    Widget::SetTooltip(text);
+}
+
+const char* WidgetProxy::GetTooltip() const {
+    auto widget = GetActiveWidget();
+    if (widget) {
+        return widget->GetTooltip();
+    }
+    return Widget::GetTooltip();
+}
+
+Size WidgetProxy::CalcPreferredSize(const LayoutContext& context,
+                               const Constraints& constraints) const {
+    auto widget = GetActiveWidget();
+    if (widget) {
+        return widget->CalcPreferredSize(context, constraints);
+    }
+    return Widget::CalcPreferredSize(context, constraints);
+}
+
+Size WidgetProxy::CalcMinimumSize(const LayoutContext& context) const {
+    auto widget = GetActiveWidget();
+    if (widget) {
+        return widget->CalcMinimumSize(context);
+    }
+    return Widget::CalcMinimumSize(context);
+}
+
+void WidgetProxy::Layout(const LayoutContext& context) {
+    auto widget = GetActiveWidget();
+    if (widget) {
+        widget->Layout(context);
+    }
+}
+
+Widget::DrawResult WidgetProxy::Draw(const DrawContext& context) {
+    if (!IsVisible()) {
+        return DrawResult::NONE;
+    }
+
+    DrawResult result = DrawResult::NONE;
+    auto widget = GetActiveWidget();
+    if (widget) {
+        result = widget->Draw(context);
+    }
+    if (impl_->need_layout_) {
+        impl_->need_layout_ = false;
+        result = DrawResult::RELAYOUT;
+    }
+    return result;
+}
+
+Widget::EventResult WidgetProxy::Mouse(const MouseEvent& e) {
+    if (!IsVisible()) {
+        return EventResult::IGNORED;
+    }
+    auto widget = GetActiveWidget();
+    if (widget) {
+        return widget->Mouse(e);
+    }
+    return EventResult::DISCARD;
+}
+
+Widget::EventResult WidgetProxy::Key(const KeyEvent& e) {
+    if (!IsVisible()) {
+        return EventResult::IGNORED;
+    }
+    auto widget = GetActiveWidget();
+    if (widget) {
+        return widget->Key(e);
+    }
+    return EventResult::DISCARD;
+}
+
+Widget::DrawResult WidgetProxy::Tick(const TickEvent& e) {
+    auto result = DrawResult::NONE;
+    auto widget = GetActiveWidget();
+    if (widget) {
+        result = widget->Tick(e);
+    }
+    return result;
+}
+
+}  // namespace gui
+}  // namespace visualization
+}  // namespace open3d

--- a/cpp/open3d/visualization/gui/WidgetProxy.cpp
+++ b/cpp/open3d/visualization/gui/WidgetProxy.cpp
@@ -47,9 +47,7 @@ void WidgetProxy::SetWidget(std::shared_ptr<Widget> widget) {
     impl_->widget_ = widget;
     impl_->need_layout_ = true;
 }
-std::shared_ptr<Widget> WidgetProxy::GetWidget() {
-    return GetActiveWidget();
-}
+std::shared_ptr<Widget> WidgetProxy::GetWidget() { return GetActiveWidget(); }
 void WidgetProxy::AddChild(std::shared_ptr<Widget> child) {
     auto widget = GetActiveWidget();
     if (widget) {
@@ -152,7 +150,7 @@ const char* WidgetProxy::GetTooltip() const {
 }
 
 Size WidgetProxy::CalcPreferredSize(const LayoutContext& context,
-                               const Constraints& constraints) const {
+                                    const Constraints& constraints) const {
     auto widget = GetActiveWidget();
     if (widget) {
         return widget->CalcPreferredSize(context, constraints);

--- a/cpp/open3d/visualization/gui/WidgetProxy.h
+++ b/cpp/open3d/visualization/gui/WidgetProxy.h
@@ -43,8 +43,7 @@ class Renderer;
 namespace visualization {
 namespace gui {
 
-class WidgetProxy : public Widget{
-
+class WidgetProxy : public Widget {
 public:
     WidgetProxy();
     ~WidgetProxy() override;
@@ -70,7 +69,7 @@ public:
     void SetTooltip(const char* text) override;
     const char* GetTooltip() const override;
     Size CalcPreferredSize(const LayoutContext& context,
-                                   const Constraints& constraints) const override;
+                           const Constraints& constraints) const override;
     Size CalcMinimumSize(const LayoutContext& context) const override;
     void Layout(const LayoutContext& context) override;
     DrawResult Draw(const DrawContext& context) override;
@@ -80,6 +79,7 @@ public:
 
 protected:
     virtual std::shared_ptr<Widget> GetActiveWidget() const;
+
 private:
     struct Impl;
     std::unique_ptr<Impl> impl_;

--- a/cpp/open3d/visualization/gui/WidgetProxy.h
+++ b/cpp/open3d/visualization/gui/WidgetProxy.h
@@ -35,14 +35,34 @@
 namespace open3d {
 
 namespace visualization {
-namespace rendering {
-class Renderer;
-}
-}  // namespace visualization
-
-namespace visualization {
 namespace gui {
 
+/// \class WidgetProxy
+///
+/// \brief Widget container to delegate any widget dynamically.
+///
+/// Widget can not be managed dynamically. Although it is allowed
+/// to add more child widgets, it's impossible to replace some child
+/// with new on or remove children. WidgetProxy is designed to solve
+/// this problem.
+///
+/// When WidgetProxy is created, it's invisible and disabled, so it
+/// won't be drawn or layout, seeming like it does not exist. When
+/// a widget is set by \ref SetWidget, all \ref Widget's APIs will be
+/// conducted to that child widget. It looks like WidgetProxy is
+/// that widget.
+///
+/// At any time, a new widget could be set, to replace the old one.
+/// and the old widget will be destroyed.
+///
+/// Due to the content changing after a new widget is set or cleared,
+/// a relayout of Window might be called after SetWidget.
+///
+/// The delegated widget could be retrieved by \ref GetWidget in case you
+/// need to access it directly, like get check status of a CheckBox.
+///
+/// API other than \ref SetWidget and \ref GetWidget has completely
+/// same function as \ref Widget.
 class WidgetProxy : public Widget {
 public:
     WidgetProxy();
@@ -51,7 +71,22 @@ public:
     void AddChild(std::shared_ptr<Widget> child) override;
     const std::vector<std::shared_ptr<Widget>> GetChildren() const override;
 
+    /// \brief set a new widget to be delegated by this one.
+    ///
+    /// After SetWidget, the previously delegated widget will be abandon,
+    /// all calls to \ref Widget's API will be conducted to \p widget.
+    ///
+    /// Before any SetWidget call, this widget is invisible and disabled,
+    /// seems it does not exist because it won't be drawn or in a layout.
+    ///
+    /// \param widget Any widget to be delegated. Set to NULL to clear
+    ///               current delegated proxy.
     virtual void SetWidget(std::shared_ptr<Widget> widget);
+
+    /// \brief Retrieve current delegated widget.
+    ///
+    /// \return Instance of current delegated widget set by \ref SetWidget.
+    ///         An empty pointer will be returned if there is none.
     virtual std::shared_ptr<Widget> GetWidget();
 
     const Rect& GetFrame() const override;

--- a/cpp/open3d/visualization/gui/WidgetProxy.h
+++ b/cpp/open3d/visualization/gui/WidgetProxy.h
@@ -1,0 +1,90 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "open3d/visualization/gui/Gui.h"
+#include "open3d/visualization/gui/Widget.h"
+
+namespace open3d {
+
+namespace visualization {
+namespace rendering {
+class Renderer;
+}
+}  // namespace visualization
+
+namespace visualization {
+namespace gui {
+
+class WidgetProxy : public Widget{
+
+public:
+    WidgetProxy();
+    ~WidgetProxy() override;
+
+    void AddChild(std::shared_ptr<Widget> child) override;
+    const std::vector<std::shared_ptr<Widget>> GetChildren() const override;
+
+    virtual void SetWidget(std::shared_ptr<Widget> widget);
+    virtual std::shared_ptr<Widget> GetWidget();
+
+    const Rect& GetFrame() const override;
+    void SetFrame(const Rect& f) override;
+
+    const Color& GetBackgroundColor() const override;
+    bool IsDefaultBackgroundColor() const override;
+    void SetBackgroundColor(const Color& color) override;
+
+    bool IsVisible() const override;
+    void SetVisible(bool vis) override;
+
+    bool IsEnabled() const override;
+    void SetEnabled(bool enabled) override;
+    void SetTooltip(const char* text) override;
+    const char* GetTooltip() const override;
+    Size CalcPreferredSize(const LayoutContext& context,
+                                   const Constraints& constraints) const override;
+    Size CalcMinimumSize(const LayoutContext& context) const override;
+    void Layout(const LayoutContext& context) override;
+    DrawResult Draw(const DrawContext& context) override;
+    EventResult Mouse(const MouseEvent& e) override;
+    EventResult Key(const KeyEvent& e) override;
+    DrawResult Tick(const TickEvent& e) override;
+
+protected:
+    virtual std::shared_ptr<Widget> GetActiveWidget() const;
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace gui
+}  // namespace visualization
+}  // namespace open3d

--- a/cpp/pybind/visualization/gui/gui.cpp
+++ b/cpp/pybind/visualization/gui/gui.cpp
@@ -56,6 +56,7 @@
 #include "open3d/visualization/gui/TreeView.h"
 #include "open3d/visualization/gui/VectorEdit.h"
 #include "open3d/visualization/gui/Widget.h"
+#include "open3d/visualization/gui/WidgetProxy.h"
 #include "open3d/visualization/gui/Window.h"
 #include "open3d/visualization/rendering/Open3DScene.h"
 #include "open3d/visualization/rendering/Renderer.h"
@@ -693,6 +694,27 @@ void pybind_gui_classes(py::module &m) {
                  "it requires some internal setup in order to function "
                  "properly");
 
+    // ---- WidgetProxy ----
+    py::class_<WidgetProxy, UnownedPointer<WidgetProxy>, Widget> widgetProxy(
+            m, "WidgetProxy", "WidgetProxy");
+    widgetProxy.def(py::init<>(),
+                 "Creates a widget proxy")
+            .def("__repr__",
+                 [](const WidgetProxy &c) {
+                     std::stringstream s;
+                     s << "Proxy (" << c.GetFrame().x << ", "
+                       << c.GetFrame().y << "), " << c.GetFrame().width << " x "
+                       << c.GetFrame().height;
+                     return s.str();
+                 })
+            .def(
+                    "set_widget",
+                    [](WidgetProxy &w, UnownedPointer<Widget> proxy) {
+                        w.SetWidget(TakeOwnership<Widget>(proxy));
+                    },
+                    "Adds a proxy widget")
+            .def( "get_widget", &WidgetProxy::GetWidget,
+                  "Get proxy widget");
     // ---- Button ----
     py::class_<Button, UnownedPointer<Button>, Widget> button(m, "Button",
                                                               "Button");

--- a/cpp/pybind/visualization/gui/gui.cpp
+++ b/cpp/pybind/visualization/gui/gui.cpp
@@ -696,7 +696,25 @@ void pybind_gui_classes(py::module &m) {
 
     // ---- WidgetProxy ----
     py::class_<WidgetProxy, UnownedPointer<WidgetProxy>, Widget> widgetProxy(
-            m, "WidgetProxy", "WidgetProxy");
+            m, "WidgetProxy",
+            "Widget container to delegate any widget dynamically."
+            " Widget can not be managed dynamically. Although it is allowed"
+            " to add more child widgets, it's impossible to replace some child"
+            " with new on or remove children. WidgetProxy is designed to solve"
+            " this problem."
+            " When WidgetProxy is created, it's invisible and disabled, so it"
+            " won't be drawn or layout, seeming like it does not exist. When"
+            " a widget is set by  set_widget, all  Widget's APIs will be"
+            " conducted to that child widget. It looks like WidgetProxy is"
+            " that widget."
+            " At any time, a new widget could be set, to replace the old one."
+            " and the old widget will be destroyed."
+            " Due to the content changing after a new widget is set or cleared,"
+            " a relayout of Window might be called after set_widget."
+            " The delegated widget could be retrieved by  get_widget in case"
+            "  you need to access it directly, like get check status of a"
+            " CheckBox. API other than  set_widget and get_widget has"
+            " completely same functions as Widget.");
     widgetProxy.def(py::init<>(), "Creates a widget proxy")
             .def("__repr__",
                  [](const WidgetProxy &c) {
@@ -711,8 +729,18 @@ void pybind_gui_classes(py::module &m) {
                     [](WidgetProxy &w, UnownedPointer<Widget> proxy) {
                         w.SetWidget(TakeOwnership<Widget>(proxy));
                     },
-                    "Adds a proxy widget")
-            .def("get_widget", &WidgetProxy::GetWidget, "Get proxy widget");
+                    "set a new widget to be delegated by this one."
+                    " After set_widget, the previously delegated widget ,"
+                    " will be abandon all calls to Widget's API will be "
+                    " conducted to widget. Before any set_widget call, "
+                    " this widget is invisible and disabled, seems it "
+                    " does not exist because it won't be drawn or in a "
+                    "layout.")
+            .def("get_widget", &WidgetProxy::GetWidget,
+                 "Retrieve current delegated widget."
+                 "return instance of current delegated widget set by "
+                 "set_widget. An empty pointer will be returned "
+                 "if there is none.");
     // ---- Button ----
     py::class_<Button, UnownedPointer<Button>, Widget> button(m, "Button",
                                                               "Button");

--- a/cpp/pybind/visualization/gui/gui.cpp
+++ b/cpp/pybind/visualization/gui/gui.cpp
@@ -697,13 +697,12 @@ void pybind_gui_classes(py::module &m) {
     // ---- WidgetProxy ----
     py::class_<WidgetProxy, UnownedPointer<WidgetProxy>, Widget> widgetProxy(
             m, "WidgetProxy", "WidgetProxy");
-    widgetProxy.def(py::init<>(),
-                 "Creates a widget proxy")
+    widgetProxy.def(py::init<>(), "Creates a widget proxy")
             .def("__repr__",
                  [](const WidgetProxy &c) {
                      std::stringstream s;
-                     s << "Proxy (" << c.GetFrame().x << ", "
-                       << c.GetFrame().y << "), " << c.GetFrame().width << " x "
+                     s << "Proxy (" << c.GetFrame().x << ", " << c.GetFrame().y
+                       << "), " << c.GetFrame().width << " x "
                        << c.GetFrame().height;
                      return s.str();
                  })
@@ -713,8 +712,7 @@ void pybind_gui_classes(py::module &m) {
                         w.SetWidget(TakeOwnership<Widget>(proxy));
                     },
                     "Adds a proxy widget")
-            .def( "get_widget", &WidgetProxy::GetWidget,
-                  "Get proxy widget");
+            .def("get_widget", &WidgetProxy::GetWidget, "Get proxy widget");
     // ---- Button ----
     py::class_<Button, UnownedPointer<Button>, Widget> button(m, "Button",
                                                               "Button");

--- a/examples/python/gui/all-widgets.py
+++ b/examples/python/gui/all-widgets.py
@@ -148,6 +148,7 @@ class ExampleWindow:
 
         self.logo_idx = 0
         proxy = gui.WidgetProxy()
+
         def switch_proxy():
             self.logo_idx += 1
             if self.logo_idx % 3 == 0:
@@ -157,7 +158,8 @@ class ExampleWindow:
                 logo = gui.ImageWidget(basedir + "/icon-32.png")
                 proxy.set_widget(logo)
             else:
-                label = gui.Label('Open3D: A Modern Library for 3D Data Processing')
+                label = gui.Label(
+                    'Open3D: A Modern Library for 3D Data Processing')
                 proxy.set_widget(label)
             w.set_needs_layout()
 
@@ -165,7 +167,6 @@ class ExampleWindow:
         logo_btn.set_on_clicked(switch_proxy)
         collapse.add_child(logo_btn)
         collapse.add_child(proxy)
-
 
         # Add a list of items
         lv = gui.ListView()

--- a/examples/python/gui/all-widgets.py
+++ b/examples/python/gui/all-widgets.py
@@ -146,9 +146,26 @@ class ExampleWindow:
         switch.set_on_clicked(self._on_switch)
         collapse.add_child(switch)
 
-        # Add a simple image
-        logo = gui.ImageWidget(basedir + "/icon-32.png")
-        collapse.add_child(logo)
+        self.logo_idx = 0
+        proxy = gui.WidgetProxy()
+        def switch_proxy():
+            self.logo_idx += 1
+            if self.logo_idx % 3 == 0:
+                proxy.set_widget(None)
+            elif self.logo_idx % 3 == 1:
+                # Add a simple image
+                logo = gui.ImageWidget(basedir + "/icon-32.png")
+                proxy.set_widget(logo)
+            else:
+                label = gui.Label('Open3D: A Modern Library for 3D Data Processing')
+                proxy.set_widget(label)
+            w.set_needs_layout()
+
+        logo_btn = gui.Button('Switch Logo')
+        logo_btn.set_on_clicked(switch_proxy)
+        collapse.add_child(logo_btn)
+        collapse.add_child(proxy)
+
 
         # Add a list of items
         lv = gui.ListView()


### PR DESCRIPTION
This PR is to create WidgetProxy as a widget container of dynamic widgets. If no widget is set, WidgetProxy will be disappeared in GUI.

An relayout is required after setting a new widget.

An example could be found in all-widgets.py.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4498)
<!-- Reviewable:end -->
