### PR TITLE
(minor) Fix Python bindings for CUDA device synchronization, voxel grid save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Remove `setuptools` and `wheel` from requirements for end users (PR #5020)
 * Fix various typos (PR #5070)
 * Fix raycasting scene: Allow setting of number of threads that are used for building a raycasting scene
-* Fix Python binding for CUDA device synchronization (PR #5425)
+* Fix Python bindings for CUDA device synchronization, voxel grid saving (PR #5425)
 
 ## 0.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Remove `setuptools` and `wheel` from requirements for end users (PR #5020)
 * Fix various typos (PR #5070)
 * Fix raycasting scene: Allow setting of number of threads that are used for building a raycasting scene
+* Fix Python binding for CUDA device synchronization (PR #5425)
 
 ## 0.13
 

--- a/cpp/pybind/core/cuda_utils.cpp
+++ b/cpp/pybind/core/cuda_utils.cpp
@@ -55,7 +55,7 @@ void pybind_cuda_utils(py::module& m) {
             "Synchronizes CUDA devices. If no device is specified, all CUDA "
             "devices will be synchronized. No effect if the specified device "
             "is not a CUDA device. No effect if Open3D is not compiled with "
-            "CUDA support."
+            "CUDA support.",
             "device"_a = py::none());
 }
 

--- a/cpp/pybind/t/geometry/voxel_block_grid.cpp
+++ b/cpp/pybind/t/geometry/voxel_block_grid.cpp
@@ -204,8 +204,7 @@ void pybind_voxel_block_grid(py::module& m) {
             "weight_threshold"_a = 3.0f, "estimated_vertex_number"_a = -1);
 
     vbg.def("save", &VoxelBlockGrid::Save,
-            "Save the voxel block grid to a npz file."
-            "file_name"_a);
+            "Save the voxel block grid to a npz file.", "file_name"_a);
     vbg.def_static("load", &VoxelBlockGrid::Load,
                    "Load a voxel block grid from a npz file.", "file_name"_a);
 }


### PR DESCRIPTION
Hi!

I was having some trouble with these bindings, which had the helptext and argument definitions accidentally combined.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5425)
<!-- Reviewable:end -->
