### PR TITLE
Updated OpenBLAS to v0.3.20 and fixed build from source.

### DIFF
--- a/3rdparty/openblas/openblas.cmake
+++ b/3rdparty/openblas/openblas.cmake
@@ -9,8 +9,8 @@ endif()
 ExternalProject_Add(
     ext_openblas
     PREFIX openblas
-    URL https://github.com/xianyi/OpenBLAS/releases/download/v0.3.19/OpenBLAS-0.3.19.tar.gz
-    URL_HASH SHA256=947f51bfe50c2a0749304fbe373e00e7637600b0a47b78a51382aeb30ca08562
+    URL https://github.com/xianyi/OpenBLAS/releases/download/v0.3.20/OpenBLAS-0.3.20.tar.gz
+    URL_HASH SHA256=8495c9affc536253648e942908e88e097f2ec7753ede55aca52e5dead3029e3c
     DOWNLOAD_DIR "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/openblas"
     CMAKE_ARGS
         ${ExternalProject_CMAKE_ARGS}

--- a/3rdparty/openblas/openblas.cmake
+++ b/3rdparty/openblas/openblas.cmake
@@ -1,16 +1,10 @@
 include(ExternalProject)
 
-set(OPENBLAS_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/openblas)
-
 if(LINUX_AARCH64 OR APPLE_AARCH64)
     set(OPENBLAS_TARGET "ARMV8")
 else()
     set(OPENBLAS_TARGET "NEHALEM")
 endif()
-
-set(OPENBLAS_INCLUDE_DIR "${OPENBLAS_INSTALL_PREFIX}/include/openblas/") # The "/"" is critical, see open3d_import_3rdparty_library.
-set(OPENBLAS_LIB_DIR "${OPENBLAS_INSTALL_PREFIX}/lib")
-set(OPENBLAS_LIBRARIES openblas)  # Extends to libopenblas.a automatically.
 
 ExternalProject_Add(
     ext_openblas
@@ -21,9 +15,15 @@ ExternalProject_Add(
     CMAKE_ARGS
         ${ExternalProject_CMAKE_ARGS}
         -DTARGET=${OPENBLAS_TARGET}
-        -DCMAKE_INSTALL_PREFIX=${OPENBLAS_INSTALL_PREFIX}
-    BUILD_BYPRODUCTS ${OPENBLAS_LIB_DIR}/libopenblas.a
+        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+    BUILD_BYPRODUCTS 
+        <INSTALL_DIR>/${Open3D_INSTALL_LIB_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${lib_name}${lib_suffix}${CMAKE_STATIC_LIBRARY_SUFFIX}
 )
+
+ExternalProject_Get_Property(ext_openblas INSTALL_DIR)
+set(OPENBLAS_INCLUDE_DIR ${INSTALL_DIR}/include/openblas/) # "/" is critical.
+set(OPENBLAS_LIB_DIR ${INSTALL_DIR}/${Open3D_INSTALL_LIB_DIR})
+set(OPENBLAS_LIBRARIES openblas)
 
 message(STATUS "OPENBLAS_INCLUDE_DIR: ${OPENBLAS_INCLUDE_DIR}")
 message(STATUS "OPENBLAS_LIB_DIR ${OPENBLAS_LIB_DIR}")


### PR DESCRIPTION
## Before these changes
Previously there was an issue with openblas paths that caused an error when building openplas from source (which is required on ARM platforms) using `-DUSE_BLAS=ON -DUSE_SYSTEM_BLAS=OFF`:
```
...
-- OPENBLAS_INCLUDE_DIR: /home/[REDACTED]/Open3D/build/openblas/include/openblas/
-- OPENBLAS_LIB_DIR /home/[REDACTED]/Open3D/build/openblas/lib
-- OPENBLAS_LIBRARIES: openblas
...
-- Third-Party Dependencies:
...
--   BLAS .................................... yes (build from source)
...
```

Resulted in this error:
```
make[2]: *** No rule to make target 'openblas/lib/libopenblas.a', needed by 'bin/GLInfo'.  Stop.
make[2]: *** Waiting for unfinished jobs....
make[2]: *** No rule to make target 'openblas/lib/libopenblas.a', needed by 'bin/ConvertPointCloud'.  Stop.
make[2]: *** Waiting for unfinished jobs....
make[2]: *** No rule to make target 'openblas/lib/libopenblas.a', needed by 'bin/ManuallyCropGeometry'.  Stop.
make[2]: *** Waiting for unfinished jobs....
make[2]: *** No rule to make target 'openblas/lib/libopenblas.a', needed by 'bin/MergeMesh'.  Stop.
make[2]: *** Waiting for unfinished jobs....
make[2]: *** No rule to make target 'openblas/lib/libopenblas.a', needed by 'bin/ViewGeometry'.  Stop.
make[2]: *** Waiting for unfinished jobs....
make[2]: *** No rule to make target 'openblas/lib/libopenblas.a', needed by 'bin/Open3D/Open3D'.  Stop.
make[2]: *** Waiting for unfinished jobs....
make[2]: *** No rule to make target 'openblas/lib/libopenblas.a', needed by 'bin/examples/CameraPoseTrajectory'.  Stop.
make[2]: *** Waiting for unfinished jobs....
```

## After these changes:
```
...
-- OPENBLAS_INCLUDE_DIR: /home/[REDACTED]/Open3D/build/openblas/include/openblas/
-- OPENBLAS_LIB_DIR /home/[REDACTED]/Open3D/build/openblas/lib/x86_64-linux-gnu
-- OPENBLAS_LIBRARIES: openblas
...
-- Third-Party Dependencies:
...
--   BLAS .................................... yes (build from source)
...
```
Resulted in a successful build:
```
...
[100%] Built target AzureKinectViewer
[100%] Built target pybind
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5006)
<!-- Reviewable:end -->
