### PR TITLE
Visualizer: remove glfwTerminate() call from destructor (fix #4960) 

### DIFF
--- a/cpp/open3d/visualization/visualizer/ViewControl.cpp
+++ b/cpp/open3d/visualization/visualizer/ViewControl.cpp
@@ -193,13 +193,16 @@ bool ViewControl::ConvertFromPinholeCameraParameters(
         bool allow_arbitrary) {
     auto intrinsic = parameters.intrinsic_;
     auto extrinsic = parameters.extrinsic_;
-    if (!allow_arbitrary && (window_height_ <= 0 || window_width_ <= 0 ||
-                             window_height_ != intrinsic.height_ ||
-                             window_width_ != intrinsic.width_ ||
-                             intrinsic.intrinsic_matrix_(0, 2) !=
-                                     (double)window_width_ / 2.0 - 0.5 ||
-                             intrinsic.intrinsic_matrix_(1, 2) !=
-                                     (double)window_height_ / 2.0 - 0.5)) {
+
+    constexpr double threshold = 1.e-6;
+    if (!allow_arbitrary &&
+        (window_height_ <= 0 || window_width_ <= 0 ||
+         window_height_ != intrinsic.height_ ||
+         window_width_ != intrinsic.width_ ||
+         std::abs(intrinsic.intrinsic_matrix_(0, 2) -
+                  ((double)window_width_ / 2.0 - 0.5)) > threshold ||
+         std::abs(intrinsic.intrinsic_matrix_(1, 2) =
+                          ((double)window_height_ / 2.0 - 0.5)) > threshold)) {
         utility::LogWarning(
                 "[ViewControl] ConvertFromPinholeCameraParameters() failed "
                 "because window height and width do not match.");

--- a/cpp/open3d/visualization/visualizer/Visualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/Visualizer.cpp
@@ -26,6 +26,8 @@
 
 #include "open3d/visualization/visualizer/Visualizer.h"
 
+#include <memory>
+
 #include "open3d/geometry/TriangleMesh.h"
 
 #if defined(__APPLE__) && defined(BUILD_GUI)
@@ -37,51 +39,63 @@ void unbind();
 
 namespace open3d {
 
-namespace {
+namespace visualization {
 
-class GLFWEnvironmentSingleton {
+/// \brief GLFW context, handled as a singleton.
+class GLFWContext {
 private:
-    GLFWEnvironmentSingleton() { utility::LogDebug("GLFW init."); }
-    GLFWEnvironmentSingleton(const GLFWEnvironmentSingleton &) = delete;
-    GLFWEnvironmentSingleton &operator=(const GLFWEnvironmentSingleton &) =
-            delete;
+    GLFWContext() {
+        utility::LogDebug("GLFW init.");
 
-public:
-    ~GLFWEnvironmentSingleton() {
-        glfwTerminate();
-        utility::LogDebug("GLFW destruct.");
-    }
-
-public:
-    static GLFWEnvironmentSingleton &GetInstance() {
-        static GLFWEnvironmentSingleton singleton;
-        return singleton;
-    }
-
-    static int InitGLFW() {
-        GLFWEnvironmentSingleton::GetInstance();
 #if defined(__APPLE__)
         // On macOS, GLFW changes the directory to the resource directory,
         // which will cause an unexpected change of directory if using a
         // framework build version of Python.
         glfwInitHint(GLFW_COCOA_CHDIR_RESOURCES, GLFW_FALSE);
 #endif
-        return glfwInit();
+        init_status_ = glfwInit();
+    }
+
+    GLFWContext(const GLFWContext &) = delete;
+    GLFWContext &operator=(const GLFWContext &) = delete;
+
+public:
+    ~GLFWContext() {
+        if (init_status_ == GLFW_TRUE) {
+            glfwTerminate();
+            utility::LogDebug("GLFW destruct.");
+        }
+    }
+
+    /// \brief Get the glfwInit status.
+    inline int InitStatus() const { return init_status_; }
+
+    /// \brief Get a shared instance of the GLFW context.
+    static std::shared_ptr<GLFWContext> GetInstance() {
+        static std::weak_ptr<GLFWContext> singleton;
+
+        auto res = singleton.lock();
+        if (res == nullptr) {
+            res = std::shared_ptr<GLFWContext>(new GLFWContext());
+            singleton = res;
+        }
+        return res;
     }
 
     static void GLFWErrorCallback(int error, const char *description) {
         utility::LogWarning("GLFW Error: {}", description);
     }
+
+private:
+    /// \brief Status of the glfwInit call.
+    int init_status_ = GLFW_FALSE;
 };
-
-}  // unnamed namespace
-
-namespace visualization {
 
 Visualizer::Visualizer() {}
 
 Visualizer::~Visualizer() {
-    glfwTerminate();  // to be safe
+    DestroyVisualizerWindow();
+
 #if defined(__APPLE__) && defined(BUILD_GUI)
     bluegl::unbind();
 #endif
@@ -96,6 +110,7 @@ bool Visualizer::CreateVisualizerWindow(
         const bool visible /* = true*/) {
     window_name_ = window_name;
     if (window_) {  // window already created
+        utility::LogDebug("[Visualizer] Reusing window.");
         UpdateWindowTitle();
         glfwSetWindowPos(window_, left, top);
         glfwSetWindowSize(window_, width, height);
@@ -110,8 +125,10 @@ bool Visualizer::CreateVisualizerWindow(
         return true;
     }
 
-    glfwSetErrorCallback(GLFWEnvironmentSingleton::GLFWErrorCallback);
-    if (!GLFWEnvironmentSingleton::InitGLFW()) {
+    utility::LogDebug("[Visualizer] Creating window.");
+    glfwSetErrorCallback(GLFWContext::GLFWErrorCallback);
+    glfw_context_ = GLFWContext::GetInstance();
+    if (glfw_context_->InitStatus() != GLFW_TRUE) {
         utility::LogWarning("Failed to initialize GLFW");
         return false;
     }
@@ -220,9 +237,17 @@ bool Visualizer::CreateVisualizerWindow(
 }
 
 void Visualizer::DestroyVisualizerWindow() {
+    if (!is_initialized_) {
+        return;
+    }
+
+    utility::LogDebug("[Visualizer] Destroying window.");
     is_initialized_ = false;
     glDeleteVertexArrays(1, &vao_id_);
+    vao_id_ = 0;
     glfwDestroyWindow(window_);
+    window_ = nullptr;
+    glfw_context_.reset();
 }
 
 void Visualizer::RegisterAnimationCallback(

--- a/cpp/open3d/visualization/visualizer/Visualizer.h
+++ b/cpp/open3d/visualization/visualizer/Visualizer.h
@@ -56,6 +56,8 @@ class Image;
 
 namespace visualization {
 
+class GLFWContext;
+
 /// \class Visualizer
 ///
 /// \brief The main Visualizer class.
@@ -270,6 +272,10 @@ protected:
     // window
     GLFWwindow *window_ = NULL;
     std::string window_name_ = "Open3D";
+
+    /// \brief Shared GLFW context.
+    std::shared_ptr<GLFWContext> glfw_context_ = nullptr;
+
     Eigen::Vector2i saved_window_size_ = Eigen::Vector2i::Zero();
     Eigen::Vector2i saved_window_pos_ = Eigen::Vector2i::Zero();
     std::function<bool(Visualizer *)> animation_callback_func_ = nullptr;

--- a/examples/python/visualization/headless_rendering.py
+++ b/examples/python/visualization/headless_rendering.py
@@ -33,8 +33,8 @@ pyexample_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 test_data_path = os.path.join(os.path.dirname(pyexample_path), 'test_data')
 
 
-def custom_draw_geometry_with_camera_trajectory(pcd, camera_trajectory_path,
-                                                render_option_path):
+def custom_draw_geometry_with_camera_trajectory(pcd, render_option_path,
+                                                camera_trajectory_path):
     custom_draw_geometry_with_camera_trajectory.index = -1
     custom_draw_geometry_with_camera_trajectory.trajectory =\
         o3d.io.read_pinhole_camera_trajectory(camera_trajectory_path)
@@ -94,10 +94,9 @@ if __name__ == "__main__":
         exit(1)
 
     sample_data = o3d.data.DemoCustomVisualization()
-    pcd = o3d.io.read_point_cloud(sample_data.path,
-                                  sample_data.camera_trajectory_path,
-                                  sample_data.render_option_path)
+    pcd = o3d.io.read_point_cloud(sample_data.point_cloud_path)
 
     print("Customized visualization playing a camera trajectory. "
           "Press ctrl+z to terminate.")
-    custom_draw_geometry_with_camera_trajectory(pcd)
+    custom_draw_geometry_with_camera_trajectory(
+        pcd, sample_data.render_option_path, sample_data.camera_trajectory_path)


### PR DESCRIPTION
Summary of changes:
- A fix for #4960: `glfwTerminate()` was called everytime a `Visualizer` is destroyed. Now a true singleton shared context is used, and terminate is only called if there is no remaining active `Visualizer`. I also fixed `DestroyVisualizerWindow()`.
- `headless_rendering.py`: fix the example.
- `ViewControl::ConvertFromPinholeCameraParameters()`: relax the equality check due to floating-point errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4963)
<!-- Reviewable:end -->
