### PR TITLE
Multithread Plane Segmentation

### DIFF
--- a/cpp/open3d/geometry/PointCloud.h
+++ b/cpp/open3d/geometry/PointCloud.h
@@ -343,6 +343,7 @@ public:
     /// \param ransac_n Number of initial points to be considered inliers in
     /// each iteration.
     /// \param num_iterations Number of iterations.
+    /// \param min_iterations Minimum number of iterations to be executed.
     /// \param seed Sets the seed value used in the random
     /// generator, set to nullopt to use a random seed value with each function
     /// call.
@@ -352,6 +353,7 @@ public:
             const double distance_threshold = 0.01,
             const int ransac_n = 3,
             const int num_iterations = 100,
+            const int min_iterations = 1,
             utility::optional<int> seed = utility::nullopt) const;
 
     /// \brief Factory function to create a pointcloud from a depth image and a

--- a/cpp/open3d/geometry/PointCloud.h
+++ b/cpp/open3d/geometry/PointCloud.h
@@ -342,8 +342,8 @@ public:
     /// model, and still be considered an inlier.
     /// \param ransac_n Number of initial points to be considered inliers in
     /// each iteration.
-    /// \param num_iterations Number of iterations.
-    /// \param min_iterations Minimum number of iterations to be executed.
+    /// \param num_iterations Maximum number of iterations.
+    /// \param probability Expected probability of finding the optimal plane.
     /// \param seed Sets the seed value used in the random
     /// generator, set to nullopt to use a random seed value with each function
     /// call.
@@ -353,7 +353,7 @@ public:
             const double distance_threshold = 0.01,
             const int ransac_n = 3,
             const int num_iterations = 100,
-            const int min_iterations = 1,
+            const double probability = 0.99999999,
             utility::optional<int> seed = utility::nullopt) const;
 
     /// \brief Factory function to create a pointcloud from a depth image and a

--- a/cpp/open3d/geometry/PointCloudSegmentation.cpp
+++ b/cpp/open3d/geometry/PointCloudSegmentation.cpp
@@ -37,6 +37,8 @@
 #include "open3d/geometry/TriangleMesh.h"
 #include "open3d/utility/Logging.h"
 
+namespace {
+
 /// \class RandomSampler
 ///
 /// \brief Helper class for random sampling
@@ -76,6 +78,7 @@ private:
     std::mt19937 rng_;
     std::mutex mutex_;
 };
