### PR TITLE
Add redwood indoor datasets (Augmented ICL-NUIM Dataset)

### DIFF
--- a/cpp/open3d/data/CMakeLists.txt
+++ b/cpp/open3d/data/CMakeLists.txt
@@ -31,6 +31,10 @@ target_sources(data PRIVATE
     dataset/PCDPointCloud.cpp
     dataset/PLYPointCloud.cpp
     dataset/PTSPointCloud.cpp
+    dataset/RedwoodIndoorLivingRoom1.cpp
+    dataset/RedwoodIndoorLivingRoom2.cpp
+    dataset/RedwoodIndoorOffice1.cpp
+    dataset/RedwoodIndoorOffice2.cpp
     dataset/SampleFountainRGBDImages.cpp
     dataset/SampleL515Bag.cpp
     dataset/SampleNYURGBDImage.cpp

--- a/cpp/open3d/data/dataset/ArmadilloMesh.cpp
+++ b/cpp/open3d/data/dataset/ArmadilloMesh.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220201-data/ArmadilloMesh.ply"},
-        "9e68ff1b1cc914ed88cd84f6a8235021",
-        false};
+        Open3DDownloadsPrefix() + "20220201-data/ArmadilloMesh.ply",
+        "9e68ff1b1cc914ed88cd84f6a8235021"};
 
 ArmadilloMesh::ArmadilloMesh(const std::string& data_root)
     : DownloadDataset("ArmadilloMesh", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/AvocadoModel.cpp
+++ b/cpp/open3d/data/dataset/AvocadoModel.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220301-data/AvocadoModel.glb"},
-        "829f96a0a3a7d5556e0a263ea0699217",
-        false};
+        Open3DDownloadsPrefix() + "20220301-data/AvocadoModel.glb",
+        "829f96a0a3a7d5556e0a263ea0699217"};
 
 AvocadoModel::AvocadoModel(const std::string& data_root)
     : DownloadDataset("AvocadoModel", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/BedroomRGBDImages.cpp
+++ b/cpp/open3d/data/dataset/BedroomRGBDImages.cpp
@@ -34,21 +34,16 @@ namespace open3d {
 namespace data {
 
 const static std::vector<DataDescriptor> data_descriptors = {
-        {{Open3DDownloadsURLPrefix() + "20220301-data/bedroom01.zip"},
-         "2d1018ceeb72680f5d16b2f419da9bb1",
-         true},
-        {{Open3DDownloadsURLPrefix() + "20220301-data/bedroom02.zip"},
-         "5e6ffbccc0907dc5acc374aa76a79081",
-         true},
-        {{Open3DDownloadsURLPrefix() + "20220301-data/bedroom03.zip"},
-         "ebf13b89ec364b1788dd492c27b9b800",
-         true},
-        {{Open3DDownloadsURLPrefix() + "20220301-data/bedroom04.zip"},
-         "94c0e6c862a54588582b06520946fb15",
-         true},
-        {{Open3DDownloadsURLPrefix() + "20220301-data/bedroom05.zip"},
-         "54b927edb6fd61838025bc66ed767408",
-         true},
+        {Open3DDownloadsPrefix() + "20220301-data/bedroom01.zip",
+         "2d1018ceeb72680f5d16b2f419da9bb1"},
+        {Open3DDownloadsPrefix() + "20220301-data/bedroom02.zip",
+         "5e6ffbccc0907dc5acc374aa76a79081"},
+        {Open3DDownloadsPrefix() + "20220301-data/bedroom03.zip",
+         "ebf13b89ec364b1788dd492c27b9b800"},
+        {Open3DDownloadsPrefix() + "20220301-data/bedroom04.zip",
+         "94c0e6c862a54588582b06520946fb15"},
+        {Open3DDownloadsPrefix() + "20220301-data/bedroom05.zip",
+         "54b927edb6fd61838025bc66ed767408"},
 };
 
 BedroomRGBDImages::BedroomRGBDImages(const std::string& data_root)

--- a/cpp/open3d/data/dataset/BunnyMesh.cpp
+++ b/cpp/open3d/data/dataset/BunnyMesh.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220201-data/BunnyMesh.ply"},
-        "568f871d1a221ba6627569f1e6f9a3f2",
-        false};
+        Open3DDownloadsPrefix() + "20220201-data/BunnyMesh.ply",
+        "568f871d1a221ba6627569f1e6f9a3f2"};
 
 BunnyMesh::BunnyMesh(const std::string& data_root)
     : DownloadDataset("BunnyMesh", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/CrateModel.cpp
+++ b/cpp/open3d/data/dataset/CrateModel.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220301-data/CrateModel.zip"},
-        "20413eada103969bb3ca5df9aebc2034",
-        true};
+        Open3DDownloadsPrefix() + "20220301-data/CrateModel.zip",
+        "20413eada103969bb3ca5df9aebc2034"};
 
 CrateModel::CrateModel(const std::string& data_root)
     : DownloadDataset("CrateModel", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/DamagedHelmetModel.cpp
+++ b/cpp/open3d/data/dataset/DamagedHelmetModel.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220301-data/DamagedHelmetModel.glb"},
-        "a3af6ad5a8329f22ba08b7f16e4a97d8",
-        false};
+        Open3DDownloadsPrefix() + "20220301-data/DamagedHelmetModel.glb",
+        "a3af6ad5a8329f22ba08b7f16e4a97d8"};
 
 DamagedHelmetModel::DamagedHelmetModel(const std::string& data_root)
     : DownloadDataset("DamagedHelmetModel", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/DemoColoredICPPointClouds.cpp
+++ b/cpp/open3d/data/dataset/DemoColoredICPPointClouds.cpp
@@ -34,10 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() +
-         "20220201-data/DemoColoredICPPointClouds.zip"},
-        "bf8d469e892d76f2e69e1213207c0e30",
-        true};
+        Open3DDownloadsPrefix() + "20220201-data/DemoColoredICPPointClouds.zip",
+        "bf8d469e892d76f2e69e1213207c0e30"};
 
 DemoColoredICPPointClouds::DemoColoredICPPointClouds(
         const std::string& data_root)

--- a/cpp/open3d/data/dataset/DemoCropPointCloud.cpp
+++ b/cpp/open3d/data/dataset/DemoCropPointCloud.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220201-data/DemoCropPointCloud.zip"},
-        "12dbcdddd3f0865d8312929506135e23",
-        true};
+        Open3DDownloadsPrefix() + "20220201-data/DemoCropPointCloud.zip",
+        "12dbcdddd3f0865d8312929506135e23"};
 
 DemoCropPointCloud::DemoCropPointCloud(const std::string& data_root)
     : DownloadDataset("DemoCropPointCloud", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/DemoCustomVisualization.cpp
+++ b/cpp/open3d/data/dataset/DemoCustomVisualization.cpp
@@ -34,10 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() +
-         "20220301-data/DemoCustomVisualization.zip"},
-        "04cb716145c51d0119b59c7876249891",
-        true};
+        Open3DDownloadsPrefix() + "20220301-data/DemoCustomVisualization.zip",
+        "04cb716145c51d0119b59c7876249891"};
 
 DemoCustomVisualization::DemoCustomVisualization(const std::string& data_root)
     : DownloadDataset("DemoCustomVisualization", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/DemoFeatureMatchingPointClouds.cpp
+++ b/cpp/open3d/data/dataset/DemoFeatureMatchingPointClouds.cpp
@@ -34,10 +34,9 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() +
-         "20220201-data/DemoFeatureMatchingPointClouds.zip"},
-        "02f0703ce0cbf4df78ce2602ae33fc79",
-        true};
+        Open3DDownloadsPrefix() +
+                "20220201-data/DemoFeatureMatchingPointClouds.zip",
+        "02f0703ce0cbf4df78ce2602ae33fc79"};
 
 DemoFeatureMatchingPointClouds::DemoFeatureMatchingPointClouds(
         const std::string& data_root)

--- a/cpp/open3d/data/dataset/DemoICPPointClouds.cpp
+++ b/cpp/open3d/data/dataset/DemoICPPointClouds.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220301-data/DemoICPPointClouds.zip"},
-        "596cffe5f9c587045e7397ad70754de9",
-        true};
+        Open3DDownloadsPrefix() + "20220301-data/DemoICPPointClouds.zip",
+        "596cffe5f9c587045e7397ad70754de9"};
 
 DemoICPPointClouds::DemoICPPointClouds(const std::string& data_root)
     : DownloadDataset("DemoICPPointClouds", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/DemoPoseGraphOptimization.cpp
+++ b/cpp/open3d/data/dataset/DemoPoseGraphOptimization.cpp
@@ -34,10 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() +
-         "20220201-data/DemoPoseGraphOptimization.zip"},
-        "af085b28d79dea7f0a50aef50c96b62c",
-        true};
+        Open3DDownloadsPrefix() + "20220201-data/DemoPoseGraphOptimization.zip",
+        "af085b28d79dea7f0a50aef50c96b62c"};
 
 DemoPoseGraphOptimization::DemoPoseGraphOptimization(
         const std::string& data_root)

