### PR TITLE
fix ubuntu 22.04 dependency installation

### DIFF
--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -1185,8 +1185,24 @@ if(BUILD_GUI)
                 endif()
                 # If the default version is not sufficient, look for some specific versions
                 if(NOT FILAMENT_C_COMPILER OR NOT FILAMENT_CXX_COMPILER)
-                    find_program(CLANG_VERSIONED_CC NAMES clang-12 clang-11 clang-10 clang-9 clang-8 clang-7)
-                    find_program(CLANG_VERSIONED_CXX NAMES clang++-12 clang++11 clang++-10 clang++-9 clang++-8 clang++-7)
+                    find_program(CLANG_VERSIONED_CC NAMES
+                                 clang-14
+                                 clang-13
+                                 clang-12
+                                 clang-11
+                                 clang-10
+                                 clang-9
+                                 clang-8
+                                 clang-7)
+                    find_program(CLANG_VERSIONED_CXX NAMES
+                                 clang-14
+                                 clang-13
+                                 clang++-12
+                                 clang++11
+                                 clang++-10
+                                 clang++-9
+                                 clang++-8
+                                 clang++-7)
                     if (CLANG_VERSIONED_CC AND CLANG_VERSIONED_CXX)
                         set(FILAMENT_C_COMPILER "${CLANG_VERSIONED_CC}")
                         set(FILAMENT_CXX_COMPILER "${CLANG_VERSIONED_CXX}")
@@ -1243,8 +1259,15 @@ if(BUILD_GUI)
             # Find CLANG_LIBDIR if it is not defined. Mutiple paths will be searched.
             if (NOT CLANG_LIBDIR)
                 find_library(CPPABI_LIBRARY c++abi PATH_SUFFIXES
-                            llvm-12/lib llvm-11/lib llvm-10/lib llvm-9/lib llvm-8/lib llvm-7/lib
-                            REQUIRED)
+                             llvm-14/lib
+                             llvm-13/lib
+                             llvm-12/lib
+                             llvm-11/lib
+                             llvm-10/lib
+                             llvm-9/lib
+                             llvm-8/lib
+                             llvm-7/lib
+                             REQUIRED)
                 get_filename_component(CLANG_LIBDIR ${CPPABI_LIBRARY} DIRECTORY)
             endif()
             # Find clang libraries at the exact path ${CLANG_LIBDIR}.

--- a/docker/Dockerfile.openblas
+++ b/docker/Dockerfile.openblas
@@ -34,7 +34,7 @@ RUN apt-get update && apt-get install -y \
 RUN apt-get update && apt-get install -y \
     build-essential \
     clang-7 \
