### PR TITLE
privately link fmt, but propagate its header

### DIFF
--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -994,7 +994,6 @@ if(USE_SYSTEM_FMT)
     endif()
 endif()
 if(NOT USE_SYSTEM_FMT)
-    # We set the FMT_HEADER_ONLY macro, so no need to actually compile the source
     include(${Open3D_3RDPARTY_DIR}/fmt/fmt.cmake)
     open3d_import_3rdparty_library(3rdparty_fmt
         HEADER

--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -997,7 +997,7 @@ if(NOT USE_SYSTEM_FMT)
     # We set the FMT_HEADER_ONLY macro, so no need to actually compile the source
     include(${Open3D_3RDPARTY_DIR}/fmt/fmt.cmake)
     open3d_import_3rdparty_library(3rdparty_fmt
-        PUBLIC
+        HEADER
         INCLUDE_DIRS ${FMT_INCLUDE_DIRS}
         LIB_DIR      ${FMT_LIB_DIR}
         LIBRARIES    ${FMT_LIBRARIES}
@@ -1008,7 +1008,7 @@ if(NOT USE_SYSTEM_FMT)
     target_compile_definitions(3rdparty_fmt INTERFACE FMT_USE_WINDOWS_H=0)
     target_compile_definitions(3rdparty_fmt INTERFACE FMT_STRING_ALIAS=1)
 endif()
-list(APPEND Open3D_3RDPARTY_PUBLIC_TARGETS Open3D::3rdparty_fmt)
+list(APPEND Open3D_3RDPARTY_HEADER_TARGETS Open3D::3rdparty_fmt)
 
 # Pybind11
 if (BUILD_PYTHON_MODULE)


### PR DESCRIPTION
This issue was introduced in #4692.

### After installation
```bash
➜  ~ tree open3d_install/include/open3d/3rdparty/fmt  
open3d_install/include/open3d/3rdparty/fmt
├── chrono.h
├── color.h
├── compile.h
├── core.h
├── format.h
├── format-inl.h
├── locale.h
├── ostream.h
├── posix.h
├── printf.h
├── ranges.h
└── safe-duration-cast.h

0 directories, 12 files
➜  ~ tree open3d_install/lib                        
open3d_install/lib
├── cmake
│   └── Open3D
│       ├── Open3DConfig.cmake
│       ├── Open3DConfigVersion.cmake
│       ├── Open3DTargets.cmake
│       └── Open3DTargets-relwithdebinfo.cmake
└── libOpen3D.so

2 directories, 5 files
```


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4779)
<!-- Reviewable:end -->
