### PR TITLE
add `--parallel` option to `make_docs.py`

### DIFF
--- a/docs/arm.rst
+++ b/docs/arm.rst
@@ -96,7 +96,6 @@ Qemu:
 
 and follow the same steps as above.
 
-
 Building Open3D directly
 ------------------------
 
@@ -124,7 +123,6 @@ Install dependencies
 
     # Check cmake version, you should have 3.19+
     cmake --version
-
 
 If the Open3D build system complains about ``CMake xxx or higher is required``,
 refer to one of the following options:
@@ -159,7 +157,6 @@ Build
     python -c "import open3d; print(open3d.__version__)"
     python -c "import open3d as o3d; c = o3d.geometry.TriangleMesh.create_box(); o3d.visualization.draw_geometries([c])"
     python -c "import open3d as o3d; c = o3d.geometry.TriangleMesh.create_box(); o3d.visualization.draw(c)"
-
 
 Compiling Open3D on ARM64 macOS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/builddocs.rst
+++ b/docs/builddocs.rst
@@ -57,8 +57,16 @@ Python package with:
     cd docs
 
     # Run `python make_docs.py --help` to usage of the flags.
-    # Example usage: execute notebooks when it has not been executed.
-    python make_docs.py --clean_notebooks --execute_notebooks=auto --sphinx --doxygen
+    python make_docs.py --help
+
+    # Example: build .rst and C++ docs only, skip notebooks.
+    python make_docs.py --execute_notebooks=never --sphinx --doxygen
+
+    # Example: build .rst and C++ docs only, skip notebooks, with parallel build.
+    python make_docs.py --execute_notebooks=never --sphinx --doxygen --parallel
+
+    # Example: build .rst and c++ docs, execute notebooks when it has not been executed.
+    python make_docs.py --execute_notebooks=auto --sphinx --doxygen
 
 The docs html will be saved in ``docs/_out`` folder.
 

--- a/docs/builddocs.rst
+++ b/docs/builddocs.rst
@@ -34,14 +34,12 @@ First, install a TeX distribution such as `MacTeX <http://www.tug.org/mactex/>`_
 
     brew install ghostscript pandoc doxygen
 
-
 2. Install Python dependencies
 ``````````````````````````````
 
 .. code-block:: bash
 
     pip install -r docs/requirements.txt
-
 
 Build
 -----

--- a/docs/builddocs.rst
+++ b/docs/builddocs.rst
@@ -58,7 +58,7 @@ Python package with:
 
     # Run `python make_docs.py --help` to usage of the flags.
     # Example usage: execute notebooks when it has not been executed.
-    python make_docs.py --clean_notebooks --execute_notebooks=auto --sphinx --doxygen --parallel
+    python make_docs.py --clean_notebooks --execute_notebooks=auto --sphinx --doxygen
 
 The docs html will be saved in ``docs/_out`` folder.
 

--- a/docs/builddocs.rst
+++ b/docs/builddocs.rst
@@ -58,7 +58,7 @@ Python package with:
 
     # Run `python make_docs.py --help` to usage of the flags.
     # Example usage: execute notebooks when it has not been executed.
-    python make_docs.py --clean_notebooks --execute_notebooks=auto --sphinx --doxygen
+    python make_docs.py --clean_notebooks --execute_notebooks=auto --sphinx --doxygen --parallel
 
 The docs html will be saved in ``docs/_out`` folder.
 

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -34,7 +34,6 @@ System requirements
   <https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html>`_ to
   install the CUDA toolkit from Nvidia.
 
-
 Cloning Open3D
 --------------
 
@@ -56,7 +55,6 @@ Ubuntu/macOS
 
     # Only needed for Ubuntu
     util/install_deps_ubuntu.sh
-
 
 .. _compilation_unix_python:
 
@@ -115,7 +113,6 @@ To install Open3D C++ library:
 To link a C++ project against the Open3D C++ library, please refer to
 :ref:`cplusplus_example_project`.
 
-
 To install Open3D Python library, build one of the following options:
 
 .. code-block:: bash
@@ -136,7 +133,6 @@ Finally, verify the python installation with:
 .. code-block:: bash
 
     python -c "import open3d"
-
 
 .. _compilation_windows:
 
@@ -270,7 +266,6 @@ Open3D-ML from GitHub during the build with
     To reproduce the Open3D PyTorch wheels see the builder repository `here.
     <https://github.com/isl-org/pytorch_builder>`_
 