-    git  \
+    git \
  && rm -rf /var/lib/apt/lists/*
 
 # Install ccache after build-essential (gcc, g++).
@@ -116,11 +116,6 @@ COPY ./util/install_deps_ubuntu.sh /root/Open3D/util/
 RUN /root/Open3D/util/install_deps_ubuntu.sh assume-yes \
  && rm -rf /var/lib/apt/lists/*
 
-# Open3D repo
-# Always keep /root/Open3D as the WORKDIR
-COPY . /root/Open3D
-WORKDIR /root/Open3D
-
 # Build Python wheel
 RUN pyenv install $(pyenv install --list | sort -r --version-sort | grep -m1 "^ *${PYTHON_VERSION}\.")
 RUN pyenv local $(pyenv versions | grep ${PYTHON_VERSION})
@@ -133,6 +128,12 @@ RUN which python \
     yapf=="0.30.0" \
     pytest=="6.0.1"
 
+# Open3D repo
+# Always keep /root/Open3D as the WORKDIR
+COPY . /root/Open3D
+WORKDIR /root/Open3D
+
+# Build
 RUN mkdir build \
  && cd build \
  && cmake \

--- a/docker/Dockerfile.openblas
+++ b/docker/Dockerfile.openblas
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install -y \
 # Minimal dependencies for building
 RUN apt-get update && apt-get install -y \
     build-essential \
-    clang-7 \
+    clang \
     git \
  && rm -rf /var/lib/apt/lists/*
 
@@ -47,15 +47,15 @@ ENV PATH="/usr/lib/ccache:${PATH}"
 RUN mkdir -p /usr/lib/ccache \
  && ln -sf $(which ccache) /usr/lib/ccache/gcc \
  && ln -sf $(which ccache) /usr/lib/ccache/g++ \
- && ln -sf $(which ccache) /usr/lib/ccache/clang-7
+ && ln -sf $(which ccache) /usr/lib/ccache/clang
 RUN echo ${PATH} \
  && ls -alh /usr/lib/ccache \
  && echo "gcc=$(which gcc)" \
  && gcc --version \
  && echo "g++=$(which g++)" \
  && g++ --version \
- && echo "clang-7=$(which clang-7)" \
- && clang-7 --version
+ && echo "clang=$(which clang)" \
+ && clang --version
 
 # Uncomment this line to always fetch the latest ccache
 # ADD "https://www.random.org/cgi-bin/randbyte?nbytes=10&format=h" skipcache

--- a/docker/Dockerfile.openblas
+++ b/docker/Dockerfile.openblas
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install -y \
 # Minimal dependencies for building
 RUN apt-get update && apt-get install -y \
     build-essential \
-    clang \
+    clang-7 \
     git \
  && rm -rf /var/lib/apt/lists/*
 
@@ -47,15 +47,15 @@ ENV PATH="/usr/lib/ccache:${PATH}"
 RUN mkdir -p /usr/lib/ccache \
  && ln -sf $(which ccache) /usr/lib/ccache/gcc \
  && ln -sf $(which ccache) /usr/lib/ccache/g++ \
- && ln -sf $(which ccache) /usr/lib/ccache/clang
+ && ln -sf $(which ccache) /usr/lib/ccache/clang-7
 RUN echo ${PATH} \
  && ls -alh /usr/lib/ccache \
  && echo "gcc=$(which gcc)" \
  && gcc --version \
  && echo "g++=$(which g++)" \
  && g++ --version \
- && echo "clang=$(which clang)" \
- && clang --version
+ && echo "clang-7=$(which clang-7)" \
+ && clang-7 --version
 
 # Uncomment this line to always fetch the latest ccache
 # ADD "https://www.random.org/cgi-bin/randbyte?nbytes=10&format=h" skipcache

--- a/docker/docker_build.sh
+++ b/docker/docker_build.sh
@@ -16,6 +16,10 @@
 #   This make the Docker image reproducible across different machines.
 set -euo pipefail
 
+# Disable Docker build kit to show all outputs, as `--progress plain`` does not
+# work on all systems.
+export DOCKER_BUILDKIT=0
+
 __usage_docker_build="USAGE:
     $(basename $0) [OPTION]
 

--- a/docs/arm.rst
+++ b/docs/arm.rst
@@ -116,7 +116,7 @@ Install dependencies
 
     # Install dependencies
     ./util/install_deps_ubuntu.sh
-    sudo apt-get install -y clang  # Or any >= 7 version of clang.
+    sudo apt-get install -y clang-7  # Or any >= 7 version of clang.
 
     # Optional: ccache is recommended to speed up subsequent builds
     sudo apt-get install -y ccache

--- a/docs/arm.rst
+++ b/docs/arm.rst
@@ -116,7 +116,7 @@ Install dependencies
 
     # Install dependencies
     ./util/install_deps_ubuntu.sh
-    sudo apt-get install -y clang-7  # Or any >= 7 version of clang.
+    sudo apt-get install -y clang  # Or any >= 7 version of clang.
 
     # Optional: ccache is recommended to speed up subsequent builds
     sudo apt-get install -y ccache

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,1 +1,2 @@
 numpy>=1.18.0
+configargparse

--- a/util/install_deps_ubuntu.sh
+++ b/util/install_deps_ubuntu.sh
@@ -40,18 +40,11 @@ if [ "$(uname -m)" == "aarch64" ]; then
     # Ubuntu 18.04 ARM64's libc++-dev and libc++abi-dev are version 6, but we need 7+.
     source /etc/lsb-release
     if [ "$DISTRIB_ID" == "Ubuntu" -a "$DISTRIB_RELEASE" == "18.04" ]; then
-        deps=("${deps[@]/libc++-dev/}")
-        deps=("${deps[@]/libc++abi-dev/}")
-        deps+=("libc++-7-dev")
-        deps+=("libc++abi-7-dev")
+        deps=("${deps[@]/libc++-dev/libc++-7-dev}")
+        deps=("${deps[@]/libc++abi-dev/libc++abi-7-dev}")
     fi
 fi
 
-# Join deps into a single string (https://stackoverflow.com/a/9429887/1255535)
-# We specify all deps to apt-get at once to better detect conflicts.
-deps_str=$(
-    IFS=" "
-    echo "${deps[*]}"
-)
+echo "apt-get install ${deps[*]}"
 $SUDO apt-get update
-$SUDO apt-get install "${APT_CONFIRM}" ${deps_str}
+$SUDO apt-get install ${APT_CONFIRM} ${deps[*]}

--- a/util/install_deps_ubuntu.sh
+++ b/util/install_deps_ubuntu.sh
@@ -1,7 +1,4 @@
 #!/usr/bin/env bash
-# Install Open3D build dependencies from Ubuntu repositories
-# CUDA (v10.1) and CUDNN (v7.6.5) are optional dependencies and are not
-# installed here
 # Use: install_deps_ubuntu.sh [ assume-yes ]
 
 set -ev
@@ -13,30 +10,48 @@ else
     APT_CONFIRM=""
 fi
 
-dependencies=(
-    # Open3D deps
+deps=(
+    # Open3D
     xorg-dev
     libglu1-mesa-dev
     python3-dev
-    # Filament build-from-source deps
+    # Filament build-from-source
     libsdl2-dev
-    libc++-7-dev
-    libc++abi-7-dev
+    libc++-dev
+    libc++abi-dev
     ninja-build
     libxi-dev
-    # OpenBLAS build-from-source deps
-    gfortran
-    # ML deps
+    # ML
     libtbb-dev
-    # Headless rendering deps
+    # Headless rendering
     libosmesa6-dev
-    # RealSense deps
+    # RealSense
     libudev-dev
     autoconf
     libtool
 )
 
+# Ubuntu ARM64
+if [ "$(uname -m)" == "aarch64" ]; then
+    # For LAPACK
+    deps+=("gfortran")
+
+    # For compiling Filament from source
+    # Ubuntu 18.04 ARM64's libc++-dev and libc++abi-dev are version 6, but we need 7+.
+    source /etc/lsb-release
+    if [ "$DISTRIB_ID" == "Ubuntu" -a "$DISTRIB_RELEASE" == "18.04" ]; then
+        deps=("${deps[@]/libc++-dev/}")
+        deps=("${deps[@]/libc++abi-dev/}")
+        deps+=("libc++-7-dev")
+        deps+=("libc++abi-7-dev")
+    fi
+fi
+
+# Join deps into a single string (https://stackoverflow.com/a/9429887/1255535)
+# We specify all deps to apt-get at once to better detect conflicts.
+deps_str=$(
+    IFS=" "
+    echo "${deps[*]}"
+)
 $SUDO apt-get update
-for package in "${dependencies[@]}"; do
-    $SUDO apt-get install "$APT_CONFIRM" "$package"
-done
+$SUDO apt-get install "${APT_CONFIRM}" ${deps_str}


### PR DESCRIPTION
Ubuntu 22.04 does not have `clang-7` in the default repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5302)
<!-- Reviewable:end -->
