### PR TITLE
fix incorrect property name

### DIFF
--- a/examples/python/reconstruction_system/make_fragments.py
+++ b/examples/python/reconstruction_system/make_fragments.py
@@ -53,7 +53,7 @@ def register_one_rgbd_pair(s, t, color_files, depth_files, intrinsic,
                                         config)
 
     option = o3d.pipelines.odometry.OdometryOption()
-    option.depth_diff_max = config["depth_diff_max"]
+    option.max_depth_diff = config["depth_diff_max"]
     if abs(s - t) != 1:
         if with_opencv:
             success_5pt, odo_init = pose_estimation(source_rgbd_image,


### PR DESCRIPTION
I noticed that the property name `max_depth_diff` was incorrectly written in `make_fragments.py`. When running the example code currently with the property name `depth_diff_max` I get an error message (see below). Upon changing the property name to the one specified in the documentation it ran correctly.

```cmd
joblib.externals.loky.process_executor._RemoteTraceback:
"""
Traceback (most recent call last):
  File "C:\Users\omar\venv\lib\site-packages\joblib\externals\loky\process_executor.py", line 436, in _process_worker
    r = call_item()
  File "C:\Users\omar\venv\lib\site-packages\joblib\externals\loky\process_executor.py", line 288, in __call__
    return self.fn(*self.args, **self.kwargs)
  File "C:\Users\omar\venv\lib\site-packages\joblib\_parallel_backends.py", line 595, in __call__
    return self.func(*args, **kwargs)
  File "C:\Users\omar\venv\lib\site-packages\joblib\parallel.py", line 262, in __call__
    return [func(*args, **kwargs)
  File "C:\Users\omar\venv\lib\site-packages\joblib\parallel.py", line 262, in <listcomp>
    return [func(*args, **kwargs)
  File "C:\Users\omar\Downloads\Open3D-master\Open3D-master\examples\python\reconstruction_system\make_fragments.py", line 174, in process_single_fragment
    make_posegraph_for_fragment(config["path_dataset"], sid, eid, color_files,
  File "C:\Users\omar\Downloads\Open3D-master\Open3D-master\examples\python\reconstruction_system\make_fragments.py", line 94, in make_posegraph_for_fragment
    info] = register_one_rgbd_pair(s, t, color_files, depth_files,
  File "C:\Users\omar\Downloads\Open3D-master\Open3D-master\examples\python\reconstruction_system\make_fragments.py", line 56, in register_one_rgbd_pair
    option.depth_diff_max = config["depth_diff_max"]
AttributeError: 'open3d.cpu.pybind.pipelines.odometry.OdometryOption' object has no attribute 'depth_diff_max'
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "C:\Users\omar\Downloads\Open3D-master\Open3D-master\examples\python\reconstruction_system\run_system.py", line 130, in <module>
    make_fragments.run(config)
  File "C:\Users\omar\Downloads\Open3D-master\Open3D-master\examples\python\reconstruction_system\make_fragments.py", line 198, in run
    Parallel(n_jobs=MAX_THREAD)(delayed(process_single_fragment)(
  File "C:\Users\omar\venv\lib\site-packages\joblib\parallel.py", line 1056, in __call__
    self.retrieve()
  File "C:\Users\omar\venv\lib\site-packages\joblib\parallel.py", line 935, in retrieve
    self._output.extend(job.get(timeout=self.timeout))
  File "C:\Users\omar\venv\lib\site-packages\joblib\_parallel_backends.py", line 542, in wrap_future_result
    return future.result(timeout=timeout)
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.9_3.9.3568.0_x64__qbz5n2kfra8p0\lib\concurrent\futures\_base.py", line 446, in result
    return self.__get_result()
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.9_3.9.3568.0_x64__qbz5n2kfra8p0\lib\concurrent\futures\_base.py", line 391, in __get_result
    raise self._exception
AttributeError: 'open3d.cpu.pybind.pipelines.odometry.OdometryOption' object has no attribute 'depth_diff_max'

(venv) C:\Users\omar\Downloads\Open3D-master\Open3D-master\examples\python\reconstruction_system>
```