### PR TITLE
Corrected documentation for KeyEvent

### DIFF
--- a/cpp/pybind/visualization/gui/events.cpp
+++ b/cpp/pybind/visualization/gui/events.cpp
@@ -281,7 +281,7 @@ void pybind_gui_events(py::module& m) {
             .export_values();
 
     py::class_<KeyEvent> key_event(m, "KeyEvent",
-                                   "Object that stores mouse events");
+                                   "Object that stores key events");
     py::enum_<KeyEvent::Type> key_event_type(key_event, "Type",
                                              py::arithmetic());
     key_event_type.value("DOWN", KeyEvent::Type::DOWN)

--- a/cpp/pybind/visualization/gui/gui.cpp
+++ b/cpp/pybind/visualization/gui/gui.cpp
@@ -1690,7 +1690,7 @@ void pybind_gui_classes(py::module &m) {
                     return new Horiz(spacing, margins);
                 }),
                 "spacing"_a = 0, "margins"_a = Margins(),
-                "Creates a layout that arranges widgets vertically, left to "
+                "Creates a layout that arranges widgets horizontally, left to "
                 "right, making their height equal to the layout's height "
                 "(which will generally be the largest height of the items). "
                 "First argument is the spacing between widgets, the second "
@@ -1699,7 +1699,7 @@ void pybind_gui_classes(py::module &m) {
                      return new Horiz(int(std::round(spacing)), margins);
                  }),
                  "spacing"_a = 0.0f, "margins"_a = Margins(),
-                 "Creates a layout that arranges widgets vertically, left to "
+                 "Creates a layout that arranges widgets horizontally, left to "
                  "right, making their height equal to the layout's height "
                  "(which will generally be the largest height of the items). "
                  "First argument is the spacing between widgets, the second "


### PR DESCRIPTION
Looks like the KeyEvent was copy/pasted from MouseEvent and the doc string wasn't changed.  I believe I've fixed that issue with this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4819)
<!-- Reviewable:end -->
