### PR TITLE
add window key interceptor callback

### DIFF
--- a/cpp/open3d/visualization/gui/Window.cpp
+++ b/cpp/open3d/visualization/gui/Window.cpp
@@ -218,6 +218,7 @@ struct Window::Impl {
     std::unordered_map<Menu::ItemId, std::function<void()>> menu_callbacks_;
     std::function<bool(void)> on_tick_event_;
     std::function<bool(void)> on_close_;
+    std::function<bool(const KeyEvent&)> on_key_event_;
     // We need these for mouse moves and wheel events.
     // The only source of ground truth is button events, so the rest of
     // the time we monitor key up/down events.
@@ -628,6 +629,10 @@ void Window::SetOnTickEvent(std::function<bool()> callback) {
 
 void Window::SetOnClose(std::function<bool()> callback) {
     impl_->on_close_ = callback;
+}
+
+void Window::SetOnKeyEvent(std::function<bool(const KeyEvent&)> callback) {
+    impl_->on_key_event_ = callback;
 }
 
 void Window::ShowDialog(std::shared_ptr<Dialog> dlg) {
@@ -1192,8 +1197,13 @@ void Window::OnKeyEvent(const KeyEvent& e) {
 
     // If an ImGUI widget is not getting keystrokes, we can send them to
     // non-ImGUI widgets
-    if (ImGui::GetCurrentContext()->ActiveId == 0 && impl_->focus_widget_) {
-        impl_->focus_widget_->Key(e);
+    if (ImGui::GetCurrentContext()->ActiveId == 0) {
+        // dispatch key event to focused widget if not intercepted
+        if (!impl_->on_key_event_ || !impl_->on_key_event_(e)) {
+            if (impl_->focus_widget_) {
+                impl_->focus_widget_->Key(e);
+            }
+        }
     }
 
     RestoreDrawContext(old_context);

--- a/cpp/open3d/visualization/gui/Window.h
+++ b/cpp/open3d/visualization/gui/Window.h
@@ -146,6 +146,11 @@ public:
     /// closing or false to cancel the close.
     void SetOnClose(std::function<bool()> callback);
 
+    /// Sets a callback that will intercept key event dispatching to focused
+    /// widget. Callback should return true to stop more dispatching or false
+    /// to dispatch to focused widget.
+    void SetOnKeyEvent(std::function<bool(const KeyEvent&)> callback);
+
     /// Shows the dialog. If a dialog is currently being shown it will be
     /// closed.
     void ShowDialog(std::shared_ptr<Dialog> dlg);

--- a/cpp/pybind/visualization/gui/gui.cpp
+++ b/cpp/pybind/visualization/gui/gui.cpp
@@ -111,7 +111,7 @@ public:
     std::function<void(const LayoutContext &)> on_layout_;
 
 protected:
-    void Layout(const LayoutContext &context) {
+    void Layout(const LayoutContext &context) override {
         if (on_layout_) {
             // the Python callback sizes the children
             on_layout_(context);
@@ -445,6 +445,11 @@ void pybind_gui_classes(py::module &m) {
                     "and device pixels (read-only)")
             .def_property_readonly("is_visible", &PyWindow::IsVisible,
                                    "True if window is visible (read-only)")
+            .def("set_on_key", &PyWindow::SetOnKeyEvent,
+                 "Sets a callback for key events. This callback is passed "
+                 "a KeyEvent object. The callback must return "
+                 "True to stop more dispatching or False to dispatch"
+                 "to focused widget")
             .def("show", &PyWindow::Show, "Shows or hides the window")
             .def("close", &PyWindow::Close,
                  "Closes the window and destroys it, unless an on_close "


### PR DESCRIPTION
Alllow callback to intercept Window key event before it is dispatched to focused widget. The similar callback is provided by SceneWidget, but it is not enough. The whole window system must has the capability to capture the key event, and Window would be the better target to deliver it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4734)
<!-- Reviewable:end -->
