### PR TITLE
t::Image::LinearTransform(), To() kernel implementation

### DIFF
--- a/cpp/open3d/core/Dispatch.h
+++ b/cpp/open3d/core/Dispatch.h
@@ -29,7 +29,7 @@
 #include "open3d/core/Dtype.h"
 #include "open3d/utility/Logging.h"
 
-/// Call a numerical templated function based on Dtype. Warp the function to
+/// Call a numerical templated function based on Dtype. Wrap the function to
 /// a lambda function to use DISPATCH_DTYPE_TO_TEMPLATE.
 ///
 /// Before:

--- a/cpp/open3d/t/geometry/kernel/Image.cpp
+++ b/cpp/open3d/t/geometry/kernel/Image.cpp
@@ -33,6 +33,20 @@ namespace geometry {
 namespace kernel {
 namespace image {
 
+void To(const core::Tensor &src,
+        core::Tensor &dst,
+        double scale,
+        double offset) {
+    core::Device device = src.GetDevice();
+    if (device.GetType() == core::Device::DeviceType::CPU) {
+        ToCPU(src, dst, scale, offset);
+    } else if (device.GetType() == core::Device::DeviceType::CUDA) {
+        CUDA_CALL(ToCUDA, src, dst, scale, offset);
+    } else {
+        utility::LogError("Unimplemented device");
+    }
+}
+
 void ClipTransform(const core::Tensor &src,
                    core::Tensor &dst,
                    float scale,

--- a/cpp/open3d/t/geometry/kernel/Image.h
+++ b/cpp/open3d/t/geometry/kernel/Image.h
@@ -34,6 +34,11 @@ namespace geometry {
 namespace kernel {
 namespace image {
 
+void To(const core::Tensor &src,
+        core::Tensor &dst,
+        double scale,
+        double offset);
+
 void ClipTransform(const core::Tensor &src,
                    core::Tensor &dst,
                    float scale,
@@ -60,6 +65,11 @@ void ColorizeDepth(const core::Tensor &src,
                    float scale,
                    float min_value,
                    float max_value);
+
+void ToCPU(const core::Tensor &src,
+           core::Tensor &dst,
+           double scale,
+           double offset);
 
 void ClipTransformCPU(const core::Tensor &src,
                       core::Tensor &dst,
@@ -89,6 +99,11 @@ void ColorizeDepthCPU(const core::Tensor &src,
                       float max_value);
 
 #ifdef BUILD_CUDA_MODULE
+void ToCUDA(const core::Tensor &src,
+            core::Tensor &dst,
+            double scale,
+            double offset);
+
 void ClipTransformCUDA(const core::Tensor &src,
                        core::Tensor &dst,
                        float scale,

--- a/cpp/open3d/t/geometry/kernel/ImageImpl.h
+++ b/cpp/open3d/t/geometry/kernel/ImageImpl.h
@@ -68,8 +68,8 @@ void ToCPU
                 [=] OPEN3D_DEVICE(int64_t workload_idx) {                      \
                     int64_t col = workload_idx % cols;                         \
                     int64_t row = workload_idx / cols;                         \
-                    auto src_ptr = src_indexer.GetDataPtr<scalar_t>(row, col); \
-                    auto dst_ptr = dst_indexer.GetDataPtr<elem_t>(row, col);   \
+                    auto src_ptr = src_indexer.GetDataPtr<scalar_t>(col, row); \
+                    auto dst_ptr = dst_indexer.GetDataPtr<elem_t>(col, row);   \
                     for (int ch = 0; ch < channels;                            \
                          ++ch, ++src_ptr, ++dst_ptr) {                         \
                         calc_t out = static_cast<calc_t>(*src_ptr) * c_scale + \

--- a/cpp/tests/t/geometry/Image.cpp
+++ b/cpp/tests/t/geometry/Image.cpp
@@ -184,14 +184,21 @@ TEST_P(ImagePermuteDevices, To_LinearTransform) {
     core::Device device = GetParam();
 
     // reference data
-    const std::vector<uint8_t> input_data = {10, 25, 0, 13};
-    auto output_ref = {FloatEq(10. / 255), FloatEq(25. / 255),
-                       FloatNear(0., 1e-8), FloatEq(13. / 255)};
-    auto negative_image_ref = {FloatEq(1. - 10. / 255), FloatEq(1. - 25. / 255),
-                               FloatEq(1.), FloatEq(1. - 13. / 255)};
-    auto saturate_ref = {180, 255, 0, 240};
-    core::Tensor t_input{input_data, {2, 2, 1}, core::UInt8, device};
-    core::Tensor t_input3 = t_input.Broadcast({2, 2, 3}).Clone();
+    const std::vector<uint8_t> input_data = {10, 25, 0, 13, 5, 40};
+    auto output_ref = {FloatEq(10. / 255),  FloatEq(25. / 255),
+                       FloatNear(0., 1e-8), FloatEq(13. / 255),
+                       FloatEq(5. / 255),   FloatEq(40. / 255)};
+    auto negative_image_ref = {FloatEq(1. - 10. / 255),
+                               FloatEq(1. - 25. / 255),
+                               FloatEq(1.),
+                               FloatEq(1. - 13. / 255),
+                               FloatEq(1. - 5. / 255),
+                               FloatEq(1. - 40. / 255)
+
+    };
+    auto saturate_ref = {180, 255, 0, 240, 80, 255};
+    core::Tensor t_input{input_data, {2, 3, 1}, core::UInt8, device};
+    core::Tensor t_input3 = t_input.Broadcast({2, 3, 3}).Clone();
 
     t::geometry::Image input(t_input);
     // UInt8 -> Float32: auto scale = 1./255


### PR DESCRIPTION
CUDA support without NPP.
Enables support for all data types and on ARM (no IPP).

Fixes: #4714

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4753)
<!-- Reviewable:end -->
