### PR TITLE
Fix 3D text position when SceneWidget is offset from window frame

### DIFF
--- a/cpp/open3d/visualization/gui/SceneWidget.cpp
+++ b/cpp/open3d/visualization/gui/SceneWidget.cpp
@@ -1158,7 +1158,7 @@ Widget::DrawResult SceneWidget::Draw(const DrawContext& context) {
             ndc.y() *= f.height;
             ImGui::SetWindowFontScale(l->GetTextScale());
             ImGui::SetCursorScreenPos(
-                    ImVec2(ndc.x() - f.x, f.height - ndc.y() - f.y));
+                    ImVec2(ndc.x() + f.x, f.height - ndc.y() - f.y));
             auto color = l->GetTextColor();
             ImGui::TextColored({color.GetRed(), color.GetGreen(),
                                 color.GetBlue(), color.GetAlpha()},


### PR DESCRIPTION
Addresses issue #4662 

To test add the following two lines to line 782 of the `DenseSLAMGUI.cpp` example. This will add a 3D label for each point of the trajectory.

```
Eigen::Vector3f tpos(traj->points_.back().cast<float>());
this->widget3d_->AddLabel(tpos, "traj tex");
```

Without this PR the label will be offset to the left from the rendered trajectory.

![2022-02-17-205457_1689x1150_scrot](https://user-images.githubusercontent.com/3722407/154602695-0ae4f6d5-e8dc-4bab-9174-65098f4d8fe1.png)

![2022-02-17-205403_1629x1168_scrot](https://user-images.githubusercontent.com/3722407/154602719-4600cd97-11c1-4ffb-8938-10806250d385.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4775)
<!-- Reviewable:end -->
