### PR TITLE
rename CopyFile to Copy to avoid conflict with windows headers

### DIFF
--- a/cpp/open3d/data/Dataset.cpp
+++ b/cpp/open3d/data/Dataset.cpp
@@ -84,8 +84,8 @@ SingleDownloadDataset::SingleDownloadDataset(
         } else {
             utility::filesystem::MakeDirectoryHierarchy(
                     Dataset::GetExtractDir());
-            utility::filesystem::CopyFile(download_file_path,
-                                          Dataset::GetExtractDir());
+            utility::filesystem::Copy(download_file_path,
+                                      Dataset::GetExtractDir());
         }
     }
 }

--- a/cpp/open3d/utility/FileSystem.cpp
+++ b/cpp/open3d/utility/FileSystem.cpp
@@ -278,7 +278,7 @@ bool FileExists(const std::string &filename) {
     return fs::exists(filename) && fs::is_regular_file(filename);
 }
 
-bool CopyFile(const std::string &src_path, const std::string &dst_path) {
+bool Copy(const std::string &src_path, const std::string &dst_path) {
     try {
         fs::copy(src_path, dst_path,
                  fs::copy_options::recursive |

--- a/cpp/open3d/utility/FileSystem.h
+++ b/cpp/open3d/utility/FileSystem.h
@@ -78,7 +78,7 @@ bool DeleteDirectory(const std::string &directory);
 
 bool FileExists(const std::string &filename);
 
-bool CopyFile(const std::string &src_path, const std::string &dst_path);
+bool Copy(const std::string &src_path, const std::string &dst_path);
 
 bool RemoveFile(const std::string &filename);
 


### PR DESCRIPTION
Windows 11 + VS 2019
```
C:\Users\yixing\repo\Open3D\cpp\open3d\data\Dataset.cpp(87,34): error C2039:
'CopyFileA': is not a member of 'open3d::utility::filesystem' [C:\Users\yixin
g\repo\Open3D\build\cpp\open3d\data\data.vcxproj]
C:\Users\yixing\repo\Open3D\cpp\open3d/utility/FileSystem.h(35): message : se
e declaration of 'open3d::utility::filesystem' [C:\Users\yixing\repo\Open3D\b
uild\cpp\open3d\data\data.vcxproj]
C:\Users\yixing\repo\Open3D\cpp\open3d\data\Dataset.cpp(87,42): error C2660:
'CopyFileA': function does not take 2 arguments [C:\Users\yixing\repo\Open3D\
build\cpp\open3d\data\data.vcxproj]
C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\um\winbase.h(5546
,1): message : see declaration of 'CopyFileA' [C:\Users\yixing\repo\Open3D\bu
ild\cpp\open3d\data\data.vcxproj]
```

and in the windows header, we have:
```
#if UNICODE
#define CopyFile CopyFileW
#else
#define CopyFile CopyFileA
#endif
```

It's not the most elegant solution, we can revisit this when we refactor the code to fully use `std::filesystem`.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4691)
<!-- Reviewable:end -->
