### PR TITLE
changed output of colored icp to be identity if no correpondence is found

### DIFF
--- a/cpp/open3d/pipelines/registration/ColoredICP.cpp
+++ b/cpp/open3d/pipelines/registration/ColoredICP.cpp
@@ -118,10 +118,9 @@ Eigen::Matrix4d TransformationEstimationForColoredICP::ComputeTransformation(
         const geometry::PointCloud &source,
         const geometry::PointCloud &target,
         const CorrespondenceSet &corres) const {
-    if (corres.empty()) {
-        utility::LogError(
-                "No correspondences found between source and target "
-                "pointcloud.");
+    if (corres.empty() || !target.HasCovariances() ||
+        !source.HasCovariances()) {
+        return Eigen::Matrix4d::Identity();
     }
     if (!target.HasNormals()) {
         utility::LogError(

--- a/cpp/open3d/pipelines/registration/ColoredICP.cpp
+++ b/cpp/open3d/pipelines/registration/ColoredICP.cpp
@@ -120,6 +120,8 @@ Eigen::Matrix4d TransformationEstimationForColoredICP::ComputeTransformation(
         const CorrespondenceSet &corres) const {
     if (corres.empty() || !target.HasCovariances() ||
         !source.HasCovariances()) {
+        utility::LogDebug("No correspondences found between source and target "
+                "pointcloud. Returning Identity");
         return Eigen::Matrix4d::Identity();
     }
     if (!target.HasNormals()) {

--- a/cpp/open3d/pipelines/registration/ColoredICP.cpp
+++ b/cpp/open3d/pipelines/registration/ColoredICP.cpp
@@ -120,7 +120,7 @@ Eigen::Matrix4d TransformationEstimationForColoredICP::ComputeTransformation(
         const CorrespondenceSet &corres) const {
     if (corres.empty() || !target.HasCovariances() ||
         !source.HasCovariances()) {
-        utility::LogDebug("No correspondences found between source and target "
+        utility::LogWarning("No correspondences found between source and target "
                 "pointcloud. Returning Identity");
         return Eigen::Matrix4d::Identity();
     }


### PR DESCRIPTION
When correspondence between source and target point cloud is not found, generalized icp returns their transformation to be identity. Updated this idea to colored icp.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5391)
<!-- Reviewable:end -->
