### PR TITLE
Add pybind for Open3D Viewer

### DIFF
--- a/cpp/apps/Open3DViewer/Open3DViewer.cpp
+++ b/cpp/apps/Open3DViewer/Open3DViewer.cpp
@@ -34,5 +34,8 @@ using namespace open3d::visualization::app;
 #if __APPLE__
 // Open3DViewer_mac.mm
 #else
-int main(int argc, const char *argv[]) { return RunViewer(argc, argv); }
+int main(int argc, const char *argv[]) {
+    RunViewer(argc, argv);
+    return 0;
+}
 #endif  // __APPLE__

--- a/cpp/apps/Open3DViewer/Open3DViewer.cpp
+++ b/cpp/apps/Open3DViewer/Open3DViewer.cpp
@@ -24,51 +24,15 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
-#include "Open3DViewer.h"
-
 #include <string>
-
 #include "open3d/Open3D.h"
-#include "open3d/visualization/gui/Native.h"
-#include "open3d/visualization/visualizer/GuiVisualizer.h"
+#include "open3d/visualization/app/Viewer.h"
 
-using namespace open3d;
-using namespace open3d::geometry;
-using namespace open3d::visualization;
-
-namespace {
-static const std::string gUsage = "Usage: Open3DViewer [meshfile|pointcloud]";
-}  // namespace
-
-int Run(int argc, const char *argv[]) {
-    const char *path = nullptr;
-    if (argc > 1) {
-        path = argv[1];
-        if (argc > 2) {
-            utility::LogWarning(gUsage.c_str());
-        }
-    }
-
-    auto &app = gui::Application::GetInstance();
-    app.Initialize(argc, argv);
-
-    auto vis = std::make_shared<GuiVisualizer>("Open3D", WIDTH, HEIGHT);
-    bool is_path_valid = (path && path[0] != '\0');
-    if (is_path_valid) {
-        vis->LoadGeometry(path);
-    }
-    gui::Application::GetInstance().AddWindow(vis);
-    // when Run() ends, Filament will be stopped, so we can't be holding on
-    // to any GUI objects.
-    vis.reset();
-
-    app.Run();
-
-    return 0;
-}
+using namespace open3d::visualization::app;
 
 #if __APPLE__
 // Open3DViewer_mac.mm
 #else
-int main(int argc, const char *argv[]) { return Run(argc, argv); }
+int main(int argc, const char *argv[]) {
+    return RunViewer(argc, argv); }
 #endif  // __APPLE__

--- a/cpp/apps/Open3DViewer/Open3DViewer.cpp
+++ b/cpp/apps/Open3DViewer/Open3DViewer.cpp
@@ -25,6 +25,7 @@
 // ----------------------------------------------------------------------------
 
 #include <string>
+
 #include "open3d/Open3D.h"
 #include "open3d/visualization/app/Viewer.h"
 
@@ -33,6 +34,5 @@ using namespace open3d::visualization::app;
 #if __APPLE__
 // Open3DViewer_mac.mm
 #else
-int main(int argc, const char *argv[]) {
-    return RunViewer(argc, argv); }
+int main(int argc, const char *argv[]) { return RunViewer(argc, argv); }
 #endif  // __APPLE__

--- a/cpp/apps/Open3DViewer/Open3DViewer.h
+++ b/cpp/apps/Open3DViewer/Open3DViewer.h
@@ -37,5 +37,3 @@ class GuiVisualizer;
 
 #define WIDTH 1280
 #define HEIGHT 960
-
-int Run(int argc, const char *argv[]);

--- a/cpp/open3d/utility/Logging.cpp
+++ b/cpp/open3d/utility/Logging.cpp
@@ -134,6 +134,10 @@ void Logger::SetPrintFunction(
     impl_->print_fcn_ = print_fcn;
 }
 
