### PR TITLE
fix: dead link in documentation

### DIFF
--- a/docs/tutorial/visualization/web_visualizer.rst
+++ b/docs/tutorial/visualization/web_visualizer.rst
@@ -102,10 +102,10 @@ Example:
 
 .. code-block:: sh
 
-    python examples/python/gui/draw_webrtc.py
+    python examples/python/visualization/draw_webrtc.py
     google-chrome http://localhost:8888  # Or, open the address in your browser
 
-Checkout `examples/python/gui/draw_webrtc.py <https://github.com/isl-org/Open3D/blob/master/examples/python/gui/draw_webrtc.py>`_
+Checkout `examples/python/visualization/draw_webrtc.py <https://github.com/isl-org/Open3D/blob/master/examples/python/visualization/draw_webrtc.py>`_
 for the complete source code.
 
 IP/port binding
@@ -121,7 +121,7 @@ custom port number, set the ``WEBRTC_PORT`` environment variable. For instance:
 .. code-block:: sh
 
     # Bind to localhost:8888 (default)
-    python examples/python/gui/draw_webrtc.py
+    python examples/python/visualization/draw_webrtc.py
 
     # Bind to 127.0.0.1:8889
     WEBRTC_IP=127.0.0.1 WEBRTC_PORT=8889 python draw_webrtc.py
@@ -231,7 +231,7 @@ The workaround is tested on Ubuntu.
     ip addr
 
     # Do WebRTC things here
-    python examples/python/gui/draw_webrtc.py
+    python examples/python/visualization/draw_webrtc.py
     google-chrome http://localhost:8888  # Or, open the address in your browser
 
     # Clean up


### PR DESCRIPTION
I have checked in release [0.15](https://github.com/isl-org/Open3D/tree/ed30e3b61fbe031e106fa64030bec3f698b316b4/examples/python), **gui** folder has already been renamed to **visualization**. But In the documentation, the path to the example file hasn't been updated simultaneously and causing dead link.

For example [this one](http://www.open3d.org/docs/0.15.1/tutorial/visualization/web_visualizer.html#python-server).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5119)
<!-- Reviewable:end -->
