### PR TITLE
Fix sample code in docstring for tensor pc, mesh, & lineset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Python 3.9 support. Tensorflow bump 2.4.1 -> 2.5.0. PyTorch bump 1.7.1 -> 1.8.1 (LTS)
 * Fix undefined names: docstr and VisibleDeprecationWarning (PR #3844)
+* Corrected documentation for Tensor based PointClound, LineSet, TriangleMesh (PR #4685)
 
 ## 0.13
 

--- a/cpp/pybind/t/geometry/lineset.cpp
+++ b/cpp/pybind/t/geometry/lineset.cpp
@@ -77,7 +77,7 @@ The attributes of the line set have different levels::
     # "color", some internal operations that expects "colors" will not work.
     # "colors" must have shape (N, 3) and must be on the same device as the
     # line set.
-    lineset.line["colors"] = o3c.core.Tensor([[0.0, 0.0, 0.0],
+    lineset.line["colors"] = o3d.core.Tensor([[0.0, 0.0, 0.0],
                                               [0.1, 0.1, 0.1],
                                               [0.2, 0.2, 0.2],
                                               [0.3, 0.3, 0.3]], dtype_f, device)
@@ -86,8 +86,8 @@ The attributes of the line set have different levels::
     # You can also attach custom attributes. The value tensor must be on the
     # same device as the line set. The are no restrictions on the shape or
     # dtype, e.g.,
-    pcd.point["labels"] = o3c.core.Tensor(...)
-    pcd.line["features"] = o3c.core.Tensor(...)
+    pcd.point["labels"] = o3d.core.Tensor(...)
+    pcd.line["features"] = o3d.core.Tensor(...)
 )");
 
     // Constructors.

--- a/cpp/pybind/t/geometry/pointcloud.cpp
+++ b/cpp/pybind/t/geometry/pointcloud.cpp
@@ -110,7 +110,7 @@ The attributes of the point cloud have different levels::
     # same device as the point cloud. The are no restrictions on the shape and
     # dtype, e.g.,
     pcd.point["intensities"] = o3d.core.Tensor([0.3, 0.1, 0.4], dtype, device)
-    pcd.point["lables"] = o3d.core.Tensor([3, 1, 4], o3d.core.int32, device)
+    pcd.point["labels"] = o3d.core.Tensor([3, 1, 4], o3d.core.int32, device)
 )");
 
     // Constructors.

--- a/cpp/pybind/t/geometry/pointcloud.cpp
+++ b/cpp/pybind/t/geometry/pointcloud.cpp
@@ -98,10 +98,10 @@ The attributes of the point cloud have different levels::
     # "normals", some internal operations that expects "normals" will not work.
     # "normals" and "colors" must have shape (N, 3) and must be on the same
     # device as the point cloud.
-    pcd.point["normals"] = o3c.core.Tensor([[0, 0, 1],
+    pcd.point["normals"] = o3d.core.Tensor([[0, 0, 1],
                                             [0, 1, 0],
                                             [1, 0, 0]], dtype, device)
-    pcd.point["normals"] = o3c.core.Tensor([[0.0, 0.0, 0.0],
+    pcd.point["normals"] = o3d.core.Tensor([[0.0, 0.0, 0.0],
                                             [0.1, 0.1, 0.1],
                                             [0.2, 0.2, 0.2]], dtype, device)
 
@@ -109,8 +109,8 @@ The attributes of the point cloud have different levels::
     # You can also attach custom attributes. The value tensor must be on the
     # same device as the point cloud. The are no restrictions on the shape and
     # dtype, e.g.,
-    pcd.point["intensities"] = o3c.core.Tensor([0.3, 0.1, 0.4], dtype, device)
-    pcd.point["lables"] = o3c.core.Tensor([3, 1, 4], o3d.core.int32, device)
+    pcd.point["intensities"] = o3d.core.Tensor([0.3, 0.1, 0.4], dtype, device)
+    pcd.point["lables"] = o3d.core.Tensor([3, 1, 4], o3d.core.int32, device)
 )");
 
     // Constructors.

--- a/cpp/pybind/t/geometry/pointcloud.cpp
+++ b/cpp/pybind/t/geometry/pointcloud.cpp
@@ -101,7 +101,7 @@ The attributes of the point cloud have different levels::
     pcd.point["normals"] = o3d.core.Tensor([[0, 0, 1],
                                             [0, 1, 0],
                                             [1, 0, 0]], dtype, device)
-    pcd.point["normals"] = o3d.core.Tensor([[0.0, 0.0, 0.0],
+    pcd.point["colors"] = o3d.core.Tensor([[0.0, 0.0, 0.0],
                                             [0.1, 0.1, 0.1],
                                             [0.2, 0.2, 0.2]], dtype, device)
 

--- a/cpp/pybind/t/geometry/trianglemesh.cpp
+++ b/cpp/pybind/t/geometry/trianglemesh.cpp
@@ -76,23 +76,23 @@ The attributes of the triangle mesh have different levels::
     # "normals", some internal operations that expects "normals" will not work.
     # "normals" and "colors" must have shape (N, 3) and must be on the same
     # device as the triangle mesh.
-    mesh.vertex["normals"] = o3c.core.Tensor([[0, 0, 1],
+    mesh.vertex["normals"] = o3d.core.Tensor([[0, 0, 1],
                                               [0, 1, 0],
                                               [1, 0, 0],
                                               [1, 1, 1]], dtype_f, device)
-    mesh.vertex["colors"] = o3c.core.Tensor([[0.0, 0.0, 0.0],
+    mesh.vertex["colors"] = o3d.core.Tensor([[0.0, 0.0, 0.0],
                                              [0.1, 0.1, 0.1],
                                              [0.2, 0.2, 0.2],
                                              [0.3, 0.3, 0.3]], dtype_f, device)
-    mesh.triangle["normals"] = o3c.core.Tensor(...)
-    mesh.triangle["colors"] = o3c.core.Tensor(...)
+    mesh.triangle["normals"] = o3d.core.Tensor(...)
+    mesh.triangle["colors"] = o3d.core.Tensor(...)
 
     # User-defined attributes
     # You can also attach custom attributes. The value tensor must be on the
     # same device as the triangle mesh. The are no restrictions on the shape and
     # dtype, e.g.,
-    pcd.vertex["labels"] = o3c.core.Tensor(...)
-    pcd.triangle["features"] = o3c.core.Tensor(...)
+    pcd.vertex["labels"] = o3d.core.Tensor(...)
+    pcd.triangle["features"] = o3d.core.Tensor(...)
 )");
 
     // Constructors.


### PR DESCRIPTION
- The examples in o3d.t.geometry [PointCloud](http://www.open3d.org/docs/release/python_api/open3d.t.geometry.PointCloud.html#open3d.t.geometry.PointCloud), [LineSet](http://www.open3d.org/docs/release/python_api/open3d.t.geometry.LineSet.html#open3d.t.geometry.LineSet), [TriangleMesh](http://www.open3d.org/docs/release/python_api/open3d.t.geometry.TriangleMesh.html#open3d.t.geometry.TriangleMesh) wrote `o3c.core` instead of `o3d.core`.

- Also it seems that in the example in PointCloud the comment seems to suggest:
```python
# Common attributes: "normals", "colors".
# Common attributes are used in built-in point cloud operations. The
# spellings must be correct. For example, if "normal" is used instead of
# "normals", some internal operations that expects "normals" will not work.
# "normals" and "colors" must have shape (N, 3) and must be on the same
# device as the point cloud.
pcd.point["normals"] = o3d.core.Tensor([[0, 0, 1],
                                        [0, 1, 0],
                                        [1, 0, 0]], dtype, device)
pcd.point["colors"] = o3d.core.Tensor([[0.0, 0.0, 0.0],
                                        [0.1, 0.1, 0.1],
                                        [0.2, 0.2, 0.2]], dtype, device)
```
instead of:
```python
pcd.point["normals"] = o3d.core.Tensor([[0, 0, 1],
                                        [0, 1, 0],
                                        [1, 0, 0]], dtype, device)
pcd.point["normals"] = o3d.core.Tensor([[0.0, 0.0, 0.0],
                                        [0.1, 0.1, 0.1],
                                        [0.2, 0.2, 0.2]], dtype, device)
```
- Also label is misspelled on the PointCloud example

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4685)
<!-- Reviewable:end -->
