### PR TITLE
TriangleMesh::CreateFromPointCloudPoisson width parameter as float

### DIFF
--- a/cpp/open3d/geometry/SurfaceReconstructionPoisson.cpp
+++ b/cpp/open3d/geometry/SurfaceReconstructionPoisson.cpp
@@ -416,7 +416,7 @@ void Execute(const open3d::geometry::PointCloud& pcd,
              std::shared_ptr<open3d::geometry::TriangleMesh>& out_mesh,
              std::vector<double>& out_densities,
              int depth,
-             size_t width,
+             float width,
              float scale,
              bool linear_fit,
              UIntPack<FEMSigs...>) {
@@ -467,7 +467,7 @@ void Execute(const open3d::geometry::PointCloud& pcd,
     {
         Open3DPointStream<Real> pointStream(&pcd);
 
-        if (width > 0) {
+        if (width > 0.0f) {
             xForm = GetPointXForm<Real, Dim>(pointStream, (Real)width,
                                              (Real)(scale > 0 ? scale : 1.),
                                              depth) *
@@ -739,7 +739,7 @@ void Execute(const open3d::geometry::PointCloud& pcd,
 std::tuple<std::shared_ptr<TriangleMesh>, std::vector<double>>
 TriangleMesh::CreateFromPointCloudPoisson(const PointCloud& pcd,
                                           size_t depth,
-                                          size_t width,
+                                          float width,
                                           float scale,
                                           bool linear_fit,
                                           int n_threads) {

--- a/cpp/open3d/geometry/TriangleMesh.h
+++ b/cpp/open3d/geometry/TriangleMesh.h
@@ -576,7 +576,7 @@ public:
     static std::tuple<std::shared_ptr<TriangleMesh>, std::vector<double>>
     CreateFromPointCloudPoisson(const PointCloud &pcd,
                                 size_t depth = 8,
-                                size_t width = 0,
+                                float width = 0.0f,
                                 float scale = 1.1f,
                                 bool linear_fit = false,
                                 int n_threads = -1);


### PR DESCRIPTION
In relation to issue #3008

Seems like the width parameter ought to be a float.

```
    /// \param depth Maximum depth of the tree that will be used for surface
    /// reconstruction. Running at depth d corresponds to solving on a grid
    /// whose resolution is no larger than 2^d x 2^d x 2^d. Note that since the
    /// reconstructor adapts the octree to the sampling density, the specified
    /// reconstruction depth is only an upper bound.
    /// \param width Specifies the
    /// target width of the finest level octree cells. This parameter is ignored
    /// if depth is specified.
```

If our point cloud is in 1m units, a target width of less than 1m seems desirable.

Builds for Ubuntu 20.04, testing for our intended use continues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4722)
<!-- Reviewable:end -->