-
 The following example shows the command for building the ops with GPU support
 for all supported ML frameworks and bundling the high level Open3D-ML code.
 
@@ -368,7 +363,6 @@ To build and run C++ unit tests:
     cmake -DBUILD_UNIT_TESTS=ON ..
     make -j$(nproc)
     ./bin/tests
-
 
 To run Python unit tests:
 

--- a/docs/contribute/contribution_recipes.rst
+++ b/docs/contribute/contribution_recipes.rst
@@ -54,7 +54,6 @@ Dos
 | [DO] Avoid “premature optimization” that may hinder code readability                                        |
 +-------------------------------------------------------------------------------------------------------------+
 
-
 Don’ts
 ------
 
@@ -68,12 +67,10 @@ Don’ts
 | [DON'T]  Do not create a massive pull request with dozens of commits and files                                          |
 +-------------------------------------------------------------------------------------------------------------------------+
 
-
 .. _review_contribution:
 
 Code reviews
 ============
-
 
 You want to contribute to Open3D by reviewing code. Your mission is to help developers comply with Open3D standards. If you are new to this, make sure you have a good understanding of code review. (See this `excellent introduction <https://google.github.io/eng-practices/review/reviewer/>`_.) Follow the procedure below.
 
@@ -101,7 +98,6 @@ Recommended procedure
 
 Congratulations, you have improved Open3D with your review. You are now part of Open3D!
 
-
 Dos
 ---
 
@@ -123,7 +119,6 @@ Don’ts
 +-----------------------------------------------------------------------------------------------------------------------------------+
 | [DON’T] Do not approve just to be nice. Do not compromise on quality. Do not compromise the :ref:`principles` of Open3D           |
 +-----------------------------------------------------------------------------------------------------------------------------------+
-
 
 .. _report_contribution:
 
@@ -171,9 +166,7 @@ Don’ts
 | [DON’T] Do not open a new issue without double-checking whether there is already an existing issue that deals with the same problem   |
 +---------------------------------------------------------------------------------------------------------------------------------------+
 
-
 .. _documentation_contribution:
-
 
 Documentation
 =============
@@ -208,7 +201,7 @@ Case 1: When documenting C++ code
         /// \return The sum of \p a and \p b.
         /// \example
         ///
-        ///     c = add(5, 4);  
+        ///     c = add(5, 4);
         int add(int a, int b) { return a + b; }
 
         /// \brief Computes subtraction.
@@ -225,7 +218,6 @@ Case 1: When documenting C++ code
     };
 
 * Add in-line comments to cpp files to explain complex or non-intuitive parts of your algorithm.
-
 
 Case 2: When documenting Python bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -256,12 +248,10 @@ Case 2: When documenting Python bindings
                                     {{"a", "LHS operand for subtraction."},
                                      {"b", "RHS operand for subtraction."}});
 
-
 Case 3: When documenting pure Python code (no bindings)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Use standard docstring syntax (`Google style <https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings>`__) as explained `here <https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html>`_ and `there <https://www.python.org/dev/peps/pep-0257/>`_.
-
 
 Case 4: When adding a Python tutorial
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/contribute/styleguide.rst
+++ b/docs/contribute/styleguide.rst
@@ -42,7 +42,6 @@ Option 2: Configure the project and run ``make``.
    cmake --build . --target check-style
    cmake --build . --target apply-style
 
-
 Coding style
 =============
 

--- a/docs/docker.in.rst
+++ b/docs/docker.in.rst
@@ -17,7 +17,6 @@ Docker is installed correctly, run:
     # You should be able to run this without sudo.
     docker run hello-world
 
-
 Install and run Open3D apps in docker
 -------------------------------------
 

--- a/docs/getting_started.in.rst
+++ b/docs/getting_started.in.rst
@@ -120,7 +120,6 @@ Try it
 
 If everything works, congratulations, now Open3D has been successfully installed!
 
-
 Troubleshooting:
 ^^^^^^^^^^^^^^^^
 
@@ -130,7 +129,6 @@ help troubleshoot the issue:
 .. code-block:: bash
 
     python -W default -c "import open3d as o3d"
-
 
 Running Open3D tutorials
 ------------------------
@@ -143,7 +141,6 @@ all Python examples.
     ``matplotlib``, ``opencv-python``. OpenCV is only used for reconstruction
     system. Please read ``util/install-deps-python.sh`` for installing these
     packages.
