### PR TITLE
Fix libfmt 8.x build issue

### DIFF
--- a/cpp/open3d/utility/ISAInfo.cpp
+++ b/cpp/open3d/utility/ISAInfo.cpp
@@ -79,7 +79,7 @@ static std::string ToString(ISATarget target) {
             return "DISABLED";
 
         default:
-            utility::LogError("Unknown target {}", target);
+            utility::LogError("Unknown target {}", static_cast<int>(target));
     }
 }
 


### PR DESCRIPTION
This PR fixes a build failure I ran into after Debian upgraded its libfmt to version 8.1. It should be backwards-compatible with earlier libfmt versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4730)
<!-- Reviewable:end -->
