### PR TITLE
support double click mouse event in webrtc

### DIFF
--- a/cpp/open3d/visualization/webrtc_server/html/webrtcstreamer.js
+++ b/cpp/open3d/visualization/webrtc_server/html/webrtcstreamer.js
@@ -281,6 +281,22 @@ let WebRtcStreamer = (function() {
                 };
                 this.sendJsonData(open3dMouseEvent);
             }, false);
+            this.videoElt.addEventListener('dblclick', (event) => {
+                event.preventDefault();
+                var open3dMouseEvent = {
+                    window_uid: windowUID,
+                    class_name: 'MouseEvent',
+                    type: 'BUTTON_DOWN',
+                    x: event.offsetX,
+                    y: event.offsetY,
+                    modifiers: WebRtcStreamer._getModifiers(event),
+                    button: {
+                        button: o3dmouseButtons[event.button],
+                        count: 2,
+                    },
+                };
+                this.sendJsonData(open3dMouseEvent);
+            }, false);
             this.videoElt.addEventListener('touchstart', (event) => {
                 event.preventDefault();
                 var rect = event.target.getBoundingClientRect();


### PR DESCRIPTION
mainly used to change center of scene in ROTATE_CAMERA view

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4903)
<!-- Reviewable:end -->