--- a/cpp/open3d/data/dataset/EaglePointCloud.cpp
+++ b/cpp/open3d/data/dataset/EaglePointCloud.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220201-data/EaglePointCloud.ply"},
-        "e4e6c77bc548e7eb7548542a0220ad78",
-        false};
+        Open3DDownloadsPrefix() + "20220201-data/EaglePointCloud.ply",
+        "e4e6c77bc548e7eb7548542a0220ad78"};
 
 EaglePointCloud::EaglePointCloud(const std::string& data_root)
     : DownloadDataset("EaglePointCloud", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/FlightHelmetModel.cpp
+++ b/cpp/open3d/data/dataset/FlightHelmetModel.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220301-data/FlightHelmetModel.zip"},
-        "597c3aa8b46955fff1949a8baa768bb4",
-        true};
+        Open3DDownloadsPrefix() + "20220301-data/FlightHelmetModel.zip",
+        "597c3aa8b46955fff1949a8baa768bb4"};
 
 FlightHelmetModel::FlightHelmetModel(const std::string& data_root)
     : DownloadDataset("FlightHelmetModel", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/JackJackL515Bag.cpp
+++ b/cpp/open3d/data/dataset/JackJackL515Bag.cpp
@@ -33,9 +33,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220301-data/JackJackL515Bag.bag"},
-        "9f670dc92569b986b739c4179a659176",
-        false};
+        Open3DDownloadsPrefix() + "20220301-data/JackJackL515Bag.bag",
+        "9f670dc92569b986b739c4179a659176"};
 
 JackJackL515Bag::JackJackL515Bag(const std::string& data_root)
     : DownloadDataset("JackJackL515Bag", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/JuneauImage.cpp
+++ b/cpp/open3d/data/dataset/JuneauImage.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220201-data/JuneauImage.jpg"},
-        "a090f6342893bdf0caefd83c6debbecd",
-        false};
+        Open3DDownloadsPrefix() + "20220201-data/JuneauImage.jpg",
+        "a090f6342893bdf0caefd83c6debbecd"};
 
 JuneauImage::JuneauImage(const std::string& data_root)
     : DownloadDataset("JuneauImage", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/KnotMesh.cpp
+++ b/cpp/open3d/data/dataset/KnotMesh.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220201-data/KnotMesh.ply"},
-        "bfc9f132ecdfb7f9fdc42abf620170fc",
-        false};
+        Open3DDownloadsPrefix() + "20220201-data/KnotMesh.ply",
+        "bfc9f132ecdfb7f9fdc42abf620170fc"};
 
 KnotMesh::KnotMesh(const std::string& data_root)
     : DownloadDataset("KnotMesh", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/LivingRoomPointClouds.cpp
+++ b/cpp/open3d/data/dataset/LivingRoomPointClouds.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "redwood/livingroom1-fragments-ply.zip"},
-        "36e0eb23a66ccad6af52c05f8390d33e",
-        true};
+        Open3DDownloadsPrefix() + "redwood/livingroom1-fragments-ply.zip",
+        "36e0eb23a66ccad6af52c05f8390d33e"};
 
 LivingRoomPointClouds::LivingRoomPointClouds(const std::string& data_root)
     : DownloadDataset("LivingRoomPointClouds", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/LoungeRGBDImages.cpp
+++ b/cpp/open3d/data/dataset/LoungeRGBDImages.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220301-data/LoungeRGBDImages.zip"},
-        "cdd307caef898519a8829ce1b6ab9f75",
-        true};
+        Open3DDownloadsPrefix() + "20220301-data/LoungeRGBDImages.zip",
+        "cdd307caef898519a8829ce1b6ab9f75"};
 
 LoungeRGBDImages::LoungeRGBDImages(const std::string& data_root)
     : DownloadDataset("LoungeRGBDImages", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/MetalTexture.cpp
+++ b/cpp/open3d/data/dataset/MetalTexture.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220301-data/MetalTexture.zip"},
-        "2b6a17e41157138868a2cd2926eedcc7",
-        true};
+        Open3DDownloadsPrefix() + "20220301-data/MetalTexture.zip",
+        "2b6a17e41157138868a2cd2926eedcc7"};
 
 MetalTexture::MetalTexture(const std::string& data_root)
     : DownloadDataset("MetalTexture", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/MonkeyModel.cpp
+++ b/cpp/open3d/data/dataset/MonkeyModel.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220301-data/MonkeyModel.zip"},
-        "fc330bf4fd8e022c1e5ded76139785d4",
-        true};
+        Open3DDownloadsPrefix() + "20220301-data/MonkeyModel.zip",
+        "fc330bf4fd8e022c1e5ded76139785d4"};
 
 MonkeyModel::MonkeyModel(const std::string& data_root)
     : DownloadDataset("MonkeyModel", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/OfficePointClouds.cpp
+++ b/cpp/open3d/data/dataset/OfficePointClouds.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "redwood/office1-fragments-ply.zip"},
-        "c519fe0495b3c731ebe38ae3a227ac25",
-        true};
+        Open3DDownloadsPrefix() + "redwood/office1-fragments-ply.zip",
+        "c519fe0495b3c731ebe38ae3a227ac25"};
 
 OfficePointClouds::OfficePointClouds(const std::string& data_root)
     : DownloadDataset("OfficePointClouds", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/PCDPointCloud.cpp
+++ b/cpp/open3d/data/dataset/PCDPointCloud.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220201-data/fragment.pcd"},
-        "f3a613fd2bdecd699aabdd858fb29606",
-        false};
+        Open3DDownloadsPrefix() + "20220201-data/fragment.pcd",
+        "f3a613fd2bdecd699aabdd858fb29606"};
 
 PCDPointCloud::PCDPointCloud(const std::string& data_root)
     : DownloadDataset("PCDPointCloud", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/PLYPointCloud.cpp
+++ b/cpp/open3d/data/dataset/PLYPointCloud.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220201-data/fragment.ply"},
-        "831ecffd4d7cbbbe02494c5c351aa6e5",
-        false};
+        Open3DDownloadsPrefix() + "20220201-data/fragment.ply",
+        "831ecffd4d7cbbbe02494c5c351aa6e5"};
 
 PLYPointCloud::PLYPointCloud(const std::string& data_root)
     : DownloadDataset("PLYPointCloud", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/PTSPointCloud.cpp
+++ b/cpp/open3d/data/dataset/PTSPointCloud.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220301-data/point_cloud_sample1.pts"},
-        "5c2c618b703d0161e6e333fcbf55a1e9",
-        false};
+        Open3DDownloadsPrefix() + "20220301-data/point_cloud_sample1.pts",
+        "5c2c618b703d0161e6e333fcbf55a1e9"};
 
 PTSPointCloud::PTSPointCloud(const std::string& data_root)
     : DownloadDataset("PTSPointCloud", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/PaintedPlasterTexture.cpp
+++ b/cpp/open3d/data/dataset/PaintedPlasterTexture.cpp
@@ -34,10 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() +
-         "20220301-data/PaintedPlasterTexture.zip"},
-        "344096b29b06f14aac58f9ad73851dc2",
-        true};
+        Open3DDownloadsPrefix() + "20220301-data/PaintedPlasterTexture.zip",
+        "344096b29b06f14aac58f9ad73851dc2"};
 
 PaintedPlasterTexture::PaintedPlasterTexture(const std::string& data_root)
     : DownloadDataset("PaintedPlasterTexture", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/RedwoodIndoorLivingRoom1.cpp
+++ b/cpp/open3d/data/dataset/RedwoodIndoorLivingRoom1.cpp
@@ -1,0 +1,100 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include <string>
+#include <vector>
+
+#include "open3d/data/Dataset.h"
+#include "open3d/utility/FileSystem.h"
+#include "open3d/utility/Logging.h"
+
+namespace open3d {
+namespace data {
+
+const static std::vector<DataDescriptor> data_descriptors = {
+        {Open3DDownloadsPrefix() + "augmented-icl-nuim/livingroom.ply.zip",
+         "841f32ff6294bb52d5f9574834e0925e"},
+        {Open3DDownloadsPrefix() + "augmented-icl-nuim/livingroom1-color.zip",
+         "c23481094ca3859b204d2fcbb4e435a4", "color"},
+        {Open3DDownloadsPrefix() +
+                 "augmented-icl-nuim/livingroom1-depth-clean.zip",
+         "6867ddac0e7aafe828a218b385f61985", "depth"},
+        {Open3DDownloadsPrefix() +
+                 "augmented-icl-nuim/livingroom1-depth-simulated.zip",
+         "2fec03a29258a29b9ffedde88fddd676", "depth_noisy"},
+        {Open3DDownloadsPrefix() + "augmented-icl-nuim/livingroom1-traj.txt",
+         "601ac4b51aba2455a90aed8aa1158c6a"},
+        {Open3DDownloadsPrefix() + "augmented-icl-nuim/livingroom1.oni.zip",
+         "fb201903f211f31ccd01886457bb004c"},
+};
+
+RedwoodIndoorLivingRoom1::RedwoodIndoorLivingRoom1(const std::string& data_root)
+    : DownloadDataset("RedwoodIndoorLivingRoom1", data_descriptors, data_root) {
+    const std::string extract_dir = GetExtractDir();
+    std::vector<std::string> all_paths;
+
+    // point_cloud_path_
+    point_cloud_path_ = extract_dir + "/livingroom.ply";
+    all_paths.push_back(point_cloud_path_);
+
+    // color_paths_
+    for (int i = 0; i <= 2869; i++) {
+        const std::string path =
+                extract_dir + "/color/" + fmt::format("{:05d}.jpg", i);
+        color_paths_.push_back(path);
+        all_paths.push_back(path);
+    }
+
+    // depth_paths_
+    for (int i = 0; i <= 2869; i++) {
+        const std::string path =
+                extract_dir + "/depth/" + fmt::format("{:05d}.png", i);
+        depth_paths_.push_back(path);
+        all_paths.push_back(path);
+    }
+
+    // noisy_depth_paths_
+    for (int i = 0; i <= 2869; i++) {
+        const std::string path =
+                extract_dir + "/depth_noisy/" + fmt::format("{:05d}.png", i);
+        noisy_depth_paths_.push_back(path);
+        all_paths.push_back(path);
+    }
+
+    // oni_path_
+    oni_path_ = extract_dir + "/livingroom1.oni";
+    all_paths.push_back(oni_path_);
+
+    // trajectory_path_
+    trajectory_path_ = extract_dir + "/livingroom1-traj.txt";
+    all_paths.push_back(trajectory_path_);
+
+    // Check all files exist.
+    CheckPathsExist(all_paths);
+}
+
+}  // namespace data
+}  // namespace open3d

--- a/cpp/open3d/data/dataset/RedwoodIndoorLivingRoom2.cpp
+++ b/cpp/open3d/data/dataset/RedwoodIndoorLivingRoom2.cpp
@@ -1,0 +1,99 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include <string>
+#include <vector>
+
+#include "open3d/data/Dataset.h"
+#include "open3d/utility/Logging.h"
+
+namespace open3d {
+namespace data {
+
+const static std::vector<DataDescriptor> data_descriptors = {
+        {Open3DDownloadsPrefix() + "augmented-icl-nuim/livingroom.ply.zip",
+         "841f32ff6294bb52d5f9574834e0925e"},
+        {Open3DDownloadsPrefix() + "augmented-icl-nuim/livingroom2-color.zip",
+         "34792f7aa35b6c8b62e394e9372b95d7", "color"},
+        {Open3DDownloadsPrefix() +
+                 "augmented-icl-nuim/livingroom2-depth-clean.zip",
+         "569c7ba065c3a84de32b0d0844699f43", "depth"},
+        {Open3DDownloadsPrefix() +
+                 "augmented-icl-nuim/livingroom2-depth-simulated.zip",
+         "cbb4a36b8488448d79ec93c202c0c90e", "depth_noisy"},
+        {Open3DDownloadsPrefix() + "augmented-icl-nuim/livingroom2-traj.txt",
+         "193961c018f4c2a753458d5231544036"},
+        {Open3DDownloadsPrefix() + "augmented-icl-nuim/livingroom2.oni.zip",
+         "b827aa33cddffc8131d9b25007930137"},
+};
+
+RedwoodIndoorLivingRoom2::RedwoodIndoorLivingRoom2(const std::string& data_root)
+    : DownloadDataset("RedwoodIndoorLivingRoom2", data_descriptors, data_root) {
+    const std::string extract_dir = GetExtractDir();
+    std::vector<std::string> all_paths;
+
+    // point_cloud_path_
+    point_cloud_path_ = extract_dir + "/livingroom.ply";
+    all_paths.push_back(point_cloud_path_);
+
+    // color_paths_
+    for (int i = 0; i <= 2349; i++) {
+        const std::string path =
+                extract_dir + "/color/" + fmt::format("{:05d}.jpg", i);
+        color_paths_.push_back(path);
+        all_paths.push_back(path);
+    }
+
+    // depth_paths_
+    for (int i = 0; i <= 2349; i++) {
+        const std::string path =
+                extract_dir + "/depth/" + fmt::format("{:05d}.png", i);
+        depth_paths_.push_back(path);
+        all_paths.push_back(path);
+    }
+
+    // noisy_depth_paths_
+    for (int i = 0; i <= 2349; i++) {
+        const std::string path =
+                extract_dir + "/depth_noisy/" + fmt::format("{:05d}.png", i);
+        noisy_depth_paths_.push_back(path);
+        all_paths.push_back(path);
+    }
+
+    // oni_path_
+    oni_path_ = extract_dir + "/livingroom2.oni";
+    all_paths.push_back(oni_path_);
+
+    // trajectory_path_
+    trajectory_path_ = extract_dir + "/livingroom2-traj.txt";
+    all_paths.push_back(trajectory_path_);
+
+    // Check all files exist.
+    CheckPathsExist(all_paths);
+}
+
+}  // namespace data
+}  // namespace open3d

--- a/cpp/open3d/data/dataset/RedwoodIndoorOffice1.cpp
+++ b/cpp/open3d/data/dataset/RedwoodIndoorOffice1.cpp
@@ -1,0 +1,98 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include <string>
+#include <vector>
+
+#include "open3d/data/Dataset.h"
+#include "open3d/utility/Logging.h"
+
+namespace open3d {
+namespace data {
+
+const static std::vector<DataDescriptor> data_descriptors = {
+        {Open3DDownloadsPrefix() + "augmented-icl-nuim/office.ply.zip",
+         "ba3640bba38f19c8f2d5e86e045eeae5"},
+        {Open3DDownloadsPrefix() + "augmented-icl-nuim/office1-color.zip",
+         "6a58750880e83ac5948e0f28de294c04", "color"},
+        {Open3DDownloadsPrefix() + "augmented-icl-nuim/office1-depth-clean.zip",
+         "0a952d68eb76e84fad63e362a59f82cd", "depth"},
+        {Open3DDownloadsPrefix() +
+                 "augmented-icl-nuim/office1-depth-simulated.zip",
+         "7c7e479191d35c2ad1f8ac1c227f4f8d", "depth_noisy"},
+        {Open3DDownloadsPrefix() + "augmented-icl-nuim/office1-traj.txt",
+         "3fac752ab38a4e8a96d1b5afa535f9f7"},
+        {Open3DDownloadsPrefix() + "augmented-icl-nuim/office1.oni.zip",
+         "1edd52a60b052fde97b05ae3d628caba"},
+};
+
+RedwoodIndoorOffice1::RedwoodIndoorOffice1(const std::string& data_root)
+    : DownloadDataset("RedwoodIndoorOffice1", data_descriptors, data_root) {
+    const std::string extract_dir = GetExtractDir();
+    std::vector<std::string> all_paths;
+
+    // point_cloud_path_
+    point_cloud_path_ = extract_dir + "/office.ply";
+    all_paths.push_back(point_cloud_path_);
+
+    // color_paths_
+    for (int i = 0; i <= 2689; i++) {
+        const std::string path =
+                extract_dir + "/color/" + fmt::format("{:05d}.jpg", i);
+        color_paths_.push_back(path);
+        all_paths.push_back(path);
+    }
+
+    // depth_paths_
+    for (int i = 0; i <= 2689; i++) {
+        const std::string path =
+                extract_dir + "/depth/" + fmt::format("{:05d}.png", i);
+        depth_paths_.push_back(path);
+        all_paths.push_back(path);
+    }
+
+    // noisy_depth_paths_
+    for (int i = 0; i <= 2689; i++) {
+        const std::string path =
+                extract_dir + "/depth_noisy/" + fmt::format("{:05d}.png", i);
+        noisy_depth_paths_.push_back(path);
+        all_paths.push_back(path);
+    }
+
+    // oni_path_
+    oni_path_ = extract_dir + "/office1.oni";
+    all_paths.push_back(oni_path_);
+
+    // trajectory_path_
+    trajectory_path_ = extract_dir + "/office1-traj.txt";
+    all_paths.push_back(trajectory_path_);
+
+    // Check all files exist.
+    CheckPathsExist(all_paths);
+}
+
+}  // namespace data
+}  // namespace open3d

--- a/cpp/open3d/data/dataset/RedwoodIndoorOffice2.cpp
+++ b/cpp/open3d/data/dataset/RedwoodIndoorOffice2.cpp
@@ -1,0 +1,98 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include <string>
+#include <vector>
+
+#include "open3d/data/Dataset.h"
+#include "open3d/utility/Logging.h"
+
+namespace open3d {
+namespace data {
+
+const static std::vector<DataDescriptor> data_descriptors = {
+        {Open3DDownloadsPrefix() + "augmented-icl-nuim/office.ply.zip",
+         "ba3640bba38f19c8f2d5e86e045eeae5"},
+        {Open3DDownloadsPrefix() + "augmented-icl-nuim/office2-color.zip",
+         "487cdfacffc8fc8247a5b21e860a3794", "color"},
+        {Open3DDownloadsPrefix() + "augmented-icl-nuim/office2-depth-clean.zip",
+         "386203a7a5dae21db6d8430ae36dcc8b", "depth"},
+        {Open3DDownloadsPrefix() +
+                 "augmented-icl-nuim/office2-depth-simulated.zip",
+         "13f1c5b7c4f44524fa91f7ba87e44bb5", "depth_noisy"},
+        {Open3DDownloadsPrefix() + "augmented-icl-nuim/office2-traj.txt",
+         "698f2f09da7d2ed3fcb604889e6f8479"},
+        {Open3DDownloadsPrefix() + "augmented-icl-nuim/office2.oni.zip",
+         "dcbd567442f29bd6080d74b5a384cd0d"},
+};
+
+RedwoodIndoorOffice2::RedwoodIndoorOffice2(const std::string& data_root)
+    : DownloadDataset("RedwoodIndoorOffice2", data_descriptors, data_root) {
+    const std::string extract_dir = GetExtractDir();
+    std::vector<std::string> all_paths;
+
+    // point_cloud_path_
+    point_cloud_path_ = extract_dir + "/office.ply";
+    all_paths.push_back(point_cloud_path_);
+
+    // color_paths_
+    for (int i = 0; i <= 2537; i++) {
+        const std::string path =
+                extract_dir + "/color/" + fmt::format("{:05d}.jpg", i);
+        color_paths_.push_back(path);
+        all_paths.push_back(path);
+    }
+
+    // depth_paths_
+    for (int i = 0; i <= 2537; i++) {
+        const std::string path =
+                extract_dir + "/depth/" + fmt::format("{:05d}.png", i);
+        depth_paths_.push_back(path);
+        all_paths.push_back(path);
+    }
+
+    // noisy_depth_paths_
+    for (int i = 0; i <= 2537; i++) {
+        const std::string path =
+                extract_dir + "/depth_noisy/" + fmt::format("{:05d}.png", i);
+        noisy_depth_paths_.push_back(path);
+        all_paths.push_back(path);
+    }
+
+    // oni_path_
+    oni_path_ = extract_dir + "/office2.oni";
+    all_paths.push_back(oni_path_);
+
+    // trajectory_path_
+    trajectory_path_ = extract_dir + "/office2-traj.txt";
+    all_paths.push_back(trajectory_path_);
+
+    // Check all files exist.
+    CheckPathsExist(all_paths);
+}
+
+}  // namespace data
+}  // namespace open3d

--- a/cpp/open3d/data/dataset/SampleFountainRGBDImages.cpp
+++ b/cpp/open3d/data/dataset/SampleFountainRGBDImages.cpp
@@ -34,10 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() +
-         "20220201-data/SampleFountainRGBDImages.zip"},
-        "c6c1b2171099f571e2a78d78675df350",
-        true};
+        Open3DDownloadsPrefix() + "20220201-data/SampleFountainRGBDImages.zip",
+        "c6c1b2171099f571e2a78d78675df350"};
 
 SampleFountainRGBDImages::SampleFountainRGBDImages(const std::string& data_root)
     : DownloadDataset("SampleFountainRGBDImages", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/SampleICPPointClouds.cpp
+++ b/cpp/open3d/data/dataset/SampleICPPointClouds.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "xxx/SampleICPPointClouds.zip"},
-        "9d1ead73e678fa2f51a70a933b0bf017",
-        true};
+        Open3DDownloadsPrefix() + "xxx/SampleICPPointClouds.zip",
+        "9d1ead73e678fa2f51a70a933b0bf017"};
 
 SampleICPPointClouds::SampleICPPointClouds(const std::string& data_root)
     : DownloadDataset("SampleICPPointClouds", data_descriptor, data_root) {}

