### PR TITLE
Tensor reconstruction system upgrade: make fragments

### DIFF
--- a/cpp/open3d/t/pipelines/kernel/RGBDOdometry.h
+++ b/cpp/open3d/t/pipelines/kernel/RGBDOdometry.h
@@ -79,6 +79,13 @@ void ComputeOdometryResultHybrid(const core::Tensor &source_depth,
                                  const float depth_huber_delta,
                                  const float intensity_huber_delta);
 
+void ComputeOdometryInformationMatrix(const core::Tensor &source_vertex_map,
+                                      const core::Tensor &target_vertex_map,
+                                      const core::Tensor &intrinsic,
+                                      const core::Tensor &source_to_target,
+                                      const float square_dist_thr,
+                                      core::Tensor &information);
+
 }  // namespace odometry
 }  // namespace kernel
 }  // namespace pipelines

--- a/cpp/open3d/t/pipelines/kernel/RGBDOdometryCPU.cpp
+++ b/cpp/open3d/t/pipelines/kernel/RGBDOdometryCPU.cpp
@@ -66,8 +66,8 @@ void ComputeOdometryInformationMatrixCPU(const core::Tensor& source_vertex_map,
 
 #ifdef _MSC_VER
     std::vector<float> zeros_21(21, 0.0);
-    A_1x29 = tbb::parallel_reduce(
-            tbb::blocked_range<int>(0, n), zeros_29,
+    A_1x21 = tbb::parallel_reduce(
+            tbb::blocked_range<int>(0, n), zeros_21,
             [&](tbb::blocked_range<int> r, std::vector<float> A_reduction) {
                 for (int workload_idx = r.begin(); workload_idx < r.end();
                      workload_idx++) {

--- a/cpp/open3d/t/pipelines/kernel/RGBDOdometryCPU.cpp
+++ b/cpp/open3d/t/pipelines/kernel/RGBDOdometryCPU.cpp
@@ -42,23 +42,17 @@ namespace pipelines {
 namespace kernel {
 namespace odometry {
 
-void ComputeOdometryResultPointToPlaneCPU(
-        const core::Tensor& source_vertex_map,
-        const core::Tensor& target_vertex_map,
-        const core::Tensor& target_normal_map,
-        const core::Tensor& intrinsics,
-        const core::Tensor& init_source_to_target,
-        core::Tensor& delta,
-        float& inlier_residual,
-        int& inlier_count,
-        const float depth_outlier_trunc,
-        const float depth_huber_delta) {
+void ComputeOdometryInformationMatrixCPU(const core::Tensor& source_vertex_map,
+                                         const core::Tensor& target_vertex_map,
+                                         const core::Tensor& intrinsic,
+                                         const core::Tensor& source_to_target,
+                                         const float square_dist_thr,
+                                         core::Tensor& information) {
     NDArrayIndexer source_vertex_indexer(source_vertex_map, 2);
     NDArrayIndexer target_vertex_indexer(target_vertex_map, 2);
-    NDArrayIndexer target_normal_indexer(target_normal_map, 2);
 
-    core::Tensor trans = init_source_to_target;
-    t::geometry::kernel::TransformIndexer ti(intrinsics, trans);
+    core::Tensor trans = source_to_target;
+    t::geometry::kernel::TransformIndexer ti(intrinsic, trans);
 
     // Output
     int64_t rows = source_vertex_indexer.GetShape(0);
@@ -68,43 +62,40 @@ void ComputeOdometryResultPointToPlaneCPU(
 
     int64_t n = rows * cols;
 
-    std::vector<float> A_1x29(29, 0.0);
+    std::vector<float> A_1x21(21, 0.0);
 
 #ifdef _MSC_VER
-    std::vector<float> zeros_29(29, 0.0);
+    std::vector<float> zeros_21(21, 0.0);
     A_1x29 = tbb::parallel_reduce(
             tbb::blocked_range<int>(0, n), zeros_29,
             [&](tbb::blocked_range<int> r, std::vector<float> A_reduction) {
                 for (int workload_idx = r.begin(); workload_idx < r.end();
                      workload_idx++) {
 #else
-    float* A_reduction = A_1x29.data();
-#pragma omp parallel for reduction(+ : A_reduction[:29]) schedule(static) num_threads(utility::EstimateMaxThreads())
+    float* A_reduction = A_1x21.data();
+#pragma omp parallel for reduction(+ : A_reduction[:21]) schedule(static) num_threads(utility::EstimateMaxThreads())
     for (int workload_idx = 0; workload_idx < n; workload_idx++) {
 #endif
                     int y = workload_idx / cols;
                     int x = workload_idx % cols;
 
-                    float J_ij[6];
-                    float r;
+                    float J_x[6], J_y[6], J_z[6];
+                    float rx, ry, rz;
 
-                    bool valid = GetJacobianPointToPlane(
-                            x, y, depth_outlier_trunc, source_vertex_indexer,
-                            target_vertex_indexer, target_normal_indexer, ti,
-                            J_ij, r);
+                    bool valid = GetJacobianPointToPoint(
+                            x, y, square_dist_thr, source_vertex_indexer,
+                            target_vertex_indexer, ti, J_x, J_y, J_z, rx, ry,
+                            rz);
 
                     if (valid) {
-                        float d_huber = HuberDeriv(r, depth_huber_delta);
-                        float r_huber = HuberLoss(r, depth_huber_delta);
                         for (int i = 0, j = 0; j < 6; j++) {
                             for (int k = 0; k <= j; k++) {
-                                A_reduction[i] += J_ij[j] * J_ij[k];
+                                A_reduction[i] += J_x[j] * J_x[k];
+                                A_reduction[i] += J_y[j] * J_y[k];
+                                A_reduction[i] += J_z[j] * J_z[k];
                                 i++;
                             }
-                            A_reduction[21 + j] += J_ij[j] * d_huber;
                         }
-                        A_reduction[27] += r_huber;
-                        A_reduction[28] += 1;
                     }
                 }
 #ifdef _MSC_VER
@@ -112,15 +103,26 @@ void ComputeOdometryResultPointToPlaneCPU(
             },
             // TBB: Defining reduction operation.
             [&](std::vector<float> a, std::vector<float> b) {
-                std::vector<float> result(29);
-                for (int j = 0; j < 29; j++) {
+                std::vector<float> result(21);
+                for (int j = 0; j < 21; j++) {
                     result[j] = a[j] + b[j];
                 }
                 return result;
             });
 #endif
-    core::Tensor A_reduction_tensor(A_1x29, {29}, core::Float32, device);
-    DecodeAndSolve6x6(A_reduction_tensor, delta, inlier_residual, inlier_count);
+    core::Tensor A_reduction_tensor(A_1x21, {21}, core::Float32, device);
+    float* reduction_ptr = A_reduction_tensor.GetDataPtr<float>();
+
+    information = core::Tensor::Empty({6, 6}, core::Float64, device);
+    double* info_ptr = information.GetDataPtr<double>();
+
+    for (int j = 0; j < 6; j++) {
+        const int64_t reduction_idx = ((j * (j + 1)) / 2);
+        for (int k = 0; k <= j; k++) {
+            info_ptr[j * 6 + k] = reduction_ptr[reduction_idx + k];
+            info_ptr[k * 6 + j] = reduction_ptr[reduction_idx + k];
+        }
+    }
 }
 
 void ComputeOdometryResultIntensityCPU(
@@ -307,6 +309,87 @@ void ComputeOdometryResultHybridCPU(const core::Tensor& source_depth,
                                     J_I[j] * d_huber_I + J_D[j] * d_huber_D;
                         }
                         A_reduction[27] += r_huber_I + r_huber_D;
+                        A_reduction[28] += 1;
+                    }
+                }
+#ifdef _MSC_VER
+                return A_reduction;
+            },
+            // TBB: Defining reduction operation.
+            [&](std::vector<float> a, std::vector<float> b) {
+                std::vector<float> result(29);
+                for (int j = 0; j < 29; j++) {
+                    result[j] = a[j] + b[j];
+                }
+                return result;
+            });
+#endif
+    core::Tensor A_reduction_tensor(A_1x29, {29}, core::Float32, device);
+    DecodeAndSolve6x6(A_reduction_tensor, delta, inlier_residual, inlier_count);
+}
+
+void ComputeOdometryResultPointToPlaneCPU(
+        const core::Tensor& source_vertex_map,
+        const core::Tensor& target_vertex_map,
+        const core::Tensor& target_normal_map,
+        const core::Tensor& intrinsics,
+        const core::Tensor& init_source_to_target,
+        core::Tensor& delta,
+        float& inlier_residual,
+        int& inlier_count,
+        const float depth_outlier_trunc,
+        const float depth_huber_delta) {
+    NDArrayIndexer source_vertex_indexer(source_vertex_map, 2);
+    NDArrayIndexer target_vertex_indexer(target_vertex_map, 2);
+    NDArrayIndexer target_normal_indexer(target_normal_map, 2);
+
+    core::Tensor trans = init_source_to_target;
+    t::geometry::kernel::TransformIndexer ti(intrinsics, trans);
+
+    // Output
+    int64_t rows = source_vertex_indexer.GetShape(0);
+    int64_t cols = source_vertex_indexer.GetShape(1);
+
+    core::Device device = source_vertex_map.GetDevice();
+
+    int64_t n = rows * cols;
+
+    std::vector<float> A_1x29(29, 0.0);
+
+#ifdef _MSC_VER
+    std::vector<float> zeros_29(29, 0.0);
+    A_1x29 = tbb::parallel_reduce(
+            tbb::blocked_range<int>(0, n), zeros_29,
+            [&](tbb::blocked_range<int> r, std::vector<float> A_reduction) {
+                for (int workload_idx = r.begin(); workload_idx < r.end();
+                     workload_idx++) {
+#else
+    float* A_reduction = A_1x29.data();
+#pragma omp parallel for reduction(+ : A_reduction[:29]) schedule(static) num_threads(utility::EstimateMaxThreads())
+    for (int workload_idx = 0; workload_idx < n; workload_idx++) {
+#endif
+                    int y = workload_idx / cols;
+                    int x = workload_idx % cols;
+
+                    float J_ij[6];
+                    float r;
+
+                    bool valid = GetJacobianPointToPlane(
+                            x, y, depth_outlier_trunc, source_vertex_indexer,
+                            target_vertex_indexer, target_normal_indexer, ti,
+                            J_ij, r);
+
+                    if (valid) {
+                        float d_huber = HuberDeriv(r, depth_huber_delta);
+                        float r_huber = HuberLoss(r, depth_huber_delta);
+                        for (int i = 0, j = 0; j < 6; j++) {
+                            for (int k = 0; k <= j; k++) {
+                                A_reduction[i] += J_ij[j] * J_ij[k];
+                                i++;
+                            }
+                            A_reduction[21 + j] += J_ij[j] * d_huber;
+                        }
+                        A_reduction[27] += r_huber;
                         A_reduction[28] += 1;
                     }
                 }

--- a/cpp/open3d/t/pipelines/kernel/RGBDOdometryCUDA.cu
+++ b/cpp/open3d/t/pipelines/kernel/RGBDOdometryCUDA.cu
@@ -402,7 +402,7 @@ __global__ void ComputeOdometryInformationMatrixCUDAKernel(
         int offset = 0;
         for (int i = 0; i < 6; ++i) {
             for (int j = 0; j <= i; ++j) {
-                local_sum[offset] += valid ? J_x[i] * J_x[j] : 0;
+                local_sum[offset] = valid ? J_x[i] * J_x[j] : 0;
                 local_sum[offset] += valid ? J_y[i] * J_y[j] : 0;
                 local_sum[offset] += valid ? J_z[i] * J_z[j] : 0;
                 offset++;

--- a/cpp/open3d/t/pipelines/kernel/RGBDOdometryCUDA.cu
+++ b/cpp/open3d/t/pipelines/kernel/RGBDOdometryCUDA.cu
@@ -70,7 +70,7 @@ __global__ void ComputeOdometryResultPointToPlaneCUDAKernel(
     int x = workload % cols;
     const int tid = threadIdx.x;
 
-    ReduceVec local_sum;
+    ReduceVec local_sum(0.0f);
     if (workload < rows * cols) {
         float J[6] = {0};
         float r = 0;
@@ -165,7 +165,7 @@ __global__ void ComputeOdometryResultIntensityCUDAKernel(
     int x = workload % cols;
     const int tid = threadIdx.x;
 
-    ReduceVec local_sum;
+    ReduceVec local_sum(0.0f);
     if (workload < rows * cols) {
         float J[6] = {0};
         float r = 0;
@@ -277,7 +277,7 @@ __global__ void ComputeOdometryResultHybridCUDAKernel(
     int x = workload % cols;
     const int tid = threadIdx.x;
 
-    ReduceVec local_sum;
+    ReduceVec local_sum(0.0f);
     if (workload < rows * cols) {
         float J_I[6] = {0}, J_D[6] = {0};
         float r_I = 0, r_D = 0;
@@ -390,7 +390,7 @@ __global__ void ComputeOdometryInformationMatrixCUDAKernel(
     int x = workload % cols;
     const int tid = threadIdx.x;
 
-    ReduceVec local_sum;
+    ReduceVec local_sum(0.0f);
     if (workload < rows * cols) {
         float J_x[6], J_y[6], J_z[6];
         float rx = 0, ry = 0, rz = 0;

--- a/cpp/open3d/t/pipelines/kernel/RGBDOdometryCUDA.cu
+++ b/cpp/open3d/t/pipelines/kernel/RGBDOdometryCUDA.cu
@@ -60,6 +60,7 @@ __global__ void ComputeOdometryResultPointToPlaneCUDAKernel(
         int cols,
         const float depth_outlier_trunc,
         const float depth_huber_delta) {
+
     __shared__ typename BlockReduce::TempStorage temp_storage;
 
     const int workload = threadIdx.x + blockIdx.x * blockDim.x;
@@ -129,6 +130,7 @@ void ComputeOdometryResultPointToPlaneCUDA(
     core::Tensor global_sum =
             core::Tensor::Zeros({kReduceDim}, core::Float32, device);
     float* global_sum_ptr = global_sum.GetDataPtr<float>();
+
 
     const dim3 blocks((rows * cols + kBlockSize - 1) / kBlockSize);
     const dim3 threads(kBlockSize);

--- a/cpp/open3d/t/pipelines/kernel/RGBDOdometryCUDA.cu
+++ b/cpp/open3d/t/pipelines/kernel/RGBDOdometryCUDA.cu
@@ -60,7 +60,6 @@ __global__ void ComputeOdometryResultPointToPlaneCUDAKernel(
         int cols,
         const float depth_outlier_trunc,
         const float depth_huber_delta) {
-
     __shared__ typename BlockReduce::TempStorage temp_storage;
 
     const int workload = threadIdx.x + blockIdx.x * blockDim.x;
@@ -130,7 +129,6 @@ void ComputeOdometryResultPointToPlaneCUDA(
     core::Tensor global_sum =
             core::Tensor::Zeros({kReduceDim}, core::Float32, device);
     float* global_sum_ptr = global_sum.GetDataPtr<float>();
-
 
     const dim3 blocks((rows * cols + kBlockSize - 1) / kBlockSize);
     const dim3 threads(kBlockSize);

--- a/cpp/open3d/t/pipelines/kernel/RGBDOdometryCUDA.cu
+++ b/cpp/open3d/t/pipelines/kernel/RGBDOdometryCUDA.cu
@@ -46,7 +46,10 @@ namespace kernel {
 namespace odometry {
 
 const int kBlockSize = 256;
-const int kReduceDim = 29;  // 21 (JtJ) + 6 (Jtr) + 1 (inlier) + 1 (r)
+const int kJtJDim = 21;
+const int kJtrDim = 6;
+const int kReduceDim =
+        kJtJDim + kJtrDim + 1 + 1;  // 21 (JtJ) + 6 (Jtr) + 1 (inlier) + 1 (r)
 typedef utility::MiniVec<float, kReduceDim> ReduceVec;
 typedef cub::BlockReduce<ReduceVec, kBlockSize> BlockReduce;
 
@@ -372,6 +375,93 @@ void ComputeOdometryResultHybridCUDA(const core::Tensor& source_depth,
     DecodeAndSolve6x6(global_sum, delta, inlier_residual, inlier_count);
 }
 
+__global__ void ComputeOdometryInformationMatrixCUDAKernel(
+        NDArrayIndexer source_vertex_indexer,
+        NDArrayIndexer target_vertex_indexer,
+        TransformIndexer ti,
+        float* global_sum,
+        int rows,
+        int cols,
+        const float square_dist_thr) {
+    __shared__ typename BlockReduce::TempStorage temp_storage;
+
+    const int workload = threadIdx.x + blockIdx.x * blockDim.x;
+    int y = workload / cols;
+    int x = workload % cols;
+    const int tid = threadIdx.x;
+
+    ReduceVec local_sum;
+    if (workload < rows * cols) {
+        float J_x[6], J_y[6], J_z[6];
+        float rx = 0, ry = 0, rz = 0;
+        bool valid = GetJacobianPointToPoint(
+                x, y, square_dist_thr, source_vertex_indexer,
+                target_vertex_indexer, ti, J_x, J_y, J_z, rx, ry, rz);
+
+        // Dump J, r into JtJ and Jtr
+        int offset = 0;
+        for (int i = 0; i < 6; ++i) {
+            for (int j = 0; j <= i; ++j) {
+                local_sum[offset] += valid ? J_x[i] * J_x[j] : 0;
+                local_sum[offset] += valid ? J_y[i] * J_y[j] : 0;
+                local_sum[offset] += valid ? J_z[i] * J_z[j] : 0;
+                offset++;
+            }
+        }
+    }
+
+    auto result = BlockReduce(temp_storage).Sum(local_sum);
+    if (tid == 0) {
+#pragma unroll
+        for (int i = 0; i < kJtJDim; ++i) {
+            atomicAdd(&global_sum[i], result[i]);
+        }
+    }
+}
+
+void ComputeOdometryInformationMatrixCUDA(const core::Tensor& source_vertex_map,
+                                          const core::Tensor& target_vertex_map,
+                                          const core::Tensor& intrinsic,
+                                          const core::Tensor& source_to_target,
+                                          const float square_dist_thr,
+                                          core::Tensor& information) {
+    NDArrayIndexer source_vertex_indexer(source_vertex_map, 2);
+    NDArrayIndexer target_vertex_indexer(target_vertex_map, 2);
+
+    core::Device device = source_vertex_map.GetDevice();
+    core::Tensor trans = source_to_target;
+    t::geometry::kernel::TransformIndexer ti(intrinsic, trans);
+
+    const int64_t rows = source_vertex_indexer.GetShape(0);
+    const int64_t cols = source_vertex_indexer.GetShape(1);
+
+    core::Tensor global_sum =
+            core::Tensor::Zeros({kJtJDim}, core::Float32, device);
+    float* global_sum_ptr = global_sum.GetDataPtr<float>();
+
+    const dim3 blocks((cols * rows + kBlockSize - 1) / kBlockSize);
+    const dim3 threads(kBlockSize);
+    ComputeOdometryInformationMatrixCUDAKernel<<<blocks, threads, 0,
+                                                 core::cuda::GetStream()>>>(
+            source_vertex_indexer, target_vertex_indexer, ti, global_sum_ptr,
+            rows, cols, square_dist_thr);
+    core::cuda::Synchronize();
+
+    // 21 => 6x6
+    const core::Device host(core::Device("CPU:0"));
+    information = core::Tensor::Empty({6, 6}, core::Float64, host);
+    global_sum = global_sum.To(host, core::Float64);
+
+    double* info_ptr = information.GetDataPtr<double>();
+    double* reduction_ptr = global_sum.GetDataPtr<double>();
+    for (int j = 0; j < 6; j++) {
+        const int64_t reduction_idx = ((j * (j + 1)) / 2);
+        for (int k = 0; k <= j; k++) {
+            info_ptr[j * 6 + k] = reduction_ptr[reduction_idx + k];
+            info_ptr[k * 6 + j] = reduction_ptr[reduction_idx + k];
+        }
+    }
+}
 }  // namespace odometry
 }  // namespace kernel
 }  // namespace pipelines

--- a/cpp/open3d/t/pipelines/kernel/RGBDOdometryImpl.h
+++ b/cpp/open3d/t/pipelines/kernel/RGBDOdometryImpl.h
@@ -80,6 +80,14 @@ void ComputeOdometryResultHybridCPU(const core::Tensor& source_depth,
                                     float depth_outlier_trunc,
                                     const float depth_huber_delta,
                                     const float intensity_huber_delta);
+
+void ComputeOdometryInformationMatrixCPU(const core::Tensor& source_depth,
+                                         const core::Tensor& target_depth,
+                                         const core::Tensor& intrinsic,
+                                         const core::Tensor& source_to_target,
+                                         const float depth_outlier_trunc,
+                                         core::Tensor& information);
+
 #ifdef BUILD_CUDA_MODULE
 
 void ComputeOdometryResultPointToPlaneCUDA(
@@ -127,6 +135,13 @@ void ComputeOdometryResultHybridCUDA(const core::Tensor& source_depth,
                                      const float depth_outlier_trunc,
                                      const float depth_huber_delta,
                                      const float intensity_huber_delta);
+
+void ComputeOdometryInformationMatrixCUDA(const core::Tensor& source_depth,
+                                          const core::Tensor& target_depth,
+                                          const core::Tensor& intrinsic,
+                                          const core::Tensor& source_to_target,
+                                          const float square_dist_thr,
+                                          core::Tensor& information);
 #endif
 
 }  // namespace odometry

--- a/cpp/open3d/t/pipelines/kernel/RGBDOdometryJacobianImpl.h
+++ b/cpp/open3d/t/pipelines/kernel/RGBDOdometryJacobianImpl.h
@@ -55,6 +55,73 @@ inline OPEN3D_HOST_DEVICE float HuberLoss(float r, float delta) {
     return abs_r < delta ? 0.5 * r * r : delta * abs_r - 0.5 * delta * delta;
 }
 
+OPEN3D_HOST_DEVICE inline bool GetJacobianPointToPoint(
+        int x,
+        int y,
+        const float square_dist_thr,
+        const NDArrayIndexer& source_vertex_indexer,
+        const NDArrayIndexer& target_vertex_indexer,
+        const TransformIndexer& ti,
+        float* J_x,
+        float* J_y,
+        float* J_z,
+        float& rx,
+        float& ry,
+        float& rz) {
+    float* source_v = source_vertex_indexer.GetDataPtr<float>(x, y);
+    if (isnan(source_v[0])) {
+        return false;
+    }
+
+    // Transform source points to the target camera's coordinate space.
+    float T_source_to_target_v[3], u, v;
+    ti.RigidTransform(source_v[0], source_v[1], source_v[2],
+                      &T_source_to_target_v[0], &T_source_to_target_v[1],
+                      &T_source_to_target_v[2]);
+    ti.Project(T_source_to_target_v[0], T_source_to_target_v[1],
+               T_source_to_target_v[2], &u, &v);
+    u = roundf(u);
+    v = roundf(v);
+
+    if (T_source_to_target_v[2] < 0 ||
+        !target_vertex_indexer.InBoundary(u, v)) {
+        return false;
+    }
+
+    int ui = static_cast<int>(u);
+    int vi = static_cast<int>(v);
+    float* target_v = target_vertex_indexer.GetDataPtr<float>(ui, vi);
+    if (isnan(target_v[0])) {
+        return false;
+    }
+
+    rx = (T_source_to_target_v[0] - target_v[0]);
+    ry = (T_source_to_target_v[1] - target_v[1]);
+    rz = (T_source_to_target_v[2] - target_v[2]);
+    float r2 = rx * rx + ry * ry + rz * rz;
+    if (r2 > square_dist_thr) {
+        return false;
+    }
+
+    // T s - t
+    J_x[0] = J_x[4] = J_x[5] = 0.0;
+    J_x[1] = T_source_to_target_v[2];
+    J_x[2] = -T_source_to_target_v[1];
+    J_x[3] = 1.0;
+
+    J_y[1] = J_y[3] = J_y[5] = 0.0;
+    J_y[0] = -T_source_to_target_v[2];
+    J_y[2] = T_source_to_target_v[0];
+    J_y[4] = 1.0;
+
+    J_z[2] = J_z[3] = J_z[4] = 0.0;
+    J_z[0] = T_source_to_target_v[1];
+    J_z[1] = -T_source_to_target_v[0];
+    J_z[5] = 1.0;
+
+    return true;
+}
+
 OPEN3D_HOST_DEVICE inline bool GetJacobianPointToPlane(
         int x,
         int y,

--- a/cpp/open3d/t/pipelines/odometry/RGBDOdometry.cpp
+++ b/cpp/open3d/t/pipelines/odometry/RGBDOdometry.cpp
@@ -505,6 +505,25 @@ OdometryResult ComputeOdometryResultHybrid(const Tensor& source_depth,
                                           source_vertex_map.GetShape(1)));
 }
 
+core::Tensor ComputeOdometryInformationMatrix(
+        const core::Tensor& source_depth,
+        const core::Tensor& target_depth,
+        const core::Tensor& intrinsic,
+        const core::Tensor& source_to_target,
+        const float dist_thr) {
+    core::Tensor information;
+
+    Image source_vertex_map =
+            Image(source_depth).CreateVertexMap(intrinsic, NAN);
+    Image target_vertex_map =
+            Image(target_depth).CreateVertexMap(intrinsic, NAN);
+
+    kernel::odometry::ComputeOdometryInformationMatrix(
+            source_vertex_map.AsTensor(), target_vertex_map.AsTensor(),
+            intrinsic, source_to_target, dist_thr * dist_thr, information);
+    return information;
+}
+
 }  // namespace odometry
 }  // namespace pipelines
 }  // namespace t

--- a/cpp/open3d/t/pipelines/odometry/RGBDOdometry.cpp
+++ b/cpp/open3d/t/pipelines/odometry/RGBDOdometry.cpp
@@ -506,17 +506,23 @@ OdometryResult ComputeOdometryResultHybrid(const Tensor& source_depth,
 }
 
 core::Tensor ComputeOdometryInformationMatrix(
-        const core::Tensor& source_depth,
-        const core::Tensor& target_depth,
+        const geometry::Image& source_depth,
+        const geometry::Image& target_depth,
         const core::Tensor& intrinsic,
         const core::Tensor& source_to_target,
-        const float dist_thr) {
+        const float dist_thr,
+        const float depth_scale,
+        const float depth_max) {
     core::Tensor information;
 
+    Image source_depth_processed =
+            source_depth.ClipTransform(depth_scale, 0, depth_max, NAN);
+    Image target_depth_processed =
+            target_depth.ClipTransform(depth_scale, 0, depth_max, NAN);
     Image source_vertex_map =
-            Image(source_depth).CreateVertexMap(intrinsic, NAN);
+            Image(source_depth_processed).CreateVertexMap(intrinsic, NAN);
     Image target_vertex_map =
-            Image(target_depth).CreateVertexMap(intrinsic, NAN);
+            Image(target_depth_processed).CreateVertexMap(intrinsic, NAN);
 
     kernel::odometry::ComputeOdometryInformationMatrix(
             source_vertex_map.AsTensor(), target_vertex_map.AsTensor(),

--- a/cpp/open3d/t/pipelines/odometry/RGBDOdometry.h
+++ b/cpp/open3d/t/pipelines/odometry/RGBDOdometry.h
@@ -318,11 +318,13 @@ OdometryResult ComputeOdometryResultHybrid(
 /// Estimates 6x6 information matrix from a pair of depth images.
 /// The process is akin to information matrix creation for point clouds.
 core::Tensor ComputeOdometryInformationMatrix(
-        const core::Tensor& source_depth,
-        const core::Tensor& target_depth,
+        const geometry::Image& source_depth,
+        const geometry::Image& target_depth,
         const core::Tensor& intrinsic,
         const core::Tensor& source_to_target,
-        const float dist_thr);
+        const float dist_thr,
+        const float depth_scale = 1000.0f,
+        const float depth_max = 3.0f);
 }  // namespace odometry
 }  // namespace pipelines
 }  // namespace t

--- a/cpp/open3d/t/pipelines/odometry/RGBDOdometry.h
+++ b/cpp/open3d/t/pipelines/odometry/RGBDOdometry.h
@@ -315,6 +315,14 @@ OdometryResult ComputeOdometryResultHybrid(
         const float depth_huber_delta,
         const float intensity_huber_delta);
 
+/// Estimates 6x6 information matrix from a pair of depth images.
+/// The process is akin to information matrix creation for point clouds.
+core::Tensor ComputeOdometryInformationMatrix(
+        const core::Tensor& source_depth,
+        const core::Tensor& target_depth,
+        const core::Tensor& intrinsic,
+        const core::Tensor& source_to_target,
+        const float dist_thr);
 }  // namespace odometry
 }  // namespace pipelines
 }  // namespace t

--- a/cpp/pybind/t/pipelines/odometry/odometry.cpp
+++ b/cpp/pybind/t/pipelines/odometry/odometry.cpp
@@ -269,6 +269,12 @@ Colored Point Cloud Registration Revisited, ICCV, 2017.)",
           "intensity_huber_delta"_a);
     docstring::FunctionDocInject(m, "compute_odometry_result_hybrid",
                                  map_shared_argument_docstrings);
+
+    m.def("compute_odometry_information_matrix",
+          &ComputeOdometryInformationMatrix,
+          py::call_guard<py::gil_scoped_release>(), "source_depth"_a,
+          "target_depth"_a, "intrinsic"_a, "source_to_target"_a,
+          "dist_threshold"_a);
 }
 
 void pybind_odometry(py::module &m) {

--- a/cpp/pybind/t/pipelines/odometry/odometry.cpp
+++ b/cpp/pybind/t/pipelines/odometry/odometry.cpp
@@ -274,7 +274,7 @@ Colored Point Cloud Registration Revisited, ICCV, 2017.)",
           &ComputeOdometryInformationMatrix,
           py::call_guard<py::gil_scoped_release>(), "source_depth"_a,
           "target_depth"_a, "intrinsic"_a, "source_to_target"_a,
-          "dist_threshold"_a);
+          "dist_threshold"_a, "depth_scale"_a = 1000.0, "depth_max"_a = 3.0);
 }
 
 void pybind_odometry(py::module &m) {

--- a/examples/python/t_reconstruction_system/config.py
+++ b/examples/python/t_reconstruction_system/config.py
@@ -86,6 +86,7 @@ class ConfigParser(configargparse.ArgParser):
         input_parser.add(
             '--depth_scale', type=float,
             help='Scale factor to convert raw input depth data to meters.')
+        input_parser.add('--fragment_size', type=int, help='Number of RGBD frames per fragment')
 
         odometry_parser = self.add_argument_group('odometry')
         odometry_parser.add(

--- a/examples/python/t_reconstruction_system/default_config.yml
+++ b/examples/python/t_reconstruction_system/default_config.yml
@@ -8,6 +8,7 @@ depth_folder: depth
 color_folder: color
 path_intrinsic: ''
 path_color_intrinsic: ''
+fragment_size: 100
 depth_min: 0.1
 depth_max: 3.0
 depth_scale: 1000.0

--- a/examples/python/t_reconstruction_system/integrate.py
+++ b/examples/python/t_reconstruction_system/integrate.py
@@ -37,67 +37,57 @@ import time
 import matplotlib.pyplot as plt
 
 from config import ConfigParser
+
 from common import load_rgbd_file_names, load_depth_file_names, load_intrinsic, load_extrinsics, get_default_dataset
 
 
 def integrate(depth_file_names, color_file_names, depth_intrinsic,
               color_intrinsic, extrinsics, config):
-    if os.path.exists(config.path_npz):
-        print('Voxel block grid npz file {} found, trying to load...'.format(
-            config.path_npz))
-        vbg = o3d.t.geometry.VoxelBlockGrid.load(config.path_npz)
-        print('Loading finished.')
-    else:
-        print('Voxel block grid npz file {} not found, trying to integrate...'.
-              format(config.path_npz))
 
-        n_files = len(depth_file_names)
-        device = o3d.core.Device(config.device)
+    n_files = len(depth_file_names)
+    device = o3d.core.Device(config.device)
+
+    if config.integrate_color:
+        vbg = o3d.t.geometry.VoxelBlockGrid(
+            attr_names=('tsdf', 'weight', 'color'),
+            attr_dtypes=(o3c.float32, o3c.float32, o3c.float32),
+            attr_channels=((1), (1), (3)),
+            voxel_size=3.0 / 512,
+            block_resolution=16,
+            block_count=50000,
+            device=device)
+    else:
+        vbg = o3d.t.geometry.VoxelBlockGrid(attr_names=('tsdf', 'weight'),
+                                            attr_dtypes=(o3c.float32,
+                                                         o3c.float32),
+                                            attr_channels=((1), (1)),
+                                            voxel_size=3.0 / 512,
+                                            block_resolution=16,
+                                            block_count=50000,
+                                            device=device)
+
+    start = time.time()
+    for i in range(n_files):
+        print('Integrating frame {}/{}'.format(i, n_files))
+
+        depth = o3d.t.io.read_image(depth_file_names[i]).to(device)
+        extrinsic = extrinsics[i]
+
+        frustum_block_coords = vbg.compute_unique_block_coordinates(
+            depth, depth_intrinsic, extrinsic, config.depth_scale,
+            config.depth_max)
 
         if config.integrate_color:
-            vbg = o3d.t.geometry.VoxelBlockGrid(
-                attr_names=('tsdf', 'weight', 'color'),
-                attr_dtypes=(o3c.float32, o3c.float32, o3c.float32),
-                attr_channels=((1), (1), (3)),
-                voxel_size=3.0 / 512,
-                block_resolution=16,
-                block_count=50000,
-                device=device)
+            color = o3d.t.io.read_image(color_file_names[i]).to(device)
+            vbg.integrate(frustum_block_coords, depth, color,
+                          depth_intrinsic, color_intrinsic, extrinsic,
+                          config.depth_scale, config.depth_max)
         else:
-            vbg = o3d.t.geometry.VoxelBlockGrid(attr_names=('tsdf', 'weight'),
-                                                attr_dtypes=(o3c.float32,
-                                                             o3c.float32),
-                                                attr_channels=((1), (1)),
-                                                voxel_size=3.0 / 512,
-                                                block_resolution=16,
-                                                block_count=50000,
-                                                device=device)
-
-        start = time.time()
-        for i in range(n_files):
-            print('Integrating frame {}/{}'.format(i, n_files))
-
-            depth = o3d.t.io.read_image(depth_file_names[i]).to(device)
-            extrinsic = extrinsics[i]
-
-            frustum_block_coords = vbg.compute_unique_block_coordinates(
-                depth, depth_intrinsic, extrinsic, config.depth_scale,
-                config.depth_max)
-
-            if config.integrate_color:
-                color = o3d.t.io.read_image(color_file_names[i]).to(device)
-                vbg.integrate(frustum_block_coords, depth, color,
-                              depth_intrinsic, color_intrinsic, extrinsic,
-                              config.depth_scale, config.depth_max)
-            else:
-                vbg.integrate(frustum_block_coords, depth, depth_intrinsic,
-                              extrinsic, config.depth_scale, config.depth_max)
-            dt = time.time() - start
-        print('Finished integrating {} frames in {} seconds'.format(
-            n_files, dt))
-        print('Saving to {}...'.format(config.path_npz))
-        vbg.save(config.path_npz)
-        print('Saving finished')
+            vbg.integrate(frustum_block_coords, depth, depth_intrinsic,
+                          extrinsic, config.depth_scale, config.depth_max)
+        dt = time.time() - start
+    print('Finished integrating {} frames in {} seconds'.format(
+        n_files, dt))
 
     return vbg
 

--- a/examples/python/t_reconstruction_system/integrate.py
+++ b/examples/python/t_reconstruction_system/integrate.py
@@ -35,19 +35,19 @@ import open3d as o3d
 import open3d.core as o3c
 import time
 import matplotlib.pyplot as plt
-
+from tqdm import tqdm
 from config import ConfigParser
 
 from common import load_rgbd_file_names, load_depth_file_names, load_intrinsic, load_extrinsics, get_default_dataset
 
 
 def integrate(depth_file_names, color_file_names, depth_intrinsic,
-              color_intrinsic, extrinsics, config):
+              color_intrinsic, extrinsics, integrate_color, config):
 
     n_files = len(depth_file_names)
     device = o3d.core.Device(config.device)
 
-    if config.integrate_color:
+    if integrate_color:
         vbg = o3d.t.geometry.VoxelBlockGrid(
             attr_names=('tsdf', 'weight', 'color'),
             attr_dtypes=(o3c.float32, o3c.float32, o3c.float32),
@@ -67,9 +67,7 @@ def integrate(depth_file_names, color_file_names, depth_intrinsic,
                                             device=device)
 
     start = time.time()
-    for i in range(n_files):
-        print('Integrating frame {}/{}'.format(i, n_files))
-
+    for i in tqdm(range(n_files)):
         depth = o3d.t.io.read_image(depth_file_names[i]).to(device)
         extrinsic = extrinsics[i]
 
@@ -77,17 +75,16 @@ def integrate(depth_file_names, color_file_names, depth_intrinsic,
             depth, depth_intrinsic, extrinsic, config.depth_scale,
             config.depth_max)
 
-        if config.integrate_color:
+        if integrate_color:
             color = o3d.t.io.read_image(color_file_names[i]).to(device)
-            vbg.integrate(frustum_block_coords, depth, color,
-                          depth_intrinsic, color_intrinsic, extrinsic,
-                          config.depth_scale, config.depth_max)
+            vbg.integrate(frustum_block_coords, depth, color, depth_intrinsic,
+                          color_intrinsic, extrinsic, config.depth_scale,
+                          config.depth_max)
         else:
             vbg.integrate(frustum_block_coords, depth, depth_intrinsic,
                           extrinsic, config.depth_scale, config.depth_max)
         dt = time.time() - start
-    print('Finished integrating {} frames in {} seconds'.format(
-        n_files, dt))
+    print('Finished integrating {} frames in {} seconds'.format(n_files, dt))
 
     return vbg
 

--- a/examples/python/t_reconstruction_system/pose_graph_optim.py
+++ b/examples/python/t_reconstruction_system/pose_graph_optim.py
@@ -114,8 +114,8 @@ class PoseGraphWrapper:
 
         return ans
 
-    def write(self, fname):
-        self.pose_grpah = self._dicts2graph()
+    def save(self, fname):
+        self.pose_graph = self._dicts2graph()
         o3d.io.write_pose_graph(fname, self.pose_graph)
 
     def export_extrinsics(self):
@@ -132,6 +132,6 @@ if __name__ == '__main__':
     pose_graph = PoseGraphWrapper.load(args.path_pose_graph)
     pose_graph.solve()
 
-    pose_graph.write('test.json')
+    pose_graph.save('test.json')
     pose_graph = PoseGraphWrapper.load('test.json')
     pose_graph.solve()

--- a/examples/python/t_reconstruction_system/pose_graph_optim.py
+++ b/examples/python/t_reconstruction_system/pose_graph_optim.py
@@ -1,0 +1,132 @@
+import open3d as o3d
+import numpy as np
+import argparse
+
+
+class PoseGraphWrapper:
+
+    def __init__(self, dict_nodes=None, dict_edges=None):
+        '''
+        \input dict_nodes: index -> 6x1 pose
+        \input dict_edges: Tuple(index, index) -> Tuple(6x1 pose, 6x6 information, is_loop)
+        They are the major maintained members.
+        Wrapped PoseGraph is the intermediate member that needs to be synchronized via _dicts2graph before performing batch ops.
+        '''
+        self.dict_nodes = {} if dict_nodes is None else dict_nodes
+        self.dict_edges = {} if dict_edges is None else dict_edges
+        self.pose_graph = o3d.pipelines.registration.PoseGraph()
+
+    def add_node(self, index, pose):
+        if index in self.dict_nodes:
+            print('Warning: node {} already exists, overwriting'.format(index))
+        self.dict_nodes[index] = pose
+
+    def add_edge(self, index_src, index_dst, pose_src2dst, info_src2dst,
+                 is_loop):
+        if (index_src, index_dst) in self.dict_edges:
+            print('Warning: edge ({}, {}) already exists, overwriting'.format(
+                index_src, index_dst))
+        self.dict_edges[(index_src, index_dst)] = (pose_src2dst, info_src2dst,
+                                                   is_loop)
+
+    def _dicts2graph(self):
+        pose_graph = o3d.pipelines.registration.PoseGraph()
+
+        # First map potentially non-consecutive indices to consecutive indices
+        n_nodes = len(self.dict_nodes)
+        if n_nodes < 3:
+            print('Only {} nodes found, abort pose graph construction'.format(
+                n_nodes))
+
+        nodes2indices = {}
+        for i, k in enumerate(sorted(self.dict_nodes.keys())):
+            nodes2indices[i] = k
+
+        for i in range(n_nodes):
+            k = nodes2indices[i]
+            pose_graph.nodes.append(
+                o3d.pipelines.registration.PoseGraphNode(self.dict_nodes[k]))
+
+        for (i, j) in self.dict_edges:
+            if not (i in self.dict_nodes) or not (j in self.dict_nodes):
+                print(
+                    'Edge node ({} {}) not found, abort pose graph construction'
+                    .format(i, j))
+            trans, info, is_loop = self.dict_edges[(i, j)]
+            ki = nodes2indices[i]
+            kj = nodes2indices[j]
+
+            pose_graph.edges.append(
+                o3d.pipelines.registration.PoseGraphEdge(ki,
+                                                         kj,
+                                                         trans,
+                                                         info,
+                                                         uncertain=is_loop))
+        return pose_graph
+
+    def _graph2dicts(self):
+        nodes = self.pose_graph.nodes
+        edges = self.pose_graph.edges
+
+        dict_nodes = {}
+        dict_edges = {}
+        for i, node in enumerate(nodes):
+            dict_nodes[i] = node.pose
+        for edge in edges:
+            dict_edges[(edge.source_node_id,
+                        edge.target_node_id)] = (edge.transformation,
+                                                 edge.information,
+                                                 edge.uncertain)
+        return dict_nodes, dict_edges
+
+    def solve(self, dist_threshold=0.07, preference_loop_closure=0.1):
+        # Update from graph
+        self.pose_graph = self._dicts2graph()
+
+        method = o3d.pipelines.registration.GlobalOptimizationLevenbergMarquardt(
+        )
+        criteria = o3d.pipelines.registration.GlobalOptimizationConvergenceCriteria(
+        )
+        option = o3d.pipelines.registration.GlobalOptimizationOption(
+            max_correspondence_distance=dist_threshold,
+            edge_prune_threshold=0.25,
+            preference_loop_closure=preference_loop_closure,
+            reference_node=0)
+
+        # In-place optimization
+        o3d.utility.set_verbosity_level(o3d.utility.VerbosityLevel.Debug)
+        o3d.pipelines.registration.global_optimization(self.pose_graph, method,
+                                                       criteria, option)
+        o3d.utility.set_verbosity_level(o3d.utility.VerbosityLevel.Info)
+
+        # Update dicts
+        self.dict_nodes, self.dict_edges = self._graph2dicts()
+
+    @staticmethod
+    def load(fname):
+        ans = PoseGraphWrapper()
+
+        # Load pose graph
+        ans.pose_graph = o3d.io.read_pose_graph(fname)
+
+        # Update dicts
+        ans.dict_nodes, ans.dict_edges = ans._graph2dicts()
+
+        return ans
+
+    def write(self, fname):
+        self.pose_grpah = self._dicts2graph()
+        o3d.io.write_pose_graph(fname, self.pose_graph)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--path_pose_graph', required=True)
+    args = parser.parse_args()
+
+    pose_graph = PoseGraphWrapper.load(args.path_pose_graph)
+    pose_graph.solve()
+
+    pose_graph.write('test.json')
+    pose_graph = PoseGraphWrapper.load('test.json')
+    pose_graph.solve()

--- a/examples/python/t_reconstruction_system/pose_graph_optim.py
+++ b/examples/python/t_reconstruction_system/pose_graph_optim.py
@@ -79,7 +79,7 @@ class PoseGraphWrapper:
                                                  edge.uncertain)
         return dict_nodes, dict_edges
 
-    def solve(self, dist_threshold=0.07, preference_loop_closure=0.1):
+    def solve_(self, dist_threshold=0.07, preference_loop_closure=0.1):
         # Update from graph
         self.pose_graph = self._dicts2graph()
 
@@ -117,6 +117,11 @@ class PoseGraphWrapper:
     def write(self, fname):
         self.pose_grpah = self._dicts2graph()
         o3d.io.write_pose_graph(fname, self.pose_graph)
+
+    def export_extrinsics(self):
+        return [
+            np.linalg.inv(self.dict_nodes[k]) for k in sorted(self.dict_nodes)
+        ]
 
 
 if __name__ == '__main__':

--- a/examples/python/t_reconstruction_system/pose_graph_optim.py
+++ b/examples/python/t_reconstruction_system/pose_graph_optim.py
@@ -1,3 +1,29 @@
+# ----------------------------------------------------------------------------
+# -                        Open3D: www.open3d.org                            -
+# ----------------------------------------------------------------------------
+# The MIT License (MIT)
+#
+# Copyright (c) 2018-2021 www.open3d.org
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ----------------------------------------------------------------------------
+
 import open3d as o3d
 import numpy as np
 import argparse

--- a/examples/python/t_reconstruction_system/ray_casting.py
+++ b/examples/python/t_reconstruction_system/ray_casting.py
@@ -44,12 +44,13 @@ import numpy as np
 
 if __name__ == '__main__':
     parser = ConfigParser()
-    parser.add(
-        '--config',
-        is_config_file=True,
-        help='YAML config file path. Please refer to default_config.yml as a '
-        'reference. It overrides the default config file, but will be '
-        'overridden by other command line inputs.')
+    parser.add('--config',
+               is_config_file=True,
+               help='YAML config file path.'
+               'Please refer to config.py for the options,'
+               'and default_config.yml for default settings '
+               'It overrides the default config file, but will be '
+               'overridden by other command line inputs.')
     parser.add('--default_dataset',
                help='Default dataset is used when config file is not provided. '
                'Default dataset may be selected from the following options: '

--- a/examples/python/t_reconstruction_system/rgbd_odometry.py
+++ b/examples/python/t_reconstruction_system/rgbd_odometry.py
@@ -24,8 +24,10 @@
 # IN THE SOFTWARE.
 # ----------------------------------------------------------------------------
 
+from tqdm import tqdm
 import numpy as np
 import open3d as o3d
+import open3d.core as o3c
 from config import ConfigParser
 from common import load_rgbd_file_names, load_depth_file_names, save_poses, load_intrinsic, load_extrinsics, get_default_dataset
 
@@ -40,6 +42,114 @@ def read_legacy_rgbd_image(color_file, depth_file, convert_rgb_to_intensity):
         depth_trunc=3.0,
         convert_rgb_to_intensity=convert_rgb_to_intensity)
     return rgbd_image
+
+
+def rgbd_loop_closure(depth_list, color_list, intrinsic, config):
+    # TODO: load it from config
+    device = o3c.Device('CUDA:0')
+
+    interval = config.odometry_loop_interval
+    n_files = len(depth_list)
+
+    key_indices = list(range(0, n_files, interval))
+    n_key_indices = len(key_indices)
+
+    edges = []
+    poses = []
+    infos = []
+
+    pairs = []
+
+    criteria_list = [
+        o3d.t.pipelines.odometry.OdometryConvergenceCriteria(20),
+        o3d.t.pipelines.odometry.OdometryConvergenceCriteria(10),
+        o3d.t.pipelines.odometry.OdometryConvergenceCriteria(5)
+    ]
+    method = o3d.t.pipelines.odometry.Method.PointToPlane
+
+    for i in range(n_key_indices - 1):
+        key_i = key_indices[i]
+        depth_curr = o3d.t.io.read_image(depth_list[key_i]).to(device)
+        color_curr = o3d.t.io.read_image(color_list[key_i]).to(device)
+        rgbd_curr = o3d.t.geometry.RGBDImage(color_curr, depth_curr)
+
+        for j in range(i + 1, n_key_indices):
+            key_j = key_indices[j]
+            depth_next = o3d.t.io.read_image(depth_list[key_j]).to(device)
+            color_next = o3d.t.io.read_image(color_list[key_j]).to(device)
+            rgbd_next = o3d.t.geometry.RGBDImage(color_next, depth_next)
+
+            # TODO: add OpenCV initialization if necessary
+            # TODO: better failure check
+            try:
+                res = o3d.t.pipelines.odometry.rgbd_odometry_multi_scale(
+                    rgbd_curr, rgbd_next, intrinsic, o3c.Tensor(np.eye(4)),
+                    1000.0, 3.0, criteria_list, method)
+                info = o3d.t.pipelines.odometry.compute_odometry_information_matrix(
+                    depth_curr, depth_next, intrinsic, res.transformation, 0.07,
+                    1000.0, 3.0)
+            except Exception as e:
+                pass
+            else:
+                if info[5, 5] / (depth_curr.columns * depth_curr.rows) > 0.3:
+                    edges.append((key_i, key_j))
+                    poses.append(res.transformation.cpu().numpy())
+                    infos.append(info.cpu().numpy())
+
+                    # pcd_src = o3d.t.geometry.PointCloud.create_from_rgbd_image(
+                    #     rgbd_curr, intrinsic)
+                    # pcd_dst = o3d.t.geometry.PointCloud.create_from_rgbd_image(
+                    #     rgbd_next, intrinsic)
+                    # o3d.visualization.draw([pcd_src, pcd_dst])
+                    # o3d.visualization.draw(
+                    #     [pcd_src.transform(res.transformation), pcd_dst])
+
+    return edges, poses, infos
+
+
+def rgbd_odometry(depth_list, color_list, intrinsic, config):
+    # TODO: load it from config
+    device = o3c.Device('CUDA:0')
+
+    n_files = len(depth_list)
+
+    depth_curr = o3d.t.io.read_image(depth_list[0]).to(device)
+    color_curr = o3d.t.io.read_image(color_list[0]).to(device)
+    rgbd_curr = o3d.t.geometry.RGBDImage(color_curr, depth_curr)
+
+    # TODO: load all params and scale/max factors from config
+    edges = []
+    poses = []
+    infos = []
+
+    criteria_list = [
+        o3d.t.pipelines.odometry.OdometryConvergenceCriteria(20),
+        o3d.t.pipelines.odometry.OdometryConvergenceCriteria(10),
+        o3d.t.pipelines.odometry.OdometryConvergenceCriteria(5)
+    ]
+    method = o3d.t.pipelines.odometry.Method.PointToPlane
+
+    for i in tqdm(range(0, n_files - 1)):
+        depth_next = o3d.t.io.read_image(depth_list[i + 1]).to(device)
+        color_next = o3d.t.io.read_image(color_list[i + 1]).to(device)
+        rgbd_next = o3d.t.geometry.RGBDImage(color_next, depth_next)
+
+        res = o3d.t.pipelines.odometry.rgbd_odometry_multi_scale(
+            rgbd_curr, rgbd_next, intrinsic, o3c.Tensor(np.eye(4)), 1000.0, 3.0,
+            criteria_list, method)
+        info = o3d.t.pipelines.odometry.compute_odometry_information_matrix(
+            depth_curr, depth_next, intrinsic, res.transformation, 0.07, 1000.0,
+            3.0)
+
+        edges.append((i, i + 1))
+        poses.append(res.transformation.cpu().numpy())
+        infos.append(info.cpu().numpy())
+
+        color_curr = color_next
+        depth_curr = depth_next
+        rgbd_curr = rgbd_next
+
+    return edges, poses, infos
 
 
 if __name__ == '__main__':
@@ -66,7 +176,7 @@ if __name__ == '__main__':
     intrinsic = load_intrinsic(config)
 
     i = 0
-    j = 1
+    j = 10
 
     depth_src = o3d.t.io.read_image(depth_file_names[i])
     color_src = o3d.t.io.read_image(color_file_names[i])
@@ -83,6 +193,7 @@ if __name__ == '__main__':
     info = o3d.t.pipelines.odometry.compute_odometry_information_matrix(
         depth_src, depth_dst, intrinsic, res.transformation, 0.07)
     print(res.transformation, info)
+    print(info[5, 5] / (depth_src.columns * depth_src.rows))
 
     # Legacy for reference, can be a little bit different due to minor implementation discrepancies
     rgbd_src_legacy = read_legacy_rgbd_image(color_file_names[i],

--- a/examples/python/t_reconstruction_system/rgbd_odometry.py
+++ b/examples/python/t_reconstruction_system/rgbd_odometry.py
@@ -1,0 +1,71 @@
+import numpy as np
+import open3d as o3d
+from config import ConfigParser
+from common import load_rgbd_file_names, load_depth_file_names, save_poses, load_intrinsic, load_extrinsics
+
+
+def read_rgbd_image(color_file, depth_file, convert_rgb_to_intensity):
+    color = o3d.io.read_image(color_file)
+    depth = o3d.io.read_image(depth_file)
+    rgbd_image = o3d.geometry.RGBDImage.create_from_color_and_depth(
+        color,
+        depth,
+        depth_scale=1000.0,
+        depth_trunc=3.0,
+        convert_rgb_to_intensity=convert_rgb_to_intensity)
+    return rgbd_image
+
+
+if __name__ == '__main__':
+    parser = ConfigParser()
+    parser.add(
+        '--config',
+        is_config_file=True,
+        help='YAML config file path. Please refer to default_config.yml as a '
+        'reference. It overrides the default config file, but will be '
+        'overridden by other command line inputs.')
+    config = parser.get_config()
+
+    depth_file_names, color_file_names = load_rgbd_file_names(config)
+
+    intrinsic = load_intrinsic(config)
+
+    i = 0
+    j = 1
+
+    depth_src = o3d.t.io.read_image(depth_file_names[i])
+    color_src = o3d.t.io.read_image(color_file_names[i])
+
+    depth_dst = o3d.t.io.read_image(depth_file_names[j])
+    color_dst = o3d.t.io.read_image(color_file_names[j])
+
+    rgbd_src = o3d.t.geometry.RGBDImage(color_src, depth_src)
+    rgbd_dst = o3d.t.geometry.RGBDImage(color_dst, depth_dst)
+
+    rgbd_src_legacy = read_rgbd_image(color_file_names[i], depth_file_names[i],
+                                      True)
+    rgbd_dst_legacy = read_rgbd_image(color_file_names[j], depth_file_names[j],
+                                      True)
+    intrinsic_legacy = o3d.camera.PinholeCameraIntrinsic(
+        o3d.camera.PinholeCameraIntrinsicParameters.PrimeSenseDefault)
+    success, trans, info = o3d.pipelines.odometry.compute_rgbd_odometry(
+        rgbd_src_legacy, rgbd_dst_legacy, intrinsic_legacy, np.eye(4),
+        o3d.pipelines.odometry.RGBDOdometryJacobianFromHybridTerm())
+    print(info)
+
+    res = o3d.t.pipelines.odometry.rgbd_odometry_multi_scale(
+        rgbd_src, rgbd_dst, intrinsic)
+    depth_srcf = depth_src.clip_transform(1000.0, 0.0, 3.0, np.nan)
+    depth_dstf = depth_dst.clip_transform(1000.0, 0.0, 3.0, np.nan)
+    info = o3d.t.pipelines.odometry.compute_odometry_information_matrix(
+        depth_srcf.as_tensor(), depth_dstf.as_tensor(), intrinsic,
+        res.transformation, 0.03)
+    print(info)
+
+    pcd_src = o3d.t.geometry.PointCloud.create_from_rgbd_image(
+        rgbd_src, intrinsic)
+    pcd_dst = o3d.t.geometry.PointCloud.create_from_rgbd_image(
+        rgbd_dst, intrinsic)
+
+    o3d.visualization.draw([pcd_src, pcd_dst])
+    o3d.visualization.draw([pcd_src.transform(res.transformation), pcd_dst])

--- a/examples/python/t_reconstruction_system/rgbd_odometry.py
+++ b/examples/python/t_reconstruction_system/rgbd_odometry.py
@@ -1,3 +1,29 @@
+# ----------------------------------------------------------------------------
+# -                        Open3D: www.open3d.org                            -
+# ----------------------------------------------------------------------------
+# The MIT License (MIT)
+#
+# Copyright (c) 2018-2021 www.open3d.org
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ----------------------------------------------------------------------------
+
 import numpy as np
 import open3d as o3d
 from config import ConfigParser

--- a/examples/python/t_reconstruction_system/run_system.py
+++ b/examples/python/t_reconstruction_system/run_system.py
@@ -1,0 +1,81 @@
+import os, sys
+import open3d as o3d
+import numpy as np
+
+from config import ConfigParser
+from split_fragments import split_fragments, load_fragments
+from rgbd_odometry import rgbd_odometry, rgbd_loop_closure
+from pose_graph_optim import PoseGraphWrapper
+from integrate import integrate
+
+from common import load_intrinsic
+
+if __name__ == '__main__':
+    parser = ConfigParser()
+    parser.add(
+        '--config',
+        is_config_file=True,
+        help='YAML config file path. Please refer to default_config.yml as a '
+        'reference. It overrides the default config file, but will be '
+        'overridden by other command line inputs.')
+    parser.add('--default_dataset',
+               help='Default dataset is used when config file is not provided. '
+               'Default dataset may be selected from the following options: '
+               '[lounge, jack_jack]',
+               default='lounge')
+    parser.add('--path_npz', type=str, default='test.npz')
+    parser.add('--integrate_color', action='store_true')
+    parser.add('--split_fragments', action='store_true')
+    parser.add('--rgbd_odometry', action='store_true')
+    config = parser.get_config()
+
+    if config.split_fragments:
+        split_fragments(config)
+
+    if config.rgbd_odometry:
+        intrinsic = load_intrinsic(config)
+        depth_lists, color_lists = load_fragments(config)
+
+        for i, (depth_list,
+                color_list) in enumerate(zip(depth_lists, color_lists)):
+            print(depth_list)
+
+            pose_graph = PoseGraphWrapper()
+
+            # Odometry: (i, i+1), trans(i, i+1), info(i, i+1)
+            edges, trans, infos = rgbd_odometry(depth_list, color_list,
+                                                intrinsic, config)
+            pose_i2w = np.eye(4)
+            pose_graph.add_node(0, pose_i2w.copy())
+
+            for i in range(len(trans)):
+                trans_i2j = trans[i]
+                info_i2j = infos[i]
+
+                trans_j2i = np.linalg.inv(trans_i2j)
+                pose_j2w = pose_i2w @ trans_j2i
+
+                pose_graph.add_node(i + 1, pose_j2w.copy())
+                pose_graph.add_edge(i, i + 1, trans_i2j.copy(), info_i2j.copy(),
+                                    False)
+                pose_i2w = pose_j2w
+
+            # Loop closure: (i, j), trans(i, j), info(i, j) where i, j are multipliers of intervals
+            edges, trans, infos = rgbd_loop_closure(depth_list, color_list,
+                                                    intrinsic, config)
+            for i in range(len(edges)):
+                ki, kj = edges[i]
+                trans_i2j = trans[i]
+                info_i2j = infos[i]
+
+                pose_graph.add_edge(ki, kj, trans_i2j.copy(), info_i2j.copy(),
+                                    True)
+
+            pose_graph.solve_()
+            extrinsics = pose_graph.export_extrinsics()
+
+            vbg = integrate(depth_list, color_list, intrinsic, intrinsic,
+                            extrinsics, config)
+            pcd = vbg.extract_point_cloud()
+            o3d.visualization.draw([pcd])
+

--- a/examples/python/t_reconstruction_system/split_fragments.py
+++ b/examples/python/t_reconstruction_system/split_fragments.py
@@ -1,0 +1,43 @@
+import os, sys
+import open3d as o3d
+import numpy as np
+
+from config import ConfigParser
+from common import load_rgbd_file_names, load_depth_file_names, save_poses, load_intrinsic, load_extrinsics, get_default_dataset
+
+if __name__ == '__main__':
+    parser = ConfigParser()
+    parser.add(
+        '--config',
+        is_config_file=True,
+        help='YAML config file path. Please refer to default_config.yml as a '
+        'reference. It overrides the default config file, but will be '
+        'overridden by other command line inputs.')
+    parser.add('--default_dataset',
+               help='Default dataset is used when config file is not provided. '
+               'Default dataset may be selected from the following options: '
+               '[lounge, jack_jack]',
+               default='lounge')
+    config = parser.get_config()
+
+    depth_file_names, color_file_names = load_rgbd_file_names(config)
+
+    os.makedirs(os.path.join(config.path_dataset, 'fragments'), exist_ok=True)
+
+    frag_id = 0
+    for i in range(0, len(depth_file_names), config.fragment_size):
+        start = i
+        end = min(i + config.fragment_size, len(depth_file_names))
+
+        np.savetxt(os.path.join(config.path_dataset, 'fragments',
+                                'fragment_{:03d}_colors.txt'.format(frag_id)),
+                   color_file_names[start:end],
+                   fmt='%s',
+                   delimiter='')
+        np.savetxt(os.path.join(config.path_dataset, 'fragments',
+                                'fragment_{:03d}_depths.txt'.format(frag_id)),
+                   depth_file_names[start:end],
+                   fmt='%s',
+                   delimiter='')
+
+        frag_id += 1

--- a/examples/python/t_reconstruction_system/split_fragments.py
+++ b/examples/python/t_reconstruction_system/split_fragments.py
@@ -1,3 +1,29 @@
+# ----------------------------------------------------------------------------
+# -                        Open3D: www.open3d.org                            -
+# ----------------------------------------------------------------------------
+# The MIT License (MIT)
+#
+# Copyright (c) 2018-2021 www.open3d.org
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ----------------------------------------------------------------------------
+
 import os, sys
 import open3d as o3d
 import numpy as np

--- a/examples/python/t_reconstruction_system/split_fragments.py
+++ b/examples/python/t_reconstruction_system/split_fragments.py
@@ -1,25 +1,13 @@
 import os, sys
 import open3d as o3d
 import numpy as np
+import glob
 
 from config import ConfigParser
 from common import load_rgbd_file_names, load_depth_file_names, save_poses, load_intrinsic, load_extrinsics, get_default_dataset
 
-if __name__ == '__main__':
-    parser = ConfigParser()
-    parser.add(
-        '--config',
-        is_config_file=True,
-        help='YAML config file path. Please refer to default_config.yml as a '
-        'reference. It overrides the default config file, but will be '
-        'overridden by other command line inputs.')
-    parser.add('--default_dataset',
-               help='Default dataset is used when config file is not provided. '
-               'Default dataset may be selected from the following options: '
-               '[lounge, jack_jack]',
-               default='lounge')
-    config = parser.get_config()
 
+def split_fragments(config):
     depth_file_names, color_file_names = load_rgbd_file_names(config)
 
     os.makedirs(os.path.join(config.path_dataset, 'fragments'), exist_ok=True)
@@ -41,3 +29,42 @@ if __name__ == '__main__':
                    delimiter='')
 
         frag_id += 1
+
+
+def load_fragments(config):
+    color_list_fnames = sorted(
+        glob.glob(os.path.join(config.path_dataset, 'fragments',
+                               '*_colors.txt')))
+    depth_list_fnames = sorted(
+        glob.glob(os.path.join(config.path_dataset, 'fragments',
+                               '*_depths.txt')))
+
+    color_lists = [
+        np.loadtxt(color_list_fname, dtype=str)
+        for color_list_fname in color_list_fnames
+    ]
+    depth_lists = [
+        np.loadtxt(depth_list_fname, dtype=str)
+        for depth_list_fname in depth_list_fnames
+    ]
+
+    return depth_lists, color_lists
+
+
+if __name__ == '__main__':
+    parser = ConfigParser()
+    parser.add(
+        '--config',
+        is_config_file=True,
+        help='YAML config file path. Please refer to default_config.yml as a '
+        'reference. It overrides the default config file, but will be '
+        'overridden by other command line inputs.')
+    parser.add('--default_dataset',
+               help='Default dataset is used when config file is not provided. '
+               'Default dataset may be selected from the following options: '
+               '[lounge, jack_jack]',
+               default='lounge')
+    config = parser.get_config()
+
+    split_fragments(config)
+    depth_lists, color_lists = load_fragments(config)


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5181)
<!-- Reviewable:end -->

This PR implements 
- Information matrix computation for RGB-D odometry
- Easier-to-use pose graph wrapper in t-reconstruction system
- Explicit Long sequence splitter (into fragments)
- Module: RGB-D odometry, pose graph construction, and optimization
- Module: RGB-D integration

For the copyroom scene (5490 frames), on RTX 3060 & i7-11700 @ 2.5Hz
- Pose graph generation and optimization takes 107.961s for 55 fragments. (~ avg 50 FPS)
- TSDF integration takes 47.590s for 55 fragments. (~ avg 120 FPS)
- Example fragments:
![image](https://user-images.githubusercontent.com/6127282/173201947-77cc0a0f-38cc-4761-bb63-4e0f9bb7b4e2.png)
![image](https://user-images.githubusercontent.com/6127282/173201959-bb6d35f8-52b8-4b3f-ab75-4f872c565c13.png)

To run the system, call
```
python examples/python/t_reconstruction_system/run_system.py --split_fragments --fragment_odometry --fragment_integration --path_dataset /path/to/dataset
```