### PR TITLE
Always return long description in ToString() for t.geometry classes

### DIFF
--- a/cpp/open3d/t/geometry/LineSet.cpp
+++ b/cpp/open3d/t/geometry/LineSet.cpp
@@ -85,7 +85,7 @@ std::string LineSet::ToString() const {
     } else {
         for (const auto &keyval : point_attr_) {
             if (keyval.first == "positions") continue;
-            str += fmt::format(" {} (dtype={}, shape={}),", keyval.first,
+            str += fmt::format(" {} (dtype = {}, shape = {}),", keyval.first,
                                keyval.second.GetDtype().ToString(),
                                keyval.second.GetShape().ToString());
         }
@@ -103,7 +103,7 @@ std::string LineSet::ToString() const {
     } else {
         for (const auto &keyval : line_attr_) {
             if (keyval.first == "indices") continue;
-            str += fmt::format(" {} (dtype={}, shape={}),", keyval.first,
+            str += fmt::format(" {} (dtype = {}, shape = {}),", keyval.first,
                                keyval.second.GetDtype().ToString(),
                                keyval.second.GetShape().ToString());
         }

--- a/cpp/open3d/t/geometry/LineSet.cpp
+++ b/cpp/open3d/t/geometry/LineSet.cpp
@@ -85,7 +85,7 @@ std::string LineSet::ToString() const {
     } else {
         for (const auto &keyval : point_attr_) {
             if (keyval.first == "positions") continue;
-            str += fmt::format(" {} (dtype = {}, shape = {}),", keyval.first,
+            str += fmt::format(" {} (dtype={}, shape={}),", keyval.first,
                                keyval.second.GetDtype().ToString(),
                                keyval.second.GetShape().ToString());
         }
@@ -103,7 +103,7 @@ std::string LineSet::ToString() const {
     } else {
         for (const auto &keyval : line_attr_) {
             if (keyval.first == "indices") continue;
-            str += fmt::format(" {} (dtype = {}, shape = {}),", keyval.first,
+            str += fmt::format(" {} (dtype={}, shape={}),", keyval.first,
                                keyval.second.GetDtype().ToString(),
                                keyval.second.GetShape().ToString());
         }

--- a/cpp/open3d/t/geometry/PointCloud.cpp
+++ b/cpp/open3d/t/geometry/PointCloud.cpp
@@ -88,15 +88,20 @@ PointCloud::PointCloud(const std::unordered_map<std::string, core::Tensor>
 }
 
 std::string PointCloud::ToString() const {
-    if (point_attr_.size() == 0)
-        return fmt::format("PointCloud on {} [0 points ()] Attributes: None.",
-                           GetDevice().ToString());
+    size_t num_points = 0;
+    std::string points_dtype_str = "";
+    if (point_attr_.count(point_attr_.GetPrimaryKey())) {
+        num_points = GetPointPositions().GetLength();
+        points_dtype_str =
+                fmt::format(" ({})", GetPointPositions().GetDtype().ToString());
+    }
     auto str =
-            fmt::format("PointCloud on {} [{} points ({})] Attributes:",
-                        GetDevice().ToString(), GetPointPositions().GetShape(0),
-                        GetPointPositions().GetDtype().ToString());
+            fmt::format("PointCloud on {} [{} points{}] Attributes:",
+                        GetDevice().ToString(), num_points, points_dtype_str);
 
-    if (point_attr_.size() == 1) return str + " None.";
+    if ((point_attr_.size() - point_attr_.count(point_attr_.GetPrimaryKey())) ==
+        0)
+        return str + " None.";
     for (const auto &keyval : point_attr_) {
         if (keyval.first != "positions") {
             str += fmt::format(" {} (dtype = {}, shape = {}),", keyval.first,

--- a/cpp/open3d/t/geometry/PointCloud.cpp
+++ b/cpp/open3d/t/geometry/PointCloud.cpp
@@ -104,7 +104,7 @@ std::string PointCloud::ToString() const {
         return str + " None.";
     for (const auto &keyval : point_attr_) {
         if (keyval.first != "positions") {
-            str += fmt::format(" {} (dtype={}, shape={}),", keyval.first,
+            str += fmt::format(" {} (dtype = {}, shape = {}),", keyval.first,
                                keyval.second.GetDtype().ToString(),
                                keyval.second.GetShape().ToString());
         }

--- a/cpp/open3d/t/geometry/PointCloud.cpp
+++ b/cpp/open3d/t/geometry/PointCloud.cpp
@@ -104,7 +104,7 @@ std::string PointCloud::ToString() const {
         return str + " None.";
     for (const auto &keyval : point_attr_) {
         if (keyval.first != "positions") {
-            str += fmt::format(" {} (dtype = {}, shape = {}),", keyval.first,
+            str += fmt::format(" {} (dtype={}, shape={}),", keyval.first,
                                keyval.second.GetDtype().ToString(),
                                keyval.second.GetShape().ToString());
         }

--- a/cpp/open3d/t/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/t/geometry/TriangleMesh.cpp
@@ -78,20 +78,29 @@ TriangleMesh::TriangleMesh(const core::Tensor &vertex_positions,
 }
 
 std::string TriangleMesh::ToString() const {
-    if (vertex_attr_.size() == 0 || triangle_attr_.size() == 0)
-        return fmt::format("TriangleMesh on {} [{} vertices and {} triangles].",
-                           GetDevice().ToString(), vertex_attr_.size(),
-                           triangle_attr_.size());
+    size_t num_vertices = 0;
+    std::string vertex_dtype_str = "";
+    size_t num_triangles = 0;
+    std::string triangles_dtype_str = "";
+    if (vertex_attr_.count(vertex_attr_.GetPrimaryKey())) {
+        num_vertices = GetVertexPositions().GetLength();
+        vertex_dtype_str = fmt::format(
+                " ({})", GetVertexPositions().GetDtype().ToString());
+    }
+    if (triangle_attr_.count(triangle_attr_.GetPrimaryKey())) {
+        num_triangles = GetTriangleIndices().GetLength();
+        triangles_dtype_str = fmt::format(
+                " ({})", GetTriangleIndices().GetDtype().ToString());
+    }
 
     auto str = fmt::format(
-            "TriangleMesh on {} [{} vertices ({}) and {} triangles ({})].",
-            GetDevice().ToString(), GetVertexPositions().GetLength(),
-            GetVertexPositions().GetDtype().ToString(),
-            GetTriangleIndices().GetLength(),
-            GetTriangleIndices().GetDtype().ToString());
+            "TriangleMesh on {} [{} vertices{} and {} triangles{}].",
+            GetDevice().ToString(), num_vertices, vertex_dtype_str,
+            num_triangles, triangles_dtype_str);
 
     std::string vertices_attr_str = "\nVertex Attributes:";
-    if (vertex_attr_.size() == 1) {
+    if ((vertex_attr_.size() -
+         vertex_attr_.count(vertex_attr_.GetPrimaryKey())) == 0) {
         vertices_attr_str += " None.";
     } else {
         for (const auto &kv : vertex_attr_) {
@@ -106,7 +115,8 @@ std::string TriangleMesh::ToString() const {
     }
 
     std::string triangles_attr_str = "\nTriangle Attributes:";
-    if (triangle_attr_.size() == 1) {
+    if ((triangle_attr_.size() -
+         triangle_attr_.count(triangle_attr_.GetPrimaryKey())) == 0) {
         triangles_attr_str += " None.";
     } else {
         for (const auto &kv : triangle_attr_) {

--- a/cpp/tests/t/geometry/PointCloud.cpp
+++ b/cpp/tests/t/geometry/PointCloud.cpp
@@ -72,7 +72,7 @@ TEST_P(PointCloudPermuteDevices, DefaultConstructor) {
 
     // ToString
     EXPECT_EQ(pcd.ToString(),
-              "PointCloud on CPU:0 [0 points ()] Attributes: None.");
+              "PointCloud on CPU:0 [0 points] Attributes: None.");
 }
 
 TEST_P(PointCloudPermuteDevices, ConstructFromPoints) {

--- a/cpp/tests/t/geometry/TriangleMesh.cpp
+++ b/cpp/tests/t/geometry/TriangleMesh.cpp
@@ -172,7 +172,8 @@ TEST_P(TriangleMeshPermuteDevices, ToString) {
     // Empty mesh.
     mesh.Clear();
     std::string text_3 = "TriangleMesh on " + device.ToString() +
-                         " [0 vertices and 0 triangles].";
+                         " [0 vertices and 0 triangles].\nVertex Attributes: "
+                         "None.\nTriangle Attributes: None.";
     EXPECT_STREQ(mesh.ToString().c_str(), text_3.c_str());
 }
 


### PR DESCRIPTION
- Always return the long description that includes attributes for Tensor PointCloud and TriangleMesh to make debugging easier.
- Fix wrong counts if there are only vertices or triangles
- Fix exception if there is an attribute but no primary key

```python
import open3d as o3d
import numpy as np

mesh = o3d.t.geometry.TriangleMesh()
mesh.vertex.positions = np.random.rand(123,3)
print(mesh, '\n')

# same string representation as before
mesh = o3d.t.geometry.TriangleMesh(np.random.rand(10,3), np.random.randint(0,10, size=(8,3)))
print(mesh, '\n')

mesh = o3d.t.geometry.TriangleMesh()
mesh.vertex.positions = np.random.rand(123,3)
mesh.triangle.bla = np.random.rand(12,3,4)
print(mesh, '\n')
```
Before
```
TriangleMesh on CPU:0 [1 vertices and 0 triangles].

TriangleMesh on CPU:0 [10 vertices (Float64) and 8 triangles (Int64)].
Vertex Attributes: None.
Triangle Attributes: None.

Traceback (most recent call last):
  File "tostr.py", line 14, in <module>
    print(mesh, '\n')
IndexError: _Map_base::at
```
New
```
TriangleMesh on CPU:0 [123 vertices (Float64) and 0 triangles].
Vertex Attributes: None.
Triangle Attributes: None.

TriangleMesh on CPU:0 [10 vertices (Float64) and 8 triangles (Int64)].
Vertex Attributes: None.
Triangle Attributes: None.

TriangleMesh on CPU:0 [123 vertices (Float64) and 0 triangles].
Vertex Attributes: None.
Triangle Attributes: bla (dtype = Float64, shape = {12, 3, 4}).
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5492)
<!-- Reviewable:end -->
