### PR TITLE
Change 'depth_diff_max' to 'max_depth_diff'

### DIFF
--- a/examples/python/reconstruction_system/config/tutorial.json
+++ b/examples/python/reconstruction_system/config/tutorial.json
@@ -4,7 +4,7 @@
     "path_intrinsic": "",
     "depth_max": 3.0,
     "voxel_size": 0.05,
-    "depth_diff_max": 0.07,
+    "max_depth_diff": 0.07,
     "preference_loop_closure_odometry": 0.1,
     "preference_loop_closure_registration": 5.0,
     "tsdf_cubic_size": 3.0,

--- a/examples/python/reconstruction_system/make_fragments.py
+++ b/examples/python/reconstruction_system/make_fragments.py
@@ -53,7 +53,7 @@ def register_one_rgbd_pair(s, t, color_files, depth_files, intrinsic,
                                         config)
 
     option = o3d.pipelines.odometry.OdometryOption()
-    option.depth_diff_max = config["depth_diff_max"]
+    option.max_depth_diff = config["max_depth_diff"]
     if abs(s - t) != 1:
         if with_opencv:
             success_5pt, odo_init = pose_estimation(source_rgbd_image,


### PR DESCRIPTION
When using the reconstruction system located in `examples/python/reconstruction_system` the first step *Make fragments* failes to run. I tested the latest version of the master branch (c43eabebc2b14b1ae3ee5371146027b887c41eee).

```shell
python run_system.py --config ./config/tutorial.json --make
```

After fixing the error

```
AttributeError: 'open3d.cpu.pybind.pipelines.odometry.OdometryOption' object has no attribute 'depth_diff_max'
```

with the in this PR provided change, the script ran without any issues.

It seems like the commit c8f8f401c1e7ef6efd728a10e0e25895fb9d8ff1 has introduced this change in the C++ source.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5219)
<!-- Reviewable:end -->
