### PR TITLE
add nbformat==5.5.0 as global deps

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,4 @@
 numpy>=1.18.0
 dash>=2.6.0
+nbformat==5.5.0
 configargparse


### PR DESCRIPTION
`nbformat` `5.6.0` was released on Sept 21, 2022, and it has a bug of reporting the version to be `0.0.0`. `nbformat` is required by `dash`.

```
➜  pip install nbformat==5.6.0
➜  python -c "import nbformat; print(nbformat.__version__)"
0.0.0

➜  pip install nbformat==5.5.0
➜  python -c "import nbformat; print(nbformat.__version__)"
5.5.0
```


Master CI is failing due to the following reason:

![image](https://user-images.githubusercontent.com/1501945/191876511-f4eba8ed-ca51-4f0d-a0c7-e11b90a48da1.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5544)
<!-- Reviewable:end -->