+std::function<void(const std::string &)> Logger::GetPrintFunction() {
+    return impl_->print_fcn_;
+}
+
 void Logger::ResetPrintFunction() {
     impl_->print_fcn_ = impl_->console_print_fcn_;
 }

--- a/cpp/open3d/utility/Logging.cpp
+++ b/cpp/open3d/utility/Logging.cpp
@@ -134,7 +134,7 @@ void Logger::SetPrintFunction(
     impl_->print_fcn_ = print_fcn;
 }
 
-std::function<void(const std::string &)> Logger::GetPrintFunction() {
+const std::function<void(const std::string &)> Logger::GetPrintFunction() {
     return impl_->print_fcn_;
 }
 

--- a/cpp/open3d/utility/Logging.h
+++ b/cpp/open3d/utility/Logging.h
@@ -147,6 +147,9 @@ public:
     /// Reset the print function to the default one (print to console).
     void ResetPrintFunction();
 
+    /// Get the print function used by the Logger.
+    std::function<void(const std::string &)> GetPrintFunction();
+
     /// Set global verbosity level of Open3D.
     ///
     /// \param verbosity_level Messages with equal or less than verbosity_level

--- a/cpp/open3d/utility/Logging.h
+++ b/cpp/open3d/utility/Logging.h
@@ -148,7 +148,7 @@ public:
     void ResetPrintFunction();
 
     /// Get the print function used by the Logger.
-    std::function<void(const std::string &)> GetPrintFunction();
+    const std::function<void(const std::string &)> GetPrintFunction();
 
     /// Set global verbosity level of Open3D.
     ///

--- a/cpp/open3d/visualization/CMakeLists.txt
+++ b/cpp/open3d/visualization/CMakeLists.txt
@@ -92,6 +92,10 @@ if (BUILD_GUI)
         visualizer/O3DVisualizer.cpp
         visualizer/O3DVisualizerSelections.cpp
     )
+
+    target_sources(visualization PRIVATE
+        app/Viewer.cpp
+    )
 endif()
 
 

--- a/cpp/open3d/visualization/app/Viewer.cpp
+++ b/cpp/open3d/visualization/app/Viewer.cpp
@@ -24,13 +24,15 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
-#include <string>
-#include <iostream>
 #include "open3d/visualization/app/Viewer.h"
-#include "open3d/visualization/gui/Native.h"
-#include "open3d/visualization/visualizer/GuiVisualizer.h"
+
+#include <iostream>
+#include <string>
+
 #include "open3d/utility/Logging.h"
 #include "open3d/visualization/gui/Application.h"
+#include "open3d/visualization/gui/Native.h"
+#include "open3d/visualization/visualizer/GuiVisualizer.h"
 
 using namespace open3d;
 using namespace open3d::geometry;
