### PR TITLE
Make SelectPolygonVolume.CropInPolygon return indices

### DIFF
--- a/cpp/open3d/visualization/utility/SelectionPolygonVolume.cpp
+++ b/cpp/open3d/visualization/utility/SelectionPolygonVolume.cpp
@@ -124,6 +124,11 @@ SelectionPolygonVolume::CropTriangleMeshInPolygon(
 }
 
 std::vector<size_t> SelectionPolygonVolume::CropInPolygon(
+        const geometry::PointCloud &input) const {
+    return CropInPolygon(input.points_);
+}
+
+std::vector<size_t> SelectionPolygonVolume::CropInPolygon(
         const std::vector<Eigen::Vector3d> &input) const {
     std::vector<size_t> output_index;
     int u, v, w;

--- a/cpp/open3d/visualization/utility/SelectionPolygonVolume.h
+++ b/cpp/open3d/visualization/utility/SelectionPolygonVolume.h
@@ -63,15 +63,18 @@ public:
     /// \param input The input triangle mesh.
     std::shared_ptr<geometry::TriangleMesh> CropTriangleMesh(
             const geometry::TriangleMesh &input) const;
+    /// Function to crop point cloud with polygon boundaries
+    ///
+    /// \param input The input point Cloud.
+    std::vector<size_t> CropInPolygon(const geometry::PointCloud &input) const;
 
-    std::vector<size_t> CropInPolygon(
-            const std::vector<Eigen::Vector3d> &input) const;
 private:
     std::shared_ptr<geometry::PointCloud> CropPointCloudInPolygon(
             const geometry::PointCloud &input) const;
     std::shared_ptr<geometry::TriangleMesh> CropTriangleMeshInPolygon(
             const geometry::TriangleMesh &input) const;
-    // std::vector<size_t> CropInPolygon(const std::vector<Eigen::Vector3d> &input) const;
+    std::vector<size_t> CropInPolygon(
+            const std::vector<Eigen::Vector3d> &input) const;
 
 public:
     /// One of `{x, y, z}`.

--- a/cpp/open3d/visualization/utility/SelectionPolygonVolume.h
+++ b/cpp/open3d/visualization/utility/SelectionPolygonVolume.h
@@ -64,13 +64,14 @@ public:
     std::shared_ptr<geometry::TriangleMesh> CropTriangleMesh(
             const geometry::TriangleMesh &input) const;
 
+    std::vector<size_t> CropInPolygon(
+            const std::vector<Eigen::Vector3d> &input) const;
 private:
     std::shared_ptr<geometry::PointCloud> CropPointCloudInPolygon(
             const geometry::PointCloud &input) const;
     std::shared_ptr<geometry::TriangleMesh> CropTriangleMeshInPolygon(
             const geometry::TriangleMesh &input) const;
-    std::vector<size_t> CropInPolygon(
-            const std::vector<Eigen::Vector3d> &input) const;
+    // std::vector<size_t> CropInPolygon(const std::vector<Eigen::Vector3d> &input) const;
 
 public:
     /// One of `{x, y, z}`.

--- a/cpp/pybind/visualization/utility.cpp
+++ b/cpp/pybind/visualization/utility.cpp
@@ -59,10 +59,10 @@ void pybind_visualization_utility(py::module &m) {
                         return s.CropTriangleMesh(input);
                     },
                     "input"_a, "Function to crop crop triangle mesh.")
-	    .def(
+            .def(
                     "crop_in_polygon",
                     [](const SelectionPolygonVolume &s,
-                       const std::vector<Eigen::Vector3d> &input) {
+                       const geometry::PointCloud &input) {
                         return s.CropInPolygon(input);
                     },
                     "input"_a, "Function to crop 3d point clouds.")

--- a/cpp/pybind/visualization/utility.cpp
+++ b/cpp/pybind/visualization/utility.cpp
@@ -59,6 +59,13 @@ void pybind_visualization_utility(py::module &m) {
                         return s.CropTriangleMesh(input);
                     },
                     "input"_a, "Function to crop crop triangle mesh.")
+	    .def(
+                    "crop_in_polygon",
+                    [](const SelectionPolygonVolume &s,
+                       const std::vector<Eigen::Vector3d> &input) {
+                        return s.CropInPolygon(input);
+                    },
+                    "input"_a, "Function to crop 3d point clouds.")
             .def("__repr__",
                  [](const SelectionPolygonVolume &s) {
                      return std::string(
@@ -84,6 +91,9 @@ void pybind_visualization_utility(py::module &m) {
     docstring::ClassMethodDocInject(m, "SelectionPolygonVolume",
                                     "crop_triangle_mesh",
                                     {{"input", "The input triangle mesh."}});
+    docstring::ClassMethodDocInject(m, "SelectionPolygonVolume",
+                                    "crop_in_polygon",
+                                    {{"input", "The input point cloud xyz."}});
 }
 
 // Visualization util functions have similar arguments, sharing arg docstrings


### PR DESCRIPTION
Following issue created at https://github.com/isl-org/Open3D/issues/3713, in some circumstance it would be really great to have the indices of the cropped point clouds in SelectionVolume.CropInPolygon() function, for example, when the point cloud size is very large, and it's expensive to make a copy of the cropped point clouds. 

This PR proposes to make the SelectionVolume.CropInPolygon() a public method, which directly returns the indices for the cropped point cloud. Python bindings function is added to make it callable from python.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5354)
<!-- Reviewable:end -->
