### PR TITLE
automatically cancel concurrent workflows

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,6 +14,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   GCE_CLI_GHA_VERSION: '302.0.0'      # Fixed to avoid dependency on API changes
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -29,11 +29,6 @@ jobs:
       OPEN3D_ML_ROOT: ${{ github.workspace }}/Open3D-ML
       DEVELOPER_BUILD: ${{ github.event.inputs.developer_build || 'ON' }}
     steps:
-      - name: Cancel outdated
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          github_token: ${{ github.token }}
-
       - name: Checkout Open3D source code
         uses: actions/checkout@v2
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -7,7 +7,6 @@ on:
         description: 'Set to OFF for Release documentation'
         required: false
         default: 'ON'
-
   push:
     branches:
       - master

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,11 +36,6 @@ jobs:
       BUILD_PYTORCH_OPS: ${{ matrix.CONFIG }}
       LOW_MEM_USAGE: ON
     steps:
-      - name: Cancel outdated
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          github_token: ${{ github.token }}
-
       - name: Checkout source code
         uses: actions/checkout@v2
       - name: Setup cache

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,6 +14,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]  # Rebuild on new pushes to PR
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
   NPROC: 3

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize] # Rebuild on new pushes to PR
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   style-check:
     runs-on: ubuntu-20.04     # No need for cmake repo

--- a/.github/workflows/ubuntu-cuda.yml
+++ b/.github/workflows/ubuntu-cuda.yml
@@ -13,6 +13,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   GCE_GPU_CI_SA: ${{ secrets.GCE_GPU_CI_SA }}
   GCE_CLI_GHA_VERSION: "302.0.0"

--- a/.github/workflows/ubuntu-openblas.yml
+++ b/.github/workflows/ubuntu-openblas.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   GCE_CLI_GHA_VERSION: '302.0.0'      # Fixed to avoid dependency on API changes
 

--- a/.github/workflows/ubuntu-openblas.yml
+++ b/.github/workflows/ubuntu-openblas.yml
@@ -21,10 +21,6 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - name: Cancel outdated
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          github_token: ${{ github.token }}
       - name: Checkout source code
         uses: actions/checkout@v2
       - name: Maximize build space
@@ -64,10 +60,6 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - name: Cancel outdated
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          github_token: ${{ github.token }}
       - name: Checkout source code
         uses: actions/checkout@v2
       - name: Maximize build space

--- a/.github/workflows/ubuntu-wheel.yml
+++ b/.github/workflows/ubuntu-wheel.yml
@@ -13,6 +13,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-wheel:
     name: Build wheel

--- a/.github/workflows/ubuntu-wheel.yml
+++ b/.github/workflows/ubuntu-wheel.yml
@@ -39,10 +39,6 @@ jobs:
       PYTHON_VERSION: ${{ matrix.python_version }}
       CCACHE_TAR_NAME: open3d-ubuntu-1804-cuda-ci-ccache
     steps:
-      - name: Cancel outdated
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          github_token: ${{ github.token }}
       - name: Checkout source code
         uses: actions/checkout@v2
       - name: Maximize build space

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -22,7 +22,6 @@ env:
   NPROC: 2
   GCE_CLI_GHA_VERSION: "302.0.0"
 
-
 jobs:
   ubuntu:
     runs-on: ubuntu-18.04

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -41,11 +41,6 @@ jobs:
       BUILD_PYTORCH_OPS: ${{ matrix.MLOPS }}
       DEVELOPER_BUILD: ${{ github.event.inputs.developer_build || 'ON' }}
     steps:
-      - name: Cancel outdated
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          github_token: ${{ github.token }}
-
       - name: Checkout source code
         uses: actions/checkout@v2
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -14,6 +14,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]  # Rebuild on new pushes to PR
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   NPROC: 2
   GCE_CLI_GHA_VERSION: "302.0.0"

--- a/.github/workflows/webrtc.yml
+++ b/.github/workflows/webrtc.yml
@@ -72,7 +72,6 @@ jobs:
                  checksum_*.txt
           if-no-files-found: error
 
-
   Windows:
     # https://chromium.googlesource.com/chromium/src/+/HEAD/docs/windows_build_instructions.md
     runs-on: windows-latest

--- a/.github/workflows/webrtc.yml
+++ b/.github/workflows/webrtc.yml
@@ -12,6 +12,10 @@ on:
         required: false
         default: 'e1a98941d3ab10549be6d82d0686bb0fb91ec903' # Date: Wed Apr 7 21:35:29 2021 +0000
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   WEBRTC_COMMIT: ${{ github.event.inputs.webrtc_commit }}
   DEPOT_TOOLS_COMMIT: ${{ github.event.inputs.depot_tools_commit }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -53,11 +53,6 @@ jobs:
       BUILD_WEBRTC: ${{ ( matrix.SHARED == 'OFF' && matrix.STATIC_RUNTIME == 'ON' ) && 'ON' || 'OFF' }}
 
     steps:
-      - name: Cancel outdated
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          github_token: ${{ github.token }}
-
       - name: Disk space used
         run: Get-PSDrive
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,6 +14,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize] # Rebuild on new pushes to PR
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   PIP_VER: "21.1.1"
   WHEEL_VER: "0.35.1"


### PR DESCRIPTION
- This works on PR
- This shall also work on master, as `github.event.pull_request.number` is undefined, and we'll fall back to `github.ref`
- `github.workflow` is needed since we have multiple workflows PR

Ref:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
https://github.com/TeamAmaze/AmazeFileManager/blob/release/3.7/.github/workflows/android-feature.yml

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4684)
<!-- Reviewable:end -->
