### PR TITLE
Add support for scaling 3D text

### DIFF
--- a/cpp/open3d/visualization/gui/Label3D.cpp
+++ b/cpp/open3d/visualization/gui/Label3D.cpp
@@ -38,6 +38,7 @@ struct Label3D::Impl {
     std::string text_;
     Eigen::Vector3f position_;
     Color color_ = DEFAULT_COLOR;
+    float scale_ = 1.f;
 };
 
 Label3D::Label3D(const Eigen::Vector3f& pos, const char* text /*= nullptr*/)
@@ -63,6 +64,10 @@ void Label3D::SetPosition(const Eigen::Vector3f& pos) {
 Color Label3D::GetTextColor() const { return impl_->color_; }
 
 void Label3D::SetTextColor(const Color& color) { impl_->color_ = color; }
+
+float Label3D::GetTextScale() const { return impl_->scale_; }
+
+void Label3D::SetTextScale(float scale) { impl_->scale_ = scale; }
 
 }  // namespace gui
 }  // namespace visualization

--- a/cpp/open3d/visualization/gui/Label3D.h
+++ b/cpp/open3d/visualization/gui/Label3D.h
@@ -49,10 +49,15 @@ public:
     Eigen::Vector3f GetPosition() const;
     void SetPosition(const Eigen::Vector3f& pos);
 
+    /// Returns the color with which the text will be drawn
     Color GetTextColor() const;
+
+    /// Set the color with which the text will be drawn
     void SetTextColor(const Color& color);
 
+    /// Get the current scale. See not below on meaning of scale.
     float GetTextScale() const;
+
     /// Sets the scale factor for the text sprite. It does not change the
     /// underlying font size but scales how large it appears. Warning: large
     /// scale factors may result in blurry text.

--- a/cpp/open3d/visualization/gui/Label3D.h
+++ b/cpp/open3d/visualization/gui/Label3D.h
@@ -52,6 +52,12 @@ public:
     Color GetTextColor() const;
     void SetTextColor(const Color& color);
 
+    float GetTextScale() const;
+    /// Sets the scale factor for the text sprite. It does not change the
+    /// underlying font size but scales how large it appears. Warning: large
+    /// scale factors may result in blurry text.
+    void SetTextScale(float scale);
+
 private:
     struct Impl;
     std::unique_ptr<Impl> impl_;

--- a/cpp/open3d/visualization/gui/SceneWidget.cpp
+++ b/cpp/open3d/visualization/gui/SceneWidget.cpp
@@ -1156,6 +1156,7 @@ Widget::DrawResult SceneWidget::Draw(const DrawContext& context) {
             ndc *= 0.5f;
             ndc.x() *= f.width;
             ndc.y() *= f.height;
+            ImGui::SetWindowFontScale(l->GetTextScale());
             ImGui::SetCursorScreenPos(
                     ImVec2(ndc.x() - f.x, f.height - ndc.y() - f.y));
             auto color = l->GetTextColor();
@@ -1163,6 +1164,7 @@ Widget::DrawResult SceneWidget::Draw(const DrawContext& context) {
                                 color.GetBlue(), color.GetAlpha()},
                                "%s", l->GetText());
         }
+        ImGui::SetWindowFontScale(1.0);
     }
 
     // Draw any interactor UI

--- a/cpp/pybind/visualization/gui/gui.cpp
+++ b/cpp/pybind/visualization/gui/gui.cpp
@@ -995,7 +995,14 @@ void pybind_gui_classes(py::module &m) {
                           "The position of the text in 3D coordinates")
             .def_property("color", &Label3D::GetTextColor,
                           &Label3D::SetTextColor,
-                          "The color of the text (gui.Color)");
+                          "The color of the text (gui.Color)")
+            .def_property(
+                    "scale", &Label3D::GetTextScale, &Label3D::SetTextScale,
+                    "The scale of the 3D label. When set to 1.0 (the default) "
+                    "text will be rendered at its native font size. Larger and "
+                    "smaller values of scale will enlarge or shrink the "
+                    "rendered text. Note: large values of scale may result in "
+                    "blurry text as the underlying font is not resized.");
 
     // ---- ListView ----
     py::class_<ListView, UnownedPointer<ListView>, Widget> listview(

--- a/examples/python/gui/text3d.py
+++ b/examples/python/gui/text3d.py
@@ -71,7 +71,8 @@ def low_level():
     widget3d.scene.add_geometry("Points", points, mat)
     for idx in range(0, len(points.points)):
         l = widget3d.add_3d_label(points.points[idx], "{}".format(idx))
-        l.color = gui.Color(points.colors[idx][0], points.colors[idx][1], points.colors[idx][2])
+        l.color = gui.Color(points.colors[idx][0], points.colors[idx][1],
+                            points.colors[idx][2])
         l.scale = np.random.uniform(0.5, 3.0)
     bbox = widget3d.scene.bounding_box
     widget3d.setup_camera(60.0, bbox, bbox.get_center())

--- a/examples/python/gui/text3d.py
+++ b/examples/python/gui/text3d.py
@@ -70,7 +70,9 @@ def low_level():
     mat.point_size = 5 * w.scaling
     widget3d.scene.add_geometry("Points", points, mat)
     for idx in range(0, len(points.points)):
-        widget3d.add_3d_label(points.points[idx], "{}".format(idx))
+        l = widget3d.add_3d_label(points.points[idx], "{}".format(idx))
+        l.color = gui.Color(points.colors[idx][0], points.colors[idx][1], points.colors[idx][2])
+        l.scale = np.random.uniform(0.5, 3.0)
     bbox = widget3d.scene.bounding_box
     widget3d.setup_camera(60.0, bbox, bbox.get_center())
     w.add_child(widget3d)


### PR DESCRIPTION
The example `examples/python/gui/text3d.py` has been modified to demonstrate both text color and scale.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4558)
<!-- Reviewable:end -->
