### PR TITLE
Radius Outlier Filter for Tensor PointCloud 

### DIFF
--- a/cpp/open3d/t/geometry/PointCloud.cpp
+++ b/cpp/open3d/t/geometry/PointCloud.cpp
@@ -38,10 +38,12 @@
 #include "open3d/core/TensorCheck.h"
 #include "open3d/core/hashmap/HashSet.h"
 #include "open3d/core/linalg/Matmul.h"
+#include "open3d/core/nns/NearestNeighborSearch.h"
 #include "open3d/t/geometry/TensorMap.h"
 #include "open3d/t/geometry/kernel/GeometryMacros.h"
 #include "open3d/t/geometry/kernel/PointCloud.h"
 #include "open3d/t/geometry/kernel/Transform.h"
+#include "open3d/t/pipelines/registration/Registration.h"
 
 namespace open3d {
 namespace t {
@@ -212,6 +214,33 @@ PointCloud &PointCloud::Rotate(const core::Tensor &R,
     return *this;
 }
 
+PointCloud PointCloud::SelectPoints(const core::Tensor &boolean_mask,
+                                    bool invert /* = false */) const {
+    const int64_t length = GetPointPositions().GetLength();
+    core::AssertTensorDtype(boolean_mask, core::Dtype::Bool);
+    core::AssertTensorShape(boolean_mask, {length});
+    core::AssertTensorDevice(boolean_mask, GetDevice());
+
+    core::Tensor indices_local;
+    if (invert) {
+        indices_local = boolean_mask.LogicalNot();
+    } else {
+        indices_local = boolean_mask;
+    }
+
+    PointCloud pcd(GetDevice());
+    for (auto &kv : GetPointAttr()) {
+        if (HasPointAttr(kv.first)) {
+            pcd.SetPointAttr(kv.first,
+                             kv.second.IndexGet({indices_local}).Clone());
+        }
+    }
+
+    utility::LogDebug("Pointcloud down sampled from {} points to {} points.",
+                      length, pcd.GetPointPositions().GetLength());
+    return pcd;
+}
+
 PointCloud PointCloud::VoxelDownSample(
         double voxel_size, const core::HashBackendType &backend) const {
     if (voxel_size <= 0) {
@@ -239,6 +268,36 @@ PointCloud PointCloud::VoxelDownSample(
     }
 
     return pcd_down;
+}
+
+std::tuple<PointCloud, core::Tensor> PointCloud::RemoveRadiusOutliers(
+        size_t nb_points, double search_radius) const {
+    if (nb_points < 1 || search_radius <= 0) {
+        utility::LogError(
+                "Illegal input parameters, number of points and radius must be "
+                "positive");
+    }
+    core::nns::NearestNeighborSearch target_nns(GetPointPositions());
+
+    const bool check = target_nns.FixedRadiusIndex(search_radius);
+    if (!check) {
+        utility::LogError("Fixed radius search index is not set.");
+    }
+
+    core::Tensor indices, distance, row_splits;
+    std::tie(indices, distance, row_splits) = target_nns.FixedRadiusSearch(
+            GetPointPositions(), search_radius, false);
+    row_splits = row_splits.To(GetDevice());
+
+    const int64_t size = row_splits.GetLength();
+    const core::Tensor num_neighbors =
+            row_splits.Slice(0, 1, size) - row_splits.Slice(0, 0, size - 1);
+
+    const core::Tensor valid =
+            num_neighbors.Ge(static_cast<int64_t>(nb_points));
+    const PointCloud pcd = SelectPoints(valid);
+
+    return std::make_tuple(pcd, valid);
 }
 
 void PointCloud::EstimateNormals(

--- a/cpp/open3d/t/geometry/PointCloud.h
+++ b/cpp/open3d/t/geometry/PointCloud.h
@@ -311,11 +311,30 @@ public:
     /// \return Rotated point cloud
     PointCloud &Rotate(const core::Tensor &R, const core::Tensor &center);
 
+    /// \brief Select points from input pointcloud, based on boolean mask
+    /// indices into output point cloud.
+    ///
+    /// \param boolean_mask Boolean indexing tensor of shape {n,} containing
+    /// true value for the indices that is to be selected.
+    /// \param invert Set to `True` to invert the selection of indices.
+    PointCloud SelectPoints(const core::Tensor &boolean_mask,
+                            bool invert = false) const;
+
     /// \brief Downsamples a point cloud with a specified voxel size.
     /// \param voxel_size Voxel size. A positive number.
     PointCloud VoxelDownSample(double voxel_size,
                                const core::HashBackendType &backend =
                                        core::HashBackendType::Default) const;
+
+    /// \brief Remove points that have less than \p nb_points neighbors in a
+    /// sphere of a given radius.
+    ///
+    /// \param nb_points Number of neighbor points required within the radius.
+    /// \param search_radius Radius of the sphere.
+    /// \return tuple of filtered PointCloud and boolean indexing tensor
+    /// w.r.t. input point cloud.
+    std::tuple<PointCloud, core::Tensor> RemoveRadiusOutliers(
+            size_t nb_points, double search_radius) const;
 
     /// \brief Returns the device attribute of this PointCloud.
     core::Device GetDevice() const { return device_; }
@@ -325,8 +344,8 @@ public:
     /// exist, the estimated normals are oriented with respect to the same.
     /// It uses KNN search if only max_nn parameter is provided, and
     /// HybridSearch if radius parameter is also provided.
-    /// \param max_nn NeighbourSearch max neighbours parameter [Default = 30].
-    /// \param radius [optional] NeighbourSearch radius parameter to use
+    /// \param max_nn Neighbor search max neighbors parameter [Default = 30].
+    /// \param radius [optional] Neighbor search radius parameter to use
     /// HybridSearch. [Recommended ~1.4x voxel size].
     void EstimateNormals(
             const int max_nn = 30,
@@ -336,8 +355,8 @@ public:
     /// then HybridSearch is used, otherwise KNN-Search is used.
     /// Reference: Park, Q.-Y. Zhou, and V. Koltun,
     /// Colored Point Cloud Registration Revisited, ICCV, 2017.
-    /// \param max_nn NeighbourSearch max neighbours parameter [Default = 30].
-    /// \param radius [optional] NeighbourSearch radius parameter to use
+    /// \param max_nn Neighbor search max neighbors parameter [Default = 30].
+    /// \param radius [optional] Neighbor search radius parameter to use
     /// HybridSearch. [Recommended ~1.4x voxel size].
     void EstimateColorGradients(
             const int max_nn = 30,

--- a/cpp/pybind/t/geometry/pointcloud.cpp
+++ b/cpp/pybind/t/geometry/pointcloud.cpp
@@ -59,10 +59,10 @@ static const std::unordered_map<std::string, std::string>
                  "normals are requested, the depth map is first filtered to "
                  "ensure smooth normals."},
                 {"max_nn",
-                 "NeighbourSearch max neighbours parameter [default = 30]."},
+                 "Neighbor search max neighbors parameter [default = 30]."},
                 {"radius",
-                 "[optional] NeighbourSearch radius parameter to use "
-                 "HybridSearch. [Recommended ~1.4x voxel size]."}};
+                 "neighbors search radius parameter to use HybridSearch. "
+                 "[Recommended ~1.4x voxel size]."}};
 
 void pybind_pointcloud(py::module& m) {
     py::class_<PointCloud, PyGeometry<PointCloud>, std::shared_ptr<PointCloud>,
@@ -181,6 +181,10 @@ The attributes of the point cloud have different levels::
     pointcloud.def("rotate", &PointCloud::Rotate, "R"_a, "center"_a,
                    "Rotate points and normals (if exist).");
 
+    pointcloud.def("select_points", &PointCloud::SelectPoints, "boolean_mask"_a,
+                   "invert"_a = false,
+                   "Select points from input pointcloud, based on boolean mask "
+                   "indices into output point cloud.");
     pointcloud.def(
             "voxel_down_sample",
             [](const PointCloud& pointcloud, const double voxel_size) {
@@ -189,6 +193,10 @@ The attributes of the point cloud have different levels::
             },
             "Downsamples a point cloud with a specified voxel size.",
             "voxel_size"_a);
+    pointcloud.def("remove_radius_outliers", &PointCloud::RemoveRadiusOutliers,
+                   "nb_points"_a, "search_radius"_a,
+                   "Remove points that have less than nb_points neighbors in a "
+                   "sphere of a given search radius.");
 
     pointcloud.def("estimate_normals", &PointCloud::EstimateNormals,
                    py::call_guard<py::gil_scoped_release>(),
@@ -256,6 +264,8 @@ The attributes of the point cloud have different levels::
                                     map_shared_argument_docstrings);
     docstring::ClassMethodDocInject(m, "PointCloud", "create_from_rgbd_image",
                                     map_shared_argument_docstrings);
+    docstring::ClassMethodDocInject(m, "PointCloud", "select_points");
+    docstring::ClassMethodDocInject(m, "PointCloud", "remove_radius_outliers");
 }
 
 }  // namespace geometry

