### PR TITLE
fix doc typo 

### DIFF
--- a/docs/jupyter/visualization/visualization.ipynb
+++ b/docs/jupyter/visualization/visualization.ipynb
@@ -129,7 +129,7 @@
    "metadata": {},
    "source": [
     "## Geometry primitives\n",
-    "The code below generates a box, a sphere, and a cylinder using `create_box`, `create_sphere`, and `create_cylinder`. The box is painted in red, the sphere is painted in blue, and the cylinder is painted in green. Normals are computed for all meshes to support Phong shading (see [Visualize 3D mesh](mesh.ipynb#visualize-a-3d-mesh) and [Surface normal estimation](mesh.ipynb#surface-normal-estimation)). We can even create a coordinate axis using `create_mesh_coordinate_frame`, with its origin point set at (-2, -2, -2)."
+    "The code below generates a box, a sphere, and a cylinder using `create_box`, `create_sphere`, and `create_cylinder`. The box is painted in red, the sphere is painted in blue, and the cylinder is painted in green. Normals are computed for all meshes to support Phong shading (see [Visualize 3D mesh](mesh.ipynb#visualize-a-3d-mesh) and [Surface normal estimation](mesh.ipynb#surface-normal-estimation)). We can even create a coordinate axis using `create_coordinate_frame`, with its origin point set at (-2, -2, -2)."
    ]
   },
   {

--- a/docs/jupyter/visualization/visualization.ipynb
+++ b/docs/jupyter/visualization/visualization.ipynb
@@ -229,7 +229,7 @@
  "metadata": {
   "celltoolbar": "Edit Metadata",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.8.10 64-bit (windows store)",
    "language": "python",
    "name": "python3"
   },
@@ -243,7 +243,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.10"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "3c9f9a500ca684ee401c6824dc59bb17f7418a54cdadde026de4b201d5bd57e6"
+   }
   }
  },
  "nbformat": 4,

--- a/docs/jupyter/visualization/visualization.ipynb
+++ b/docs/jupyter/visualization/visualization.ipynb
@@ -229,7 +229,7 @@
  "metadata": {
   "celltoolbar": "Edit Metadata",
   "kernelspec": {
-   "display_name": "Python 3.8.10 64-bit (windows store)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -243,12 +243,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "3c9f9a500ca684ee401c6824dc59bb17f7418a54cdadde026de4b201d5bd57e6"
-   }
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fix documentation typo in geometry primitives section, which related to issue #5322.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5323)
<!-- Reviewable:end -->
