### PR TITLE
Add FillHoles() to Tensor TriangleMesh

### DIFF
--- a/cpp/open3d/t/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/t/geometry/TriangleMesh.cpp
@@ -29,6 +29,7 @@
 #include <vtkBooleanOperationPolyDataFilter.h>
 #include <vtkCleanPolyData.h>
 #include <vtkClipPolyData.h>
+#include <vtkFillHolesFilter.h>
 #include <vtkPlane.h>
 #include <vtkQuadricDecimation.h>
 
@@ -379,6 +380,17 @@ TriangleMesh TriangleMesh::BooleanDifference(const TriangleMesh &mesh,
                                              double tolerance) const {
     return BooleanOperation(*this, mesh, tolerance,
                             vtkBooleanOperationPolyDataFilter::VTK_DIFFERENCE);
+}
+
+TriangleMesh TriangleMesh::FillHoles(double hole_size) const {
+    using namespace vtkutils;
+    auto polydata = CreateVtkPolyDataFromGeometry(*this);
+    vtkNew<vtkFillHolesFilter> fill_holes;
+    fill_holes->SetInputData(polydata);
+    fill_holes->SetHoleSize(hole_size);
+    fill_holes->Update();
+    auto result = fill_holes->GetOutput();
+    return CreateTriangleMeshFromVtkPolyData(result);
 }
 
 }  // namespace geometry

--- a/cpp/open3d/t/geometry/TriangleMesh.h
+++ b/cpp/open3d/t/geometry/TriangleMesh.h
@@ -548,6 +548,16 @@ public:
     TriangleMesh BooleanDifference(const TriangleMesh &mesh,
                                    double tolerance = 1e-6) const;
 
+    /// Fill holes by triangulating boundary edges.
+    ///
+    /// This function always uses the CPU device.
+    ///
+    /// \param hole_size This is the approximate threshold for filling holes.
+    /// The value describes the maximum radius of holes to be filled.
+    ///
+    /// \return New mesh after filling holes.
+    TriangleMesh FillHoles(double hole_size = 1e6) const;
+
 protected:
     core::Device device_ = core::Device("CPU:0");
     TensorMap vertex_attr_;

--- a/cpp/pybind/t/geometry/trianglemesh.cpp
+++ b/cpp/pybind/t/geometry/trianglemesh.cpp
@@ -362,6 +362,28 @@ Example:
 
         o3d.visualization.draw([{'name': 'difference', 'geometry': ans}])
 )");
+
+    triangle_mesh.def("fill_holes", &TriangleMesh::FillHoles,
+                      "hole_size"_a = 1e6,
+                      R"(Fill holes by triangulating boundary edges.
+
+This function always uses the CPU device.
+
+Args:
+    hole_size (float): This is the approximate threshold for filling holes.
+        The value describes the maximum radius of holes to be filled.
+
+Returns:
+    New mesh after filling holes.
+
+Example:
+    Fill holes at the bottom of the Stanford Bunny mesh::
+
+        bunny = o3d.data.BunnyMesh()
+        mesh = o3d.t.geometry.TriangleMesh.from_legacy(o3d.io.read_triangle_mesh(bunny.path))
+        filled = mesh.fill_holes()
+        o3d.visualization.draw([{'name': 'filled', 'geometry': ans}])
+)");
 }
 
 }  // namespace geometry

--- a/python/test/t/geometry/test_trianglemesh.py
+++ b/python/test/t/geometry/test_trianglemesh.py
@@ -113,3 +113,12 @@ def test_boolean_operations():
     ans = box.boolean_difference(sphere)
     assert ans.vertex['positions'].shape == (160, 3)
     assert ans.triangle['indices'].shape == (244, 3)
+
+
+def test_hole_filling():
+    sphere = o3d.geometry.TriangleMesh.create_sphere(1.0)
+    sphere = o3d.t.geometry.TriangleMesh.from_legacy(sphere)
+    clipped = sphere.clip_plane([0.8, 0, 0], [1, 0, 0])
+    assert not clipped.to_legacy().is_watertight()
+    filled = clipped.fill_holes()
+    assert filled.to_legacy().is_watertight()


### PR DESCRIPTION
This PR adds a wrapper for the FillHoles filter from vtk to the Tensor TriangleMesh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5285)
<!-- Reviewable:end -->