@@ -45,9 +47,10 @@ namespace visualization {
 namespace app {
 
 int RunViewer(int argc, const char *argv[]) {
-    std::function<void(const std::string &)> print_fcn = utility::Logger::GetInstance().GetPrintFunction();
+    std::function<void(const std::string &)> print_fcn =
+            utility::Logger::GetInstance().GetPrintFunction();
     utility::Logger::GetInstance().ResetPrintFunction();
-    
+
     const char *path = nullptr;
     if (argc > 1) {
         path = argv[1];
@@ -70,7 +73,7 @@ int RunViewer(int argc, const char *argv[]) {
     vis.reset();
 
     app.Run();
-    
+
     utility::Logger::GetInstance().SetPrintFunction(print_fcn);
     return 0;
 }

--- a/cpp/open3d/visualization/app/Viewer.cpp
+++ b/cpp/open3d/visualization/app/Viewer.cpp
@@ -34,17 +34,13 @@
 #include "open3d/visualization/gui/Native.h"
 #include "open3d/visualization/visualizer/GuiVisualizer.h"
 
-using namespace open3d;
-using namespace open3d::geometry;
-using namespace open3d::visualization;
-
-namespace {
-static const std::string gUsage = "Usage: Open3DViewer [meshfile|pointcloud]";
-}  // namespace
-
 namespace open3d {
 namespace visualization {
 namespace app {
+
+static const std::string usage = "usage: ./Open3D [meshfile|pointcloud]";
+static const int width = 1280;
+static const int height = 960;
 
 void RunViewer(int argc, const char *argv[]) {
     std::function<void(const std::string &)> print_fcn =
@@ -52,22 +48,18 @@ void RunViewer(int argc, const char *argv[]) {
     utility::Logger::GetInstance().ResetPrintFunction();
 
     const char *path = nullptr;
-    if (argc > 1) {
+    if (argc == 2) {
         path = argv[1];
-        if (argc > 2) {
-            utility::LogWarning(gUsage.c_str());
-        }
+    } else if (argc > 2) {
+        utility::LogWarning(usage.c_str());
     }
 
     auto &app = gui::Application::GetInstance();
     app.Initialize(argc, argv);
 
-    const int width = 1280;
-    const int height = 960;
     auto vis = std::make_shared<open3d::visualization::GuiVisualizer>(
             "Open3D", width, height);
-    bool is_path_valid = (path && path[0] != '\0');
-    if (is_path_valid) {
+    if (path && path[0] != '\0') {
         vis->LoadGeometry(path);
     }
     gui::Application::GetInstance().AddWindow(vis);

--- a/cpp/open3d/visualization/app/Viewer.cpp
+++ b/cpp/open3d/visualization/app/Viewer.cpp
@@ -45,6 +45,9 @@ namespace visualization {
 namespace app {
 
 int RunViewer(int argc, const char *argv[]) {
+    std::function<void(const std::string &)> print_fcn = utility::Logger::GetInstance().GetPrintFunction();
+    utility::Logger::GetInstance().ResetPrintFunction();
+    
     const char *path = nullptr;
     if (argc > 1) {
         path = argv[1];
@@ -67,7 +70,8 @@ int RunViewer(int argc, const char *argv[]) {
     vis.reset();
 
     app.Run();
-
+    
+    utility::Logger::GetInstance().SetPrintFunction(print_fcn);
     return 0;
 }
 

--- a/cpp/open3d/visualization/app/Viewer.cpp
+++ b/cpp/open3d/visualization/app/Viewer.cpp
@@ -46,7 +46,7 @@ namespace open3d {
 namespace visualization {
 namespace app {
 
-int RunViewer(int argc, const char *argv[]) {
+void RunViewer(int argc, const char *argv[]) {
     std::function<void(const std::string &)> print_fcn =
             utility::Logger::GetInstance().GetPrintFunction();
     utility::Logger::GetInstance().ResetPrintFunction();
@@ -62,20 +62,22 @@ int RunViewer(int argc, const char *argv[]) {
     auto &app = gui::Application::GetInstance();
     app.Initialize(argc, argv);
 
-    auto vis = std::make_shared<GuiVisualizer>("Open3D", WIDTH, HEIGHT);
+    const int width = 1280;
+    const int height = 960;
+    auto vis = std::make_shared<open3d::visualization::GuiVisualizer>(
+            "Open3D", width, height);
     bool is_path_valid = (path && path[0] != '\0');
     if (is_path_valid) {
         vis->LoadGeometry(path);
     }
     gui::Application::GetInstance().AddWindow(vis);
-    // when Run() ends, Filament will be stopped, so we can't be holding on
+    // When Run() ends, Filament will be stopped, so we can't be holding on
     // to any GUI objects.
     vis.reset();
 
     app.Run();
 
     utility::Logger::GetInstance().SetPrintFunction(print_fcn);
-    return 0;
 }
 
 }  // namespace app

--- a/cpp/open3d/visualization/app/Viewer.h
+++ b/cpp/open3d/visualization/app/Viewer.h
@@ -27,22 +27,10 @@
 #include <memory>
 
 namespace open3d {
-namespace geometry {
-class Geometry;
-}
-namespace visualizer {
-class GuiVisualizer;
-}
-}  // namespace open3d
-
-#define WIDTH 1280
-#define HEIGHT 960
-
-namespace open3d {
 namespace visualization {
 namespace app {
 
-int RunViewer(int argc, const char *argv[]);
+void RunViewer(int argc, const char *argv[]);
 
 }  // namespace app
 }  // namespace visualization

--- a/cpp/open3d/visualization/app/Viewer.h
+++ b/cpp/open3d/visualization/app/Viewer.h
@@ -24,43 +24,26 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
-#include "pybind/visualization/visualization.h"
+#include <memory>
 
-#include "pybind/visualization/gui/gui.h"
-#include "pybind/visualization/rendering/material.h"
-#include "pybind/visualization/rendering/rendering.h"
-#include "pybind/visualization/app/viewer.h"
+namespace open3d {
+namespace geometry {
+class Geometry;
+}
+namespace visualizer {
+class GuiVisualizer;
+}
+}  // namespace open3d
 
-#ifdef BUILD_WEBRTC
-#include "pybind/visualization/webrtc_server/webrtc_window_system.h"
-#endif
+#define WIDTH 1280
+#define HEIGHT 960
 
 namespace open3d {
 namespace visualization {
+namespace app {
 
-void pybind_visualization(py::module &m) {
-    py::module m_visualization = m.def_submodule("visualization");
-    pybind_renderoption(m_visualization);
-    pybind_viewcontrol(m_visualization);
-    pybind_visualizer(m_visualization);
-    pybind_visualization_utility(m_visualization);
-    pybind_renderoption_method(m_visualization);
-    pybind_viewcontrol_method(m_visualization);
-    pybind_visualizer_method(m_visualization);
-    pybind_visualization_utility_methods(m_visualization);
-    rendering::pybind_material(m_visualization);  // For RPC serialization
+int RunViewer(int argc, const char *argv[]);
 
-#ifdef BUILD_GUI
-    rendering::pybind_rendering(m_visualization);
-    gui::pybind_gui(m_visualization);
-    pybind_o3dvisualizer(m_visualization);
-    app::pybind_app(m_visualization);
-#endif
-
-#ifdef BUILD_WEBRTC
-    webrtc_server::pybind_webrtc_server(m_visualization);
-#endif
-}
-
+}  // namespace app
 }  // namespace visualization
 }  // namespace open3d

--- a/cpp/open3d/visualization/app/Viewer.h
+++ b/cpp/open3d/visualization/app/Viewer.h
@@ -30,6 +30,14 @@ namespace open3d {
 namespace visualization {
 namespace app {
 
+/// Runs Open3D Viewer. This function is called when the standalone viewer app
+/// is run or when the draw command is called from the command line interface.
+
+/// \param argc (argument count) is the number of arguments in \p argv .
+/// \param argv (argument vector) is the array of arguments stored as character
+/// arrays. It contains the path of the calling program (which should be in the
+/// same directory as the gui resoruces folder) as the first argument. The
+/// optional second argument is the path of the geometry file to be visualized
 void RunViewer(int argc, const char *argv[]);
 
 }  // namespace app

--- a/cpp/pybind/make_python_package.cmake
+++ b/cpp/pybind/make_python_package.cmake
@@ -48,6 +48,8 @@ configure_file("${PYTHON_PACKAGE_SRC_DIR}/open3d/__init__.py"
                "${PYTHON_PACKAGE_DST_DIR}/open3d/__init__.py")
 configure_file("${PYTHON_PACKAGE_SRC_DIR}/open3d/visualization/__init__.py"
                "${PYTHON_PACKAGE_DST_DIR}/open3d/visualization/__init__.py")
+configure_file("${PYTHON_PACKAGE_SRC_DIR}/open3d/visualization/app/__init__.py"
+               "${PYTHON_PACKAGE_DST_DIR}/open3d/visualization/app/__init__.py")
 configure_file("${PYTHON_PACKAGE_SRC_DIR}/open3d/visualization/gui/__init__.py"
                "${PYTHON_PACKAGE_DST_DIR}/open3d/visualization/gui/__init__.py")
 configure_file("${PYTHON_PACKAGE_SRC_DIR}/open3d/visualization/rendering/__init__.py"

--- a/cpp/pybind/make_python_package.cmake
+++ b/cpp/pybind/make_python_package.cmake
@@ -46,6 +46,8 @@ configure_file("${PYTHON_PACKAGE_SRC_DIR}/setup.py"
                "${PYTHON_PACKAGE_DST_DIR}/setup.py")
 configure_file("${PYTHON_PACKAGE_SRC_DIR}/open3d/__init__.py"
                "${PYTHON_PACKAGE_DST_DIR}/open3d/__init__.py")
+configure_file("${PYTHON_PACKAGE_SRC_DIR}/tools/app.py"
+               "${PYTHON_PACKAGE_DST_DIR}/open3d/app.py")
 configure_file("${PYTHON_PACKAGE_SRC_DIR}/open3d/visualization/__init__.py"
                "${PYTHON_PACKAGE_DST_DIR}/open3d/visualization/__init__.py")
 configure_file("${PYTHON_PACKAGE_SRC_DIR}/open3d/visualization/app/__init__.py"

--- a/cpp/pybind/visualization/CMakeLists.txt
+++ b/cpp/pybind/visualization/CMakeLists.txt
@@ -13,6 +13,10 @@ if (BUILD_GUI)
     )
 
     target_sources(pybind PRIVATE
+        app/viewer.cpp
+    )
+
+    target_sources(pybind PRIVATE
         gui/events.cpp
         gui/gui.cpp
     )

--- a/cpp/pybind/visualization/app/viewer.cpp
+++ b/cpp/pybind/visualization/app/viewer.cpp
@@ -36,14 +36,13 @@ namespace app {
 static void pybind_app_functions(py::module &m) {
     m.def(
             "run_viewer",
-            [](const std::vector<std::string> args) {
+            [](const std::vector<std::string> &args) {
                 const char **argv = new const char *[args.size()];
-                for (uint it = 0; it < args.size(); it++) {
+                for (size_t it = 0; it < args.size(); it++) {
                     argv[it] = args[it].c_str();
                 }
                 RunViewer(args.size(), argv);
                 delete[] argv;
-                return 0;
             },
             "args"_a);
 

--- a/cpp/pybind/visualization/app/viewer.cpp
+++ b/cpp/pybind/visualization/app/viewer.cpp
@@ -46,10 +46,12 @@ static void pybind_app_functions(py::module &m) {
             },
             "args"_a);
 
-    docstring::FunctionDocInject(m, "run_viewer",
-                                 {{"args",
-                                   "Command line arguments containing the "
-                                   "filename of the geometry to visualize."}});
+    docstring::FunctionDocInject(
+            m, "run_viewer",
+            {{"args",
+              "List of arguments containing the path of the calling program "
+              "(which should be in the same directory as the gui resoruces "
+              "folder) and the optional path of the geometry to visualize."}});
 }
 
 void pybind_app(py::module &m) {

--- a/cpp/pybind/visualization/app/viewer.cpp
+++ b/cpp/pybind/visualization/app/viewer.cpp
@@ -24,43 +24,41 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
-#include "pybind/visualization/visualization.h"
-
-#include "pybind/visualization/gui/gui.h"
-#include "pybind/visualization/rendering/material.h"
-#include "pybind/visualization/rendering/rendering.h"
 #include "pybind/visualization/app/viewer.h"
 
-#ifdef BUILD_WEBRTC
-#include "pybind/visualization/webrtc_server/webrtc_window_system.h"
-#endif
+#include "open3d/visualization/app/Viewer.h"
+#include "pybind/docstring.h"
 
 namespace open3d {
 namespace visualization {
+namespace app {
 
-void pybind_visualization(py::module &m) {
-    py::module m_visualization = m.def_submodule("visualization");
-    pybind_renderoption(m_visualization);
-    pybind_viewcontrol(m_visualization);
-    pybind_visualizer(m_visualization);
-    pybind_visualization_utility(m_visualization);
-    pybind_renderoption_method(m_visualization);
-    pybind_viewcontrol_method(m_visualization);
-    pybind_visualizer_method(m_visualization);
-    pybind_visualization_utility_methods(m_visualization);
-    rendering::pybind_material(m_visualization);  // For RPC serialization
+static void pybind_app_functions(py::module &m) {
+    m.def(
+            "run_viewer",
+            [](const std::vector<std::string> args) {
+                const char **argv = new const char *[args.size()];
+                for (uint it = 0; it < args.size(); it++) {
+                    argv[it] = args[it].c_str();
+                }
+                RunViewer(args.size(), argv);
+                delete[] argv;
+                return 0;
+            },
+            "args"_a);
 
-#ifdef BUILD_GUI
-    rendering::pybind_rendering(m_visualization);
-    gui::pybind_gui(m_visualization);
-    pybind_o3dvisualizer(m_visualization);
-    app::pybind_app(m_visualization);
-#endif
-
-#ifdef BUILD_WEBRTC
-    webrtc_server::pybind_webrtc_server(m_visualization);
-#endif
+    docstring::FunctionDocInject(m, "run_viewer",
+                                 {{"args",
+                                   "Command line arguments containing the "
+                                   "filename of the geometry to visualize."}});
 }
 
+void pybind_app(py::module &m) {
+    py::module m_submodule = m.def_submodule(
+            "app", "Functionality for running the open3d viewer.");
+    pybind_app_functions(m_submodule);
+}
+
+}  // namespace app
 }  // namespace visualization
 }  // namespace open3d

--- a/cpp/pybind/visualization/app/viewer.h
+++ b/cpp/pybind/visualization/app/viewer.h
@@ -24,43 +24,16 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
-#include "pybind/visualization/visualization.h"
+#pragma once
 
-#include "pybind/visualization/gui/gui.h"
-#include "pybind/visualization/rendering/material.h"
-#include "pybind/visualization/rendering/rendering.h"
-#include "pybind/visualization/app/viewer.h"
-
-#ifdef BUILD_WEBRTC
-#include "pybind/visualization/webrtc_server/webrtc_window_system.h"
-#endif
+#include "pybind/open3d_pybind.h"
 
 namespace open3d {
 namespace visualization {
+namespace app {
 
-void pybind_visualization(py::module &m) {
-    py::module m_visualization = m.def_submodule("visualization");
-    pybind_renderoption(m_visualization);
-    pybind_viewcontrol(m_visualization);
-    pybind_visualizer(m_visualization);
-    pybind_visualization_utility(m_visualization);
-    pybind_renderoption_method(m_visualization);
-    pybind_viewcontrol_method(m_visualization);
-    pybind_visualizer_method(m_visualization);
-    pybind_visualization_utility_methods(m_visualization);
-    rendering::pybind_material(m_visualization);  // For RPC serialization
+void pybind_app(py::module &m);
 
-#ifdef BUILD_GUI
-    rendering::pybind_rendering(m_visualization);
-    gui::pybind_gui(m_visualization);
-    pybind_o3dvisualizer(m_visualization);
-    app::pybind_app(m_visualization);
-#endif
-
-#ifdef BUILD_WEBRTC
-    webrtc_server::pybind_webrtc_server(m_visualization);
-#endif
-}
-
+}  // namespace app
 }  // namespace visualization
 }  // namespace open3d

--- a/cpp/pybind/visualization/visualization.cpp
+++ b/cpp/pybind/visualization/visualization.cpp
@@ -26,10 +26,10 @@
 
 #include "pybind/visualization/visualization.h"
 
+#include "pybind/visualization/app/viewer.h"
 #include "pybind/visualization/gui/gui.h"
 #include "pybind/visualization/rendering/material.h"
 #include "pybind/visualization/rendering/rendering.h"
-#include "pybind/visualization/app/viewer.h"
 
 #ifdef BUILD_WEBRTC
 #include "pybind/visualization/webrtc_server/webrtc_window_system.h"

--- a/examples/python/gui/vis-gui.py
+++ b/examples/python/gui/vis-gui.py
@@ -742,12 +742,13 @@ class AppWindow:
                     if len(meshinfo.mesh.vertex_colors) == 0:
                         meshinfo.mesh.paint_uniform_color([1, 1, 1])
                 for meshinfo in model.meshes:
-                    geometries.append(
-                        (meshinfo.mesh_name, meshinfo.mesh, model.materials[meshinfo.material_idx]))
+                    geometries.append((meshinfo.mesh_name, meshinfo.mesh,
+                                       model.materials[meshinfo.material_idx]))
             # Make sure the mesh has texture coordinates
             for meshinfo in model.meshes:
                 if not meshinfo.mesh.has_triangle_uvs():
-                    uv = np.array([[0.0, 0.0]] * (3 * len(meshinfo.mesh.triangles)))
+                    uv = np.array([[0.0, 0.0]] *
+                                  (3 * len(meshinfo.mesh.triangles)))
                     meshinfo.mesh.triangle_uvs = o3d.utility.Vector2dVector(uv)
         else:
             print("[Info]", path, "appears to be a point cloud")

--- a/examples/python/gui/vis-gui.py
+++ b/examples/python/gui/vis-gui.py
@@ -722,30 +722,37 @@ class AppWindow:
     def load(self, path):
         self._scene.scene.clear_geometry()
 
-        geometry = None
+        geometries = []
         geometry_type = o3d.io.read_file_geometry_type(path)
 
-        mesh = None
+        model = None
         if geometry_type & o3d.io.CONTAINS_TRIANGLES:
-            mesh = o3d.io.read_triangle_mesh(path)
-        if mesh is not None:
-            if len(mesh.triangles) == 0:
+            model = o3d.io.read_triangle_model(path)
+        if model is not None:
+            num_triangles = []
+            for meshinfo in model.meshes:
+                num_triangles.append(len(meshinfo.mesh.triangles))
+            if sum(num_triangles) == 0:
                 print(
                     "[WARNING] Contains 0 triangles, will read as point cloud")
-                mesh = None
+                model = None
             else:
-                mesh.compute_vertex_normals()
-                if len(mesh.vertex_colors) == 0:
-                    mesh.paint_uniform_color([1, 1, 1])
-                geometry = mesh
+                for meshinfo in model.meshes:
+                    meshinfo.mesh.compute_vertex_normals()
+                    if len(meshinfo.mesh.vertex_colors) == 0:
+                        meshinfo.mesh.paint_uniform_color([1, 1, 1])
+                for meshinfo in model.meshes:
+                    geometries.append(
+                        (meshinfo.mesh_name, meshinfo.mesh, model.materials[meshinfo.material_idx]))
             # Make sure the mesh has texture coordinates
-            if not mesh.has_triangle_uvs():
-                uv = np.array([[0.0, 0.0]] * (3 * len(mesh.triangles)))
-                mesh.triangle_uvs = o3d.utility.Vector2dVector(uv)
+            for meshinfo in model.meshes:
+                if not meshinfo.mesh.has_triangle_uvs():
+                    uv = np.array([[0.0, 0.0]] * (3 * len(meshinfo.mesh.triangles)))
+                    meshinfo.mesh.triangle_uvs = o3d.utility.Vector2dVector(uv)
         else:
             print("[Info]", path, "appears to be a point cloud")
 
-        if geometry is None:
+        if len(geometries) == 0:
             cloud = None
             try:
                 cloud = o3d.io.read_point_cloud(path)
@@ -756,15 +763,16 @@ class AppWindow:
                 if not cloud.has_normals():
                     cloud.estimate_normals()
                 cloud.normalize_normals()
-                geometry = cloud
+                geometries.append(("__model__", cloud, self.settings.material))
             else:
                 print("[WARNING] Failed to read points", path)
 
-        if geometry is not None:
+        if len(geometries) != 0:
             try:
-                self._scene.scene.add_geometry("__model__", geometry,
-                                               self.settings.material)
-                bounds = geometry.get_axis_aligned_bounding_box()
+                for (name, geometry, material) in geometries:
+                    material.shader = "defaultLit"
+                    self._scene.scene.add_geometry(name, geometry, material)
+                bounds = self._scene.scene.bounding_box
                 self._scene.setup_camera(60, bounds, bounds.get_center())
             except Exception as e:
                 print(e)

--- a/python/open3d/visualization/app/__init__.py
+++ b/python/open3d/visualization/app/__init__.py
@@ -1,0 +1,36 @@
+# ----------------------------------------------------------------------------
+# -                        Open3D: www.open3d.org                            -
+# ----------------------------------------------------------------------------
+# The MIT License (MIT)
+#
+# Copyright (c) 2018-2021 www.open3d.org
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ----------------------------------------------------------------------------
+"""Functionality for running Open3D viewer."""
+
+if "@BUILD_GUI@" == "ON":
+    import open3d
+    if open3d.__DEVICE_API__ == 'cuda':
+        from open3d.cuda.pybind.visualization.app import *
+    else:
+        from open3d.cpu.pybind.visualization.app import *
+else:
+    print("Open3D was not compiled with BUILD_GUI, but script is importing "
+          "open3d.visualization.app")

--- a/python/tools/app.py
+++ b/python/tools/app.py
@@ -35,8 +35,6 @@ def main():
         args.append(sys.argv[1])
     o3d.visualization.app.run_viewer(args)
 
-    o3d.utility.reset_print_function()
-
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/python/tools/app.py
+++ b/python/tools/app.py
@@ -37,4 +37,4 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/python/tools/app.py
+++ b/python/tools/app.py
@@ -28,6 +28,7 @@ import open3d as o3d
 import os
 import sys
 
+
 def main():
     args = [os.path.abspath(__file__)]
     if len(sys.argv) > 1:
@@ -36,5 +37,6 @@ def main():
 
     o3d.utility.reset_print_function()
 
-if __name__=="__main__":
+
+if __name__ == "__main__":
     sys.exit(main())

--- a/python/tools/app.py
+++ b/python/tools/app.py
@@ -1,0 +1,40 @@
+# ----------------------------------------------------------------------------
+# -                        Open3D: www.open3d.org                            -
+# ----------------------------------------------------------------------------
+# The MIT License (MIT)
+#
+# Copyright (c) 2018-2021 www.open3d.org
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ----------------------------------------------------------------------------
+
+import open3d as o3d
+import os
+import sys
+
+def main():
+    args = [os.path.abspath(__file__)]
+    if len(sys.argv) > 1:
+        args.append(sys.argv[1])
+    o3d.visualization.app.run_viewer(args)
+
+    o3d.utility.reset_print_function()
+
+if __name__=="__main__":
+    sys.exit(main())


### PR DESCRIPTION
Python wrapper for the Open3D Viewer can be used like this:

```python
import open3d.app as app
app.main()
```
or by running 
```python
o3d.visualization.app.run_viewer(args)
```
The second way of running viewer is not meant to be used by the user as `args` should be of the format:
```python
args = ["path/to/open3d_python_installation/app.py", "path/to/mesh_or_ptcloud.file"]
```

Mesh or pointcloud files as arguments to the python wrapper for Open3D Viewer will be made available for the user in the command line interface PR #4594.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4586)
<!-- Reviewable:end -->
