### PR TITLE
support F1~F12 keys definitions

### DIFF
--- a/cpp/open3d/visualization/gui/Events.h
+++ b/cpp/open3d/visualization/gui/Events.h
@@ -204,6 +204,18 @@ enum KeyName {
     KEY_END,
     KEY_PAGEUP,
     KEY_PAGEDOWN,
+    KEY_F1 = 290,
+    KEY_F2,
+    KEY_F3,
+    KEY_F4,
+    KEY_F5,
+    KEY_F6,
+    KEY_F7,
+    KEY_F8,
+    KEY_F9,
+    KEY_F10,
+    KEY_F11,
+    KEY_F12,
     KEY_UNKNOWN = 1000
 };
 

--- a/cpp/pybind/visualization/gui/events.cpp
+++ b/cpp/pybind/visualization/gui/events.cpp
@@ -265,6 +265,18 @@ void pybind_gui_events(py::module& m) {
             .value("END", KeyName::KEY_END)
             .value("PAGE_UP", KeyName::KEY_PAGEUP)
             .value("PAGE_DOWN", KeyName::KEY_PAGEDOWN)
+            .value("F1", KeyName::KEY_F1)
+            .value("F2", KeyName::KEY_F2)
+            .value("F3", KeyName::KEY_F3)
+            .value("F4", KeyName::KEY_F4)
+            .value("F5", KeyName::KEY_F5)
+            .value("F6", KeyName::KEY_F6)
+            .value("F7", KeyName::KEY_F7)
+            .value("F8", KeyName::KEY_F8)
+            .value("F9", KeyName::KEY_F9)
+            .value("F10", KeyName::KEY_F10)
+            .value("F11", KeyName::KEY_F11)
+            .value("F12", KeyName::KEY_F12)
             .value("UNKNOWN", KeyName::KEY_UNKNOWN)
             .export_values();
 


### PR DESCRIPTION
Add F1 ~ F12 definition so that it could be processed by python key callbacks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4666)
<!-- Reviewable:end -->
