### PR TITLE
fix mouse event filter issue in popup menu covered area

### DIFF
--- a/cpp/open3d/visualization/gui/Window.cpp
+++ b/cpp/open3d/visualization/gui/Window.cpp
@@ -1108,7 +1108,8 @@ void Window::OnMouseEvent(const MouseEvent& e) {
     if (e.type == MouseEvent::BUTTON_DOWN || e.type == MouseEvent::BUTTON_UP) {
         ImGuiContext* context = ImGui::GetCurrentContext();
         for (auto* w : context->Windows) {
-            if (!w->Hidden && w->Flags & ImGuiWindowFlags_Popup) {
+            if (w->Flags & ImGuiWindowFlags_Popup &&
+                ImGui::IsPopupOpen(w->PopupId)) {
                 Rect r(int(w->Pos.x), int(w->Pos.y), int(w->Size.x),
                        int(w->Size.y));
                 if (r.Contains(e.x, e.y)) {


### PR DESCRIPTION
fix issue #4843 

once a menu is activated, that area will never be processed by Window's child widget any more. 

Using `ImGui::IsPopupOpen()` instead of `w->Hidden` to judge if popup window is closed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4844)
<!-- Reviewable:end -->
