### PR TITLE
Set correct default material for triangle mesh with triangle normals

### DIFF
--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
@@ -877,6 +877,8 @@ struct O3DVisualizer::Impl {
                     std::dynamic_pointer_cast<geometry::AxisAlignedBoundingBox>(
                             geom);
             auto mesh = std::dynamic_pointer_cast<geometry::MeshBase>(geom);
+            auto tmesh =
+                    std::dynamic_pointer_cast<geometry::TriangleMesh>(geom);
             auto voxel_grid =
                     std::dynamic_pointer_cast<geometry::VoxelGrid>(geom);
             auto octree = std::dynamic_pointer_cast<geometry::Octree>(geom);
@@ -907,10 +909,12 @@ struct O3DVisualizer::Impl {
                 has_colors = (aabb->color_ != Eigen::Vector3d{0.0, 0.0, 0.0});
                 no_shadows = true;
             } else if (mesh) {
-                has_normals = !mesh->vertex_normals_.empty();
+                has_normals = !mesh->vertex_normals_.empty() ||
+                              (tmesh && !tmesh->triangle_normals_.empty());
                 has_colors = true;  // always want base_color as white
             } else if (t_mesh) {
-                has_normals = t_mesh->HasVertexNormals();
+                has_normals = t_mesh->HasVertexNormals() ||
+                              t_mesh->HasTriangleNormals();
                 has_colors = true;  // always want base_color as white
             } else if (voxel_grid) {
                 has_normals = false;
@@ -948,8 +952,6 @@ struct O3DVisualizer::Impl {
             }
 
             // Finally assign material properties if geometry is a triangle mesh
-            auto tmesh =
-                    std::dynamic_pointer_cast<geometry::TriangleMesh>(geom);
             if (tmesh && tmesh->materials_.size() > 0) {
                 // Only a single material is supported for TriangleMesh so we
                 // just grab the first one we find. Users should be using


### PR DESCRIPTION
`O3DVisualizer` was creating an unlit default material for triangle meshes with triangle normals. This PR fixes that so such meshes will show lit with flat shading. The following script can be used to test:
```
import open3d as o3d

sphere = o3d.geometry.TriangleMesh.create_sphere(2.0)
sphere.compute_triangle_normals()
o3d.visualization.draw(sphere)
```

Before:
![2022-03-08-173347_1024x768_scrot](https://user-images.githubusercontent.com/3722407/157338371-ab73b47f-c28e-4a41-9560-1f0762ac39c3.png)
After:
![2022-03-08-173816_1024x768_scrot](https://user-images.githubusercontent.com/3722407/157338387-fab92484-36a3-4487-8775-e1f5e936b5d0.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4867)
<!-- Reviewable:end -->
