### PR TITLE
Remove incorrect doc comment from CorrespondenceChecker

### DIFF
--- a/cpp/open3d/pipelines/registration/CorrespondenceChecker.h
+++ b/cpp/open3d/pipelines/registration/CorrespondenceChecker.h
@@ -62,8 +62,6 @@ public:
 public:
     /// \brief Function to check if two points can be aligned.
     ///
-    /// The two input point
-    /// clouds must have exact the same number of points.
     /// \param source Source point cloud.
     /// \param target Target point cloud.
     /// \param corres Correspondence set between source and target point cloud.


### PR DESCRIPTION
Remove incorrect doc comment from CorrespondenceChecker

The initial version of correspondence checker was committed with a requirement that the input point clouds had the same length.  However this ceased to be required when the class was updated to only check correspondence at specified points rather than scanning all points in both inputs.  The docs were never updated with the removal of that requirement, fixing the docs here to reduce confusion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5005)
<!-- Reviewable:end -->
