### PR TITLE
fix list view draws in incorrect position while scroll is triggered

### DIFF
--- a/cpp/open3d/visualization/gui/ListView.cpp
+++ b/cpp/open3d/visualization/gui/ListView.cpp
@@ -111,13 +111,13 @@ Size ListView::CalcPreferredSize(const LayoutContext &context,
         // at most max_visible_item_ items.
         h = std::max((int)impl_->items_.size(), g_min_visible_items);
         h = std::min(h, impl_->max_visible_item_);
-        h = int(std::ceil((float)h * fh + 2.0f * padding.y));
+        h = int(std::ceil((float)h * fh));
     }
     return Size{int(std::ceil(size.x + 2.0f * padding.x)), h};
 }
 
 Size ListView::CalcMinimumSize(const LayoutContext &context) const {
-    return Size(0, impl_->max_visible_item_ * context.theme.font_size);
+    return Size(0, g_min_visible_items * context.theme.font_size);
 }
 
 Widget::DrawResult ListView::Draw(const DrawContext &context) {

--- a/cpp/open3d/visualization/gui/ListView.cpp
+++ b/cpp/open3d/visualization/gui/ListView.cpp
@@ -123,7 +123,7 @@ Size ListView::CalcMinimumSize(const LayoutContext &context) const {
 Widget::DrawResult ListView::Draw(const DrawContext &context) {
     auto &frame = GetFrame();
     ImGui::SetCursorScreenPos(
-            ImVec2(float(frame.x), float(frame.y) + ImGui::GetScrollY()));
+            ImVec2(float(frame.x), float(frame.y) - ImGui::GetScrollY()));
     ImGui::PushItemWidth(float(frame.width));
 
     ImGui::PushStyleColor(ImGuiCol_FrameBg,


### PR DESCRIPTION
while Vert contains too long content and scroll bar is triggered, a ListView child will be drawn in incorrect y position:

https://user-images.githubusercontent.com/18083216/152144815-bae6718d-ee89-41d6-8da2-b927c1c16d17.mov


And this is the correct behavior:

https://user-images.githubusercontent.com/18083216/152144932-1244a362-f6d5-451d-9a9b-d674d6e6de1a.mov

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4686)
<!-- Reviewable:end -->
