### PR TITLE
Fix raycasting scene: Allow setting of number of threads that are used for building a raycasting scene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Corrected documentation for KDTree (typo in Notebook) (PR #4744)
 * Remove `setuptools` and `wheel` from requirements for end users (PR #5020)
 * Fix various typos (PR #5070)
+* Fix raycasting scene: Allow setting of number of threads that are used for building a raycasting scene
 
 ## 0.13
 

--- a/cpp/open3d/t/geometry/RaycastingScene.cpp
+++ b/cpp/open3d/t/geometry/RaycastingScene.cpp
@@ -469,9 +469,9 @@ struct RaycastingScene::Impl {
     }
 };
 
-RaycastingScene::RaycastingScene(int64_t build_threads) : impl_(new RaycastingScene::Impl()) {
-    if (build_threads > 0) {
-        std::string config("threads=" + std::to_string(build_threads));
+RaycastingScene::RaycastingScene(int64_t nthreads) : impl_(new RaycastingScene::Impl()) {
+    if (nthreads > 0) {
+        std::string config("threads=" + std::to_string(nthreads));
         impl_->device_ = rtcNewDevice(config.c_str());
     } else {
         impl_->device_ = rtcNewDevice(NULL);

--- a/cpp/open3d/t/geometry/RaycastingScene.cpp
+++ b/cpp/open3d/t/geometry/RaycastingScene.cpp
@@ -469,8 +469,13 @@ struct RaycastingScene::Impl {
     }
 };
 
-RaycastingScene::RaycastingScene() : impl_(new RaycastingScene::Impl()) {
-    impl_->device_ = rtcNewDevice(NULL);
+RaycastingScene::RaycastingScene(int64_t build_threads) : impl_(new RaycastingScene::Impl()) {
+    if (build_threads > 0) {
+        std::string config("threads=" + std::to_string(build_threads));
+        impl_->device_ = rtcNewDevice(config.c_str());
+    } else {
+        impl_->device_ = rtcNewDevice(NULL);
+    }
     rtcSetDeviceErrorFunction(impl_->device_, ErrorFunction, NULL);
 
     impl_->scene_ = rtcNewScene(impl_->device_);

--- a/cpp/open3d/t/geometry/RaycastingScene.cpp
+++ b/cpp/open3d/t/geometry/RaycastingScene.cpp
@@ -469,7 +469,8 @@ struct RaycastingScene::Impl {
     }
 };
 
-RaycastingScene::RaycastingScene(int64_t nthreads) : impl_(new RaycastingScene::Impl()) {
+RaycastingScene::RaycastingScene(int64_t nthreads)
+    : impl_(new RaycastingScene::Impl()) {
     if (nthreads > 0) {
         std::string config("threads=" + std::to_string(nthreads));
         impl_->device_ = rtcNewDevice(config.c_str());

--- a/cpp/open3d/t/geometry/RaycastingScene.h
+++ b/cpp/open3d/t/geometry/RaycastingScene.h
@@ -49,7 +49,7 @@ namespace geometry {
 class RaycastingScene {
 public:
     /// \brief Default Constructor.
-    RaycastingScene(int64_t build_threads = 0);
+    RaycastingScene(int64_t nthreads = 0);
 
     ~RaycastingScene();
 

--- a/cpp/open3d/t/geometry/RaycastingScene.h
+++ b/cpp/open3d/t/geometry/RaycastingScene.h
@@ -49,7 +49,7 @@ namespace geometry {
 class RaycastingScene {
 public:
     /// \brief Default Constructor.
-    RaycastingScene();
+    RaycastingScene(int64_t build_threads = 0);
 
     ~RaycastingScene();
 

--- a/cpp/pybind/t/geometry/raycasting_scene.cpp
+++ b/cpp/pybind/t/geometry/raycasting_scene.cpp
@@ -74,7 +74,7 @@ The following shows how to create a scene and compute ray intersections::
 
     // Constructors.
     raycasting_scene.def(py::init<int64_t>(),
-                         "build_threads"_a = 0);
+                         "nthreads"_a = 0);
 
     raycasting_scene.def(
             "add_triangles",

--- a/cpp/pybind/t/geometry/raycasting_scene.cpp
+++ b/cpp/pybind/t/geometry/raycasting_scene.cpp
@@ -73,7 +73,8 @@ The following shows how to create a scene and compute ray intersections::
 )doc");
 
     // Constructors.
-    raycasting_scene.def(py::init<>());
+    raycasting_scene.def(py::init<int64_t>(),
+                         "build_threads"_a = 0);
 
     raycasting_scene.def(
             "add_triangles",

--- a/cpp/pybind/t/geometry/raycasting_scene.cpp
+++ b/cpp/pybind/t/geometry/raycasting_scene.cpp
@@ -74,7 +74,12 @@ The following shows how to create a scene and compute ray intersections::
 
     // Constructors.
     raycasting_scene.def(py::init<int64_t>(),
-                         "nthreads"_a = 0);
+                         "nthreads"_a = 0, R"doc(
+Create a RaycastingScene.
+
+Args:
+    nthreads (int): The number of threads to use for building the scene. Set to 0 for automatic.
+)doc");
 
     raycasting_scene.def(
             "add_triangles",

--- a/cpp/pybind/t/geometry/raycasting_scene.cpp
+++ b/cpp/pybind/t/geometry/raycasting_scene.cpp
@@ -73,8 +73,7 @@ The following shows how to create a scene and compute ray intersections::
 )doc");
 
     // Constructors.
-    raycasting_scene.def(py::init<int64_t>(),
-                         "nthreads"_a = 0, R"doc(
+    raycasting_scene.def(py::init<int64_t>(), "nthreads"_a = 0, R"doc(
 Create a RaycastingScene.
 
 Args:


### PR DESCRIPTION
This PR adds an argument to the constructor of RaycastingScene to allow the user to control the number of threads that are used for building a RaycastingScene. It completes the intention of PR #4100, where the user was enabled to control the number of threads for doing computations in a RaycastingScene.

Currently all hardware threads are used for building a RaycastingScene, since a `RTCDevice` is created using this: `rtcNewDevice(NULL)`. This is unwanted behavior and can lead to problems, e.g. if many cores are present (>=16), and the scene is not huge, using all hardware threads results actually in a slowdown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5384)
<!-- Reviewable:end -->
