### PR TITLE
bump version to 0.15.2

### DIFF
--- a/docs/versions.js
+++ b/docs/versions.js
@@ -18,8 +18,8 @@ document.write('\
             <td><a href="http://www.open3d.org/docs/latest/cpp_api">master C++</a></td>\
         </tr>\
         <tr>\
-            <td><a href="http://www.open3d.org/docs/release">0.15.1 (release)</a></td>\
-            <td><a href="http://www.open3d.org/docs/release/cpp_api">0.15.1 C++ (release)</a></td>\
+            <td><a href="http://www.open3d.org/docs/release">0.15.2 (release)</a></td>\
+            <td><a href="http://www.open3d.org/docs/release/cpp_api">0.15.2 C++ (release)</a></td>\
         </tr>\
         <tr>\
             <td><a href="http://www.open3d.org/docs/0.14.1">0.14.1</a></td>\


### PR DESCRIPTION
Special release for PyPI Linux only. To get around wheel size limit of 400 MB.

The docs are not updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4815)
<!-- Reviewable:end -->
