### PR TITLE
build openblas with cmake instead of gnu make

### DIFF
--- a/3rdparty/openblas/openblas.cmake
+++ b/3rdparty/openblas/openblas.cmake
@@ -8,7 +8,7 @@ else()
     set(OPENBLAS_TARGET "NEHALEM")
 endif()
 
-set(OPENBLAS_INCLUDE_DIR "${OPENBLAS_INSTALL_PREFIX}/include/") # The "/"" is critical, see open3d_import_3rdparty_library.
+set(OPENBLAS_INCLUDE_DIR "${OPENBLAS_INSTALL_PREFIX}/include/openblas/") # The "/"" is critical, see open3d_import_3rdparty_library.
 set(OPENBLAS_LIB_DIR "${OPENBLAS_INSTALL_PREFIX}/lib")
 set(OPENBLAS_LIBRARIES openblas)  # Extends to libopenblas.a automatically.
 
@@ -18,12 +18,10 @@ ExternalProject_Add(
     URL https://github.com/xianyi/OpenBLAS/archive/refs/tags/v0.3.18.tar.gz
     URL_HASH SHA256=1632c1e8cca62d8bed064b37747e331a1796fc46f688626337362bf0d16aeadb
     DOWNLOAD_DIR "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/openblas"
-    UPDATE_COMMAND ""
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND $(MAKE) CC="${CMAKE_C_COMPILER}" TARGET=${OPENBLAS_TARGET} NO_SHARED=1 LIBNAME=CUSTOM_LIB_NAME
-    BUILD_IN_SOURCE True
-    INSTALL_COMMAND $(MAKE) install PREFIX=${OPENBLAS_INSTALL_PREFIX} NO_SHARED=1 LIBNAME=CUSTOM_LIB_NAME
-    COMMAND ${CMAKE_COMMAND} -E rename ${OPENBLAS_LIB_DIR}/CUSTOM_LIB_NAME ${OPENBLAS_LIB_DIR}/libopenblas.a
+    CMAKE_ARGS
+        ${ExternalProject_CMAKE_ARGS}
+        -DTARGET=${OPENBLAS_TARGET}
+        -DCMAKE_INSTALL_PREFIX=${OPENBLAS_INSTALL_PREFIX}
     BUILD_BYPRODUCTS ${OPENBLAS_LIB_DIR}/libopenblas.a
 )
 

--- a/3rdparty/openblas/openblas.cmake
+++ b/3rdparty/openblas/openblas.cmake
@@ -15,8 +15,8 @@ set(OPENBLAS_LIBRARIES openblas)  # Extends to libopenblas.a automatically.
 ExternalProject_Add(
     ext_openblas
     PREFIX openblas
-    URL https://github.com/xianyi/OpenBLAS/archive/refs/tags/v0.3.18.tar.gz
-    URL_HASH SHA256=1632c1e8cca62d8bed064b37747e331a1796fc46f688626337362bf0d16aeadb
+    URL https://github.com/xianyi/OpenBLAS/releases/download/v0.3.19/OpenBLAS-0.3.19.tar.gz
+    URL_HASH SHA256=947f51bfe50c2a0749304fbe373e00e7637600b0a47b78a51382aeb30ca08562
     DOWNLOAD_DIR "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/openblas"
     CMAKE_ARGS
         ${ExternalProject_CMAKE_ARGS}


### PR DESCRIPTION
Advantages:
- We pass `ExternalProject_CMAKE_ARGS`, such that the cache info can be used by OpenBLAS build. According to my local test, all C compilations are cached. Fortran compilations are not cached, but they compile relatively fast. 
- Potential cross-platform support for Windows (not verified).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4621)
<!-- Reviewable:end -->
