### PR TITLE
fix: O3DVisualizer::RemoveGeometry() function vector subscript out of…

### DIFF
--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
@@ -1058,8 +1058,8 @@ struct O3DVisualizer::Impl {
         for (size_t i = 0; i < objects_.size(); ++i) {
             if (objects_[i].name == name) {
                 group = objects_[i].group;
-                objects_.erase(objects_.begin() + i);
                 settings.object2itemid.erase(objects_[i].name);
+                objects_.erase(objects_.begin() + i);
                 break;
             }
         }


### PR DESCRIPTION
After `objects_.erase()`, `objects_[i].name` has out-of-bounds access risk

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4931)
<!-- Reviewable:end -->
