### PR TITLE
Use attr() to expose constexpr static values from C++

### DIFF
--- a/cpp/pybind/visualization/gui/gui.cpp
+++ b/cpp/pybind/visualization/gui/gui.cpp
@@ -197,14 +197,9 @@ void pybind_gui_classes(py::module &m) {
     // ---- FontDescription ----
     py::class_<FontDescription> fd(m, "FontDescription",
                                    "Class to describe a custom font");
-    fd.def_readonly_static("SANS_SERIF", &FontDescription::SANS_SERIF,
-                           "Name of the default sans-serif font that comes "
-                           "with Open3D")
-            .def_readonly_static(
-                    "MONOSPACE", &FontDescription::MONOSPACE,
-                    "Name of the default monospace font that comes "
-                    "with Open3D")
-            .def(py::init<const char *, FontStyle, int>(),
+    fd.attr("SANS_SERIF") = FontDescription::SANS_SERIF;
+    fd.attr("MONOSPACE") = FontDescription::MONOSPACE;
+    fd.def(py::init<const char *, FontStyle, int>(),
                  "typeface"_a = FontDescription::SANS_SERIF,
                  "style"_a = FontStyle::NORMAL, "point_size"_a = 0,
                  "Creates a FontDescription. 'typeface' is a path to a "
@@ -244,10 +239,8 @@ void pybind_gui_classes(py::module &m) {
                                         "Global application singleton. This "
                                         "owns the menubar, windows, and event "
                                         "loop");
-    application
-            .def_readonly_static("DEFAULT_FONT_ID",
-                                 &Application::DEFAULT_FONT_ID)
-            .def("__repr__",
+    application.attr("DEFAULT_FONT_ID") = Application::DEFAULT_FONT_ID;
+    application.def("__repr__",
                  [](const Application &app) {
                      return std::string("Application singleton instance");
                  })


### PR DESCRIPTION
I ran into a problem with GCC 11 and `.def_readonly_static`, where the Python module would fail to load with unresolved symbols for `FontDescription::SANS_SERIF`, `FontDescription::MONOSPACE`, and `Application::DEFAULT_FONT_ID`. Presumably, this has something to do with C++17, because it makes `constexpr static` class members implicitly inline. After a few unsuccessful attempts to fix the definition, I came up with this workaround, which copies the string constants and avoids the library symbol reference.
