### PR TITLE
Typo in index: arrays are 0-indexed

### DIFF
--- a/docs/jupyter/geometry/kdtree.ipynb
+++ b/docs/jupyter/geometry/kdtree.ipynb
@@ -56,7 +56,7 @@
    "metadata": {},
    "source": [
     "## Find neighboring points\n",
-    "We pick the 1500th point as the anchor point and paint it red."
+    "We pick the 1501st (arrays are 0-indexed) point as the anchor point and paint it red."
    ]
   },
   {
@@ -65,7 +65,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"Paint the 1500th point red.\")\n",
+    "print(\"Paint the 1501st point red.\")\n",
     "pcd.colors[1500] = [1, 0, 0]"
    ]
   },


### PR DESCRIPTION
As stated, there is a typo the documentation.

I don't know if it was intended, but I think it is important to not confuse users about how arrays are indexed.

I am open to comment from your side ;-)

Thanks for your great work!