### PR TITLE
Bugfix for Visual Studio 2022 compile #4788

### DIFF
--- a/3rdparty/assimp/assimp.cmake
+++ b/3rdparty/assimp/assimp.cmake
@@ -1,7 +1,7 @@
 include(ExternalProject)
 
 if(MSVC)
-    set(lib_name assimp-vc142-mt)
+    set(lib_name assimp-vc${MSVC_TOOLSET_VERSION}-mt)
 else()
     set(lib_name assimp)
 endif()


### PR DESCRIPTION
Fixed linking error for Visual Studio 2022 compile.  #4788

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5115)
<!-- Reviewable:end -->
