### PR TITLE
Fix floating point texture usage

### DIFF
--- a/cpp/open3d/visualization/rendering/filament/FilamentResourceManager.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentResourceManager.cpp
@@ -231,24 +231,34 @@ void FormatSettingsFromImage(TextureSettings& settings,
                     {(2 << 4 | 1), filament::Texture::InternalFormat::R16UI},
                     {(2 << 4 | 2), filament::Texture::InternalFormat::RG16UI},
                     {(2 << 4 | 3), filament::Texture::InternalFormat::RGB16UI},
+                    {(2 << 4 | 4), filament::Texture::InternalFormat::RGBA16UI},
                     {(1 << 4 | 1), filament::Texture::InternalFormat::R8},
                     {(1 << 4 | 2), filament::Texture::InternalFormat::RG8},
                     {(1 << 4 | 3), filament::Texture::InternalFormat::RGB8},
                     {(1 << 4 | 4), filament::Texture::InternalFormat::RGBA8}};
 
     // Set image format
+    bool int_format = (bytes_per_channel == 2);
     switch (num_channels) {
         case 1:
-            settings.image_format = filament::Texture::Format::R;
+            settings.image_format =
+                    (int_format ? filament::Texture::Format::R_INTEGER
+                                : filament::Texture::Format::R);
             break;
         case 2:
-            settings.image_format = filament::Texture::Format::RG;
+            settings.image_format =
+                    (int_format ? filament::Texture::Format::RG_INTEGER
+                                : filament::Texture::Format::RG);
             break;
         case 3:
-            settings.image_format = filament::Texture::Format::RGB;
+            settings.image_format =
+                    (int_format ? filament::Texture::Format::RGB_INTEGER
+                                : filament::Texture::Format::RGB);
             break;
         case 4:
-            settings.image_format = filament::Texture::Format::RGBA;
+            settings.image_format =
+                    (int_format ? filament::Texture::Format::RGBA_INTEGER
+                                : filament::Texture::Format::RGBA);
             break;
         default:
             utility::LogError("Unsupported image number of channels: {}",
@@ -879,7 +889,7 @@ filament::Texture* FilamentResourceManager::LoadTextureFromImage(
     auto levels = maxLevelCount(texture_settings.texel_width,
                                 texture_settings.texel_height);
     bool mipmappable =
-            (texture_settings.image_type != filament::Texture::Type::FLOAT);
+            (texture_settings.image_type == filament::Texture::Type::UBYTE);
     if (!mipmappable) {
         levels = 1;
     }
@@ -911,7 +921,7 @@ filament::Texture* FilamentResourceManager::LoadTextureFromImage(
     auto levels = maxLevelCount(texture_settings.texel_width,
                                 texture_settings.texel_height);
     // Float textures cannot be mipmapped
-    bool mipmappable = (image.GetDtype() != core::Dtype::Float32);
+    bool mipmappable = (image.GetDtype() == core::Dtype::UInt8);
     if (mipmappable) {
         levels = 1;
     }

--- a/cpp/open3d/visualization/rendering/filament/FilamentResourceManager.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentResourceManager.cpp
@@ -878,6 +878,11 @@ filament::Texture* FilamentResourceManager::LoadTextureFromImage(
     auto texture_settings = GetSettingsFromImage(*image, srgb);
     auto levels = maxLevelCount(texture_settings.texel_width,
                                 texture_settings.texel_height);
+    bool mipmappable =
+            (texture_settings.image_type != filament::Texture::Type::FLOAT);
+    if (!mipmappable) {
+        levels = 1;
+    }
 
     Texture::PixelBufferDescriptor pb(
             image->data_.data(), image->data_.size(),
@@ -892,7 +897,9 @@ filament::Texture* FilamentResourceManager::LoadTextureFromImage(
                            .build(engine_);
 
     texture->setImage(engine_, 0, std::move(pb));
-    texture->generateMipmaps(engine_);
+    if (mipmappable) {
+        texture->generateMipmaps(engine_);
+    }
     return texture;
 }
 
@@ -903,6 +910,11 @@ filament::Texture* FilamentResourceManager::LoadTextureFromImage(
     auto texture_settings = GetSettingsFromImage(image, srgb);
     auto levels = maxLevelCount(texture_settings.texel_width,
                                 texture_settings.texel_height);
+    // Float textures cannot be mipmapped
+    bool mipmappable = (image.GetDtype() != core::Dtype::Float32);
+    if (mipmappable) {
+        levels = 1;
+    }
 
     const size_t image_bytes = image.GetRows() * image.GetCols() *
                                image.GetChannels() *
@@ -922,7 +934,9 @@ filament::Texture* FilamentResourceManager::LoadTextureFromImage(
                                .sampler(Texture::Sampler::SAMPLER_2D)
                                .build(engine_);
         texture->setImage(engine_, 0, std::move(pb));
-        texture->generateMipmaps(engine_);
+        if (mipmappable) {
+            texture->generateMipmaps(engine_);
+        }
         return texture;
     } else {
         Texture::PixelBufferDescriptor pb(image.GetDataPtr(), image_bytes,
@@ -936,7 +950,9 @@ filament::Texture* FilamentResourceManager::LoadTextureFromImage(
                                .sampler(Texture::Sampler::SAMPLER_2D)
                                .build(engine_);
         texture->setImage(engine_, 0, std::move(pb));
-        texture->generateMipmaps(engine_);
+        if (mipmappable) {
+            texture->generateMipmaps(engine_);
+        }
         return texture;
     }
 }


### PR DESCRIPTION
The following script should visualize a box with random colors on it:
```
import open3d as o3d
import numpy as np
tex = np.random.rand(128,128,3).astype(np.float32)

box = o3d.geometry.TriangleMesh.create_box(create_uv_map=True)
box = o3d.t.geometry.TriangleMesh.from_legacy(box)
box.material.set_default_properties()
box.material.texture_maps['albedo'] = o3d.t.geometry.Image(tex)

o3d.visualization.draw([box])
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5438)
<!-- Reviewable:end -->
