### PR TITLE
Random seed Open3D globally

### DIFF
--- a/cpp/benchmarks/core/BinaryEW.cpp
+++ b/cpp/benchmarks/core/BinaryEW.cpp
@@ -26,7 +26,6 @@
 
 #include <benchmark/benchmark.h>
 
-#include <random>
 #include <type_traits>
 
 #include "benchmarks/benchmark_utilities/Rand.h"

--- a/cpp/open3d/Open3D.h.in
+++ b/cpp/open3d/Open3D.h.in
@@ -113,6 +113,7 @@
 #include "open3d/utility/Parallel.h"
 #include "open3d/utility/ProgressBar.h"
 #include "open3d/utility/ProgressReporters.h"
+#include "open3d/utility/Random.h"
 #include "open3d/utility/Timer.h"
 #include "open3d/visualization/gui/Application.h"
 #include "open3d/visualization/gui/Button.h"

--- a/cpp/open3d/core/hashmap/CUDA/SlabNodeManager.h
+++ b/cpp/open3d/core/hashmap/CUDA/SlabNodeManager.h
@@ -43,12 +43,12 @@
 #include <thrust/device_vector.h>
 
 #include <memory>
-#include <random>
 
 #include "open3d/core/CUDAUtils.h"
 #include "open3d/core/MemoryManager.h"
 #include "open3d/core/hashmap/CUDA/SlabMacros.h"
 #include "open3d/core/hashmap/HashBackendBuffer.h"
