### PR TITLE
Fix Point Clouds Getting Culled Prematurely

### DIFF
--- a/cpp/open3d/visualization/rendering/Camera.cpp
+++ b/cpp/open3d/visualization/rendering/Camera.cpp
@@ -72,14 +72,13 @@ float Camera::CalcFarPlane(
     // The far plane needs to be the max absolute distance, not just the
     // max extent, so that axes are visible if requested.
     // See also RotationInteractorLogic::UpdateCameraFarPlane().
-    auto far1 = scene_bounds.GetMinBound().norm();
-    auto far2 = scene_bounds.GetMaxBound().norm();
     auto cam_xlate = camera.GetModelMatrix().translation().cast<double>();
+    auto far1 = (scene_bounds.GetMinBound() - cam_xlate).norm();
+    auto far2 = (scene_bounds.GetMaxBound() - cam_xlate).norm();
     auto far3 = cam_xlate.norm();
-    auto far4 = (scene_bounds.GetCenter() - cam_xlate).norm();
     auto model_size = 2.0 * scene_bounds.GetExtent().norm();
-    auto far = std::max(MIN_FAR_PLANE,
-                        std::max({far1, far2, far3, far4}) + model_size);
+    auto far =
+            std::max(MIN_FAR_PLANE, std::max({far1, far2, far3}) + model_size);
     return far;
 }
 

--- a/cpp/open3d/visualization/rendering/Camera.cpp
+++ b/cpp/open3d/visualization/rendering/Camera.cpp
@@ -24,6 +24,7 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
+#include "open3d/utility/Logging.h"
 #include "open3d/visualization/rendering/Camera.h"
 
 #include "open3d/geometry/BoundingVolume.h"
@@ -73,12 +74,10 @@ float Camera::CalcFarPlane(
     // max extent, so that axes are visible if requested.
     // See also RotationInteractorLogic::UpdateCameraFarPlane().
     auto cam_xlate = camera.GetModelMatrix().translation().cast<double>();
-    auto far1 = (scene_bounds.GetMinBound() - cam_xlate).norm();
-    auto far2 = (scene_bounds.GetMaxBound() - cam_xlate).norm();
-    auto far3 = cam_xlate.norm();
-    auto model_size = 2.0 * scene_bounds.GetExtent().norm();
-    auto far =
-            std::max(MIN_FAR_PLANE, std::max({far1, far2, far3}) + model_size);
+    auto far1 = (scene_bounds.GetCenter() - cam_xlate).norm() * 2.5;
+    auto far2 = cam_xlate.norm();
+    auto model_size = 4.0 * scene_bounds.GetExtent().norm();
+    auto far = std::max(MIN_FAR_PLANE, std::max(far1, far2) + model_size);
     return far;
 }
 

--- a/cpp/open3d/visualization/rendering/Camera.cpp
+++ b/cpp/open3d/visualization/rendering/Camera.cpp
@@ -74,10 +74,12 @@ float Camera::CalcFarPlane(
     // See also RotationInteractorLogic::UpdateCameraFarPlane().
     auto far1 = scene_bounds.GetMinBound().norm();
     auto far2 = scene_bounds.GetMaxBound().norm();
-    auto far3 = camera.GetModelMatrix().translation().cast<double>().norm();
+    auto cam_xlate = camera.GetModelMatrix().translation().cast<double>();
+    auto far3 = cam_xlate.norm();
+    auto far4 = (scene_bounds.GetCenter() - cam_xlate).norm();
     auto model_size = 2.0 * scene_bounds.GetExtent().norm();
     auto far = std::max(MIN_FAR_PLANE,
-                        std::max(std::max(far1, far2), far3) + model_size);
+                        std::max({far1, far2, far3, far4}) + model_size);
     return far;
 }
 

--- a/cpp/open3d/visualization/rendering/Camera.cpp
+++ b/cpp/open3d/visualization/rendering/Camera.cpp
@@ -24,7 +24,6 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
-#include "open3d/utility/Logging.h"
 #include "open3d/visualization/rendering/Camera.h"
 
 #include "open3d/geometry/BoundingVolume.h"


### PR DESCRIPTION
Fixes #4831 Can be tested using the the model provided by issue author.

Computation of dynamic far plane implicitly assumed the point cloud is near the origin. If it is sufficiently far from the origin then the point cloud get prematurely/unexpectedly culled out at certain view angles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4842)
<!-- Reviewable:end -->
