### PR TITLE
reduce frame drawing by setup WEBRTC_FPS env

### DIFF
--- a/cpp/open3d/visualization/gui/BitmapWindowSystem.cpp
+++ b/cpp/open3d/visualization/gui/BitmapWindowSystem.cpp
@@ -57,27 +57,27 @@ struct BitmapWindow {
 struct BitmapEvent {
     BitmapWindow *event_target;
 
-    BitmapEvent(BitmapWindow *target) : event_target(target) {}
+    explicit BitmapEvent(BitmapWindow *target) : event_target(target) {}
     virtual ~BitmapEvent() {}
 
     virtual void Execute() = 0;
 };
 
 struct BitmapDrawEvent : public BitmapEvent {
-    BitmapDrawEvent(BitmapWindow *target) : BitmapEvent(target) {}
+    explicit BitmapDrawEvent(BitmapWindow *target) : BitmapEvent(target) {}
 
     void Execute() override { event_target->o3d_window->OnDraw(); }
 };
 
 struct BitmapResizeEvent : public BitmapEvent {
-    BitmapResizeEvent(BitmapWindow *target) : BitmapEvent(target) {}
+    explicit BitmapResizeEvent(BitmapWindow *target) : BitmapEvent(target) {}
 
     void Execute() override { event_target->o3d_window->OnResize(); }
 };
 
 struct BitmapCallableEvent : public BitmapEvent {
     std::function<void()> callable;
-    BitmapCallableEvent(std::function<void()> todo)
+    explicit BitmapCallableEvent(std::function<void()> todo)
         : BitmapEvent(nullptr), callable(todo) {}
 
     void Execute() override {

--- a/cpp/open3d/visualization/gui/BitmapWindowSystem.h
+++ b/cpp/open3d/visualization/gui/BitmapWindowSystem.h
@@ -72,6 +72,7 @@ public:
 
     Size GetScreenSize(OSWindow w) override;
 
+    void PostCallableEvent(std::function<void()> todo);
     void PostRedrawEvent(OSWindow w) override;
     void PostMouseEvent(OSWindow w, const MouseEvent& e);
     void PostKeyEvent(OSWindow w, const KeyEvent& e);
@@ -110,6 +111,9 @@ public:
                         rendering::FilamentRenderer* renderer) override;
 
     MenuBase* CreateOSMenu() override;
+
+    void SetMaxRenderFPS(int fps);
+    void ForceRender(bool render);
 
 private:
     struct Impl;


### PR DESCRIPTION
rendering every frame in webrtc is actually not necessary and expansive.
This PR allows user setup a max FPS to limit the rendering frequency, it reduces the CPU usage to 10% ~ 50%, with a little bit bad experience. 
Most importantly, it enables application with large resolution like 1080p, and editing complex point clouds in webrtc, without feeling terrible latency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4909)
<!-- Reviewable:end -->
