### PR TITLE
CompilerInfo to print cxx standard and compiler name/version

### DIFF
--- a/cpp/benchmarks/Main.cpp
+++ b/cpp/benchmarks/Main.cpp
@@ -42,6 +42,7 @@
 #include "open3d/Open3D.h"
 
 int main(int argc, char** argv) {
+    open3d::utility::CompilerInfo::GetInstance().Print();
     open3d::utility::CPUInfo::GetInstance().Print();
     open3d::utility::ISAInfo::GetInstance().Print();
     benchmark::Initialize(&argc, argv);

--- a/cpp/open3d/Open3D.h.in
+++ b/cpp/open3d/Open3D.h.in
@@ -103,6 +103,7 @@
 #include "open3d/t/pipelines/slam/Frame.h"
 #include "open3d/t/pipelines/slam/Model.h"
 #include "open3d/utility/CPUInfo.h"
+#include "open3d/utility/CompilerInfo.h"
 #include "open3d/utility/Console.h"
 #include "open3d/utility/DataManager.h"
 #include "open3d/utility/Eigen.h"

--- a/cpp/open3d/utility/CMakeLists.txt
+++ b/cpp/open3d/utility/CMakeLists.txt
@@ -1,12 +1,13 @@
 open3d_ispc_add_library(utility OBJECT)
 
 target_sources(utility PRIVATE
+    CompilerInfo.cpp
     Console.cpp
     CPUInfo.cpp
     Download.cpp
+    Eigen.cpp
     Extract.cpp
     ExtractZIP.cpp
-    Eigen.cpp
     FileSystem.cpp
     Helper.cpp
     IJsonConvertible.cpp
@@ -15,8 +16,13 @@ target_sources(utility PRIVATE
     Parallel.cpp
     ProgressBar.cpp
     Timer.cpp
-
 )
+
+if (BUILD_CUDA_MODULE)
+    target_sources(utility PRIVATE
+        CompilerInfo.cu
+    )
+endif()
 
 if (BUILD_ISPC_MODULE)
     target_sources(utility PRIVATE

--- a/cpp/open3d/utility/CompilerInfo.cpp
+++ b/cpp/open3d/utility/CompilerInfo.cpp
@@ -1,0 +1,102 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "open3d/utility/CompilerInfo.h"
+
+#include <fmt/format.h>
+
+#include <memory>
+#include <string>
+
+#include "open3d/utility/Helper.h"
+#include "open3d/utility/Logging.h"
+
+namespace open3d {
+namespace utility {
+
+CompilerInfo::CompilerInfo() {}
+
+CompilerInfo& CompilerInfo::GetInstance() {
+    static CompilerInfo instance;
+    return instance;
+}
+
+std::string CompilerInfo::CxxCompilerName() const {
+#if defined(__clang__)
+    return "clang";
+#elif defined(__GNUC__)
+    return "gcc";
+#elif defined(_MSC_VER)
+    return "msvc";
+#else
+    return "unknown";
+#endif
+}
+
+std::string CompilerInfo::CxxCompilerVersion() const {
+#if defined(__clang__)
+    return fmt::format("{}.{}.{}", __clang_major__, __clang_minor__,
+                       __clang_patchlevel__);
+#elif defined(__GNUC__)
+    return fmt::format("{}.{}.{}", __GNUC__, __GNUC_MINOR__,
+                       __GNUC_PATCHLEVEL__);
+#elif defined(_MSC_VER)
+    return fmt::format("{}", MSVC_VERSION);
+#else
+    return "unknown";
+#endif
+}
+
+#ifdef BUILD_CUDA_MODULE
+// See CompilerInfo.cu
+#else
+std::string CompilerInfo::CUDACompilerVersion() const { return "disabled"; }
+#endif
+
+std::string CompilerInfo::CxxStandard() const {
+    if (__cplusplus == 202002L) {
+        return "20";
+    } else if (__cplusplus == 201703L) {
+        return "17";
+    } else if (__cplusplus == 201402L) {
+        return "14";
+    } else if (__cplusplus == 201103L) {
+        return "11";
+    } else if (__cplusplus == 199711L) {
+        return "98";
+    } else {
+        return "unknown";
+    }
+}
+
+void CompilerInfo::Print() const {
+    utility::LogInfo("CompilerInfo: C++{}, {} {}, nvcc {}.", CxxStandard(),
+                     CxxCompilerName(), CxxCompilerVersion(),
+                     CUDACompilerVersion());
+}
+
+}  // namespace utility
+}  // namespace open3d

--- a/cpp/open3d/utility/CompilerInfo.cu
+++ b/cpp/open3d/utility/CompilerInfo.cu
@@ -24,48 +24,22 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
+#include <fmt/format.h>
 
-#include <cstring>
+#include <memory>
 #include <string>
 
-#ifdef BUILD_CUDA_MODULE
-#include "open3d/core/CUDAUtils.h"
-#endif
+#include "open3d/utility/CompilerInfo.h"
 
-#include "open3d/Open3D.h"
-#include "tests/Tests.h"
+namespace open3d {
+namespace utility {
 
 #ifdef BUILD_CUDA_MODULE
-/// Returns true if --disable_p2p flag is used.
-bool ShallDisableP2P(int argc, char** argv) {
-    bool shall_disable_p2p = false;
-    for (int i = 1; i < argc; ++i) {
-        if (std::strcmp(argv[i], "--disable_p2p") == 0) {
-            shall_disable_p2p = true;
-            break;
-        }
-    }
-    return shall_disable_p2p;
+std::string CompilerInfo::CUDACompilerVersion() const {
+    return fmt::format("{}.{}.{}", __CUDACC_VER_MAJOR__, __CUDACC_VER_MINOR__,
+                       __CUDACC_VER_BUILD__);
 }
 #endif
 
-int main(int argc, char** argv) {
-    using namespace open3d;
-
-    utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
-    utility::CompilerInfo::GetInstance().Print();
-    utility::CPUInfo::GetInstance().Print();
-    utility::ISAInfo::GetInstance().Print();
-
-#ifdef BUILD_CUDA_MODULE
-    if (ShallDisableP2P(argc, argv)) {
-        core::CUDAState::GetInstance().ForceDisableP2PForTesting();
-        utility::LogInfo("P2P device transfer has been disabled.");
-    }
-#endif
-
-    testing::InitGoogleMock(&argc, argv);
-    return RUN_ALL_TESTS();
-}
+}  // namespace utility
+}  // namespace open3d

--- a/cpp/open3d/utility/CompilerInfo.h
+++ b/cpp/open3d/utility/CompilerInfo.h
@@ -31,7 +31,7 @@
 namespace open3d {
 namespace utility {
 
-/// \brief CPU information.
+/// \brief Compiler information.
 class CompilerInfo {
 public:
     static CompilerInfo& GetInstance();

--- a/cpp/open3d/utility/CompilerInfo.h
+++ b/cpp/open3d/utility/CompilerInfo.h
@@ -23,49 +23,32 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
+#pragma once
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
-
-#include <cstring>
+#include <memory>
 #include <string>
 
-#ifdef BUILD_CUDA_MODULE
-#include "open3d/core/CUDAUtils.h"
-#endif
+namespace open3d {
+namespace utility {
 
-#include "open3d/Open3D.h"
-#include "tests/Tests.h"
+/// \brief CPU information.
+class CompilerInfo {
+public:
+    static CompilerInfo& GetInstance();
 
-#ifdef BUILD_CUDA_MODULE
-/// Returns true if --disable_p2p flag is used.
-bool ShallDisableP2P(int argc, char** argv) {
-    bool shall_disable_p2p = false;
-    for (int i = 1; i < argc; ++i) {
-        if (std::strcmp(argv[i], "--disable_p2p") == 0) {
-            shall_disable_p2p = true;
-            break;
-        }
-    }
-    return shall_disable_p2p;
-}
-#endif
+    ~CompilerInfo() = default;
+    CompilerInfo(const CompilerInfo&) = delete;
+    void operator=(const CompilerInfo&) = delete;
 
-int main(int argc, char** argv) {
-    using namespace open3d;
+    std::string CxxCompilerName() const;
+    std::string CxxCompilerVersion() const;
+    std::string CUDACompilerVersion() const;
+    std::string CxxStandard() const;
+    void Print() const;
 
-    utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
-    utility::CompilerInfo::GetInstance().Print();
-    utility::CPUInfo::GetInstance().Print();
-    utility::ISAInfo::GetInstance().Print();
+private:
+    CompilerInfo();
+};
 
-#ifdef BUILD_CUDA_MODULE
-    if (ShallDisableP2P(argc, argv)) {
-        core::CUDAState::GetInstance().ForceDisableP2PForTesting();
-        utility::LogInfo("P2P device transfer has been disabled.");
-    }
-#endif
-
-    testing::InitGoogleMock(&argc, argv);
-    return RUN_ALL_TESTS();
-}
+}  // namespace utility
+}  // namespace open3d

--- a/cpp/tests/core/CUDAUtils.cpp
+++ b/cpp/tests/core/CUDAUtils.cpp
@@ -95,7 +95,7 @@ void CheckScopedStreamMultiThreaded(const std::function<void()>& func) {
     const int kIterations = 100000;
     const int kThreads = 8;
     for (int i = 0; i < kThreads; ++i) {
-        threads.emplace_back([&kIterations, &func]() {
+        threads.emplace_back([&func]() {
             utility::LogDebug("Starting thread with ID {}",
                               std::this_thread::get_id());
 


### PR DESCRIPTION
This is printed every time we run unit tests or benchmarks:

```
make tests -j && ./bin/tests --gtest_filter=""
[Open3D INFO] CompilerInfo: C++14, clang 10.0.0, nvcc 11.6.55.
[Open3D INFO] CPUInfo: 18 cores, 36 threads.
[Open3D INFO] ISAInfo: DISABLED instruction set used in ISPC code.
```

This is needed to verify https://github.com/isl-org/Open3D/pull/4698. In the future, it could also be helpful for detecting DPC++.

BTW, after the Faiss removal, clang-10 + cuda-11 works under ubuntu. This is the first time that we can compile Open3D with Clang and CUDA. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4700)
<!-- Reviewable:end -->
