### PR TITLE
Add overload for t.geometry.TriangleMesh to RPC module

### DIFF
--- a/cpp/open3d/io/rpc/RemoteFunctions.cpp
+++ b/cpp/open3d/io/rpc/RemoteFunctions.cpp
@@ -98,6 +98,8 @@ bool SetTriangleMesh(const geometry::TriangleMesh& mesh,
     msg.time = time;
     msg.layer = layer;
 
+    msg.data.SetO3DTypeToTriangleMesh();
+
     msg.data.vertices =
             messages::Array::FromPtr((double*)mesh.vertices_.data(),
                                      {int64_t(mesh.vertices_.size()), 3});
@@ -158,6 +160,47 @@ bool SetTriangleMesh(const geometry::TriangleMesh& mesh,
     }
     auto reply = connection->Send(send_msg);
     return ReplyIsOKStatus(*reply);
+}
+
+bool SetTriangleMesh(const t::geometry::TriangleMesh& mesh,
+                     const std::string& path,
+                     int time,
+                     const std::string& layer,
+                     std::shared_ptr<ConnectionBase> connection) {
+    std::map<std::string, core::Tensor> vertex_attributes(
+            mesh.GetVertexAttr().begin(), mesh.GetVertexAttr().end());
+    std::map<std::string, core::Tensor> face_attributes(
+            mesh.GetTriangleAttr().begin(), mesh.GetTriangleAttr().end());
+
+    std::string material_name;
+    std::map<std::string, float> material_scalar_attributes;
+    std::map<std::string, std::array<float, 4>> material_vector_attributes;
+    std::map<std::string, t::geometry::Image> texture_maps;
+    if (mesh.HasMaterial()) {
+        const auto& material = mesh.GetMaterial();
+        material_name = material.GetMaterialName();
+        material_scalar_attributes = std::map<std::string, float>(
+                material.GetScalarProperties().begin(),
+                material.GetScalarProperties().end());
+        for (const auto& it : material.GetVectorProperties()) {
+            std::array<float, 4> vec = {it.second(0), it.second(1),
+                                        it.second(2), it.second(3)};
+            material_vector_attributes[it.first] = vec;
+        }
+        texture_maps = std::map<std::string, t::geometry::Image>(
+                material.GetTextureMaps().begin(),
+                material.GetTextureMaps().end());
+    }
+
+    messages::MeshData o3d_type;
+    o3d_type.SetO3DTypeToTriangleMesh();
+
+    return SetMeshData(path, time, layer, mesh.GetVertexPositions(),
+                       vertex_attributes, mesh.GetTriangleIndices(),
+                       face_attributes, core::Tensor(),
+                       std::map<std::string, core::Tensor>(), material_name,
+                       material_scalar_attributes, material_vector_attributes,
+                       texture_maps, o3d_type.o3d_type, connection);
 }
 
 bool SetMeshData(const std::string& path,

--- a/cpp/open3d/io/rpc/RemoteFunctions.h
+++ b/cpp/open3d/io/rpc/RemoteFunctions.h
@@ -35,6 +35,7 @@
 #include "open3d/geometry/TriangleMesh.h"
 #include "open3d/io/rpc/ConnectionBase.h"
 #include "open3d/t/geometry/Image.h"
+#include "open3d/t/geometry/TriangleMesh.h"
 
 namespace zmq {
 class message_t;
@@ -82,6 +83,26 @@ bool SetPointCloud(const geometry::PointCloud& pcd,
 ///                    If nullptr a default connection object will be used.
 ///
 bool SetTriangleMesh(const geometry::TriangleMesh& mesh,
+                     const std::string& path = "",
+                     int time = 0,
+                     const std::string& layer = "",
+                     std::shared_ptr<ConnectionBase> connection =
+                             std::shared_ptr<ConnectionBase>());
+
+/// Function for sending a TriangleMesh.
+/// \param mesh        The TriangleMesh object.
+///
+/// \param path        Path descriptor defining a location in the scene tree.
+/// E.g., 'mygroup/mypoints'.
+///
+/// \param time        The time point associated with the object.
+///
+/// \param layer       The layer for this object.
+///
+/// \param connection  The connection object used for sending the data.
+///                    If nullptr a default connection object will be used.
+///
+bool SetTriangleMesh(const t::geometry::TriangleMesh& mesh,
                      const std::string& path = "",
                      int time = 0,
                      const std::string& layer = "",

--- a/cpp/pybind/io/rpc.cpp
+++ b/cpp/pybind/io/rpc.cpp
@@ -111,21 +111,43 @@ A connection writing to a memory buffer.
                      "the connection."},
             });
 
-    m.def("set_triangle_mesh", &rpc::SetTriangleMesh, "mesh"_a, "path"_a = "",
-          "time"_a = 0, "layer"_a = "",
+    m.def("set_triangle_mesh",
+          py::overload_cast<const geometry::TriangleMesh&, const std::string&,
+                            int, const std::string&,
+                            std::shared_ptr<rpc::ConnectionBase>>(
+                  &rpc::SetTriangleMesh),
+          "mesh"_a, "path"_a = "", "time"_a = 0, "layer"_a = "",
           "connection"_a = std::shared_ptr<rpc::ConnectionBase>(),
-          "Sends a point cloud message to a viewer.");
-    docstring::FunctionDocInject(
-            m, "set_triangle_mesh",
-            {
-                    {"mesh", "The TriangleMesh object."},
-                    {"path", "A path descriptor, e.g., 'mygroup/mesh'."},
-                    {"time", "The time associated with this data."},
-                    {"layer", "The layer associated with this data."},
-                    {"connection",
-                     "A Connection object. Use None to automatically create "
-                     "the connection."},
-            });
+          R"doc(Sends a triangle mesh to a viewer.
+Args:
+    mesh (o3d.geometry.TriangleMesh): The triangle mesh.
+    path (str): The path in the scene graph.
+    time (int): The time associated with the data.
+    layer (str): A layer name that can be used by receivers that support layers.
+    connection (o3d.io.rpc.Connection): A connection object that will be used for sending the data.
+
+Returns:
+    Returns True if the data was successfully received.
+)doc");
+
+    m.def("set_triangle_mesh",
+          py::overload_cast<const t::geometry::TriangleMesh&,
+                            const std::string&, int, const std::string&,
+                            std::shared_ptr<rpc::ConnectionBase>>(
+                  &rpc::SetTriangleMesh),
+          "mesh"_a, "path"_a = "", "time"_a = 0, "layer"_a = "",
+          "connection"_a = std::shared_ptr<rpc::ConnectionBase>(),
+          R"doc(Sends a triangle mesh to a viewer.
+Args:
+    mesh (o3d.t.geometry.TriangleMesh): The triangle mesh.
+    path (str): The path in the scene graph.
+    time (int): The time associated with the data.
+    layer (str): A layer name that can be used by receivers that support layers.
+    connection (o3d.io.rpc.Connection): A connection object that will be used for sending the data.
+
+Returns:
+    Returns True if the data was successfully received.
+)doc");
 
     m.def("set_mesh_data", &rpc::SetMeshData, "path"_a = "", "time"_a = 0,
           "layer"_a = "", "vertices"_a = core::Tensor({0}, core::Float32),

--- a/python/open3d/visualization/_external_visualizer.py
+++ b/python/open3d/visualization/_external_visualizer.py
@@ -109,7 +109,8 @@ class ExternalVisualizer:
                                                 layer=layer,
                                                 connection=connection)
             result.append(status)
-        elif isinstance(obj, o3d.geometry.TriangleMesh):
+        elif isinstance(
+                obj, (o3d.t.geometry.TriangleMesh, o3d.geometry.TriangleMesh)):
             status = o3d.io.rpc.set_triangle_mesh(obj,
                                                   path=path,
                                                   time=time,


### PR DESCRIPTION
This PR adds an overload for the RPC module for t.geometry.TriangleMesh