### PR TITLE
Fix model load regression when loading through ASSIMP

### DIFF
--- a/cpp/open3d/io/file_format/FileASSIMP.cpp
+++ b/cpp/open3d/io/file_format/FileASSIMP.cpp
@@ -320,7 +320,7 @@ bool ReadModelUsingAssimp(const std::string& filename,
     for (size_t midx = 0; midx < scene->mNumMeshes; ++midx) {
         const auto* assimp_mesh = scene->mMeshes[midx];
         // Only process triangle meshes
-        if (assimp_mesh->mPrimitiveTypes != aiPrimitiveType_TRIANGLE) {
+        if (!(assimp_mesh->mPrimitiveTypes & aiPrimitiveType_TRIANGLE)) {
             utility::LogInfo(
                     "Skipping non-triangle primitive geometry of type: "
                     "{}",

--- a/examples/test_data/sword/UV.mtl
+++ b/examples/test_data/sword/UV.mtl
@@ -5,6 +5,6 @@ newmtl blinn1SG
 Kd 0.9 0.9 0.9
 map_Kd UV_blinn1SG_BaseColor.png
 map_Pr UV_blinn1SG_Roughness.png
-map_Pm UV_blinn1SG_Metallic.png 
+map_Pm UV_blinn1SG_Metallic.png
 Pm 1.0
 norm UV_blinn1SG_Normal.png


### PR DESCRIPTION
The version of ASSIMP we now use added support for a Khronos glTF extension (see [here](https://github.com/KhronosGroup/glTF/pull/1620)) related to quad geometry. This PR makes sure Open3D IO handles the new flag correctly.

Resolves #4821

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4841)
<!-- Reviewable:end -->
