### PR TITLE
fix bug in AddTrianglesByEarClipping where not the whole poly was searched for ears

### DIFF
--- a/cpp/open3d/io/TriangleMeshIO.cpp
+++ b/cpp/open3d/io/TriangleMeshIO.cpp
@@ -212,7 +212,7 @@ bool AddTrianglesByEarClipping(geometry::TriangleMesh &mesh,
         }
 
         found_ear = false;
-        for (int i = 1; i < n - 2; i++) {
+        for (int i = 1; i < n - 1; i++) {
             const Eigen::Vector3d &v1 =
                     mesh.vertices_[indices[i]] - mesh.vertices_[indices[i - 1]];
             const Eigen::Vector3d &v2 =

--- a/cpp/tests/io/TriangleMeshIO.cpp
+++ b/cpp/tests/io/TriangleMeshIO.cpp
@@ -24,6 +24,8 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
+#include "open3d/io/TriangleMeshIO.h"
+
 #include "tests/Tests.h"
 
 namespace open3d {
@@ -38,6 +40,33 @@ TEST(TriangleMeshIO, DISABLED_WriteTriangleMesh) { NotImplemented(); }
 TEST(TriangleMeshIO, DISABLED_ReadTriangleMeshFromPLY) { NotImplemented(); }
 
 TEST(TriangleMeshIO, DISABLED_WriteTriangleMeshToPLY) { NotImplemented(); }
+
+TEST(TriangleMeshIO, AddTrianglesByEarClippingNonconvexPoly) {
+    // This test checks if a bug in AddTrianglesByEarClipping() is fixed.
+
+    auto poly = std::make_shared<geometry::TriangleMesh>();
+    poly->vertices_.resize(5);
+
+    //  1      3
+    //  |\    /|
+    //  | \2 / |    y
+    //  |  \/  |    |
+    //  |______|    /-- x
+    //  0      4   z
+    Eigen::Vector3d v1(0., 0., 0.);
+    Eigen::Vector3d v2(0., 2., 0.);
+    Eigen::Vector3d v3(1., 1., 0.);
+    Eigen::Vector3d v4(2., 2., 0.);
+    Eigen::Vector3d v5(2., 0., 0.);
+    poly->vertices_[0] = v1;
+    poly->vertices_[1] = v2;
+    poly->vertices_[2] = v3;
+    poly->vertices_[3] = v4;
+    poly->vertices_[4] = v5;
+    std::vector<unsigned int> indices{0, 1, 2, 3, 4};
+
+    EXPECT_TRUE(io::AddTrianglesByEarClipping(*poly, indices));
+}
 
 }  // namespace tests
 }  // namespace open3d


### PR DESCRIPTION
This PR addresses issue #2632 

Not the whole polygon was searched for ears, which lets the algorithm give up too early on the polygon in #2632.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4609)
<!-- Reviewable:end -->