-
 
 .. _install_open3d_c++:
 
@@ -216,7 +213,6 @@ Extract the archive and move the contents to a local folder (such as
         ├── libOpen3D.so                  │       ├── ...
         ├── open3d_tf_ops.so              └── lib
         └── open3d_torch_ops.so               └── Open3D.lib
-
 
 Some files may be absent in the case of unsupported functionality. To use Open3D
 with your programs through `cmake`, add ``-D

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,6 @@ Open3D: A Modern Library for 3D Data Processing
     arm
     docker
 
-
 .. toctree::
     :maxdepth: 2
     :caption: Tutorial
@@ -46,7 +45,6 @@ Open3D: A Modern Library for 3D Data Processing
     tutorial/sensor/index
     tutorial/reference
 
-
 .. toctree::
     :maxdepth: 1
     :caption: Contribute
@@ -54,7 +52,6 @@ Open3D: A Modern Library for 3D Data Processing
     contribute/contribute
     contribute/contribution_recipes
     contribute/styleguide
-
 
 .. toctree::
     :maxdepth: 1

--- a/docs/python_api_in/open3d.io.rpc.rst
+++ b/docs/python_api_in/open3d.io.rpc.rst
@@ -10,7 +10,6 @@ open3d.io.rpc
     BufferConnection
     Connection
 
-
 **Functions**
 
 .. autosummary::
@@ -23,7 +22,6 @@ open3d.io.rpc
     set_point_cloud
     set_time
     set_triangle_mesh
-
 
 .. toctree::
     :hidden:

--- a/docs/python_api_in/open3d.ml.tf.layers.rst
+++ b/docs/python_api_in/open3d.ml.tf.layers.rst
@@ -17,7 +17,6 @@ open3d.ml.tf.layers
     SparseConvTranspose
     VoxelPooling
 
-
 .. toctree::
     :hidden:
 

--- a/docs/python_api_in/open3d.ml.tf.ops.rst
+++ b/docs/python_api_in/open3d.ml.tf.ops.rst
@@ -24,7 +24,6 @@ open3d.ml.tf.ops
     voxel_pooling_grad
     voxelize
 
-
 .. toctree::
     :hidden:
 

--- a/docs/python_api_in/open3d.ml.torch.layers.rst
+++ b/docs/python_api_in/open3d.ml.torch.layers.rst
@@ -17,7 +17,6 @@ open3d.ml.torch.layers
     SparseConvTranspose
     VoxelPooling
 
-
 .. toctree::
     :hidden:
 

--- a/docs/python_api_in/open3d.ml.torch.ops.rst
+++ b/docs/python_api_in/open3d.ml.torch.ops.rst
@@ -21,7 +21,6 @@ open3d.ml.torch.ops
     voxel_pooling
     voxelize
 
-
 .. toctree::
     :hidden:
 

--- a/docs/python_api_in/open3d.visualization.rst
+++ b/docs/python_api_in/open3d.visualization.rst
@@ -26,7 +26,6 @@ open3d.visualization
     VisualizerWithKeyCallback
     VisualizerWithVertexSelection
 
-
 **Functions**
 
 .. autosummary::
@@ -40,7 +39,6 @@ open3d.visualization
     draw_geometries_with_vertex_selection
     read_selection_polygon_volume
 
-
 **Modules**
 
 .. autosummary::
@@ -49,7 +47,6 @@ open3d.visualization
     rendering
     webrtc_server
     tensorboard_plugin.summary
-
 
 .. toctree::
     :hidden:

--- a/docs/tutorial/reconstruction_system/capture_your_own_dataset.rst
+++ b/docs/tutorial/reconstruction_system/capture_your_own_dataset.rst
@@ -68,7 +68,6 @@ A new configuration file is required to specify path to the new dataset.
 Note that ``path_dataset`` and ``path_intrinsic`` indicates paths of dataset
 and intrinsic parameters.
 
-
 Run reconstruction system
 ``````````````````````````````````````
 

--- a/docs/tutorial/reconstruction_system/integrate_scene.rst
+++ b/docs/tutorial/reconstruction_system/integrate_scene.rst
@@ -31,7 +31,6 @@ This function first reads the alignment results from both
 RGBD image in the global space. After that, RGBD images are integrated using
 :ref:`/tutorial/pipelines/rgbd_integration.ipynb`.
 
-
 Results
 ``````````````````````````````````````
 This is a printed log from the volume integration script.

--- a/docs/tutorial/reconstruction_system/make_fragments.rst
+++ b/docs/tutorial/reconstruction_system/make_fragments.rst
@@ -38,7 +38,6 @@ computes OpenCV ORB feature to match sparse features over wide baseline images,
 then performs 5-point RANSAC to estimate a rough alignment, which is used as
 the initialization of ``compute_rgbd_odometry``.
 
-
 .. _make_fragments_make_a_posegraph:
 
 Multiway registration

--- a/docs/tutorial/reconstruction_system/refine_registration.rst
+++ b/docs/tutorial/reconstruction_system/refine_registration.rst
@@ -15,7 +15,6 @@ The first function performs pairwise registration on the pairs detected by
 :ref:`reconstruction_system_register_fragments`. The second function performs
 multiway registration.
 
-
 Fine-grained registration
 ``````````````````````````````````````
 
@@ -28,7 +27,6 @@ Fine-grained registration
 Two options are given for the fine-grained registration. The ``color`` option is
 recommended since it uses color information to prevent drift. See [Park2017]_
 for details.
-
 
 Multiway registration
 ``````````````````````````````````````
@@ -84,7 +82,6 @@ The pose graph optimization outputs the following messages:
     Delta.norm() < 1.000000e-06 * (x.norm() + 1.000000e-06)
     [GlobalOptimizationLM] total time : 0.000 sec.
     CompensateReferencePoseGraphNode : reference : 0
-
 
 There are 14 fragments and 52 valid matching pairs between fragments. After 23
 iterations, 11 edges are detected to be false positives. After they are pruned,

--- a/docs/tutorial/reconstruction_system/register_fragments.rst
+++ b/docs/tutorial/reconstruction_system/register_fragments.rst
@@ -15,7 +15,6 @@ The main function runs ``make_posegraph_for_scene`` and
 ``optimize_posegraph_for_scene``. The first function performs pairwise
 registration. The second function performs multiway registration.
 
-
 Preprocess point cloud
 ``````````````````````````````````````
 
@@ -32,7 +31,6 @@ distributed. Normals and FPFH feature are precomputed. See
 :ref:`/tutorial/pipelines/global_registration.ipynb#extract-geometric-feature`
 for more details.
 
-
 Compute initial registration
 ``````````````````````````````````````
 
@@ -48,7 +46,6 @@ RGBD odometry obtained from :ref:`reconstruction_system_make_fragments`.
 Otherwise, ``register_point_cloud_fpfh`` is called to perform global
 registration. Note that global registration is less reliable according to [Choi2015]_.
 
-
 .. _reconstruction_system_feature_matching:
 
 Pairwise global registration
@@ -61,7 +58,6 @@ Pairwise global registration
    :linenos:
 
 This function uses :ref:`/tutorial/pipelines/global_registration.ipynb#RANSAC` or :ref:`/tutorial/pipelines/global_registration.ipynb#fast-global-registration` for pairwise global registration.
-
 
 .. _reconstruction_system_compute_initial_registration:
 
@@ -127,7 +123,6 @@ The pose graph optimization outputs the following messages:
     Current_residual - new_residual < 1.000000e-06 * current_residual
     [GlobalOptimizationLM] total time : 0.001 sec.
     CompensateReferencePoseGraphNode : reference : 0
-
 
 There are 14 fragments and 52 valid matching pairs among the fragments. After
 23 iterations, 11 edges are detected to be false positives. After they are

--- a/docs/tutorial/reconstruction_system/system_overview.rst
+++ b/docs/tutorial/reconstruction_system/system_overview.rst
@@ -84,7 +84,6 @@ own dataset, use an appropriate camera intrinsic and visualize a depth image
     an unexpected program termination. To avoid this issue, set this flag to
     ``false``.
 
-
 Capture your own dataset
 ``````````````````````````````````````
 

--- a/docs/tutorial/sensor/azure_kinect.rst
+++ b/docs/tutorial/sensor/azure_kinect.rst
@@ -24,7 +24,6 @@ After installation, you may run ``k4aviewer`` from the Linux terminal or
 Currently, Open3D supports the Azure Kinect SDK version ``v1.4.1``, though future
 versions might also be compatible.
 
-
 Install Open3D from Pip
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -58,7 +57,6 @@ CMake config step. That is,
 .. code-block:: sh
 
     cmake -DBUILD_AZURE_KINECT=ON -DOTHER_FLAGS ..
-
 
 Open3D Azure Kinect Viewer
 ==========================
@@ -115,7 +113,6 @@ configs, refer to `this file <https://github.com/microsoft/Azure-Kinect-Sensor-S
         "wired_sync_mode" : "K4A_WIRED_SYNC_MODE_STANDALONE"
     }
 
-
 Open3D Azure Kinect Recorder
 ============================
 
@@ -140,7 +137,6 @@ recording or press ``ESC`` to quit the recorder.
 
 .. image:: https://storage.googleapis.com/open3d-bin/docs/images/azure_kinect_recorder.png
     :alt: azure_kinect_recorder.png
-
 
 Open3D Azure Kinect MKV Reader
 ==============================

--- a/docs/tutorial/t_reconstruction_system/dense_slam.rst
+++ b/docs/tutorial/t_reconstruction_system/dense_slam.rst
@@ -7,7 +7,6 @@ Equipped with the fast volumetric reconstruction backend, we in addition provide
 .. note::
    This SLAM prototype is mainly a showcase of the real-time volumetric processing. Please be aware that the tracking/RGB-D odometry module is **not fully optimized for accuracy**, and there is **no relocalization module** implemented currently. In general, it should work for room-scale scenes with relatively moderate motion, and may fail on more challenging sequences. More robust and reliable localization is our future work.
 
-
 Model and frame initialization
 ````````````````````````````````
 In a SLAM system, we maintain a ``model`` built upon a :ref:`voxel_block_grid`, an input ``frame`` containing raw RGB-D input, and a synthesized ``frame`` generated from the ``model`` with volumetric ray casting.
@@ -30,7 +29,6 @@ where we iteratively update the synthesized frame via ray-casting from the model
 
 The reconstruction results can be saved following :ref:`optimized_integration`, and the trajectory of the camera pose in the world coordinate system can be obtained by accumulating ``T_frame_to_model``.
 
-
 FAQ
 ``````````
 **Q**: Why did my tracking fail?
@@ -44,11 +42,9 @@ FAQ
 
 If all above have been correctly set but still no luck, please file an issue.
 
-
 **Q**: So WHY did my tracking fail?
 
 **A**: For the front end, we are using direct RGB-D odometry. Comparing to feature-based odometry, RGB-D odometry is more accurate when it completes successfully but is less robust. We will add support for feature-based tracking in the future. For the backend, unlike our offline reconstruction system, we do not detect loop closures, and do not perform pose graph optimization or bundle adjustment at the moment.
-
 
 **Q**: Why don't you implement loop closure or relocalization?
 

--- a/docs/tutorial/t_reconstruction_system/integration.rst
+++ b/docs/tutorial/t_reconstruction_system/integration.rst
@@ -53,7 +53,6 @@ You may use the provided APIs to extract surface points.
 
 Note ``extract_triangle_mesh`` applies marching cubes and generate mesh. ``extract_point_cloud`` uses the similar algorithm, but skips the triangle face generation step.
 
-
 Save and load
 ``````````````
 The voxel block grids can be saved to and loaded from `.npz` files that are accessible via numpy.
@@ -62,7 +61,7 @@ The voxel block grids can be saved to and loaded from `.npz` files that are acce
    :language: python
    :lineno-start: 47
    :lines: 27,48,98
-   
+
 The `.npz` file of the aforementioned voxel block grid contains the following entries:
 
 - ``attr_name_tsdf``: stores the value buffer index: 0

--- a/docs/tutorial/visualization/customized_visualization.rst
+++ b/docs/tutorial/visualization/customized_visualization.rst
@@ -7,7 +7,6 @@ The usage of Open3D convenient visualization functions ``draw_geometries`` and `
 
 This tutorial focuses on more advanced functionalities to customize the behavior of the visualizer window. Please refer to examples/python/visualization/customized_visualization.py to try the following examples.
 
-
 Mimic draw_geometries() with Visualizer class
 ````````````````````````````````````````````````````
 
@@ -34,7 +33,6 @@ Outputs:
 
 .. image:: ../../_static/visualization/customized_visualization/normal.png
     :width: 400px
-
 
 Change field of view
 ````````````````````````````````````
@@ -67,7 +65,6 @@ will set FoV to 5 degrees, because 60 - 90 = -30 is less than 5 degrees.
 
 .. image:: ../../_static/visualization/customized_visualization/fov_5.png
     :width: 400px
-
 
 Callback functions
 ````````````````````````````````````

--- a/docs/tutorial/visualization/headless_rendering.rst
+++ b/docs/tutorial/visualization/headless_rendering.rst
@@ -37,7 +37,6 @@ This script installs and activates ``py3env``. The necessary modules, ``numpy`` 
 .. Error:: Anaconda users are recommended to use this configuration as ``conda install matplotlib`` installs additional modules that are not based on OSMesa.
            This will result in **segmentation fault error** at runtime.
 
-
 Build Open3D with OSMesa
 ````````````````````````
 
@@ -105,7 +104,6 @@ Rendered images are at ~/Open3D/examples/test_data/depth and the image folder.
 .. Note:: | ``headless_rendering.py`` saves png files.
           | This may take some time, so try to tweak the script for your purpose.
 
-
 Possible Issues
 ````````````````````````
 
@@ -116,7 +114,6 @@ Try ``cmake`` with ``-DUSE_SYSTEM_GLEW=OFF`` and ``-DUSE_SYSTEM_GLFW=OFF`` flags
 
 .. Error:: | If OSMesa does not support GL 3.3 Core you will get the following error:
            | **GLFW Error: OSMesa: Failed to create context**
-
 
 Open3D currently uses GL 3.3 Core Profile, if that is not supported you will get the above error.
 You can run

--- a/docs/tutorial/visualization/non_blocking_visualization.rst
+++ b/docs/tutorial/visualization/non_blocking_visualization.rst
@@ -56,7 +56,6 @@ Prepare example data
 
 This part reads two point clouds and downsamples them. The source point cloud is intentionally transformed for the misalignment. Both point clouds are flipped for better visualization.
 
-
 Initialize Visualizer class
 ````````````````````````````````````````````````````
 

--- a/docs/tutorial/visualization/web_visualizer.rst
+++ b/docs/tutorial/visualization/web_visualizer.rst
@@ -126,7 +126,6 @@ custom port number, set the ``WEBRTC_PORT`` environment variable. For instance:
     # Bind to 127.0.0.1:8889
     WEBRTC_IP=127.0.0.1 WEBRTC_PORT=8889 python draw_webrtc.py
 
-
 To enable remote visualization, we typically bind to the internal IP and
 internal port as seen by the server. The router may translate the internal IP
 and internal port to external IP and port. For instance, on Google cloud, we
@@ -144,7 +143,6 @@ external IP address from the browser.
     by any one with network access. For sensitive or confidential data, please
     rebuild with `appropriate web server configuration and SSL certificates
     <https://github.com/civetweb/civetweb/blob/master/docs/OpenSSL.md>`_.
-
 
 Jupyter mode
 ------------
@@ -214,7 +212,6 @@ need to :
      cmake -DBUILD_JUPYTER_EXTENSION ..
      make install-pip-package -j$(nproc)
 
-
 Advanced topic: local server in airplane mode
 ------------------------------------------------
 
@@ -222,7 +219,6 @@ When the computer has no active network interfaces (e.g. Wi-Fi is turned off and
 ethernet is unplugged, the machine only has the loopback ``lo`` interface),
 WebRTC may fail to work. In this case, we need to create a dummy interface.
 The workaround is tested on Ubuntu.
-
 
 .. code-block:: sh
 
@@ -241,7 +237,6 @@ The workaround is tested on Ubuntu.
     # Clean up
     sudo ip link set dummy0 down
     sudo ip link delete dummy0
-
 
 Advanced topic: TURN server
 ------------------------------
@@ -266,7 +261,6 @@ with ``;``. For instance:
     WEBRTC_STUN_SERVER="turn:user:password@my_tcp_turn_server.com:3478?transport=tcp"
     # UDP and TCP (more than one TURN servers)
     WEBRTC_STUN_SERVER="turn:user:password@my_turn_server.com:3478;turn:user:password@my_tcp_turn_server.com:3478?transport=tcp"
-
 
 Advanced topic: debugging network issues
 -------------------------------------------


### PR DESCRIPTION
This PR:
- Adds `--parallel` option to `make_docs.py`
- Standardizes empty lines in docs:`\n\n\n` -> `\n\n`

Example usage:

```bash
python make_docs.py --parallel --clean_notebooks --execute_notebooks=never --sphinx
```

Merge this PR before merging https://github.com/isl-org/Open3D/pull/4898. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5029)
<!-- Reviewable:end -->