+}  // namespace
 
 namespace open3d {
 namespace geometry {

--- a/cpp/open3d/geometry/PointCloudSegmentation.cpp
+++ b/cpp/open3d/geometry/PointCloudSegmentation.cpp
@@ -30,6 +30,7 @@
 #include <numeric>
 #include <random>
 #include <unordered_set>
+#include <mutex>
 
 #include "open3d/geometry/PointCloud.h"
 #include "open3d/geometry/TriangleMesh.h"
@@ -51,12 +52,14 @@ public:
     }
 
     std::vector<T> operator()(size_t sample_size) {
+        std::lock_guard<std::mutex> guard(mutex_);
+
         std::vector<T> sample;
         sample.reserve(sample_size);
 
         size_t valid_sample = 0;
         while (valid_sample < sample_size) {
-            size_t idx = rng_() % size_;
+            const size_t idx = rng_() % size_;
             if (std::find(sample.begin(), sample.end(), idx) == sample.end()) {
                 sample.push_back(idx);
                 valid_sample++;
@@ -69,6 +72,7 @@ public:
 private:
     size_t size_;
     std::mt19937 rng_;
+    std::mutex mutex_;
 };
 
 /// \class RANSACResult

--- a/cpp/open3d/geometry/PointCloudSegmentation.cpp
+++ b/cpp/open3d/geometry/PointCloudSegmentation.cpp
@@ -37,13 +37,14 @@
 #include "open3d/geometry/TriangleMesh.h"
 #include "open3d/utility/Logging.h"
 
-namespace open3d {
-namespace geometry {
-
+/// \class RandomSampler
+///
+/// \brief Helper class for random sampling
 template <typename T>
 class RandomSampler {
 public:
-    explicit RandomSampler(const size_t size, utility::optional<int> seed)
+    explicit RandomSampler(const size_t size,
+                           open3d::utility::optional<int> seed)
         : size_(size) {
         if (!seed.has_value()) {
             std::random_device rd;
@@ -75,6 +76,9 @@ private:
     std::mt19937 rng_;
     std::mutex mutex_;
 };
+
+namespace open3d {
+namespace geometry {
 
 /// \class RANSACResult
 ///

--- a/cpp/open3d/geometry/PointCloudSegmentation.cpp
+++ b/cpp/open3d/geometry/PointCloudSegmentation.cpp
@@ -27,10 +27,10 @@
 #include <Eigen/Dense>
 #include <algorithm>
 #include <iterator>
+#include <mutex>
 #include <numeric>
 #include <random>
 #include <unordered_set>
-#include <mutex>
 
 #include "open3d/geometry/PointCloud.h"
 #include "open3d/geometry/TriangleMesh.h"

--- a/cpp/pybind/geometry/pointcloud.cpp
+++ b/cpp/pybind/geometry/pointcloud.cpp
@@ -202,7 +202,7 @@ Returns:
                  "Segments a plane in the point cloud using the RANSAC "
                  "algorithm.",
                  "distance_threshold"_a, "ransac_n"_a, "num_iterations"_a,
-                 "seed"_a = py::none())
+                 "min_iterations"_a = 1, "seed"_a = py::none())
             .def_static(
                     "create_from_depth_image",
                     &PointCloud::CreateFromDepthImage,
@@ -353,6 +353,7 @@ camera. Given depth value d at (u, v) image coordinate, the corresponding 3d poi
               "Number of initial points to be considered inliers in each "
               "iteration."},
              {"num_iterations", "Number of iterations."},
+             {"min_iterations", "Minimum number of iterations to be executed."},
              {"seed",
               "Seed value used in the random generator, set to None to use a "
               "random seed value with each function call."}});

--- a/cpp/pybind/geometry/pointcloud.cpp
+++ b/cpp/pybind/geometry/pointcloud.cpp
@@ -353,7 +353,8 @@ camera. Given depth value d at (u, v) image coordinate, the corresponding 3d poi
               "Number of initial points to be considered inliers in each "
               "iteration."},
              {"num_iterations", "Number of iterations."},
-             {"min_iterations", "Minimum number of iterations to be executed."},
+             {"probability",
+              "Expected probability of finding the optimal plane."},
              {"seed",
               "Seed value used in the random generator, set to None to use a "
               "random seed value with each function call."}});

--- a/cpp/pybind/geometry/pointcloud.cpp
+++ b/cpp/pybind/geometry/pointcloud.cpp
@@ -202,7 +202,7 @@ Returns:
                  "Segments a plane in the point cloud using the RANSAC "
                  "algorithm.",
                  "distance_threshold"_a, "ransac_n"_a, "num_iterations"_a,
-                 "min_iterations"_a = 1, "seed"_a = py::none())
+                 "probability"_a = 0.99999999, "seed"_a = py::none())
             .def_static(
                     "create_from_depth_image",
                     &PointCloud::CreateFromDepthImage,

--- a/cpp/tests/geometry/PointCloud.cpp
+++ b/cpp/tests/geometry/PointCloud.cpp
@@ -1254,6 +1254,27 @@ TEST(PointCloud, SegmentPlaneKnownPlane) {
     ExpectEQ(pcd.SelectByIndex(inliers)->points_, ref);
 }
 
+TEST(PointCloud, SegmentPlaneSpecialCase) {
+    // Test SegmentPlane with probability == 1, <= 0 and > 1.
+
+    // Points sampled from the plane x + y + z + 1 = 0
+    std::vector<Eigen::Vector3d> ref = {{2.0, 1.0, -4.0},
+                                        {1.0, 3.0, -5.0},
+                                        {-2.0, -1.0, 2.0},
+                                        {-2.0, -2.0, 3.0},
+                                        {10.0, 10.0, -21.0}};
+    geometry::PointCloud pcd(ref);
+
+    Eigen::Vector4d plane_model;
+    std::vector<size_t> inliers;
+    std::tie(plane_model, inliers) = pcd.SegmentPlane(0.01, 3, 10, 1);
+    ExpectEQ(pcd.SelectByIndex(inliers)->points_, ref);
+
+    EXPECT_ANY_THROW(pcd.SegmentPlane(0.01, 3, 10, 0));
+    EXPECT_ANY_THROW(pcd.SegmentPlane(0.01, 3, 10, -1));
+    EXPECT_ANY_THROW(pcd.SegmentPlane(0.01, 3, 10, 1.5));
+}
+
 TEST(PointCloud, CreateFromDepthImage) {
     data::SampleRedwoodRGBDImages redwood_data;
     const std::string trajectory_path = redwood_data.GetTrajectoryLogPath();

--- a/cpp/tests/geometry/PointCloud.cpp
+++ b/cpp/tests/geometry/PointCloud.cpp
@@ -1238,9 +1238,9 @@ TEST(PointCloud, SegmentPlane) {
 
 TEST(PointCloud, SegmentPlaneKnownPlane) {
     // Points sampled from the plane x + y + z + 1 = 0
-    std::vector<Eigen::Vector3d> ref = {{1.0, 1.0, -3.0},
-                                        {2.0, 2.0, -5.0},
-                                        {-1.0, -1.0, 1.0},
+    std::vector<Eigen::Vector3d> ref = {{2.0, 1.0, -4.0},
+                                        {1.0, 3.0, -5.0},
+                                        {-2.0, -1.0, 2.0},
                                         {-2.0, -2.0, 3.0},
                                         {10.0, 10.0, -21.0}};
     geometry::PointCloud pcd(ref);


### PR DESCRIPTION
I implement a multi-thread version of `SegmentPlane` function in `PointCloud`. I also compare the time cost with original implementation using the python example `point_cloud_plane_segmentation.py`, and the results are as follow:

cpu info: intel@core i7-1165G7 2.8Gz 8 threads 
point size: 113662
original time cost: 0.95s
multi-thread version: 0.16s

**Update**:
I use this equation: `iter = log(1 - probability) / log(1 - fitness ^ minimal_sample)` to update the number of iteration, such that the best result can be found without taken up to `num_iterations`. Then the time cost is reduced to about 0.03-0.05s.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4863)
<!-- Reviewable:end -->
