### PR TITLE
fix bug: file dialog not updated after new selection

### DIFF
--- a/cpp/open3d/visualization/gui/FileDialog.cpp
+++ b/cpp/open3d/visualization/gui/FileDialog.cpp
@@ -147,7 +147,7 @@ struct FileDialog::Impl {
         }
     }
 
-    void UpdateDirectoryListing() {
+    std::string UpdateDirectoryListing() {
         auto path = CalcCurrentDirectory();
 
         std::vector<std::string> raw_subdirs, raw_files;
@@ -208,6 +208,7 @@ struct FileDialog::Impl {
             UpdateOk();
         }
         filelist_->SetItems(display);
+        return path;
     }
 
     std::string CalcCurrentDirectory() const {
@@ -285,7 +286,8 @@ FileDialog::FileDialog(Mode mode, const char *title, const Theme &theme)
     impl_->filename_->SetOnTextChanged(
             [this](const char *) { this->impl_->UpdateOk(); });
     impl_->dirtree_->SetOnValueChanged([this](const char *, int) {
-        this->impl_->UpdateDirectoryListing();
+        auto newpath = this->impl_->UpdateDirectoryListing();
+        SetPath(newpath.c_str());
     });
     impl_->filelist_->SetOnValueChanged([this](const char *value,
                                                bool is_double_click) {


### PR DESCRIPTION
While select an item in dir tree of FileDialog, the dir tree is not refreshed, which is not the expected behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4717)
<!-- Reviewable:end -->
