### PR TITLE
add SimplifyQuadricDecimation to tensor TriangleMesh

### DIFF
--- a/cpp/open3d/t/geometry/TriangleMesh.h
+++ b/cpp/open3d/t/geometry/TriangleMesh.h
@@ -474,6 +474,19 @@ public:
     /// corresponding vertex in the original mesh.
     TriangleMesh ComputeConvexHull(bool joggle_inputs = false) const;
 
+    /// Function to simplify mesh using Quadric Error Metric Decimation by
+    /// Garland and Heckbert.
+    /// \param target_reduction The factor of triangles to delete, i.e.,
+    /// setting this to 0.9 will return a mesh with about 10% of the original
+    /// triangle count.
+    /// It is not guaranteed that the target reduction factor will be reached.
+    /// \param preserve_volume If set to true this enables volume preservation
+    /// which reduces the error in triangle normal direction.
+    ///
+    /// \return Simplified TriangleMesh.
+    TriangleMesh SimplifyQuadricDecimation(double target_reduction,
+                                           bool preserve_volume = true) const;
+
 protected:
     core::Device device_ = core::Device("CPU:0");
     TensorMap vertex_attr_;

--- a/cpp/pybind/t/geometry/trianglemesh.cpp
+++ b/cpp/pybind/t/geometry/trianglemesh.cpp
@@ -195,8 +195,7 @@ Example:
 
     triangle_mesh.def("clip_plane", &TriangleMesh::ClipPlane, "point"_a,
                       "normal"_a,
-                      R"(
-Returns a new triangle mesh clipped with the plane.
+                      R"(Returns a new triangle mesh clipped with the plane.
 
 This method clips the triangle mesh with the specified plane.
 Parts of the mesh on the positive side of the plane will be kept and triangles
@@ -220,6 +219,33 @@ This example shows how to create a hemisphere from a sphere::
     hemisphere = sphere.clip_plane(point=[0,0,0], normal=[1,0,0])
 
     o3d.visualization.draw(hemisphere)
+)");
+
+    triangle_mesh.def(
+            "simplify_quadric_decimation",
+            &TriangleMesh::SimplifyQuadricDecimation, "target_reduction"_a,
+            "preserve_volume"_a = true,
+            R"(Function to simplify mesh using Quadric Error Metric Decimation by Garland and Heckbert.
+
+Args:
+    target_reduction (float): The factor of triangles to delete, i.e., setting
+        this to 0.9 will return a mesh with about 10% of the original triangle
+        count. It is not guaranteed that the target reduction factor will be
+        reached.
+    
+    preserve_volume (bool): If set to True this enables volume preservation
+        which reduces the error in triangle normal direction.
+    
+Returns:
+    Simplified TriangleMesh.
+
+Example:
+    This shows how to simplifify the Stanford Bunny mesh::
+
+        bunny = o3d.data.BunnyMesh()
+        mesh = o3d.t.geometry.TriangleMesh.from_legacy(o3d.io.read_triangle_mesh(bunny.path))
+        simplified = mesh.simplify_quadric_decimation(0.99)
+        o3d.visualization.draw([{'name': 'bunny', 'geometry': simplified}])
 )");
 }
 

--- a/python/test/t/geometry/test_trianglemesh.py
+++ b/python/test/t/geometry/test_trianglemesh.py
@@ -35,3 +35,16 @@ def test_clip_plane():
     clipped_cube = cube.clip_plane(point=[0.5, 0, 0], normal=[1, 0, 0])
     assert clipped_cube.vertex['positions'].shape == (12, 3)
     assert clipped_cube.triangle['indices'].shape == (14, 3)
+
+
+def test_simplify_quadric_decimation():
+    cube = o3d.t.geometry.TriangleMesh.from_legacy(
+        o3d.geometry.TriangleMesh.create_box().subdivide_midpoint(3))
+
+    # chose reduction factor such that we get 12 faces
+    target_reduction = 1 - (12 / cube.triangle['indices'].shape[0])
+    simplified = cube.simplify_quadric_decimation(
+        target_reduction=target_reduction)
+
+    assert simplified.vertex['positions'].shape == (8, 3)
+    assert simplified.triangle['indices'].shape == (12, 3)


### PR DESCRIPTION
This PR adds a new function for quadric decimation to the tensor TriangleMesh.
The function does not produce duplicate vertices for the mesh described here #2581 and does not produce the hole in #4083 .
Note that the function arguments are different from the legacy function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5199)
<!-- Reviewable:end -->