--- a/cpp/open3d/data/dataset/SampleL515Bag.cpp
+++ b/cpp/open3d/data/dataset/SampleL515Bag.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220301-data/SampleL515Bag.zip"},
-        "9770eeb194c78103037dbdbec78b9c8c",
-        true};
+        Open3DDownloadsPrefix() + "20220301-data/SampleL515Bag.zip",
+        "9770eeb194c78103037dbdbec78b9c8c"};
 
 SampleL515Bag::SampleL515Bag(const std::string& data_root)
     : DownloadDataset("SampleL515Bag", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/SampleNYURGBDImage.cpp
+++ b/cpp/open3d/data/dataset/SampleNYURGBDImage.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220201-data/SampleNYURGBDImage.zip"},
-        "b0baaf892c7ff9b202eb5fb40c5f7b58",
-        true};
+        Open3DDownloadsPrefix() + "20220201-data/SampleNYURGBDImage.zip",
+        "b0baaf892c7ff9b202eb5fb40c5f7b58"};
 
 SampleNYURGBDImage::SampleNYURGBDImage(const std::string& data_root)
     : DownloadDataset("SampleNYURGBDImage", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/SampleRedwoodRGBDImages.cpp
+++ b/cpp/open3d/data/dataset/SampleRedwoodRGBDImages.cpp
@@ -34,10 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() +
-         "20220301-data/SampleRedwoodRGBDImages.zip"},
-        "43971c5f690c9cfc52dda8c96a0140ee",
-        true};
+        Open3DDownloadsPrefix() + "20220301-data/SampleRedwoodRGBDImages.zip",
+        "43971c5f690c9cfc52dda8c96a0140ee"};
 
 SampleRedwoodRGBDImages::SampleRedwoodRGBDImages(const std::string& data_root)
     : DownloadDataset("SampleRedwoodRGBDImages", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/SampleSUNRGBDImage.cpp
+++ b/cpp/open3d/data/dataset/SampleSUNRGBDImage.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220201-data/SampleSUNRGBDImage.zip"},
-        "b1a430586547c8986bdf8b36179a8e67",
-        true};
+        Open3DDownloadsPrefix() + "20220201-data/SampleSUNRGBDImage.zip",
+        "b1a430586547c8986bdf8b36179a8e67"};
 
 SampleSUNRGBDImage::SampleSUNRGBDImage(const std::string& data_root)
     : DownloadDataset("SampleSUNRGBDImage", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/SampleTUMRGBDImage.cpp
+++ b/cpp/open3d/data/dataset/SampleTUMRGBDImage.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220201-data/SampleTUMRGBDImage.zip"},
-        "91758d42b142dbad7b0d90e857ad47a8",
-        true};
+        Open3DDownloadsPrefix() + "20220201-data/SampleTUMRGBDImage.zip",
+        "91758d42b142dbad7b0d90e857ad47a8"};
 
 SampleTUMRGBDImage::SampleTUMRGBDImage(const std::string& data_root)
     : DownloadDataset("SampleTUMRGBDImage", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/SwordModel.cpp
+++ b/cpp/open3d/data/dataset/SwordModel.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220301-data/SwordModel.zip"},
-        "eb7df358b5c31c839f03c4b3b4157c04",
-        true};
+        Open3DDownloadsPrefix() + "20220301-data/SwordModel.zip",
+        "eb7df358b5c31c839f03c4b3b4157c04"};
 
 SwordModel::SwordModel(const std::string& data_root)
     : DownloadDataset("SwordModel", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/TerrazzoTexture.cpp
+++ b/cpp/open3d/data/dataset/TerrazzoTexture.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220301-data/TerrazzoTexture.zip"},
-        "8d67f191fb5d80a27d8110902cac008e",
-        true};
+        Open3DDownloadsPrefix() + "20220301-data/TerrazzoTexture.zip",
+        "8d67f191fb5d80a27d8110902cac008e"};
 
 TerrazzoTexture::TerrazzoTexture(const std::string& data_root)
     : DownloadDataset("TerrazzoTexture", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/TilesTexture.cpp
+++ b/cpp/open3d/data/dataset/TilesTexture.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220301-data/TilesTexture.zip"},
-        "23f47f1e8e1799216724eb0c837c274d",
-        true};
+        Open3DDownloadsPrefix() + "20220301-data/TilesTexture.zip",
+        "23f47f1e8e1799216724eb0c837c274d"};
 
 TilesTexture::TilesTexture(const std::string& data_root)
     : DownloadDataset("TilesTexture", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/WoodFloorTexture.cpp
+++ b/cpp/open3d/data/dataset/WoodFloorTexture.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220301-data/WoodFloorTexture.zip"},
-        "f11b3e50208095e87340049b9ac3c319",
-        true};
+        Open3DDownloadsPrefix() + "20220301-data/WoodFloorTexture.zip",
+        "f11b3e50208095e87340049b9ac3c319"};
 
 WoodFloorTexture::WoodFloorTexture(const std::string& data_root)
     : DownloadDataset("WoodFloorTexture", data_descriptor, data_root) {

--- a/cpp/open3d/data/dataset/WoodTexture.cpp
+++ b/cpp/open3d/data/dataset/WoodTexture.cpp
@@ -34,9 +34,8 @@ namespace open3d {
 namespace data {
 
 const static DataDescriptor data_descriptor = {
-        {Open3DDownloadsURLPrefix() + "20220301-data/WoodTexture.zip"},
-        "28788c7ecc42d78d4d623afbab2301e9",
-        true};
+        Open3DDownloadsPrefix() + "20220301-data/WoodTexture.zip",
+        "28788c7ecc42d78d4d623afbab2301e9"};
 
 WoodTexture::WoodTexture(const std::string& data_root)
     : DownloadDataset("WoodTexture", data_descriptor, data_root) {

--- a/cpp/open3d/utility/Extract.cpp
+++ b/cpp/open3d/utility/Extract.cpp
@@ -42,18 +42,27 @@ static const std::unordered_map<
                 {"zip", ExtractFromZIP},
         };
 
-void Extract(const std::string& file_path, const std::string& extract_dir) {
+bool IsSupportedCompressedFilePath(const std::string& file_path) {
     const std::string format =
             utility::filesystem::GetFileExtensionInLowerCase(file_path);
-    utility::LogInfo("Extracting {}.", file_path);
+    return file_extension_to_extract_function.count(format) != 0;
+}
 
-    if (file_extension_to_extract_function.count(format) == 0) {
-        utility::LogError(
-                "Extraction Failed: unknown file extension for "
-                "{} (format: {}).",
-                file_path, format);
+void Extract(const std::string& file_path, const std::string& extract_dir) {
+    if (!utility::filesystem::FileExists(file_path)) {
+        utility::LogError("File {} does not exist.", file_path);
     }
-
+    if (!IsSupportedCompressedFilePath(file_path)) {
+        utility::LogError("Extraction Failed: unknown extension for {}.",
+                          file_path);
+    }
+    if (!utility::filesystem::DirectoryExists(extract_dir)) {
+        utility::filesystem::MakeDirectoryHierarchy(extract_dir);
+        utility::LogInfo("Created directory {}.", extract_dir);
+    }
+    utility::LogInfo("Extracting {}.", file_path);
+    const std::string format =
+            utility::filesystem::GetFileExtensionInLowerCase(file_path);
     file_extension_to_extract_function.at(format)(file_path, extract_dir);
     utility::LogInfo("Extracted to {}.", extract_dir);
 }

--- a/cpp/open3d/utility/Extract.h
+++ b/cpp/open3d/utility/Extract.h
@@ -31,9 +31,15 @@
 namespace open3d {
 namespace utility {
 
+/// \brief Returns true if the file is a supported compressed file path. It does
+/// not check if the file exists. It only checks the file extension.
+/// \param file_path The file path to check.
+bool IsSupportedCompressedFilePath(const std::string& file_path);
+
 /// \brief Function to extract compressed files.
 /// \param file_path Path to file. Example: "/path/to/file/file.zip"
-/// \param extract_dir Directory path where the file will be extracted to.
+/// \param extract_dir Directory path where the file will be extracted to. If
+/// the directory does not exist, it will be created.
 void Extract(const std::string& file_path, const std::string& extract_dir);
 
 }  // namespace utility

--- a/cpp/open3d/utility/ExtractZIP.cpp
+++ b/cpp/open3d/utility/ExtractZIP.cpp
@@ -134,8 +134,6 @@ static int ExtractCurrentFile(unzFile uf,
         }
 
         if (fout != nullptr) {
-            utility::LogDebug(" Extracting: {}", write_filename);
-
             do {
                 err = unzReadCurrentFile(uf, buf, size_buf);
                 if (err < 0) {

--- a/cpp/pybind/data/dataset.cpp
+++ b/cpp/pybind/data/dataset.cpp
@@ -46,6 +46,9 @@ public:
 };
 
 void pybind_data_classes(py::module& m) {
+    // open3d.data.open3d_downloads_prefix as static attr of open3d.data.
+    m.attr("open3d_downloads_prefix") = py::cast(Open3DDownloadsPrefix());
+
     // open3d.data.DataDescriptor
     py::class_<DataDescriptor> data_descriptor(
             m, "DataDescriptor",
@@ -54,16 +57,26 @@ void pybind_data_classes(py::module& m) {
             "and wether to extract the file.");
     data_descriptor
             .def(py::init([](const std::vector<std::string>& urls,
-                             const std::string& md5, const bool do_extract) {
-                     return DataDescriptor{urls, md5, do_extract};
+                             const std::string& md5,
+                             const std::string& extract_in_subdir) {
+                     return DataDescriptor{urls, md5, extract_in_subdir};
                  }),
-                 "urls"_a, "md5"_a, "do_extract"_a)
+                 "urls"_a, "md5"_a, "extract_in_subdir"_a = "")
+            .def(py::init([](const std::string& url, const std::string& md5,
+                             const std::string& extract_in_subdir) {
+                     return DataDescriptor{std::vector<std::string>{url}, md5,
+                                           extract_in_subdir};
+                 }),
+                 "url"_a, "md5"_a, "extract_in_subdir"_a = "")
             .def_readonly("urls", &DataDescriptor::urls_,
                           "URL to download the data file.")
             .def_readonly("md5", &DataDescriptor::md5_,
                           "MD5 hash of the data file.")
-            .def_readonly("do_extract", &DataDescriptor::do_extract_,
-                          "Whether to extract the downloaded file.");
+            .def_readonly("extract_in_subdir",
+                          &DataDescriptor::extract_in_subdir_,
+                          "Subdirectory to extract the file. If empty, the "
+                          "file will be extracted in the root extract "
+                          "directory of the dataset.");
 
     // open3d.data.Dataset
     py::class_<Dataset, PyDataset<Dataset>, std::shared_ptr<Dataset>> dataset(
@@ -257,7 +270,7 @@ void pybind_demo_custom_visualization(py::module& m) {
                                    "Returns path to the point cloud (ply).")
             .def_property_readonly(
                     "camera_trajectory_path",
-                    &DemoCustomVisualization::GetCameraTrajectoryPath,
+                    &DemoCustomVisualization::GetTrajectoryPath,
                     "Returns path to the camera_trajectory.json.")
             .def_property_readonly(
                     "render_option_path",
@@ -972,6 +985,206 @@ void pybind_jackjack_l515_bag(py::module& m) {
     docstring::ClassMethodDocInject(m, "JackJackL515Bag", "path");
 }
 
+void pybind_redwood_indoor_living_room1(py::module& m) {
+    py::class_<RedwoodIndoorLivingRoom1,
+               PyDownloadDataset<RedwoodIndoorLivingRoom1>,
+               std::shared_ptr<RedwoodIndoorLivingRoom1>, DownloadDataset>
+            dataset(m, "RedwoodIndoorLivingRoom1",
+                    R"doc(RedwoodIndoorLivingRoom1 (Augmented ICL-NUIM Dataset)
+Data class for `RedwoodIndoorLivingRoom1`, containing dense point
+cloud, rgb sequence, clean depth sequence, noisy depth sequence, oni
+sequence, and ground-truth camera trajectory.
+
+RedwoodIndoorLivingRoom1
+├── colors
+│   ├── 00000.jpg
+│   ├── 00001.jpg
+│   ├── ...
+│   └── 02869.jpg
+├── depth
+│   ├── 00000.png
+│   ├── 00001.png
+│   ├── ...
+│   └── 02869.png
+├── depth_noisy
+│   ├── 00000.png
+│   ├── 00001.png
+│   ├── ...
+│   └── 02869.png
+├── livingroom1.oni
+├── livingroom1-traj.txt
+└── livingroom.ply
+)doc");
+    dataset.def(py::init<const std::string&>(), "data_root"_a = "");
+    dataset.def_property_readonly("point_cloud_path",
+                                  &RedwoodIndoorLivingRoom1::GetPointCloudPath,
+                                  "Path to the point cloud.");
+    dataset.def_property_readonly("color_paths",
+                                  &RedwoodIndoorLivingRoom1::GetColorPaths,
+                                  "List of paths to color images.");
+    dataset.def_property_readonly("depth_paths",
+                                  &RedwoodIndoorLivingRoom1::GetDepthPaths,
+                                  "List of paths to depth images.");
+    dataset.def_property_readonly("noisy_depth_paths",
+                                  &RedwoodIndoorLivingRoom1::GetNoisyDepthPaths,
+                                  "List of paths to noisy depth images.");
+    dataset.def_property_readonly("oni_path",
+                                  &RedwoodIndoorLivingRoom1::GetONIPath,
+                                  "Path to the oni file.");
+    dataset.def_property_readonly("trajectory_path",
+                                  &RedwoodIndoorLivingRoom1::GetTrajectoryPath,
+                                  "Path to the trajectory file.");
+}
+
+void pybind_redwood_indoor_living_room2(py::module& m) {
+    py::class_<RedwoodIndoorLivingRoom2,
+               PyDownloadDataset<RedwoodIndoorLivingRoom2>,
+               std::shared_ptr<RedwoodIndoorLivingRoom2>, DownloadDataset>
+            dataset(m, "RedwoodIndoorLivingRoom2",
+                    R"doc(RedwoodIndoorLivingRoom2 (Augmented ICL-NUIM Dataset)
+Data class for `RedwoodIndoorLivingRoom2`, containing dense point
+cloud, rgb sequence, clean depth sequence, noisy depth sequence, oni
+sequence, and ground-truth camera trajectory.
+
+RedwoodIndoorLivingRoom2
+├── colors
+│   ├── 00000.jpg
+│   ├── 00001.jpg
+│   ├── ...
+│   └── 02349.jpg
+├── depth
+│   ├── 00000.png
+│   ├── 00001.png
+│   ├── ...
+│   └── 02349.png
+├── depth_noisy
+│   ├── 00000.png
+│   ├── 00001.png
+│   ├── ...
+│   └── 02349.png
+├── livingroom2.oni
+├── livingroom2-traj.txt
+└── livingroom.ply
+)doc");
+    dataset.def(py::init<const std::string&>(), "data_root"_a = "");
+    dataset.def_property_readonly("point_cloud_path",
+                                  &RedwoodIndoorLivingRoom2::GetPointCloudPath,
+                                  "Path to the point cloud.");
+    dataset.def_property_readonly("color_paths",
+                                  &RedwoodIndoorLivingRoom2::GetColorPaths,
+                                  "List of paths to color images.");
+    dataset.def_property_readonly("depth_paths",
+                                  &RedwoodIndoorLivingRoom2::GetDepthPaths,
+                                  "List of paths to depth images.");
+    dataset.def_property_readonly("noisy_depth_paths",
+                                  &RedwoodIndoorLivingRoom2::GetNoisyDepthPaths,
+                                  "List of paths to noisy depth images.");
+    dataset.def_property_readonly("oni_path",
+                                  &RedwoodIndoorLivingRoom2::GetONIPath,
+                                  "Path to the oni file.");
+    dataset.def_property_readonly("trajectory_path",
+                                  &RedwoodIndoorLivingRoom2::GetTrajectoryPath,
+                                  "Path to the trajectory file.");
+}
+
+void pybind_redwood_indoor_office1(py::module& m) {
+    py::class_<RedwoodIndoorOffice1, PyDownloadDataset<RedwoodIndoorOffice1>,
+               std::shared_ptr<RedwoodIndoorOffice1>, DownloadDataset>
+            dataset(m, "RedwoodIndoorOffice1",
+                    R"doc(RedwoodIndoorOffice1 (Augmented ICL-NUIM Dataset)
+Data class for `RedwoodIndoorOffice1`, containing dense point
+cloud, rgb sequence, clean depth sequence, noisy depth sequence, oni
+sequence, and ground-truth camera trajectory.
+
+RedwoodIndoorOffice1
+├── colors
+│   ├── 00000.jpg
+│   ├── 00001.jpg
+│   ├── ...
+│   └── 02689.jpg
+├── depth
+│   ├── 00000.png
+│   ├── 00001.png
+│   ├── ...
+│   └── 02689.png
+├── depth_noisy
+│   ├── 00000.png
+│   ├── 00001.png
+│   ├── ...
+│   └── 02689.png
+├── office1.oni
+├── office1-traj.txt
+└── office.ply
+)doc");
+    dataset.def(py::init<const std::string&>(), "data_root"_a = "");
+    dataset.def_property_readonly("point_cloud_path",
+                                  &RedwoodIndoorOffice1::GetPointCloudPath,
+                                  "Path to the point cloud.");
+    dataset.def_property_readonly("color_paths",
+                                  &RedwoodIndoorOffice1::GetColorPaths,
+                                  "List of paths to color images.");
+    dataset.def_property_readonly("depth_paths",
+                                  &RedwoodIndoorOffice1::GetDepthPaths,
+                                  "List of paths to depth images.");
+    dataset.def_property_readonly("noisy_depth_paths",
+                                  &RedwoodIndoorOffice1::GetNoisyDepthPaths,
+                                  "List of paths to noisy depth images.");
+    dataset.def_property_readonly("oni_path", &RedwoodIndoorOffice1::GetONIPath,
+                                  "Path to the oni file.");
+    dataset.def_property_readonly("trajectory_path",
+                                  &RedwoodIndoorOffice1::GetTrajectoryPath,
+                                  "Path to the trajectory file.");
+}
+
+void pybind_redwood_indoor_office2(py::module& m) {
+    py::class_<RedwoodIndoorOffice2, PyDownloadDataset<RedwoodIndoorOffice2>,
+               std::shared_ptr<RedwoodIndoorOffice2>, DownloadDataset>
+            dataset(m, "RedwoodIndoorOffice2",
+                    R"doc(RedwoodIndoorOffice2 (Augmented ICL-NUIM Dataset)
+Data class for `RedwoodIndoorOffice2`, containing dense point
+cloud, rgb sequence, clean depth sequence, noisy depth sequence, oni
+sequence, and ground-truth camera trajectory.
+
+RedwoodIndoorOffice2
+├── colors
+│   ├── 00000.jpg
+│   ├── 00001.jpg
+│   ├── ...
+│   └── 02537.jpg
+├── depth
+│   ├── 00000.png
+│   ├── 00001.png
+│   ├── ...
+│   └── 02537.png
+├── depth_noisy
+│   ├── 00000.png
+│   ├── 00001.png
+│   ├── ...
+│   └── 02537.png
+├── office2.oni
+├── office2-traj.txt
+└── office.ply
+)doc");
+    dataset.def(py::init<const std::string&>(), "data_root"_a = "");
+    dataset.def_property_readonly("point_cloud_path",
+                                  &RedwoodIndoorOffice2::GetPointCloudPath,
+                                  "Path to the point cloud.");
+    dataset.def_property_readonly("color_paths",
+                                  &RedwoodIndoorOffice2::GetColorPaths,
+                                  "List of paths to color images.");
+    dataset.def_property_readonly("depth_paths",
+                                  &RedwoodIndoorOffice2::GetDepthPaths,
+                                  "List of paths to depth images.");
+    dataset.def_property_readonly("noisy_depth_paths",
+                                  &RedwoodIndoorOffice2::GetNoisyDepthPaths,
+                                  "List of paths to noisy depth images.");
+    dataset.def_property_readonly("oni_path", &RedwoodIndoorOffice2::GetONIPath,
+                                  "Path to the oni file.");
+    dataset.def_property_readonly("trajectory_path",
+                                  &RedwoodIndoorOffice2::GetTrajectoryPath,
+                                  "Path to the trajectory file.");
+}
+
 void pybind_data(py::module& m) {
     py::module m_submodule = m.def_submodule("data", "Data handling module.");
     pybind_data_classes(m_submodule);
@@ -1021,6 +1234,11 @@ void pybind_data(py::module& m) {
     pybind_lounge_rgbd_images(m_submodule);
     pybind_bedroom_rgbd_images(m_submodule);
     pybind_jackjack_l515_bag(m_submodule);
+    // RedwoodIndoor (Augmented ICL-NUIM Dataset).
+    pybind_redwood_indoor_living_room1(m_submodule);
+    pybind_redwood_indoor_living_room2(m_submodule);
+    pybind_redwood_indoor_office1(m_submodule);
+    pybind_redwood_indoor_office2(m_submodule);
 }
 
 }  // namespace data

--- a/cpp/tests/data/Dataset.cpp
+++ b/cpp/tests/data/Dataset.cpp
@@ -26,6 +26,7 @@
 
 #include "open3d/data/Dataset.h"
 
+#include "open3d/io/ImageIO.h"
 #include "open3d/t/io/PointCloudIO.h"
 #include "open3d/utility/FileSystem.h"
 #include "open3d/utility/Helper.h"
@@ -62,8 +63,8 @@ TEST(Dataset, DownloadDataset) {
             "20220201-data/BunnyMesh.ply"};
     const std::string md5 = "568f871d1a221ba6627569f1e6f9a3f2";
 
-    data::DownloadDataset single_download_dataset(
-            prefix, {url_mirrors, md5, false}, data_root);
+    data::DownloadDataset single_download_dataset(prefix, {url_mirrors, md5},
+                                                  data_root);
 
     EXPECT_TRUE(
             utility::filesystem::FileExists(download_dir + "/BunnyMesh.ply"));
@@ -603,7 +604,7 @@ TEST(Dataset, PaintedPlasterTexture) {
     EXPECT_EQ(dataset.GetExtractDir(), extract_dir);
 }
 
-TEST(Dataset, DISABLED_RedwoodLivingRoomPointClouds) {
+TEST(Dataset, DISABLED_LivingRoomPointClouds) {
     const std::string prefix = "LivingRoomPointClouds";
     const std::string data_root =
             utility::filesystem::GetHomeDirectory() + "/open3d_data";
@@ -631,7 +632,7 @@ TEST(Dataset, DISABLED_RedwoodLivingRoomPointClouds) {
     EXPECT_EQ(dataset.GetExtractDir(), extract_dir);
 }
 
-TEST(Dataset, DISABLED_RedwoodOfficePointClouds) {
+TEST(Dataset, DISABLED_OfficePointClouds) {
     const std::string prefix = "OfficePointClouds";
     const std::string data_root =
             utility::filesystem::GetHomeDirectory() + "/open3d_data";
@@ -657,6 +658,138 @@ TEST(Dataset, DISABLED_RedwoodOfficePointClouds) {
     EXPECT_EQ(dataset.GetDataRoot(), data_root);
     EXPECT_EQ(dataset.GetDownloadDir(), download_dir);
     EXPECT_EQ(dataset.GetExtractDir(), extract_dir);
+}
+
+TEST(Dataset, DISABLED_RedwoodIndoorLivingRoom1) {
+    const std::string prefix = "RedwoodIndoorLivingRoom1";
+    const std::string data_root =
+            utility::filesystem::GetHomeDirectory() + "/open3d_data";
+    const std::string download_dir = data_root + "/download/" + prefix;
+    const std::string extract_dir = data_root + "/extract/" + prefix;
+
+    data::RedwoodIndoorLivingRoom1 dataset;
+    EXPECT_TRUE(utility::filesystem::DirectoryExists(download_dir));
+    EXPECT_TRUE(utility::filesystem::DirectoryExists(extract_dir));
+
+    auto pcd = io::CreatePointCloudFromFile(dataset.GetPointCloudPath());
+
+    std::vector<std::shared_ptr<geometry::RGBDImage>> im_rgbds;
+    for (size_t i = 0; i < dataset.GetColorPaths().size(); ++i) {
+        auto im_color = io::CreateImageFromFile(dataset.GetColorPaths()[i]);
+        auto im_depth = io::CreateImageFromFile(dataset.GetDepthPaths()[i]);
+        auto im_rgbd = geometry::RGBDImage::CreateFromColorAndDepth(*im_color,
+                                                                    *im_depth);
+        im_rgbds.push_back(im_rgbd);
+    }
+
+    std::vector<std::shared_ptr<geometry::RGBDImage>> im_noisy_rgbds;
+    for (size_t i = 0; i < dataset.GetColorPaths().size(); ++i) {
+        auto im_color = io::CreateImageFromFile(dataset.GetColorPaths()[i]);
+        auto im_depth =
+                io::CreateImageFromFile(dataset.GetNoisyDepthPaths()[i]);
+        auto im_rgbd = geometry::RGBDImage::CreateFromColorAndDepth(*im_color,
+                                                                    *im_depth);
+        im_noisy_rgbds.push_back(im_rgbd);
+    }
+}
+
+TEST(Dataset, DISABLED_RedwoodIndoorLivingRoom2) {
+    const std::string prefix = "RedwoodIndoorLivingRoom2";
+    const std::string data_root =
+            utility::filesystem::GetHomeDirectory() + "/open3d_data";
+    const std::string download_dir = data_root + "/download/" + prefix;
+    const std::string extract_dir = data_root + "/extract/" + prefix;
+
+    data::RedwoodIndoorLivingRoom2 dataset;
+    EXPECT_TRUE(utility::filesystem::DirectoryExists(download_dir));
+    EXPECT_TRUE(utility::filesystem::DirectoryExists(extract_dir));
+
+    auto pcd = io::CreatePointCloudFromFile(dataset.GetPointCloudPath());
+
+    std::vector<std::shared_ptr<geometry::RGBDImage>> im_rgbds;
+    for (size_t i = 0; i < dataset.GetColorPaths().size(); ++i) {
+        auto im_color = io::CreateImageFromFile(dataset.GetColorPaths()[i]);
+        auto im_depth = io::CreateImageFromFile(dataset.GetDepthPaths()[i]);
+        auto im_rgbd = geometry::RGBDImage::CreateFromColorAndDepth(*im_color,
+                                                                    *im_depth);
+        im_rgbds.push_back(im_rgbd);
+    }
+
+    std::vector<std::shared_ptr<geometry::RGBDImage>> im_noisy_rgbds;
+    for (size_t i = 0; i < dataset.GetColorPaths().size(); ++i) {
+        auto im_color = io::CreateImageFromFile(dataset.GetColorPaths()[i]);
+        auto im_depth =
+                io::CreateImageFromFile(dataset.GetNoisyDepthPaths()[i]);
+        auto im_rgbd = geometry::RGBDImage::CreateFromColorAndDepth(*im_color,
+                                                                    *im_depth);
+        im_noisy_rgbds.push_back(im_rgbd);
+    }
+}
+
+TEST(Dataset, DISABLED_RedwoodIndoorOffice1) {
+    const std::string prefix = "RedwoodIndoorOffice1";
+    const std::string data_root =
+            utility::filesystem::GetHomeDirectory() + "/open3d_data";
+    const std::string download_dir = data_root + "/download/" + prefix;
+    const std::string extract_dir = data_root + "/extract/" + prefix;
+
+    data::RedwoodIndoorOffice1 dataset;
+    EXPECT_TRUE(utility::filesystem::DirectoryExists(download_dir));
+    EXPECT_TRUE(utility::filesystem::DirectoryExists(extract_dir));
+
+    auto pcd = io::CreatePointCloudFromFile(dataset.GetPointCloudPath());
+
+    std::vector<std::shared_ptr<geometry::RGBDImage>> im_rgbds;
+    for (size_t i = 0; i < dataset.GetColorPaths().size(); ++i) {
+        auto im_color = io::CreateImageFromFile(dataset.GetColorPaths()[i]);
+        auto im_depth = io::CreateImageFromFile(dataset.GetDepthPaths()[i]);
+        auto im_rgbd = geometry::RGBDImage::CreateFromColorAndDepth(*im_color,
+                                                                    *im_depth);
+        im_rgbds.push_back(im_rgbd);
+    }
+
+    std::vector<std::shared_ptr<geometry::RGBDImage>> im_noisy_rgbds;
+    for (size_t i = 0; i < dataset.GetColorPaths().size(); ++i) {
+        auto im_color = io::CreateImageFromFile(dataset.GetColorPaths()[i]);
+        auto im_depth =
+                io::CreateImageFromFile(dataset.GetNoisyDepthPaths()[i]);
+        auto im_rgbd = geometry::RGBDImage::CreateFromColorAndDepth(*im_color,
+                                                                    *im_depth);
+        im_noisy_rgbds.push_back(im_rgbd);
+    }
+}
+
+TEST(Dataset, DISABLED_RedwoodIndoorOffice2) {
+    const std::string prefix = "RedwoodIndoorOffice2";
+    const std::string data_root =
+            utility::filesystem::GetHomeDirectory() + "/open3d_data";
+    const std::string download_dir = data_root + "/download/" + prefix;
+    const std::string extract_dir = data_root + "/extract/" + prefix;
+
+    data::RedwoodIndoorOffice2 dataset;
+    EXPECT_TRUE(utility::filesystem::DirectoryExists(download_dir));
+    EXPECT_TRUE(utility::filesystem::DirectoryExists(extract_dir));
+
+    auto pcd = io::CreatePointCloudFromFile(dataset.GetPointCloudPath());
+
+    std::vector<std::shared_ptr<geometry::RGBDImage>> im_rgbds;
+    for (size_t i = 0; i < dataset.GetColorPaths().size(); ++i) {
+        auto im_color = io::CreateImageFromFile(dataset.GetColorPaths()[i]);
+        auto im_depth = io::CreateImageFromFile(dataset.GetDepthPaths()[i]);
+        auto im_rgbd = geometry::RGBDImage::CreateFromColorAndDepth(*im_color,
+                                                                    *im_depth);
+        im_rgbds.push_back(im_rgbd);
+    }
+
+    std::vector<std::shared_ptr<geometry::RGBDImage>> im_noisy_rgbds;
+    for (size_t i = 0; i < dataset.GetColorPaths().size(); ++i) {
+        auto im_color = io::CreateImageFromFile(dataset.GetColorPaths()[i]);
+        auto im_depth =
+                io::CreateImageFromFile(dataset.GetNoisyDepthPaths()[i]);
+        auto im_rgbd = geometry::RGBDImage::CreateFromColorAndDepth(*im_color,
+                                                                    *im_depth);
+        im_noisy_rgbds.push_back(im_rgbd);
+    }
 }
 
 TEST(Dataset, SampleFountainRGBDImages) {

--- a/docs/tutorial/data/index.rst
+++ b/docs/tutorial/data/index.rst
@@ -621,7 +621,7 @@ RGBD dataset.
 LoungeRGBDImages
 ------------------
 
-Lounge RGBD dataset from Stanford containing ``color`` and ``depth`` 
+Lounge RGBD dataset from Stanford containing ``color`` and ``depth``
 sequence of 3000 images, along with ``camera trajectory`` and ``reconstruction``.
 
 .. code-block:: python
@@ -660,7 +660,7 @@ sequence of 3000 images, along with ``camera trajectory`` and ``reconstruction``
 BedroomRGBDImages
 ------------------
 
-Bedroom RGBD dataset from Redwood containing ``color`` and ``depth`` 
+Bedroom RGBD dataset from Redwood containing ``color`` and ``depth``
 sequence of 21931 images, along with ``camera trajectory`` and ``reconstruction``.
 
 .. code-block:: python
@@ -811,3 +811,228 @@ graph optimization demo.
                         dataset.GetPoseGraphFragmentPath());
     auto pose_graph_global = io::CreatePoseGraphFromFile(
                         dataset.GetPoseGraphGlobalPath());
+
+RedwoodIndoorLivingRoom1
+------------------------
+
+The living room 1 scene of the Redwood indoor dataset (Augmented ICL-NUIM
+Dataset). The dataset contains a dense point cloud, a rgb sequence, a clean
+depth sequence, a noisy depth sequence, an oni file, and camera trajectory.
+
+
+.. code-block:: python
+
+    dataset = o3d.data.RedwoodIndoorLivingRoom1()
+    assert Path(gt_download_dir).is_dir()
+    pcd = o3d.io.read_point_cloud(dataset.point_cloud_path)
+
+    im_rgbds = []
+    for color_path, depth_path in zip(dataset.color_paths, dataset.depth_paths):
+        im_color = o3d.io.read_image(color_path)
+        im_depth = o3d.io.read_image(depth_path)
+        im_rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
+            im_color, im_depth)
+        im_rgbds.append(im_rgbd)
+
+    im_noisy_rgbds = []
+    for color_path, depth_path in zip(dataset.color_paths,
+                                      dataset.noisy_depth_paths):
+        im_color = o3d.io.read_image(color_path)
+        im_depth = o3d.io.read_image(depth_path)
+        im_rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
+            im_color, im_depth)
+        im_noisy_rgbds.append(im_rgbd)
+
+.. code-block:: cpp
+
+    data::RedwoodIndoorLivingRoom1 dataset;
+
+    auto pcd = io::CreatePointCloudFromFile(dataset.GetPointCloudPath());
+
+    std::vector<std::shared_ptr<geometry::RGBDImage>> im_rgbds;
+    for (size_t i = 0; i < dataset.GetColorPaths().size(); ++i) {
+        auto im_color = io::CreateImageFromFile(dataset.GetColorPaths()[i]);
+        auto im_depth = io::CreateImageFromFile(dataset.GetDepthPaths()[i]);
+        auto im_rgbd = geometry::RGBDImage::CreateFromColorAndDepth(*im_color,
+                                                                    *im_depth);
+        im_rgbds.push_back(im_rgbd);
+    }
+
+    std::vector<std::shared_ptr<geometry::RGBDImage>> im_noisy_rgbds;
+    for (size_t i = 0; i < dataset.GetColorPaths().size(); ++i) {
+        auto im_color = io::CreateImageFromFile(dataset.GetColorPaths()[i]);
+        auto im_depth =
+                io::CreateImageFromFile(dataset.GetNoisyDepthPaths()[i]);
+        auto im_rgbd = geometry::RGBDImage::CreateFromColorAndDepth(*im_color,
+                                                                    *im_depth);
+        im_noisy_rgbds.push_back(im_rgbd);
+    }
+
+RedwoodIndoorLivingRoom2
+------------------------
+
+The living room 2 scene of the Redwood indoor dataset (Augmented ICL-NUIM
+Dataset). The dataset contains a dense point cloud, a rgb sequence, a clean
+depth sequence, a noisy depth sequence, an oni file, and camera trajectory.
+
+
+.. code-block:: python
+
+    dataset = o3d.data.RedwoodIndoorLivingRoom2()
+    assert Path(gt_download_dir).is_dir()
+    pcd = o3d.io.read_point_cloud(dataset.point_cloud_path)
+
+    im_rgbds = []
+    for color_path, depth_path in zip(dataset.color_paths, dataset.depth_paths):
+        im_color = o3d.io.read_image(color_path)
+        im_depth = o3d.io.read_image(depth_path)
+        im_rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
+            im_color, im_depth)
+        im_rgbds.append(im_rgbd)
+
+    im_noisy_rgbds = []
+    for color_path, depth_path in zip(dataset.color_paths,
+                                      dataset.noisy_depth_paths):
+        im_color = o3d.io.read_image(color_path)
+        im_depth = o3d.io.read_image(depth_path)
+        im_rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
+            im_color, im_depth)
+        im_noisy_rgbds.append(im_rgbd)
+
+.. code-block:: cpp
+
+    data::RedwoodIndoorLivingRoom2 dataset;
+
+    auto pcd = io::CreatePointCloudFromFile(dataset.GetPointCloudPath());
+
+    std::vector<std::shared_ptr<geometry::RGBDImage>> im_rgbds;
+    for (size_t i = 0; i < dataset.GetColorPaths().size(); ++i) {
+        auto im_color = io::CreateImageFromFile(dataset.GetColorPaths()[i]);
+        auto im_depth = io::CreateImageFromFile(dataset.GetDepthPaths()[i]);
+        auto im_rgbd = geometry::RGBDImage::CreateFromColorAndDepth(*im_color,
+                                                                    *im_depth);
+        im_rgbds.push_back(im_rgbd);
+    }
+
+    std::vector<std::shared_ptr<geometry::RGBDImage>> im_noisy_rgbds;
+    for (size_t i = 0; i < dataset.GetColorPaths().size(); ++i) {
+        auto im_color = io::CreateImageFromFile(dataset.GetColorPaths()[i]);
+        auto im_depth =
+                io::CreateImageFromFile(dataset.GetNoisyDepthPaths()[i]);
+        auto im_rgbd = geometry::RGBDImage::CreateFromColorAndDepth(*im_color,
+                                                                    *im_depth);
+        im_noisy_rgbds.push_back(im_rgbd);
+    }
+
+
+RedwoodIndoorOffice1
+--------------------
+
+The office 1 scene of the Redwood indoor dataset (Augmented ICL-NUIM
+Dataset). The dataset contains a dense point cloud, a rgb sequence, a clean
+depth sequence, a noisy depth sequence, an oni file, and camera trajectory.
+
+
+.. code-block:: python
+
+    dataset = o3d.data.RedwoodIndoorOffice1()
+    assert Path(gt_download_dir).is_dir()
+    pcd = o3d.io.read_point_cloud(dataset.point_cloud_path)
+
+    im_rgbds = []
+    for color_path, depth_path in zip(dataset.color_paths, dataset.depth_paths):
+        im_color = o3d.io.read_image(color_path)
+        im_depth = o3d.io.read_image(depth_path)
+        im_rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
+            im_color, im_depth)
+        im_rgbds.append(im_rgbd)
+
+    im_noisy_rgbds = []
+    for color_path, depth_path in zip(dataset.color_paths,
+                                      dataset.noisy_depth_paths):
+        im_color = o3d.io.read_image(color_path)
+        im_depth = o3d.io.read_image(depth_path)
+        im_rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
+            im_color, im_depth)
+        im_noisy_rgbds.append(im_rgbd)
+
+.. code-block:: cpp
+
+    data::RedwoodIndoorOffice1 dataset;
+
+    auto pcd = io::CreatePointCloudFromFile(dataset.GetPointCloudPath());
+
+    std::vector<std::shared_ptr<geometry::RGBDImage>> im_rgbds;
+    for (size_t i = 0; i < dataset.GetColorPaths().size(); ++i) {
+        auto im_color = io::CreateImageFromFile(dataset.GetColorPaths()[i]);
+        auto im_depth = io::CreateImageFromFile(dataset.GetDepthPaths()[i]);
+        auto im_rgbd = geometry::RGBDImage::CreateFromColorAndDepth(*im_color,
+                                                                    *im_depth);
+        im_rgbds.push_back(im_rgbd);
+    }
+
+    std::vector<std::shared_ptr<geometry::RGBDImage>> im_noisy_rgbds;
+    for (size_t i = 0; i < dataset.GetColorPaths().size(); ++i) {
+        auto im_color = io::CreateImageFromFile(dataset.GetColorPaths()[i]);
+        auto im_depth =
+                io::CreateImageFromFile(dataset.GetNoisyDepthPaths()[i]);
+        auto im_rgbd = geometry::RGBDImage::CreateFromColorAndDepth(*im_color,
+                                                                    *im_depth);
+        im_noisy_rgbds.push_back(im_rgbd);
+    }
+
+RedwoodIndoorOffice2
+--------------------
+
+The office 2 scene of the Redwood indoor dataset (Augmented ICL-NUIM
+Dataset). The dataset contains a dense point cloud, a rgb sequence, a clean
+depth sequence, a noisy depth sequence, an oni file, and camera trajectory.
+
+
+.. code-block:: python
+
+    dataset = o3d.data.RedwoodIndoorOffice2()
+    assert Path(gt_download_dir).is_dir()
+    pcd = o3d.io.read_point_cloud(dataset.point_cloud_path)
+
+    im_rgbds = []
+    for color_path, depth_path in zip(dataset.color_paths, dataset.depth_paths):
+        im_color = o3d.io.read_image(color_path)
+        im_depth = o3d.io.read_image(depth_path)
+        im_rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
+            im_color, im_depth)
+        im_rgbds.append(im_rgbd)
+
+    im_noisy_rgbds = []
+    for color_path, depth_path in zip(dataset.color_paths,
+                                      dataset.noisy_depth_paths):
+        im_color = o3d.io.read_image(color_path)
+        im_depth = o3d.io.read_image(depth_path)
+        im_rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
+            im_color, im_depth)
+        im_noisy_rgbds.append(im_rgbd)
+
+.. code-block:: cpp
+
+    data::RedwoodIndoorOffice2 dataset;
+
+    auto pcd = io::CreatePointCloudFromFile(dataset.GetPointCloudPath());
+
+    std::vector<std::shared_ptr<geometry::RGBDImage>> im_rgbds;
+    for (size_t i = 0; i < dataset.GetColorPaths().size(); ++i) {
+        auto im_color = io::CreateImageFromFile(dataset.GetColorPaths()[i]);
+        auto im_depth = io::CreateImageFromFile(dataset.GetDepthPaths()[i]);
+        auto im_rgbd = geometry::RGBDImage::CreateFromColorAndDepth(*im_color,
+                                                                    *im_depth);
+        im_rgbds.push_back(im_rgbd);
+    }
+
+    std::vector<std::shared_ptr<geometry::RGBDImage>> im_noisy_rgbds;
+    for (size_t i = 0; i < dataset.GetColorPaths().size(); ++i) {
+        auto im_color = io::CreateImageFromFile(dataset.GetColorPaths()[i]);
+        auto im_depth =
+                io::CreateImageFromFile(dataset.GetNoisyDepthPaths()[i]);
+        auto im_rgbd = geometry::RGBDImage::CreateFromColorAndDepth(*im_color,
+                                                                    *im_depth);
+        im_noisy_rgbds.push_back(im_rgbd);
+    }

--- a/python/test/data/test_data.py
+++ b/python/test/data/test_data.py
@@ -27,7 +27,7 @@
 import open3d as o3d
 
 from pathlib import Path
-import shutil
+import pytest
 
 
 def test_dataset_base():
@@ -56,13 +56,8 @@ def test_simple_dataset_base():
         gt_prefix)
 
     data_descriptor = o3d.data.DataDescriptor(
-        urls=[
-            "https://github.com/isl-org/open3d_downloads/releases/download/"
-            "20220201-data/BunnyMesh.ply"
-        ],
-        md5="568f871d1a221ba6627569f1e6f9a3f2",
-        do_extract=False,
-    )
+        url=o3d.data.open3d_downloads_prefix + "20220201-data/BunnyMesh.ply",
+        md5="568f871d1a221ba6627569f1e6f9a3f2")
     single_download_dataset = o3d.data.DownloadDataset(
         prefix=gt_prefix,
         data_descriptor=data_descriptor,
@@ -911,3 +906,127 @@ def test_juneau():
     assert Path(juneau.data_root) == gt_data_root
     assert Path(juneau.download_dir) == gt_download_dir
     assert Path(juneau.extract_dir) == gt_extract_dir
+
+
+@pytest.mark.skip()
+def test_redwood_indoor_living_room1():
+    gt_prefix = "RedwoodIndoorLivingRoom1"
+    _, gt_download_dir, gt_extract_dir = get_test_data_dirs(gt_prefix)
+    dataset = o3d.data.RedwoodIndoorLivingRoom1()
+
+    assert Path(gt_download_dir).is_dir()
+    assert Path(gt_extract_dir).is_dir()
+
+    pcd = o3d.io.read_point_cloud(dataset.point_cloud_path)
+
+    im_rgbds = []
+    for color_path, depth_path in zip(dataset.color_paths, dataset.depth_paths):
+        im_color = o3d.io.read_image(color_path)
+        im_depth = o3d.io.read_image(depth_path)
+        im_rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
+            im_color, im_depth)
+        im_rgbds.append(im_rgbd)
+    assert len(im_rgbds) == 2870
+
+    im_noisy_rgbds = []
+    for color_path, depth_path in zip(dataset.color_paths,
+                                      dataset.noisy_depth_paths):
+        im_color = o3d.io.read_image(color_path)
+        im_depth = o3d.io.read_image(depth_path)
+        im_rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
+            im_color, im_depth)
+        im_noisy_rgbds.append(im_rgbd)
+    assert len(im_noisy_rgbds) == 2870
+
+
+@pytest.mark.skip()
+def test_redwood_indoor_living_room2():
+    gt_prefix = "RedwoodIndoorLivingRoom2"
+    _, gt_download_dir, gt_extract_dir = get_test_data_dirs(gt_prefix)
+    dataset = o3d.data.RedwoodIndoorLivingRoom2()
+
+    assert Path(gt_download_dir).is_dir()
+    assert Path(gt_extract_dir).is_dir()
+
+    pcd = o3d.io.read_point_cloud(dataset.point_cloud_path)
+
+    im_rgbds = []
+    for color_path, depth_path in zip(dataset.color_paths, dataset.depth_paths):
+        im_color = o3d.io.read_image(color_path)
+        im_depth = o3d.io.read_image(depth_path)
+        im_rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
+            im_color, im_depth)
+        im_rgbds.append(im_rgbd)
+    assert len(im_rgbds) == 2350
+
+    im_noisy_rgbds = []
+    for color_path, depth_path in zip(dataset.color_paths,
+                                      dataset.noisy_depth_paths):
+        im_color = o3d.io.read_image(color_path)
+        im_depth = o3d.io.read_image(depth_path)
+        im_rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
+            im_color, im_depth)
+        im_noisy_rgbds.append(im_rgbd)
+    assert len(im_noisy_rgbds) == 2350
+
+
+@pytest.mark.skip()
+def test_redwood_indoor_office1():
+    gt_prefix = "RedwoodIndoorOffice1"
+    _, gt_download_dir, gt_extract_dir = get_test_data_dirs(gt_prefix)
+    dataset = o3d.data.RedwoodIndoorOffice1()
+
+    assert Path(gt_download_dir).is_dir()
+    assert Path(gt_extract_dir).is_dir()
+
+    pcd = o3d.io.read_point_cloud(dataset.point_cloud_path)
+
+    im_rgbds = []
+    for color_path, depth_path in zip(dataset.color_paths, dataset.depth_paths):
+        im_color = o3d.io.read_image(color_path)
+        im_depth = o3d.io.read_image(depth_path)
+        im_rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
+            im_color, im_depth)
+        im_rgbds.append(im_rgbd)
+    assert len(im_rgbds) == 2690
+
+    im_noisy_rgbds = []
+    for color_path, depth_path in zip(dataset.color_paths,
+                                      dataset.noisy_depth_paths):
+        im_color = o3d.io.read_image(color_path)
+        im_depth = o3d.io.read_image(depth_path)
+        im_rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
+            im_color, im_depth)
+        im_noisy_rgbds.append(im_rgbd)
+    assert len(im_noisy_rgbds) == 2690
+
+
+@pytest.mark.skip()
+def test_redwood_indoor_office2():
+    gt_prefix = "RedwoodIndoorOffice2"
+    _, gt_download_dir, gt_extract_dir = get_test_data_dirs(gt_prefix)
+    dataset = o3d.data.RedwoodIndoorOffice2()
+
+    assert Path(gt_download_dir).is_dir()
+    assert Path(gt_extract_dir).is_dir()
+
+    pcd = o3d.io.read_point_cloud(dataset.point_cloud_path)
+
+    im_rgbds = []
+    for color_path, depth_path in zip(dataset.color_paths, dataset.depth_paths):
+        im_color = o3d.io.read_image(color_path)
+        im_depth = o3d.io.read_image(depth_path)
+        im_rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
+            im_color, im_depth)
+        im_rgbds.append(im_rgbd)
+    assert len(im_rgbds) == 2538
+
+    im_noisy_rgbds = []
+    for color_path, depth_path in zip(dataset.color_paths,
+                                      dataset.noisy_depth_paths):
+        im_color = o3d.io.read_image(color_path)
+        im_depth = o3d.io.read_image(depth_path)
+        im_rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
+            im_color, im_depth)
+        im_noisy_rgbds.append(im_rgbd)
+    assert len(im_noisy_rgbds) == 2538

