### PR TITLE
fix selection lines are drawn without offset of frame topleft in SceneWidget on non-Mac system

### DIFF
--- a/cpp/open3d/visualization/gui/SceneWidget.cpp
+++ b/cpp/open3d/visualization/gui/SceneWidget.cpp
@@ -1172,8 +1172,8 @@ Widget::DrawResult SceneWidget::Draw(const DrawContext& context) {
         for (size_t i = 0; i < impl_->ui_lines_.size() - 1; i += 2) {
             auto& p0 = impl_->ui_lines_[i];
             auto& p1 = impl_->ui_lines_[i + 1];
-            draw_list->AddLine({float(p0.x()+f.x), float(p0.y()+f.y)},
-                               {float(p1.x()+f.x), float(p1.y()+f.y)},
+            draw_list->AddLine({float(p0.x() + f.x), float(p0.y() + f.y)},
+                               {float(p1.x() + f.x), float(p1.y() + f.y)},
                                ui_color, 2);
         }
     }

--- a/cpp/open3d/visualization/gui/SceneWidget.cpp
+++ b/cpp/open3d/visualization/gui/SceneWidget.cpp
@@ -1172,8 +1172,9 @@ Widget::DrawResult SceneWidget::Draw(const DrawContext& context) {
         for (size_t i = 0; i < impl_->ui_lines_.size() - 1; i += 2) {
             auto& p0 = impl_->ui_lines_[i];
             auto& p1 = impl_->ui_lines_[i + 1];
-            draw_list->AddLine({float(p0.x()), float(p0.y())},
-                               {float(p1.x()), float(p1.y())}, ui_color, 2);
+            draw_list->AddLine({float(p0.x()+f.x), float(p0.y()+f.y)},
+                               {float(p1.x()+f.x), float(p1.y()+f.y)},
+                               ui_color, 2);
         }
     }
 


### PR DESCRIPTION
While points are picked by SceneWidget mouse interactors and reported to UI, their coordinates are based on the frame's topleft. But when SceneWidget draws those lines by imgui, the points coordinates are  based on Window's topleft.

In Mac, it works because menu bar is not integrated by Window, but in other systems the lines are drawn above the correct position because the menu bar height is not considered.

This video shows the problem:

https://user-images.githubusercontent.com/18083216/149350936-4d60972c-385e-47a2-b112-c69ccb73b3b7.mp4

and this video shows what this PR does:

https://user-images.githubusercontent.com/18083216/149351025-f3f43738-f888-4dde-9064-122b5a6bd27f.mp4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4593)
<!-- Reviewable:end -->
