### PR TITLE
add boolean mesh operations to Tensor TriangleMesh

### DIFF
--- a/cpp/open3d/t/geometry/TriangleMesh.h
+++ b/cpp/open3d/t/geometry/TriangleMesh.h
@@ -476,6 +476,9 @@ public:
 
     /// Function to simplify mesh using Quadric Error Metric Decimation by
     /// Garland and Heckbert.
+    ///
+    /// This function always uses the CPU device.
+    ///
     /// \param target_reduction The factor of triangles to delete, i.e.,
     /// setting this to 0.9 will return a mesh with about 10% of the original
     /// triangle count.
@@ -486,6 +489,46 @@ public:
     /// \return Simplified TriangleMesh.
     TriangleMesh SimplifyQuadricDecimation(double target_reduction,
                                            bool preserve_volume = true) const;
+
+    /// Computes the mesh that encompasses the union of the volumes of two
+    /// meshes.
+    /// Both meshes should be manifold.
+    ///
+    /// This function always uses the CPU device.
+    ///
+    /// \param mesh This is the second operand for the boolean operation.
+    /// \param tolerance Threshold which determines when point distances are
+    /// considered to be 0.
+    ///
+    /// \return The mesh describing the union volume.
+    TriangleMesh BooleanUnion(const TriangleMesh &mesh,
+                              double tolerance = 1e-6) const;
+
+    /// Computes the mesh that encompasses the intersection of the volumes of
+    /// two meshes. Both meshes should be manifold.
+    ///
+    /// This function always uses the CPU device.
+    ///
+    /// \param mesh This is the second operand for the boolean operation.
+    /// \param tolerance Threshold which determines when point distances are
+    /// considered to be 0.
+    ///
+    /// \return The mesh describing the intersection volume.
+    TriangleMesh BooleanIntersection(const TriangleMesh &mesh,
+                                     double tolerance = 1e-6) const;
+
+    /// Computes the mesh that encompasses the volume after subtracting the
+    /// volume of the second operand. Both meshes should be manifold.
+    ///
+    /// This function always uses the CPU device.
+    ///
+    /// \param mesh This is the second operand for the boolean operation.
+    /// \param tolerance Threshold which determines when point distances are
+    /// considered to be 0.
+    ///
+    /// \return The mesh describing the difference volume.
+    TriangleMesh BooleanDifference(const TriangleMesh &mesh,
+                                   double tolerance = 1e-6) const;
 
 protected:
     core::Device device_ = core::Device("CPU:0");

--- a/cpp/pybind/t/geometry/trianglemesh.cpp
+++ b/cpp/pybind/t/geometry/trianglemesh.cpp
@@ -226,6 +226,8 @@ This example shows how to create a hemisphere from a sphere::
             &TriangleMesh::SimplifyQuadricDecimation, "target_reduction"_a,
             "preserve_volume"_a = true,
             R"(Function to simplify mesh using Quadric Error Metric Decimation by Garland and Heckbert.
+    
+This function always uses the CPU device.
 
 Args:
     target_reduction (float): The factor of triangles to delete, i.e., setting
@@ -246,6 +248,99 @@ Example:
         mesh = o3d.t.geometry.TriangleMesh.from_legacy(o3d.io.read_triangle_mesh(bunny.path))
         simplified = mesh.simplify_quadric_decimation(0.99)
         o3d.visualization.draw([{'name': 'bunny', 'geometry': simplified}])