--- a/python/test/visualization/test_tensorboard_plugin.py
+++ b/python/test/visualization/test_tensorboard_plugin.py
@@ -373,13 +373,9 @@ def check_material_dict(o3d_geo, material, batch_idx):
 def logdir():
     """Extract logdir zip to provide logdir for tests, cleanup afterwards."""
     data_descriptor = o3d.data.DataDescriptor(
-        urls=[
-            "https://github.com/isl-org/open3d_downloads/releases/"
-            "download/20220301-data/test_tensorboard_plugin.zip"
-        ],
-        md5="746612f1d3b413236091d263bff29dc9",
-        do_extract=True,
-    )
+        url=o3d.data.open3d_downloads_prefix +
+        "20220301-data/test_tensorboard_plugin.zip",
+        md5="746612f1d3b413236091d263bff29dc9")
     test_data = o3d.data.DownloadDataset(
         prefix="TestTensorboardPlugin",
         data_descriptor=data_descriptor,


### PR DESCRIPTION
This is a follow up to: #5529

- [x] Added `RedwoodIndoorLivingRoom1`, `RedwoodIndoorLivingRoom2`, `RedwoodIndoorOffice1`, `RedwoodIndoorOffice2` datasets.
- [x] C++ and Python unit tests
- [x] Allow specification of the extraction sub directory
- [x] Simplified the constructor of `DataDescriptor`
- [x] Fix extraction for loop logic to extract all files in the list

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5545)
<!-- Reviewable:end -->