--- a/cpp/tests/t/geometry/PointCloud.cpp
+++ b/cpp/tests/t/geometry/PointCloud.cpp
@@ -671,20 +671,31 @@ TEST_P(PointCloudPermuteDevices, CreateFromRGBDOrDepthImageWithNormals) {
     EXPECT_TRUE(pcd_out.GetPointNormals().AllClose(t_normal_ref));
 }
 
-TEST_P(PointCloudPermuteDevices, VoxelDownSample) {
+TEST_P(PointCloudPermuteDevices, SelectPoints) {
     core::Device device = GetParam();
 
-    data::PCDPointCloud sample_pcd;
-    // Sanity test to visualize
-    t::geometry::PointCloud pcd =
-            t::geometry::PointCloud::FromLegacy(
-                    *io::CreatePointCloudFromFile(sample_pcd.GetPath()))
-                    .To(device);
-    auto pcd_down = pcd.VoxelDownSample(0.1);
+    const t::geometry::PointCloud pcd_small(
+            core::Tensor::Init<float>({{0.1, 0.3, 0.9},
+                                       {0.9, 0.2, 0.4},
+                                       {0.3, 0.6, 0.8},
+                                       {0.2, 0.4, 0.2}},
+                                      device));
+    const core::Tensor boolean_mask =
+            core::Tensor::Init<bool>({true, false, false, true}, device);
 
-    const std::string file_path =
-            utility::filesystem::GetTempDirectoryPath() + "/down.pcd";
-    t::io::WritePointCloud(file_path, pcd_down);
+    const auto pcd_select = pcd_small.SelectPoints(boolean_mask, false);
+    EXPECT_TRUE(
+            pcd_select.GetPointPositions().AllClose(core::Tensor::Init<float>(
+                    {{0.1, 0.3, 0.9}, {0.2, 0.4, 0.2}}, device)));
+
+    const auto pcd_select_invert = pcd_small.SelectPoints(boolean_mask, true);
+    EXPECT_TRUE(pcd_select_invert.GetPointPositions().AllClose(
+            core::Tensor::Init<float>({{0.9, 0.2, 0.4}, {0.3, 0.6, 0.8}},
+                                      device)));
+}
+
+TEST_P(PointCloudPermuteDevices, VoxelDownSample) {
+    core::Device device = GetParam();
 
     // Value test
     t::geometry::PointCloud pcd_small(
@@ -696,6 +707,31 @@ TEST_P(PointCloudPermuteDevices, VoxelDownSample) {
     auto pcd_small_down = pcd_small.VoxelDownSample(1);
     EXPECT_TRUE(pcd_small_down.GetPointPositions().AllClose(
             core::Tensor::Init<float>({{0, 0, 0}}, device)));
+}
+
+TEST_P(PointCloudPermuteDevices, RemoveRadiusOutliers) {
+    core::Device device = GetParam();
+
+    const t::geometry::PointCloud pcd_small(
+            core::Tensor::Init<float>({{1.0, 1.0, 1.0},
+                                       {1.1, 1.1, 1.1},
+                                       {1.2, 1.2, 1.2},
+                                       {1.3, 1.3, 1.3},
+                                       {5.0, 5.0, 5.0},
+                                       {5.1, 5.1, 5.1}},
+                                      device));
+
+    t::geometry::PointCloud output_pcd;
+    core::Tensor selected_boolean_mask;
+    std::tie(output_pcd, selected_boolean_mask) =
+            pcd_small.RemoveRadiusOutliers(3, 0.5);
+
+    EXPECT_TRUE(output_pcd.GetPointPositions().AllClose(
+            core::Tensor::Init<float>({{1.0, 1.0, 1.0},
+                                       {1.1, 1.1, 1.1},
+                                       {1.2, 1.2, 1.2},
+                                       {1.3, 1.3, 1.3}},
+                                      device)));
 }
 
 }  // namespace tests


### PR DESCRIPTION
Python Example:
```python
import open3d as o3d

# Sample PCD data.
sample_pcd_data = o3d.data.PCDPointCloud()

# Load the data, and down-sample.
tpcd = o3d.t.io.read_point_cloud(sample_pcd_data.path).voxel_down_sample(0.02)
o3d.visualization.draw(tpcd)

# Remove Radius Outliers. 
tpcd_filtered, indices = tpcd.remove_radius_outliers(nb_points=20, search_radius=0.05)
o3d.visualization.draw(tpcd_filtered)

# Print len of points before and after to check.
print(len(tpcd.point["positions"]))
print(len(tpcd_filtered.point["positions"]))
```

Performance Comparision (for `o3d.data.PLYPointCloud`)
```
---------------------------------------------------------------------------------------
Benchmark                                             Time             CPU 
---------------------------------------------------------------------------------------
RemoveRadiusOutliers/CPU[50 | 0.05]                46.5 ms         46.0 ms 
RemoveRadiusOutliers/CUDA[50 | 0.05]               2.05 ms         2.04 ms
LegacyRemoveRadiusOutliers/Legacy[50 | 0.05]       59.2 ms         57.9 ms
```

TODO:
- [x] Add Unit Tests.
- [x] Merge after https://github.com/isl-org/Open3D/pull/4955 is merged to master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/4990)
<!-- Reviewable:end -->
