### PR TITLE
Windows build fixups for disabled OpenMP

### DIFF
--- a/cmake/Open3DSetGlobalProperties.cmake
+++ b/cmake/Open3DSetGlobalProperties.cmake
@@ -113,7 +113,7 @@ function(open3d_set_global_properties target)
         target_compile_definitions(${target} PUBLIC _GLIBCXX_USE_CXX11_ABI=0)
     endif()
 
-    if(NOT WITH_OPENMP)
+    if(UNIX AND NOT WITH_OPENMP)
         target_compile_options(${target} PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:-Wno-unknown-pragmas>")
     endif()
     if(WIN32)

--- a/cpp/open3d/utility/Parallel.cpp
+++ b/cpp/open3d/utility/Parallel.cpp
@@ -59,7 +59,7 @@ int EstimateMaxThreads() {
         return utility::CPUInfo::GetInstance().NumCores();
     }
 #else
-    (void)GetEnvVar;  // Avoids compiler warning.
+    (void)&GetEnvVar;  // Avoids compiler warning.
     return 1;
 #endif
 }


### PR DESCRIPTION
We observed some minor compilation issues on Windows with OpenMP disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4914)
<!-- Reviewable:end -->