+)");
+
+    triangle_mesh.def(
+            "boolean_union", &TriangleMesh::BooleanUnion, "mesh"_a,
+            "tolerance"_a = 1e-6,
+            R"(Computes the mesh that encompasses the union of the volumes of two meshes.
+Both meshes should be manifold.
+
+This function always uses the CPU device.
+
+Args:
+    mesh (open3d.t.geometry.TriangleMesh): This is the second operand for the 
+        boolean operation.
+
+    tolerance (float): Threshold which determines when point distances are
+        considered to be 0.
+
+Returns:
+    The mesh describing the union volume.
+
+Example:
+    This copmutes the union of a sphere and a cube::
+
+        box = o3d.geometry.TriangleMesh.create_box()
+        box = o3d.t.geometry.TriangleMesh.from_legacy(box)
+        sphere = o3d.geometry.TriangleMesh.create_sphere(0.8)
+        sphere = o3d.t.geometry.TriangleMesh.from_legacy(sphere)
+
+        ans = box.boolean_union(sphere)
+
+        o3d.visualization.draw([{'name': 'union', 'geometry': ans}])
+)");
+
+    triangle_mesh.def(
+            "boolean_intersection", &TriangleMesh::BooleanIntersection,
+            "mesh"_a, "tolerance"_a = 1e-6,
+            R"(Computes the mesh that encompasses the intersection of the volumes of two meshes.
+Both meshes should be manifold.
+
+This function always uses the CPU device.
+
+Args:
+    mesh (open3d.t.geometry.TriangleMesh): This is the second operand for the 
+        boolean operation.
+
+    tolerance (float): Threshold which determines when point distances are
+        considered to be 0.
+
+Returns:
+    The mesh describing the intersection volume.
+
+Example:
+    This copmutes the intersection of a sphere and a cube::
+
+        box = o3d.geometry.TriangleMesh.create_box()
+        box = o3d.t.geometry.TriangleMesh.from_legacy(box)
+        sphere = o3d.geometry.TriangleMesh.create_sphere(0.8)
+        sphere = o3d.t.geometry.TriangleMesh.from_legacy(sphere)
+
+        ans = box.boolean_intersection(sphere)
+
+        o3d.visualization.draw([{'name': 'intersection', 'geometry': ans}])
+)");
+
+    triangle_mesh.def(
+            "boolean_difference", &TriangleMesh::BooleanDifference, "mesh"_a,
+            "tolerance"_a = 1e-6,
+            R"(Computes the mesh that encompasses the volume after subtracting the volume of the second operand.
+Both meshes should be manifold.
+
+This function always uses the CPU device.
+
+Args:
+    mesh (open3d.t.geometry.TriangleMesh): This is the second operand for the 
+        boolean operation.
+
+    tolerance (float): Threshold which determines when point distances are
+        considered to be 0.
+
+Returns:
+    The mesh describing the difference volume.
+
+Example:
+    This subtracts the sphere from the cube volume::
+
+        box = o3d.geometry.TriangleMesh.create_box()
+        box = o3d.t.geometry.TriangleMesh.from_legacy(box)
+        sphere = o3d.geometry.TriangleMesh.create_sphere(0.8)
+        sphere = o3d.t.geometry.TriangleMesh.from_legacy(sphere)
+
+        ans = box.boolean_difference(sphere)
+
+        o3d.visualization.draw([{'name': 'difference', 'geometry': ans}])
 )");
 }
 

--- a/python/test/t/geometry/test_trianglemesh.py
+++ b/python/test/t/geometry/test_trianglemesh.py
@@ -48,3 +48,25 @@ def test_simplify_quadric_decimation():
 
     assert simplified.vertex['positions'].shape == (8, 3)
     assert simplified.triangle['indices'].shape == (12, 3)
+
+
+def test_boolean_operations():
+    box = o3d.geometry.TriangleMesh.create_box()
+    box = o3d.t.geometry.TriangleMesh.from_legacy(box)
+    sphere = o3d.geometry.TriangleMesh.create_sphere(0.8)
+    sphere = o3d.t.geometry.TriangleMesh.from_legacy(sphere)
+    # check input sphere
+    assert sphere.vertex['positions'].shape == (762, 3)
+    assert sphere.triangle['indices'].shape == (1520, 3)
+
+    ans = box.boolean_union(sphere)
+    assert ans.vertex['positions'].shape == (730, 3)
+    assert ans.triangle['indices'].shape == (1384, 3)
+
+    ans = box.boolean_intersection(sphere)
+    assert ans.vertex['positions'].shape == (154, 3)
+    assert ans.triangle['indices'].shape == (232, 3)
+
+    ans = box.boolean_difference(sphere)
+    assert ans.vertex['positions'].shape == (160, 3)
+    assert ans.triangle['indices'].shape == (244, 3)


### PR DESCRIPTION
This PR adds 3 new functions to t::geometry::TriangleMesh for computing the boolean union, intersection, and difference

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5257)
<!-- Reviewable:end -->