+#include "open3d/utility/Random.h"
 
 namespace open3d {
 namespace core {
@@ -239,8 +239,7 @@ class SlabNodeManager {
 public:
     SlabNodeManager(const Device& device) : device_(device) {
         /// Random coefficients for allocator's hash function.
-        std::mt19937 rng(time(0));
-        impl_.hash_coef_ = rng();
+        impl_.hash_coef_ = utility::random::RandUint32();
 
         /// In the light version, we put num_super_blocks super blocks within
         /// a single array.

--- a/cpp/open3d/geometry/MeshBase.cpp
+++ b/cpp/open3d/geometry/MeshBase.cpp
@@ -29,7 +29,6 @@
 #include <Eigen/Dense>
 #include <numeric>
 #include <queue>
-#include <random>
 #include <tuple>
 
 #include "open3d/geometry/BoundingVolume.h"

--- a/cpp/open3d/geometry/PointCloud.h
+++ b/cpp/open3d/geometry/PointCloud.h
@@ -355,17 +355,13 @@ public:
     /// each iteration.
     /// \param num_iterations Maximum number of iterations.
     /// \param probability Expected probability of finding the optimal plane.
-    /// \param seed Sets the seed value used in the random
-    /// generator, set to nullopt to use a random seed value with each function
-    /// call.
     /// \return Returns the plane model ax + by + cz + d = 0 and the indices of
     /// the plane inliers.
     std::tuple<Eigen::Vector4d, std::vector<size_t>> SegmentPlane(
             const double distance_threshold = 0.01,
             const int ransac_n = 3,
             const int num_iterations = 100,
-            const double probability = 0.99999999,
-            utility::optional<int> seed = utility::nullopt) const;
+            const double probability = 0.99999999) const;
 
     /// \brief Factory function to create a pointcloud from a depth image and a
     /// camera model.

--- a/cpp/open3d/geometry/PointCloudSegmentation.cpp
+++ b/cpp/open3d/geometry/PointCloudSegmentation.cpp
@@ -28,16 +28,16 @@
 #include <algorithm>
 #include <iostream>
 #include <iterator>
-#include <mutex>
 #include <numeric>
-#include <random>
 #include <unordered_set>
 
 #include "open3d/geometry/PointCloud.h"
 #include "open3d/geometry/TriangleMesh.h"
 #include "open3d/utility/Logging.h"
+#include "open3d/utility/Random.h"
 
-namespace {
+namespace open3d {
+namespace geometry {
 
 /// \class RandomSampler
 ///
@@ -45,43 +45,29 @@ namespace {
 template <typename T>
 class RandomSampler {
 public:
-    explicit RandomSampler(const size_t size,
-                           open3d::utility::optional<int> seed)
-        : size_(size) {
-        if (!seed.has_value()) {
-            std::random_device rd;
-            seed = rd();
-        }
-        rng_ = std::mt19937(seed.value());
-    }
+    explicit RandomSampler(const size_t total_size) : total_size_(total_size) {}
 
     std::vector<T> operator()(size_t sample_size) {
-        std::lock_guard<std::mutex> guard(mutex_);
-
-        std::vector<T> sample;
-        sample.reserve(sample_size);
+        std::vector<T> samples;
+        samples.reserve(sample_size);
 
         size_t valid_sample = 0;
         while (valid_sample < sample_size) {
-            const size_t idx = rng_() % size_;
-            if (std::find(sample.begin(), sample.end(), idx) == sample.end()) {
-                sample.push_back(idx);
+            const size_t idx = utility::random::RandUint32() % total_size_;
+            // Well, this is slow. But typically the sample_size is small.
+            if (std::find(samples.begin(), samples.end(), idx) ==
+                samples.end()) {
+                samples.push_back(idx);
                 valid_sample++;
             }
         }
 
-        return sample;
+        return samples;
     }
 
 private:
-    size_t size_;
-    std::mt19937 rng_;
-    std::mutex mutex_;
+    size_t total_size_;
 };
-}  // namespace
-
-namespace open3d {
-namespace geometry {
 
 /// \class RANSACResult
 ///
@@ -181,8 +167,7 @@ std::tuple<Eigen::Vector4d, std::vector<size_t>> PointCloud::SegmentPlane(
         const double distance_threshold /* = 0.01 */,
         const int ransac_n /* = 3 */,
         const int num_iterations /* = 100 */,
-        const double probability /* = 0.99999999 */,
-        utility::optional<int> seed /* = utility::nullopt */) const {
+        const double probability /* = 0.99999999 */) const {
     if (probability <= 0 || probability > 1) {
         utility::LogError("Probability must be > 0 or <= 1.0");
     }
@@ -193,7 +178,7 @@ std::tuple<Eigen::Vector4d, std::vector<size_t>> PointCloud::SegmentPlane(
     Eigen::Vector4d best_plane_model = Eigen::Vector4d(0, 0, 0, 0);
 
     size_t num_points = points_.size();
-    RandomSampler<size_t> sampler(num_points, seed);
+    RandomSampler<size_t> sampler(num_points);
 
     // Return if ransac_n is less than the required plane model parameters.
     if (ransac_n < 3) {

--- a/cpp/open3d/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/geometry/TriangleMesh.cpp
@@ -29,7 +29,6 @@
 #include <Eigen/Dense>
 #include <numeric>
 #include <queue>
-#include <random>
 #include <tuple>
 
 #include "open3d/geometry/BoundingVolume.h"
@@ -39,6 +38,7 @@
 #include "open3d/geometry/Qhull.h"
 #include "open3d/utility/Logging.h"
 #include "open3d/utility/Parallel.h"
+#include "open3d/utility/Random.h"
 
 namespace open3d {
 namespace geometry {
@@ -454,8 +454,7 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformlyImpl(
         size_t number_of_points,
         std::vector<double> &triangle_areas,
         double surface_area,
-        bool use_triangle_normal,
-        int seed) {
+        bool use_triangle_normal) {
     if (surface_area <= 0) {
         utility::LogError("Invalid surface area {}, it must be > 0.",
                           surface_area);
@@ -471,12 +470,7 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformlyImpl(
     // sample point cloud
     bool has_vert_normal = HasVertexNormals();
     bool has_vert_color = HasVertexColors();
-    if (seed == -1) {
-        std::random_device rd;
-        seed = rd();
-    }
-    std::mt19937 mt(seed);
-    std::uniform_real_distribution<double> dist(0.0, 1.0);
+    utility::random::UniformDoubleGenerator uniform_generator(0.0, 1.0);
     auto pcd = std::make_shared<PointCloud>();
     pcd->points_.resize(number_of_points);
     if (has_vert_normal || use_triangle_normal) {
@@ -492,8 +486,8 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformlyImpl(
     for (size_t tidx = 0; tidx < triangles_.size(); ++tidx) {
         size_t n = size_t(std::round(triangle_areas[tidx] * number_of_points));
         while (point_idx < n) {
-            double r1 = dist(mt);
-            double r2 = dist(mt);
+            double r1 = uniform_generator();
+            double r2 = uniform_generator();
             double a = (1 - std::sqrt(r1));
             double b = std::sqrt(r1) * (1 - r2);
             double c = std::sqrt(r1) * r2;
@@ -524,9 +518,7 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformlyImpl(
 }
 
 std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformly(
-        size_t number_of_points,
-        bool use_triangle_normal /* = false */,
-        int seed /* = -1 */) {
+        size_t number_of_points, bool use_triangle_normal /* = false */) {
     if (number_of_points <= 0) {
         utility::LogError("number_of_points <= 0");
     }
@@ -539,15 +531,14 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformly(
     double surface_area = GetSurfaceArea(triangle_areas);
 
     return SamplePointsUniformlyImpl(number_of_points, triangle_areas,
-                                     surface_area, use_triangle_normal, seed);
+                                     surface_area, use_triangle_normal);
 }
 
 std::shared_ptr<PointCloud> TriangleMesh::SamplePointsPoissonDisk(
         size_t number_of_points,
         double init_factor /* = 5 */,
         const std::shared_ptr<PointCloud> pcl_init /* = nullptr */,
-        bool use_triangle_normal /* = false */,
-        int seed /* = -1 */) {
+        bool use_triangle_normal /* = false */) {
     if (number_of_points <= 0) {
         utility::LogError("number_of_points <= 0");
     }
@@ -574,7 +565,7 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsPoissonDisk(
     if (pcl_init == nullptr) {
         pcl = SamplePointsUniformlyImpl(size_t(init_factor * number_of_points),
                                         triangle_areas, surface_area,
-                                        use_triangle_normal, seed);
+                                        use_triangle_normal);
     } else {
         pcl = std::make_shared<PointCloud>();
         pcl->points_ = pcl_init->points_;

--- a/cpp/open3d/geometry/TriangleMesh.h
+++ b/cpp/open3d/geometry/TriangleMesh.h
@@ -358,8 +358,7 @@ public:
             size_t number_of_points,
             std::vector<double> &triangle_areas,
             double surface_area,
-            bool use_triangle_normal,
-            int seed);
+            bool use_triangle_normal);
 
     /// Function to sample points uniformly from the mesh.
     ///
@@ -367,12 +366,8 @@ public:
     /// \param use_triangle_normal Set to true to assign the triangle normals to
     /// the returned points instead of the interpolated vertex normals. The
     /// triangle normals will be computed and added to the mesh if necessary.
-    /// \param seed Sets the seed value used in the random generator, set to -1
-    /// to use a random seed value with each function call.
     std::shared_ptr<PointCloud> SamplePointsUniformly(
-            size_t number_of_points,
-            bool use_triangle_normal = false,
-            int seed = -1);
+            size_t number_of_points, bool use_triangle_normal = false);
 
     /// Function to sample points from the mesh with Possion disk, based on the
     /// method presented in Yuksel, "Sample Elimination for Generating Poisson
@@ -386,14 +381,11 @@ public:
     /// \param use_triangle_normal If True assigns the triangle normals instead
     /// of the interpolated vertex normals to the returned points. The triangle
     /// normals will be computed and added to the mesh if necessary.
-    /// \param seed Sets the seed value used in the random generator, set to -1
-    /// to use a random seed value with each function call.
     std::shared_ptr<PointCloud> SamplePointsPoissonDisk(
             size_t number_of_points,
             double init_factor = 5,
             const std::shared_ptr<PointCloud> pcl_init = nullptr,
-            bool use_triangle_normal = false,
-            int seed = -1);
+            bool use_triangle_normal = false);
 
     /// Function to subdivide triangle mesh using the simple midpoint algorithm.
     /// Each triangle is subdivided into four triangles per iteration and the

--- a/cpp/open3d/pipelines/registration/FastGlobalRegistration.cpp
+++ b/cpp/open3d/pipelines/registration/FastGlobalRegistration.cpp
@@ -32,8 +32,8 @@
 #include "open3d/geometry/PointCloud.h"
 #include "open3d/pipelines/registration/Feature.h"
 #include "open3d/pipelines/registration/Registration.h"
-#include "open3d/utility/Helper.h"
 #include "open3d/utility/Logging.h"
+#include "open3d/utility/Random.h"
 
 namespace open3d {
 namespace pipelines {
@@ -88,9 +88,7 @@ static std::vector<std::pair<int, int>> AdvancedMatching(
     int ncorr = static_cast<int>(corres_cross.size());
     int number_of_trial = ncorr * 100;
 
-    unsigned int seed_val = option.seed_.has_value() ? option.seed_.value()
-                                                     : std::random_device{}();
-    utility::UniformRandIntGenerator rand_generator(0, ncorr - 1, seed_val);
+    utility::random::UniformIntGenerator rand_generator(0, ncorr - 1);
     std::vector<std::pair<int, int>> corres_tuple;
     for (i = 0; i < number_of_trial; i++) {
         rand0 = rand_generator();

--- a/cpp/open3d/pipelines/registration/FastGlobalRegistration.h
+++ b/cpp/open3d/pipelines/registration/FastGlobalRegistration.h
@@ -66,17 +66,14 @@ public:
     /// \param maximum_tuple_count Maximum numer of tuples.
     /// \param tuple_test Set to `true` to perform geometric compatibility tests
     /// on initial set of correspondences.
-    /// \param seed Random seed.
-    FastGlobalRegistrationOption(
-            double division_factor = 1.4,
-            bool use_absolute_scale = false,
-            bool decrease_mu = true,
-            double maximum_correspondence_distance = 0.025,
-            int iteration_number = 64,
-            double tuple_scale = 0.95,
-            int maximum_tuple_count = 1000,
-            bool tuple_test = true,
-            utility::optional<unsigned int> seed = utility::nullopt)
+    FastGlobalRegistrationOption(double division_factor = 1.4,
+                                 bool use_absolute_scale = false,
+                                 bool decrease_mu = true,
+                                 double maximum_correspondence_distance = 0.025,
+                                 int iteration_number = 64,
+                                 double tuple_scale = 0.95,
+                                 int maximum_tuple_count = 1000,
+                                 bool tuple_test = true)
         : division_factor_(division_factor),
           use_absolute_scale_(use_absolute_scale),
           decrease_mu_(decrease_mu),
@@ -84,8 +81,7 @@ public:
           iteration_number_(iteration_number),
           tuple_scale_(tuple_scale),
           maximum_tuple_count_(maximum_tuple_count),
-          tuple_test_(tuple_test),
-          seed_(seed) {}
+          tuple_test_(tuple_test) {}
     ~FastGlobalRegistrationOption() {}
 
 public:
@@ -109,8 +105,6 @@ public:
     /// Set to `true` to perform geometric compatibility tests on initial set of
     /// correspondences.
     bool tuple_test_;
-    /// Random seed
-    utility::optional<unsigned int> seed_;
 };
 
 /// \brief Fast Global Registration based on a given set of correspondences.

--- a/cpp/open3d/pipelines/registration/Registration.cpp
+++ b/cpp/open3d/pipelines/registration/Registration.cpp
@@ -302,11 +302,13 @@ RegistrationResult RegistrationRANSACBasedOnFeatureMatching(
         const Feature &target_feature,
         bool mutual_filter,
         double max_correspondence_distance,
-        const TransformationEstimation &estimation,
-        int ransac_n,
+        const TransformationEstimation
+                &estimation /* = TransformationEstimationPointToPoint(false)*/,
+        int ransac_n /* = 3*/,
         const std::vector<std::reference_wrapper<const CorrespondenceChecker>>
-                &checkers,
-        const RANSACConvergenceCriteria &criteria) {
+                &checkers /* = {}*/,
+        const RANSACConvergenceCriteria
+                &criteria /* = RANSACConvergenceCriteria()*/) {
     if (ransac_n < 3 || max_correspondence_distance <= 0.0) {
         return RegistrationResult();
     }

--- a/cpp/open3d/pipelines/registration/Registration.cpp
+++ b/cpp/open3d/pipelines/registration/Registration.cpp
@@ -29,9 +29,9 @@
 #include "open3d/geometry/KDTreeFlann.h"
 #include "open3d/geometry/PointCloud.h"
 #include "open3d/pipelines/registration/Feature.h"
-#include "open3d/utility/Helper.h"
 #include "open3d/utility/Logging.h"
 #include "open3d/utility/Parallel.h"
+#include "open3d/utility/Random.h"
 
 namespace open3d {
 namespace pipelines {
@@ -196,9 +196,8 @@ RegistrationResult RegistrationRANSACBasedOnCorrespondence(
         int ransac_n /* = 3*/,
         const std::vector<std::reference_wrapper<const CorrespondenceChecker>>
                 &checkers /* = {}*/,
-        const RANSACConvergenceCriteria &criteria,
-        /* = RANSACConvergenceCriteria()*/
-        utility::optional<unsigned int> seed /* = utility::nullopt*/) {
+        const RANSACConvergenceCriteria &criteria
+        /* = RANSACConvergenceCriteria()*/) {
     if (ransac_n < 3 || (int)corres.size() < ransac_n ||
         max_correspondence_distance <= 0.0) {
         return RegistrationResult();
@@ -214,10 +213,7 @@ RegistrationResult RegistrationRANSACBasedOnCorrespondence(
         CorrespondenceSet ransac_corres(ransac_n);
         RegistrationResult best_result_local;
         int est_k_local = criteria.max_iteration_;
-        unsigned int seed_val =
-                seed.has_value() ? seed.value() : std::random_device{}();
-        utility::UniformRandIntGenerator rand_gen(0, corres.size() - 1,
-                                                  seed_val);
+        utility::random::UniformIntGenerator rand_gen(0, corres.size() - 1);
 
 #pragma omp for nowait
         for (int itr = 0; itr < criteria.max_iteration_; itr++) {
@@ -306,14 +302,11 @@ RegistrationResult RegistrationRANSACBasedOnFeatureMatching(
         const Feature &target_feature,
         bool mutual_filter,
         double max_correspondence_distance,
-        const TransformationEstimation &estimation
-        /* = TransformationEstimationPointToPoint(false)*/,
-        int ransac_n /* = 3*/,
+        const TransformationEstimation &estimation,
+        int ransac_n,
         const std::vector<std::reference_wrapper<const CorrespondenceChecker>>
-                &checkers /* = {}*/,
-        const RANSACConvergenceCriteria &criteria,
-        /* = RANSACConvergenceCriteria()*/
-        utility::optional<unsigned int> seed /* = utility::nullopt*/) {
+                &checkers,
+        const RANSACConvergenceCriteria &criteria) {
     if (ransac_n < 3 || max_correspondence_distance <= 0.0) {
         return RegistrationResult();
     }
@@ -365,7 +358,7 @@ RegistrationResult RegistrationRANSACBasedOnFeatureMatching(
                               corres_mutual.size());
             return RegistrationRANSACBasedOnCorrespondence(
                     source, target, corres_mutual, max_correspondence_distance,
-                    estimation, ransac_n, checkers, criteria, seed);
+                    estimation, ransac_n, checkers, criteria);
         }
         utility::LogDebug(
                 "Too few correspondences after mutual filter, fall back to "
@@ -374,7 +367,7 @@ RegistrationResult RegistrationRANSACBasedOnFeatureMatching(
 
     return RegistrationRANSACBasedOnCorrespondence(
             source, target, corres_ij, max_correspondence_distance, estimation,
-            ransac_n, checkers, criteria, seed);
+            ransac_n, checkers, criteria);
 }
 
 Eigen::Matrix6d GetInformationMatrixFromPointClouds(

--- a/cpp/open3d/pipelines/registration/Registration.h
+++ b/cpp/open3d/pipelines/registration/Registration.h
@@ -187,7 +187,6 @@ RegistrationResult RegistrationICP(
 /// \param ransac_n Fit ransac with `ransac_n` correspondences.
 /// \param checkers Correspondence checker.
 /// \param criteria Convergence criteria.
-/// \param seed Random seed.
 RegistrationResult RegistrationRANSACBasedOnCorrespondence(
         const geometry::PointCloud &source,
         const geometry::PointCloud &target,
@@ -198,8 +197,8 @@ RegistrationResult RegistrationRANSACBasedOnCorrespondence(
         int ransac_n = 3,
         const std::vector<std::reference_wrapper<const CorrespondenceChecker>>
                 &checkers = {},
-        const RANSACConvergenceCriteria &criteria = RANSACConvergenceCriteria(),
-        utility::optional<unsigned int> seed = utility::nullopt);
+        const RANSACConvergenceCriteria &criteria =
+                RANSACConvergenceCriteria());
 
 /// \brief Function for global RANSAC registration based on feature matching.
 ///
@@ -214,7 +213,6 @@ RegistrationResult RegistrationRANSACBasedOnCorrespondence(
 /// \param ransac_n Fit ransac with `ransac_n` correspondences.
 /// \param checkers Correspondence checker.
 /// \param criteria Convergence criteria.
-/// \param seed Random seed.
 RegistrationResult RegistrationRANSACBasedOnFeatureMatching(
         const geometry::PointCloud &source,
         const geometry::PointCloud &target,
@@ -227,8 +225,8 @@ RegistrationResult RegistrationRANSACBasedOnFeatureMatching(
         int ransac_n = 3,
         const std::vector<std::reference_wrapper<const CorrespondenceChecker>>
                 &checkers = {},
-        const RANSACConvergenceCriteria &criteria = RANSACConvergenceCriteria(),
-        utility::optional<unsigned int> seed = utility::nullopt);
+        const RANSACConvergenceCriteria &criteria =
+                RANSACConvergenceCriteria());
 
 /// \param source The source point cloud.
 /// \param target The target point cloud.

--- a/cpp/open3d/utility/CMakeLists.txt
+++ b/cpp/open3d/utility/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(utility PRIVATE
     Logging.cpp
     Parallel.cpp
     ProgressBar.cpp
+    Random.cpp
     Timer.cpp
 )
 

--- a/cpp/open3d/utility/Random.cpp
+++ b/cpp/open3d/utility/Random.cpp
@@ -1,0 +1,115 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "open3d/utility/Random.h"
+
+#include "open3d/utility/Logging.h"
+
+namespace open3d {
+namespace utility {
+namespace random {
+
+/// Global thread-safe singleton instance for random generation.
+/// Generates compiler/OS/device independent random numbers.
+class GlobalContext {
+public:
+    GlobalContext(GlobalContext const&) = delete;
+    void operator=(GlobalContext const&) = delete;
+
+    /// Returns the singleton instance.
+    static GlobalContext& GetInstance() {
+        static GlobalContext instance;
+        return instance;
+    }
+
+    /// Seed the random number generator (globally).
+    void Seed(const int seed) {
+        seed_ = seed;
+        engine_ = std::mt19937(seed_);
+    }
+
+    /// This is used by other downstream random generators.
+    /// You must also lock the GetMutex() before calling the engine.
+    std::mt19937* GetEngine() { return &engine_; }
+
+    /// Get global singleton mutex to protect the engine call.
+    std::mutex* GetMutex() { return &mutex_; }
+
+private:
+    GlobalContext() {
+        // Randomly seed the seed by default.
+        std::random_device rd;
+        Seed(rd());
+    }
+    int seed_;
+    std::mt19937 engine_;
+    std::mutex mutex_;
+};
+
+void Seed(const int seed) { GlobalContext::GetInstance().Seed(seed); }
+
+std::mt19937* GetEngine() { return GlobalContext::GetInstance().GetEngine(); }
+
+std::mutex* GetMutex() { return GlobalContext::GetInstance().GetMutex(); }
+
+uint32_t RandUint32() {
+    std::lock_guard<std::mutex> lock(*GetMutex());
+    return (*GetEngine())();
+}
+
+UniformIntGenerator::UniformIntGenerator(const int low, const int high)
+    : distribution_(low, high) {
+    if (low < 0) {
+        utility::LogError("low must be > 0, but got {}.", low);
+    }
+    if (low >= high) {
+        utility::LogError("low must be < high, but got low={} and high={}.",
+                          low, high);
+    }
+}
+
+int UniformIntGenerator::operator()() {
+    std::lock_guard<std::mutex> lock(*GetMutex());
+    return distribution_(*GetEngine());
+}
+
+UniformDoubleGenerator::UniformDoubleGenerator(const double low,
+                                               const double high) {
+    if (low >= high) {
+        utility::LogError("low must be < high, but got low={} and high={}.",
+                          low, high);
+    }
+    distribution_ = std::uniform_real_distribution<double>(low, high);
+}
+
+double UniformDoubleGenerator::operator()() {
+    std::lock_guard<std::mutex> lock(*GetMutex());
+    return distribution_(*GetEngine());
+}
+
+}  // namespace random
+}  // namespace utility
+}  // namespace open3d

--- a/cpp/open3d/utility/Random.h
+++ b/cpp/open3d/utility/Random.h
@@ -1,0 +1,129 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <mutex>
+#include <random>
+
+namespace open3d {
+namespace utility {
+namespace random {
+
+/// Set Open3D global random seed.
+void Seed(const int seed);
+
+/// Get global singleton random engine.
+/// You must also lock the global mutex before calling the engine.
+///
+/// Example:
+/// ```cpp
+/// #include "open3d/utility/Random.h"
+/// {
+///     // Put the lock and the call to the engine in the same scope.
+///     std::lock_guard<std::mutex> lock(*utility::random::GetMutex());
+///     std::shuffle(vals.begin(), vals.end(), *utility::random::GetEngine());
+/// }
+/// ```
+std::mt19937* GetEngine();
+
+/// Get global singleton mutex to protect the engine call. Also see
+/// random::GetEngine().
+std::mutex* GetMutex();
+
+/// Generate a random uint32.
+/// This function is globally seeded by utility::random::Seed().
+/// This function is automatically protected by the global random mutex.
+uint32_t RandUint32();
+
+/// Generates uniformly distributed random integers in [low, high).
+/// This class is globally seeded by utility::random::Seed().
+/// This class is automatically protected by the global random mutex.
+///
+/// Example:
+/// ```cpp
+/// #include "open3d/utility/Random.h"
+///
+/// // Globally seed Open3D. This will affect all random functions.
+/// utility::random::Seed(0);
+///
+/// // Generate a random integer in [0, 100).
+/// utility::random::UniformIntGenerator gen(0, 100);
+/// for (int i = 0; i < 10; i++) {
+///     std::cout << gen() << std::endl;
+/// }
+/// ```
+class UniformIntGenerator {
+public:
+    /// Generate uniformly distributed random integer from
+    /// [low, low + 1, ... high - 1].
+    ///
+    /// \param low The lower bound (inclusive). \p low must be >= 0.
+    /// \param high The upper bound (exclusive). \p high must be > \p low.
+    UniformIntGenerator(const int low, const int high);
+
+    /// Call this to generate a uniformly distributed random integer.
+    int operator()();
+
+protected:
+    std::uniform_int_distribution<int> distribution_;
+};
+
+/// Generates uniformly distributed random doubles in [low, high).
+/// This class is globally seeded by utility::random::Seed().
+/// This class is automatically protected by the global random mutex.
+///
+/// Example:
+/// ```cpp
+/// #include "open3d/utility/Random.h"
+///
+/// // Globally seed Open3D. This will affect all random functions.
+/// utility::random::Seed(0);
+///
+/// // Generate a random double in [0, 1).
+/// utility::random::UniformDoubleGenerator gen(0, 1);
+/// for (int i = 0; i < 10; i++) {
+///    std::cout << gen() << std::endl;
+/// }
+/// ```
+class UniformDoubleGenerator {
+public:
+    /// Generate uniformly distributed random doubles in [low, high).
+    ///
+    /// \param low The lower bound (inclusive).
+    /// \param high The upper bound (exclusive).
+    UniformDoubleGenerator(const double low, const double high);
+
+    /// Call this to generate a uniformly distributed random double.
+    double operator()();
+
+protected:
+    std::uniform_real_distribution<double> distribution_;
+};
+
+}  // namespace random
+}  // namespace utility
+}  // namespace open3d

--- a/cpp/open3d/visualization/visualizer/GuiVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/GuiVisualizer.cpp
@@ -26,8 +26,6 @@
 
 #include "open3d/visualization/visualizer/GuiVisualizer.h"
 
-#include <random>
-
 #include "open3d/Open3DConfig.h"
 #include "open3d/geometry/BoundingVolume.h"
 #include "open3d/geometry/Image.h"

--- a/cpp/pybind/geometry/pointcloud.cpp
+++ b/cpp/pybind/geometry/pointcloud.cpp
@@ -184,7 +184,7 @@ Computes the convex hull of the point cloud.
 
 Args:
      joggle_inputs (bool): If True allows the algorithm to add random noise to
-          the points to work around degenerate inputs. This adds the 'QJ' 
+          the points to work around degenerate inputs. This adds the 'QJ'
           option to the qhull command.
 
 Returns:
@@ -209,7 +209,7 @@ Returns:
                  "Segments a plane in the point cloud using the RANSAC "
                  "algorithm.",
                  "distance_threshold"_a, "ransac_n"_a, "num_iterations"_a,
-                 "probability"_a = 0.99999999, "seed"_a = py::none())
+                 "probability"_a = 0.99999999)
             .def_static(
                     "create_from_depth_image",
                     &PointCloud::CreateFromDepthImage,
@@ -361,10 +361,7 @@ camera. Given depth value d at (u, v) image coordinate, the corresponding 3d poi
               "iteration."},
              {"num_iterations", "Number of iterations."},
              {"probability",
-              "Expected probability of finding the optimal plane."},
-             {"seed",
-              "Seed value used in the random generator, set to None to use a "
-              "random seed value with each function call."}});
+              "Expected probability of finding the optimal plane."}});
     docstring::ClassMethodDocInject(
             m, "PointCloud", "create_from_depth_image",
             {{"depth",

--- a/cpp/pybind/geometry/trianglemesh.cpp
+++ b/cpp/pybind/geometry/trianglemesh.cpp
@@ -240,8 +240,7 @@ void pybind_trianglemesh(py::module &m) {
             .def("sample_points_uniformly",
                  &TriangleMesh::SamplePointsUniformly,
                  "Function to uniformly sample points from the mesh.",
-                 "number_of_points"_a = 100, "use_triangle_normal"_a = false,
-                 "seed"_a = -1)
+                 "number_of_points"_a = 100, "use_triangle_normal"_a = false)
             .def("sample_points_poisson_disk",
                  &TriangleMesh::SamplePointsPoissonDisk,
                  "Function to sample points from the mesh, where each point "
@@ -251,7 +250,7 @@ void pybind_trianglemesh(py::module &m) {
                  "noise). Method is based on Yuksel, \"Sample Elimination for "
                  "Generating Poisson Disk Sample Sets\", EUROGRAPHICS, 2015.",
                  "number_of_points"_a, "init_factor"_a = 5, "pcl"_a = nullptr,
-                 "use_triangle_normal"_a = false, "seed"_a = -1)
+                 "use_triangle_normal"_a = false)
             .def("subdivide_midpoint", &TriangleMesh::SubdivideMidpoint,
                  "Function subdivide mesh using midpoint algorithm.",
                  "number_of_iterations"_a = 1)
@@ -268,8 +267,7 @@ void pybind_trianglemesh(py::module &m) {
             .def("simplify_quadric_decimation",
                  &TriangleMesh::SimplifyQuadricDecimation,
                  "Function to simplify mesh using Quadric Error Metric "
-                 "Decimation by "
-                 "Garland and Heckbert",
+                 "Decimation by Garland and Heckbert",
                  "target_number_of_triangles"_a,
                  "maximum_error"_a = std::numeric_limits<double>::infinity(),
                  "boundary_weight"_a = 1.0)
@@ -279,7 +277,7 @@ void pybind_trianglemesh(py::module &m) {
                  &TriangleMesh::ClusterConnectedTriangles,
                  "Function that clusters connected triangles, i.e., triangles "
                  "that are connected via edges are assigned the same cluster "
-                 "index.  This function returns an array that contains the "
+                 "index. This function returns an array that contains the "
                  "cluster index per triangle, a second array contains the "
                  "number of triangles per cluster, and a third vector contains "
                  "the surface area per cluster.")
@@ -569,10 +567,7 @@ void pybind_trianglemesh(py::module &m) {
               "If True assigns the triangle normals instead of the "
               "interpolated vertex normals to the returned points. The "
               "triangle normals will be computed and added to the mesh if "
-              "necessary."},
-             {"seed",
-              "Seed value used in the random generator, set to -1 to use a "
-              "random seed value with each function call."}});
+              "necessary."}});
     docstring::ClassMethodDocInject(
             m, "TriangleMesh", "sample_points_poisson_disk",
             {{"number_of_points", "Number of points that should be sampled."},
@@ -586,10 +581,7 @@ void pybind_trianglemesh(py::module &m) {
               "If True assigns the triangle normals instead of the "
               "interpolated vertex normals to the returned points. The "
               "triangle normals will be computed and added to the mesh if "
-              "necessary."},
-             {"seed",
-              "Seed value used in the random generator, set to -1 to use a "
-              "random seed value with each function call."}});
+              "necessary."}});
     docstring::ClassMethodDocInject(
             m, "TriangleMesh", "subdivide_midpoint",
             {{"number_of_iterations",

--- a/cpp/pybind/pipelines/registration/registration.cpp
+++ b/cpp/pybind/pipelines/registration/registration.cpp
@@ -468,20 +468,17 @@ must hold true for all edges.)");
                              bool decrease_mu,
                              double maximum_correspondence_distance,
                              int iteration_number, double tuple_scale,
-                             int maximum_tuple_count, bool tuple_test,
-                             utility::optional<unsigned int> seed) {
+                             int maximum_tuple_count, bool tuple_test) {
                      return new FastGlobalRegistrationOption(
                              division_factor, use_absolute_scale, decrease_mu,
                              maximum_correspondence_distance, iteration_number,
-                             tuple_scale, maximum_tuple_count, tuple_test,
-                             seed);
+                             tuple_scale, maximum_tuple_count, tuple_test);
                  }),
                  "division_factor"_a = 1.4, "use_absolute_scale"_a = false,
                  "decrease_mu"_a = false,
                  "maximum_correspondence_distance"_a = 0.025,
                  "iteration_number"_a = 64, "tuple_scale"_a = 0.95,
-                 "maximum_tuple_count"_a = 1000, "tuple_test"_a = true,
-                 "seed"_a = py::none())
+                 "maximum_tuple_count"_a = 1000, "tuple_test"_a = true)
             .def_readwrite(
                     "division_factor",
                     &FastGlobalRegistrationOption::division_factor_,
@@ -513,8 +510,6 @@ must hold true for all edges.)");
                     "tuple_test", &FastGlobalRegistrationOption::tuple_test_,
                     "bool: Set to `true` to perform geometric compatibility "
                     "tests on initial set of correspondences.")
-            .def_readwrite("seed", &FastGlobalRegistrationOption::seed_,
-                           "unsigned int: Random seed.")
             .def("__repr__", [](const FastGlobalRegistrationOption &c) {
                 return fmt::format(
                         ""
@@ -526,12 +521,10 @@ must hold true for all edges.)");
                         "\niteration_number={}"
                         "\ntuple_scale={}"
                         "\nmaximum_tuple_count={}",
-                        "\ntuple_test={}", "\nseed={}", c.division_factor_,
+                        "\ntuple_test={}", c.division_factor_,
                         c.use_absolute_scale_, c.decrease_mu_,
                         c.maximum_correspondence_distance_, c.iteration_number_,
-                        c.tuple_scale_, c.maximum_tuple_count_, c.tuple_test_,
-                        c.seed_.has_value() ? std::to_string(c.seed_.value())
-                                            : "None");
+                        c.tuple_scale_, c.maximum_tuple_count_, c.tuple_test_);
             });
 
     // open3d.registration.RegistrationResult
@@ -604,7 +597,6 @@ static const std::unordered_map<std::string, std::string>
                  "source point's correspondence is itself."},
                 {"option", "Registration option"},
                 {"ransac_n", "Fit ransac with ``ransac_n`` correspondences"},
-                {"seed", "Random seed."},
                 {"source_feature", "Source point cloud feature."},
                 {"source", "The source point cloud."},
                 {"target_feature", "Target point cloud feature."},
@@ -662,8 +654,7 @@ void pybind_registration_methods(py::module &m) {
           "ransac_n"_a = 3,
           "checkers"_a = std::vector<
                   std::reference_wrapper<const CorrespondenceChecker>>(),
-          "criteria"_a = RANSACConvergenceCriteria(100000, 0.999),
-          "seed"_a = py::none());
+          "criteria"_a = RANSACConvergenceCriteria(100000, 0.999));
     docstring::FunctionDocInject(m,
                                  "registration_ransac_based_on_correspondence",
                                  map_shared_argument_docstrings);
@@ -678,8 +669,7 @@ void pybind_registration_methods(py::module &m) {
           "ransac_n"_a = 3,
           "checkers"_a = std::vector<
                   std::reference_wrapper<const CorrespondenceChecker>>(),
-          "criteria"_a = RANSACConvergenceCriteria(100000, 0.999),
-          "seed"_a = py::none());
+          "criteria"_a = RANSACConvergenceCriteria(100000, 0.999));
     docstring::FunctionDocInject(
             m, "registration_ransac_based_on_feature_matching",
             map_shared_argument_docstrings);

--- a/cpp/pybind/utility/CMakeLists.txt
+++ b/cpp/pybind/utility/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(pybind PRIVATE
     eigen.cpp
     logging.cpp
+    random.cpp
     utility.cpp
 )

--- a/cpp/pybind/utility/random.cpp
+++ b/cpp/pybind/utility/random.cpp
@@ -24,18 +24,23 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
-#pragma once
+#include "open3d/utility/Random.h"
 
+#include "pybind/docstring.h"
 #include "pybind/open3d_pybind.h"
 
 namespace open3d {
 namespace utility {
 
-void pybind_utility(py::module &m);
+void pybind_random(py::module &m) {
+    py::module m_submodule = m.def_submodule("random");
 
-void pybind_eigen(py::module &m);
-void pybind_logging(py::module &m);
-void pybind_random(py::module &m);
+    m_submodule.def("seed", &random::Seed, "seed"_a,
+                    "Set Open3D global random seed.");
+
+    docstring::FunctionDocInject(m_submodule, "seed",
+                                 {{"seed", "Random seed value."}});
+}
 
 }  // namespace utility
 }  // namespace open3d

--- a/cpp/pybind/utility/utility.cpp
+++ b/cpp/pybind/utility/utility.cpp
@@ -34,8 +34,9 @@ namespace utility {
 
 void pybind_utility(py::module &m) {
     py::module m_submodule = m.def_submodule("utility");
-    pybind_logging(m_submodule);
     pybind_eigen(m_submodule);
+    pybind_logging(m_submodule);
+    pybind_random(m_submodule);
 }
 
 }  // namespace utility

--- a/cpp/tests/core/Tensor.cpp
+++ b/cpp/tests/core/Tensor.cpp
@@ -35,7 +35,7 @@
 #include "open3d/core/SizeVector.h"
 #include "open3d/core/kernel/Kernel.h"
 #include "open3d/utility/FileSystem.h"
-#include "open3d/utility/Helper.h"
+#include "open3d/utility/Random.h"
 #include "tests/Tests.h"
 #include "tests/core/CoreTest.h"
 
@@ -2009,7 +2009,7 @@ TEST_P(TensorPermuteDevices, ReduceSumLargeArray) {
     int64_t max_size = *std::max_element(sizes.begin(), sizes.end());
     std::vector<int> vals(max_size);
     std::transform(vals.begin(), vals.end(), vals.begin(), [](int x) -> int {
-        return utility::UniformRandIntGenerator(0, 3)();
+        return utility::random::UniformIntGenerator(0, 3)();
     });
 
     for (int64_t size : sizes) {

--- a/cpp/tests/geometry/PointCloud.cpp
+++ b/cpp/tests/geometry/PointCloud.cpp
@@ -1245,8 +1245,6 @@ TEST(PointCloud, SegmentPlane) {
     Eigen::Vector4d plane_model;
     std::vector<size_t> inliers;
     std::tie(plane_model, inliers) = pcd.SegmentPlane(0.01, 3, 1000);
-
-    // TODO: seed the ransac
     ExpectEQ(plane_model, Eigen::Vector4d(-0.06, -0.10, 0.99, -1.06), 0.1);
 
     std::tie(plane_model, inliers) = pcd.SegmentPlane(0.01, 10, 1000);

--- a/cpp/tests/utility/CMakeLists.txt
+++ b/cpp/tests/utility/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(tests PRIVATE
     Preprocessor.cpp
     ProgressBar.cpp
     Timer.cpp
+    Random.cpp
 )
 
 if (BUILD_ISPC_MODULE)

--- a/cpp/tests/utility/Helper.cpp
+++ b/cpp/tests/utility/Helper.cpp
@@ -65,36 +65,6 @@ TEST(Helper, StringEndsWith) {
     EXPECT_FALSE(utility::StringEndsWith("", "c"));
 }
 
-TEST(Helper, UniformRandIntGeneratorWithFixedSeed) {
-    std::array<int, 1024> values;
-    utility::UniformRandIntGenerator rand_generator(0, 9, 42);
-    for (auto it = values.begin(); it != values.end(); ++it)
-        *it = rand_generator();
-
-    for (int i = 0; i < 10; i++) {
-        std::array<int, 1024> new_values;
-        utility::UniformRandIntGenerator new_rand_generator(0, 9, 42);
-        for (auto it = new_values.begin(); it != new_values.end(); ++it)
-            *it = new_rand_generator();
-        EXPECT_TRUE(values == new_values);
-    }
-}
-
-TEST(Helper, UniformRandIntGeneratorWithRandomSeed) {
-    std::array<int, 1024> values;
-    utility::UniformRandIntGenerator rand_generator(0, 9);
-    for (auto it = values.begin(); it != values.end(); ++it)
-        *it = rand_generator();
-
-    for (int i = 0; i < 10; i++) {
-        std::array<int, 1024> new_values;
-        utility::UniformRandIntGenerator new_rand_generator(0, 9);
-        for (auto it = new_values.begin(); it != new_values.end(); ++it)
-            *it = new_rand_generator();
-        EXPECT_FALSE(values == new_values);
-    }
-}
-
 TEST(Helper, CHAR_BIT_constant) {
 #ifdef BUILD_ISPC_MODULE
     int32_t value;

--- a/cpp/tests/utility/Random.cpp
+++ b/cpp/tests/utility/Random.cpp
@@ -1,0 +1,91 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "open3d/utility/Random.h"
+
+#include "tests/Tests.h"
+
+namespace open3d {
+namespace tests {
+
+TEST(Random, UniformRandIntGeneratorWithFixedSeed) {
+    utility::random::Seed(42);
+    std::array<int, 1024> values;
+    utility::random::UniformIntGenerator rand_generator(0, 9);
+    for (auto it = values.begin(); it != values.end(); ++it) {
+        *it = rand_generator();
+    }
+
+    for (int i = 0; i < 10; i++) {
+        utility::random::Seed(42);
+        std::array<int, 1024> new_values;
+        utility::random::UniformIntGenerator new_rand_generator(0, 9);
+        for (auto it = new_values.begin(); it != new_values.end(); ++it) {
+            *it = new_rand_generator();
+        }
+        EXPECT_TRUE(values == new_values);
+    }
+}
+
+TEST(Random, UniformRandIntGeneratorWithRandomSeed) {
+    std::array<int, 1024> values;
+    utility::random::UniformIntGenerator rand_generator(0, 9);
+    for (auto it = values.begin(); it != values.end(); ++it) {
+        *it = rand_generator();
+    }
+
+    for (int i = 0; i < 10; i++) {
+        std::array<int, 1024> new_values;
+        utility::random::UniformIntGenerator new_rand_generator(0, 9);
+        for (auto it = new_values.begin(); it != new_values.end(); ++it) {
+            *it = new_rand_generator();
+        }
+        EXPECT_FALSE(values == new_values);
+    }
+}
+
+TEST(Random, DeviceIndependentRandomValue) {
+    const std::vector<int> expected_vals{10, 10, 6, 5, 2, 10, 8,  6,  10, 10,
+                                         9,  10, 8, 0, 2, 8,  10, 10, 2,  4};
+
+    utility::random::UniformIntGenerator rand_generator(0, 10);
+
+    std::vector<int> vals_without_seed;
+    for (int i = 0; i < 20; i++) {
+        vals_without_seed.push_back(rand_generator());
+    }
+    EXPECT_NE(vals_without_seed, expected_vals);
+
+    utility::random::Seed(314);
+    std::vector<int> vals_with_seed;
+    for (int i = 0; i < 20; i++) {
+        vals_with_seed.push_back(rand_generator());
+    }
+    EXPECT_EQ(vals_with_seed, expected_vals);
+}
+
+}  // namespace tests
+}  // namespace open3d

--- a/cpp/tests/utility/Random.cpp
+++ b/cpp/tests/utility/Random.cpp
@@ -67,25 +67,5 @@ TEST(Random, UniformRandIntGeneratorWithRandomSeed) {
     }
 }
 
-TEST(Random, DeviceIndependentRandomValue) {
-    const std::vector<int> expected_vals{10, 10, 6, 5, 2, 10, 8,  6,  10, 10,
-                                         9,  10, 8, 0, 2, 8,  10, 10, 2,  4};
-
-    utility::random::UniformIntGenerator rand_generator(0, 10);
-
-    std::vector<int> vals_without_seed;
-    for (int i = 0; i < 20; i++) {
-        vals_without_seed.push_back(rand_generator());
-    }
-    EXPECT_NE(vals_without_seed, expected_vals);
-
-    utility::random::Seed(314);
-    std::vector<int> vals_with_seed;
-    for (int i = 0; i < 20; i++) {
-        vals_with_seed.push_back(rand_generator());
-    }
-    EXPECT_EQ(vals_with_seed, expected_vals);
-}
-
 }  // namespace tests
 }  // namespace open3d

--- a/examples/cpp/MultipleWindows.cpp
+++ b/examples/cpp/MultipleWindows.cpp
@@ -27,7 +27,6 @@
 #include <atomic>
 #include <chrono>
 #include <mutex>
-#include <random>
 #include <thread>
 
 #include "open3d/Open3D.h"
@@ -132,9 +131,7 @@ private:
                 });
 
         Eigen::Vector3d magnitude = 0.005 * extent;
-        auto seed = std::random_device()();
-        std::mt19937 gen_algo(seed);
-        std::uniform_real_distribution<> random(-0.5, 0.5);
+        utility::random::UniformDoubleGenerator uniform_gen(-0.5, 0.5);
 
         while (main_vis_) {
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -143,9 +140,9 @@ private:
             {
                 std::lock_guard<std::mutex> lock(cloud_lock_);
                 for (size_t i = 0; i < cloud_->points_.size(); ++i) {
-                    Eigen::Vector3d perturb(magnitude[0] * random(gen_algo),
-                                            magnitude[1] * random(gen_algo),
-                                            magnitude[2] * random(gen_algo));
+                    Eigen::Vector3d perturb(magnitude[0] * uniform_gen(),
+                                            magnitude[1] * uniform_gen(),
+                                            magnitude[2] * uniform_gen());
                     cloud_->points_[i] += perturb;
                 }
             }

--- a/examples/cpp/TICP.cpp
+++ b/examples/cpp/TICP.cpp
@@ -30,7 +30,6 @@
 #include <iomanip>
 #include <iostream>
 #include <mutex>
-#include <random>
 #include <sstream>
 #include <thread>
 


### PR DESCRIPTION
## Summary

This PR allows all of Open3D's random number generator and random samplers to be globally seeded. If you plan to add a new random number or random sampling feature to Open3D, you should always use one of these helper functions/classes, instead of seeding your own random numbers.

## Changes

- Global singleton and mutex for random number generation.
- Several helper functions and helper classes to generate random numbers or use the random number engine.
- Adapt all code to use the new random number mechanism, and removed all other code for seeding.

## Usage

```cpp
#include <algorithm>
#include <iostream>

#include "open3d/utility/Random.h"

int main() {
    using namespace open3d;

    // Globally seed.
    utility::random::Seed(0);

    // Simply get a random number.
    std::cout << utility::random::RandUint32() << std::endl;

    // Using the random engine.
    std::vector<int> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
    {
        std::lock_guard<std::mutex> lock(*utility::random::GetMutex());
        std::shuffle(vals.begin(), vals.end(), *utility::random::GetEngine());
    }

    // Create a generator: integer in [0, 10).
    utility::random::UniformIntGenerator gen_int(0, 10);
    for (int i = 0; i < 5; i++) {
        std::cout << gen_int() << std::endl;
    }

    // Create a generator: double in [-1.0, 1.0).
    utility::random::UniformDoubleGenerator gen_double(-1.0, 1.0);
    for (int i = 0; i < 5; i++) {
        std::cout << gen_double() << std::endl;
    }

    return 0;
}
```

```python
import open3d as o3d

o3d.utility.random.seed(xxx);
```

## Known limitations
- The random number is not platform-independent.
  - `std::mt19937` is platform-independent.
  - `std::uniform_int_distribution` is **not** platform-independent. 
  - `uniform_real_distribution` is **not** platform-independent.
- No CUDA support yet.

## Future PR
1. Port or write our own `uniform_int_distribution` and `uniform_real_distribution`, such that everything becomes OS/compiler independent.
2. Add CUDA support. We don't require CUDA to generate the same random number as the CPU.
3. Add Tenosr rand operation to generate randomized Tensor.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5247)
<!-- Reviewable:end -->
