### PR TITLE
Fix issue when using Dispatch in external project

### DIFF
--- a/cpp/open3d/core/Dispatch.h
+++ b/cpp/open3d/core/Dispatch.h
@@ -46,41 +46,41 @@
 ///
 /// Inspired by:
 ///     https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/Dispatch.h
-#define DISPATCH_DTYPE_TO_TEMPLATE(DTYPE, ...)           \
-    [&] {                                                \
-        if (DTYPE == open3d::core::Float32) {            \
-            using scalar_t = float;                      \
-            return __VA_ARGS__();                        \
-        } else if (DTYPE == open3d::core::Float64) {     \
-            using scalar_t = double;                     \
-            return __VA_ARGS__();                        \
-        } else if (DTYPE == open3d::core::Int8) {        \
-            using scalar_t = int8_t;                     \
-            return __VA_ARGS__();                        \
-        } else if (DTYPE == open3d::core::Int16) {       \
-            using scalar_t = int16_t;                    \
-            return __VA_ARGS__();                        \
-        } else if (DTYPE == open3d::core::Int32) {       \
-            using scalar_t = int32_t;                    \
-            return __VA_ARGS__();                        \
-        } else if (DTYPE == open3d::core::Int64) {       \
-            using scalar_t = int64_t;                    \
-            return __VA_ARGS__();                        \
-        } else if (DTYPE == open3d::core::UInt8) {       \
-            using scalar_t = uint8_t;                    \
-            return __VA_ARGS__();                        \
-        } else if (DTYPE == open3d::core::UInt16) {      \
-            using scalar_t = uint16_t;                   \
-            return __VA_ARGS__();                        \
-        } else if (DTYPE == open3d::core::UInt32) {      \
-            using scalar_t = uint32_t;                   \
-            return __VA_ARGS__();                        \
-        } else if (DTYPE == open3d::core::UInt64) {      \
-            using scalar_t = uint64_t;                   \
-            return __VA_ARGS__();                        \
-        } else {                                         \
-            utility::LogError("Unsupported data type."); \
-        }                                                \
+#define DISPATCH_DTYPE_TO_TEMPLATE(DTYPE, ...)                   \
+    [&] {                                                        \
+        if (DTYPE == open3d::core::Float32) {                    \
+            using scalar_t = float;                              \
+            return __VA_ARGS__();                                \
+        } else if (DTYPE == open3d::core::Float64) {             \
+            using scalar_t = double;                             \
+            return __VA_ARGS__();                                \
+        } else if (DTYPE == open3d::core::Int8) {                \
+            using scalar_t = int8_t;                             \
+            return __VA_ARGS__();                                \
+        } else if (DTYPE == open3d::core::Int16) {               \
+            using scalar_t = int16_t;                            \
+            return __VA_ARGS__();                                \
+        } else if (DTYPE == open3d::core::Int32) {               \
+            using scalar_t = int32_t;                            \
+            return __VA_ARGS__();                                \
+        } else if (DTYPE == open3d::core::Int64) {               \
+            using scalar_t = int64_t;                            \
+            return __VA_ARGS__();                                \
+        } else if (DTYPE == open3d::core::UInt8) {               \
+            using scalar_t = uint8_t;                            \
+            return __VA_ARGS__();                                \
+        } else if (DTYPE == open3d::core::UInt16) {              \
+            using scalar_t = uint16_t;                           \
+            return __VA_ARGS__();                                \
+        } else if (DTYPE == open3d::core::UInt32) {              \
+            using scalar_t = uint32_t;                           \
+            return __VA_ARGS__();                                \
+        } else if (DTYPE == open3d::core::UInt64) {              \
+            using scalar_t = uint64_t;                           \
+            return __VA_ARGS__();                                \
+        } else {                                                 \
+            open3d::utility::LogError("Unsupported data type."); \
+        }                                                        \
     }()
 
 #define DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(DTYPE, ...)    \
@@ -93,17 +93,17 @@
         }                                                   \
     }()
 
-#define DISPATCH_FLOAT_DTYPE_TO_TEMPLATE(DTYPE, ...)     \
-    [&] {                                                \
-        if (DTYPE == open3d::core::Float32) {            \
-            using scalar_t = float;                      \
-            return __VA_ARGS__();                        \
-        } else if (DTYPE == open3d::core::Float64) {     \
-            using scalar_t = double;                     \
-            return __VA_ARGS__();                        \
-        } else {                                         \
-            utility::LogError("Unsupported data type."); \
-        }                                                \
+#define DISPATCH_FLOAT_DTYPE_TO_TEMPLATE(DTYPE, ...)             \
+    [&] {                                                        \
+        if (DTYPE == open3d::core::Float32) {                    \
+            using scalar_t = float;                              \
+            return __VA_ARGS__();                                \
+        } else if (DTYPE == open3d::core::Float64) {             \
+            using scalar_t = double;                             \
+            return __VA_ARGS__();                                \
+        } else {                                                 \
+            open3d::utility::LogError("Unsupported data type."); \
+        }                                                        \
     }()
 
 #define DISPATCH_FLOAT_INT_DTYPE_TO_TEMPLATE(FDTYPE, IDTYPE, ...) \
@@ -129,6 +129,6 @@
             using int_t = int64_t;                                \
             return __VA_ARGS__();                                 \
         } else {                                                  \
-            utility::LogError("Unsupported data type.");          \
+            open3d::utility::LogError("Unsupported data type.");  \
         }                                                         \
     }()


### PR DESCRIPTION
Using `DISPATCH_XXX` in external project will result  in the following issue:
![image](https://user-images.githubusercontent.com/42235877/187391219-d5a19aa2-f9bd-4a85-a510-8973eba10a5c.png)
This can be fixed by adding `open3d` namespcae before `utility`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5490)
<!-- Reviewable:end -->
