### PR TITLE
Fix ImGui assertion about empty IDs on menu draw

### DIFF
--- a/cpp/open3d/visualization/gui/MenuImgui.cpp
+++ b/cpp/open3d/visualization/gui/MenuImgui.cpp
@@ -293,7 +293,7 @@ MenuBase::ItemId MenuImgui::Draw(const DrawContext &context,
                 // Save y position, then draw empty item for the highlight.
                 // Set the enabled flag, in case the real item isn't.
                 auto y = ImGui::GetCursorPosY();
-                if (ImGui::MenuItem("", "", false, item.is_enabled_)) {
+                if (ImGui::MenuItem(" ", "", false, item.is_enabled_)) {
                     activate_id = item.id_;
                 }
                 // Restore the y position, and draw the menu item with the


### PR DESCRIPTION
ImGui started verifying that widgets have no empty ID by assertion, which triggers when the empty placeholder menu item is drawn:
```
Open3D: imgui.cpp:7793: bool ImGui::ItemAdd(const ImRect&, ImGuiID, const ImRect*, ImGuiItemFlags): Assertion `id != window->ID && "Cannot have an empty ID at the root of a window. If you need an empty label, use ## and read the FAQ about how the ID Stack works!"' failed.
```
This PR works around the problem by drawing a menu item with a single space instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4746)
<!-- Reviewable:end -->
