### PR TITLE
make faces generated by ComputeConvexHull oriented

### DIFF
--- a/cpp/open3d/geometry/Qhull.cpp
+++ b/cpp/open3d/geometry/Qhull.cpp
@@ -98,10 +98,24 @@ Qhull::ComputeConvexHull(const std::vector<Eigen::Vector3d>& points,
         tidx++;
     }
 
+    auto center = convex_hull->GetCenter();
     for (Eigen::Vector3i& triangle : convex_hull->triangles_) {
         triangle(0) = vert_map[triangle(0)];
         triangle(1) = vert_map[triangle(1)];
         triangle(2) = vert_map[triangle(2)];
+
+        Eigen::Vector3d e1 = convex_hull->vertices_[triangle(1)] -
+                             convex_hull->vertices_[triangle(0)];
+        Eigen::Vector3d e2 = convex_hull->vertices_[triangle(2)] -
+                             convex_hull->vertices_[triangle(0)];
+        auto normal = e1.cross(e2);
+
+        auto triangle_center = (1. / 3) * (convex_hull->vertices_[triangle(0)] +
+                                           convex_hull->vertices_[triangle(1)] +
+                                           convex_hull->vertices_[triangle(2)]);
+        if (normal.dot(triangle_center - center) < 0) {
+            std::swap(triangle(0), triangle(1));
+        }
     }
 
     return std::make_tuple(convex_hull, pt_map);

--- a/cpp/tests/geometry/PointCloud.cpp
+++ b/cpp/tests/geometry/PointCloud.cpp
@@ -1171,17 +1171,17 @@ TEST(PointCloud, ComputeConvexHull) {
     std::tie(mesh, pt_map) = pcd.ComputeConvexHull();
     EXPECT_EQ(pt_map, std::vector<size_t>({7, 3, 1, 5, 6, 2, 8, 4}));
     ExpectEQ(mesh->vertices_, ApplyIndices(pcd.points_, pt_map));
-    ExpectEQ(mesh->triangles_, std::vector<Eigen::Vector3i>({{0, 1, 2},
+    ExpectEQ(mesh->triangles_, std::vector<Eigen::Vector3i>({{1, 0, 2},
                                                              {0, 3, 2},
-                                                             {4, 3, 2},
+                                                             {3, 4, 2},
                                                              {4, 5, 2},
-                                                             {4, 0, 3},
+                                                             {0, 4, 3},
                                                              {4, 0, 6},
                                                              {7, 1, 2},
-                                                             {7, 5, 2},
+                                                             {5, 7, 2},
                                                              {7, 0, 1},
-                                                             {7, 0, 6},
-                                                             {7, 4, 5},
+                                                             {0, 7, 6},
+                                                             {4, 7, 5},
                                                              {7, 4, 6}}));
 }
 


### PR DESCRIPTION
This PR adds code to fix the orientation of the faces generated by qhull.
This fixes the workflow in #3776

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4508)
<!-- Reviewable:end -->
