### PR TITLE
Fix build compatibility with fmtlib 8

### DIFF
--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -1052,7 +1052,7 @@ if(NOT USE_SYSTEM_FMT)
     target_compile_definitions(3rdparty_fmt INTERFACE FMT_STRING_ALIAS=1)
     list(APPEND Open3D_3RDPARTY_HEADER_TARGETS_FROM_CUSTOM Open3D::3rdparty_fmt)
 else()
-    list(APPEND Open3D_3RDPARTY_HEADER_TARGETS_FROM_SYSTEM Open3D::3rdparty_fmt)
+    list(APPEND Open3D_3RDPARTY_PUBLIC_TARGETS_FROM_SYSTEM Open3D::3rdparty_fmt)
 endif()
 
 # Pybind11

--- a/3rdparty/fmt/fmt.cmake
+++ b/3rdparty/fmt/fmt.cmake
@@ -5,8 +5,8 @@ set(FMT_LIB_NAME fmt)
 ExternalProject_Add(
     ext_fmt
     PREFIX fmt
-    URL https://github.com/fmtlib/fmt/archive/refs/tags/6.0.0.tar.gz
-    URL_HASH SHA256=f1907a58d5e86e6c382e51441d92ad9e23aea63827ba47fd647eacc0d3a16c78
+    URL https://github.com/fmtlib/fmt/archive/refs/tags/9.0.0.tar.gz
+    URL_HASH SHA256=9a1e0e9e843a356d65c7604e2c8bf9402b50fe294c355de0095ebd42fb9bd2c5
     DOWNLOAD_DIR "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/fmt"
     UPDATE_COMMAND ""
     CMAKE_ARGS

--- a/cpp/benchmarks/core/BinaryEW.cpp
+++ b/cpp/benchmarks/core/BinaryEW.cpp
@@ -53,6 +53,7 @@ enum class BinaryOpCode {
     Eq,
     Neq,
 };
+using fmt::enums::format_as;
 
 static std::function<Tensor(const Tensor&, const Tensor&)> MakeOperation(
         BinaryOpCode op) {

--- a/cpp/benchmarks/core/UnaryEW.cpp
+++ b/cpp/benchmarks/core/UnaryEW.cpp
@@ -56,6 +56,8 @@ enum class UnaryOpCode {
     LogicalNot,
 };
 
+using fmt::enums::format_as;
+
 std::function<Tensor(const Tensor&)> MakeOperation(UnaryOpCode op) {
     switch (op) {
         case UnaryOpCode::Sqrt:

--- a/cpp/open3d/core/SizeVector.cpp
+++ b/cpp/open3d/core/SizeVector.cpp
@@ -148,7 +148,9 @@ int64_t SizeVector::GetLength() const {
     }
 }
 
-std::string SizeVector::ToString() const { return fmt::format("{}", *this); }
+std::string SizeVector::ToString() const {
+    return fmt::format("{{{}}}", fmt::join(*this, ", "));
+}
 
 void SizeVector::AssertCompatible(const DynamicSizeVector& dsv,
                                   const std::string msg) const {

--- a/cpp/open3d/io/IJsonConvertibleIO.h
+++ b/cpp/open3d/io/IJsonConvertibleIO.h
@@ -76,9 +76,10 @@ bool WriteIJsonConvertibleToJSONString(std::string &json_string,
 /// - enum_from_string(const std::string &str, ENUM_TYPE &e) -> void
 /// for conversion between the enum and string. Invalid string values are mapped
 /// to the first specified option in the macro.
-#define DECLARE_STRINGIFY_ENUM(ENUM_TYPE)    \
-    std::string enum_to_string(ENUM_TYPE e); \
-    void enum_from_string(const std::string &str, ENUM_TYPE &e);
+#define DECLARE_STRINGIFY_ENUM(ENUM_TYPE)                        \
+    std::string enum_to_string(ENUM_TYPE e);                     \
+    void enum_from_string(const std::string &str, ENUM_TYPE &e); \
+    inline auto format_as(ENUM_TYPE e) { return enum_to_string(e); }
 
 #define STRINGIFY_ENUM(ENUM_TYPE, ...)                                    \
     std::string enum_to_string(ENUM_TYPE e) {                             \

--- a/cpp/open3d/t/geometry/Geometry.h
+++ b/cpp/open3d/t/geometry/Geometry.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <fmt/format.h>
+
 #include <string>
 
 #include "open3d/core/Device.h"
@@ -109,6 +111,8 @@ private:
     int dimension_;
     std::string name_;
 };
+
+using fmt::enums::format_as;
 
 }  // namespace geometry
 }  // namespace t

--- a/cpp/open3d/utility/IJsonConvertible.cpp
+++ b/cpp/open3d/utility/IJsonConvertible.cpp
@@ -47,7 +47,7 @@ Json::Value StringToJson(const std::string &json_str) {
     return json;
 }
 
-std::string JsonToString(const Json::Value json) {
+std::string JsonToString(const Json::Value &json) {
     return Json::writeString(Json::StreamWriterBuilder(), json);
 }
 

--- a/cpp/open3d/utility/IJsonConvertible.h
+++ b/cpp/open3d/utility/IJsonConvertible.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <fmt/format.h>
+
 #include <Eigen/Core>
 
 #include "open3d/utility/Eigen.h"
@@ -50,7 +52,7 @@ Json::Value StringToJson(const std::string &json_str);
 ///
 /// \param json The Json::Value object to be converted.
 /// \return A string containing the json value.
-std::string JsonToString(const Json::Value json);
+std::string JsonToString(const Json::Value &json);
 
 /// Class IJsonConvertible defines the behavior of a class that can convert
 /// itself to/from a json::Value.
@@ -98,3 +100,20 @@ public:
 
 }  // namespace utility
 }  // namespace open3d
+
+namespace fmt {
+template <>
+struct formatter<Json::Value> {
+    template <typename FormatContext>
+    auto format(const Json::Value &value, FormatContext &ctx)
+            -> decltype(ctx.out()) {
+        return format_to(ctx.out(), "{}", open3d::utility::JsonToString(value));
+    }
+
+    template <typename ParseContext>
+    constexpr auto parse(ParseContext &ctx) -> decltype(ctx.begin()) {
+        return ctx.begin();
+    }
+};
+
+}  // namespace fmt

--- a/cpp/open3d/visualization/rendering/RendererHandle.h
+++ b/cpp/open3d/visualization/rendering/RendererHandle.h
@@ -31,6 +31,7 @@
 #include <array>
 #include <cstdint>
 #include <functional>
+#include <type_traits>
 
 namespace open3d {
 
@@ -173,12 +174,16 @@ public:
 }  // namespace std
 
 namespace fmt {
-using namespace open3d::visualization;
-template <>
-struct formatter<open3d::visualization::rendering::REHandle_abstract> {
+template <typename T>
+struct formatter<
+        T,
+        std::enable_if_t<std::is_base_of<open3d::visualization::rendering::
+                                                 REHandle_abstract,
+                                         T>::value,
+                         char>> {
     template <typename FormatContext>
     auto format(const open3d::visualization::rendering::REHandle_abstract& uid,
-                FormatContext& ctx) {
+                FormatContext& ctx) -> decltype(ctx.out()) {
         return format_to(ctx.out(), "[{}, {}, hash: {}]",
                          open3d::visualization::rendering::REHandle_abstract::
                                  TypeToString(uid.type),
@@ -186,7 +191,7 @@ struct formatter<open3d::visualization::rendering::REHandle_abstract> {
     }
 
     template <typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
+    constexpr auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
         return ctx.begin();
     }
 };

--- a/cpp/tests/core/Tensor.cpp
+++ b/cpp/tests/core/Tensor.cpp
@@ -686,7 +686,7 @@ TEST_P(TensorPermuteDevices, ToString) {
 
     // 0D
     t = core::Tensor::Ones({}, core::Float32, device);
-    EXPECT_EQ(t.ToString(/*with_suffix=*/false), R"(1.0)");
+    EXPECT_EQ(t.ToString(/*with_suffix=*/false), R"(1)");
     t = core::Tensor::Full({}, std::numeric_limits<float>::quiet_NaN(),
                            core::Float32, device);
     EXPECT_EQ(t.ToString(/*with_suffix=*/false), R"(nan)");
@@ -697,7 +697,7 @@ TEST_P(TensorPermuteDevices, ToString) {
     // 1D float
     t = core::Tensor(std::vector<float>{0, 1, 2, 3, 4}, {5}, core::Float32,
                      device);
-    EXPECT_EQ(t.ToString(/*with_suffix=*/false), R"([0.0 1.0 2.0 3.0 4.0])");
+    EXPECT_EQ(t.ToString(/*with_suffix=*/false), R"([0 1 2 3 4])");
 
     // 1D int
     std::vector<int32_t> vals{0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,

--- a/cpp/tools/GLInfo.cpp
+++ b/cpp/tools/GLInfo.cpp
@@ -85,7 +85,8 @@ void TryGLVersion(int major,
         if (!r) {
             utility::LogWarning("Unable to get info on {} id {:d}", name, id);
         } else {
-            utility::LogDebug("{}:\t{}", name, r);
+            utility::LogDebug("{}:\t{}", name,
+                              reinterpret_cast<const char *>(r));
         }
     };
 #define OPEN3D_REPORT_GL_STRING(n) reportGlStringFunc(n, #n)


### PR DESCRIPTION
This PR updates the fmt::formatter specialization as documented in the fmtlib documentation for fmtlib >= 7, and fixes the build errors with fmtlib >= 8.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5303)
<!-- Reviewable:end -->
