### PR TITLE
Added additional python bindings for RGBD odometry functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Corrected documentation for KDTree (typo in Notebook) (PR #4744)
 * Remove `setuptools` and `wheel` from requirements for end users (PR #5020)
 * Fix various typos (PR #5070)
-* Exposed more functionality in SLAM pipeline
+* Exposed more functionality in SLAM and odometry pipelines
 * Fix for depth estimation for VoxelBlockGrid
 * Reserve fragment buffer for VoxelBlockGrid operations
 * Fix raycasting scene: Allow setting of number of threads that are used for building a raycasting scene

--- a/cpp/open3d/pipelines/odometry/Odometry.cpp
+++ b/cpp/open3d/pipelines/odometry/Odometry.cpp
@@ -116,8 +116,8 @@ static int CountCorrespondence(const geometry::Image &correspondence_map) {
     return correspondence_count;
 }
 
-static CorrespondenceSetPixelWise ComputeCorrespondence(
-        const Eigen::Matrix3d intrinsic_matrix,
+CorrespondenceSetPixelWise ComputeCorrespondence(
+        const Eigen::Matrix3d &intrinsic_matrix,
         const Eigen::Matrix4d &extrinsic,
         const geometry::Image &depth_s,
         const geometry::Image &depth_t,

--- a/cpp/open3d/pipelines/odometry/Odometry.h
+++ b/cpp/open3d/pipelines/odometry/Odometry.h
@@ -65,6 +65,23 @@ std::tuple<bool, Eigen::Matrix4d, Eigen::Matrix6d> ComputeRGBDOdometry(
                 RGBDOdometryJacobianFromHybridTerm(),
         const OdometryOption &option = OdometryOption());
 
+/// \brief Function to estimate point to point correspondences from two depth
+/// images
+///
+/// \param intrinsic_matrix Camera intrinsic parameters.
+/// \param extrinsic Estimation of transform from source to target.
+/// \param depth_s Source depth image.
+/// \param depth_t Target depth image.
+/// \param option Odometry hyper parameters.
+/// \return A vector of u_s, v_s, u_t, v_t which maps the 2d coordinates of
+/// source to target
+CorrespondenceSetPixelWise ComputeCorrespondence(
+        const Eigen::Matrix3d &intrinsic_matrix,
+        const Eigen::Matrix4d &extrinsic,
+        const geometry::Image &depth_s,
+        const geometry::Image &depth_t,
+        const OdometryOption &option);
+
 }  // namespace odometry
 }  // namespace pipelines
 }  // namespace open3d

--- a/cpp/open3d/pipelines/odometry/Odometry.h
+++ b/cpp/open3d/pipelines/odometry/Odometry.h
@@ -66,7 +66,7 @@ std::tuple<bool, Eigen::Matrix4d, Eigen::Matrix6d> ComputeRGBDOdometry(
         const OdometryOption &option = OdometryOption());
 
 /// \brief Function to estimate point to point correspondences from two depth
-/// images
+/// images.
 ///
 /// \param intrinsic_matrix Camera intrinsic parameters.
 /// \param extrinsic Estimation of transform from source to target.
@@ -74,7 +74,7 @@ std::tuple<bool, Eigen::Matrix4d, Eigen::Matrix6d> ComputeRGBDOdometry(
 /// \param depth_t Target depth image.
 /// \param option Odometry hyper parameters.
 /// \return A vector of u_s, v_s, u_t, v_t which maps the 2d coordinates of
-/// source to target
+/// source to target.
 CorrespondenceSetPixelWise ComputeCorrespondence(
         const Eigen::Matrix3d &intrinsic_matrix,
         const Eigen::Matrix4d &extrinsic,

--- a/cpp/pybind/pipelines/odometry/odometry.cpp
+++ b/cpp/pybind/pipelines/odometry/odometry.cpp
@@ -127,17 +127,17 @@ void pybind_odometry_classes(py::module &m) {
                     m, "RGBDOdometryJacobian",
                     "Base class that computes Jacobian from two RGB-D images.");
 
-    jacobian.def("compute_jacobian_and_residual",
-                 &RGBDOdometryJacobian::ComputeJacobianAndResidual,
-                 py::call_guard<py::gil_scoped_release>(),
-                 "Function to compute i-th row of J and r"
-                 "the vector form of J_r is basically 6x1 matrix, but it can be"
-                 "easily extendable to 6xn matrix."
-                 "See RGBDOdometryJacobianFromHybridTerm for this case."
-                 "row"_a,
-                 "J_r"_a, "r"_a, "w"_a, "source"_a, "target"_a, "source_xyz"_a,
-                 "target_dx"_a, "target_dy"_a, "intrinsic"_a, "extrinsic"_a,
-                 "corresps"_a);
+    jacobian.def(
+            "compute_jacobian_and_residual",
+            &RGBDOdometryJacobian::ComputeJacobianAndResidual,
+            py::call_guard<py::gil_scoped_release>(),
+            "Function to compute i-th row of J and r the vector form of J_r is "
+            "basically 6x1 matrix, but it can be easily extendable to 6xn "
+            "matrix. See RGBDOdometryJacobianFromHybridTerm for this case."
+            "row"_a,
+            "J_r"_a, "r"_a, "w"_a, "source"_a, "target"_a, "source_xyz"_a,
+            "target_dx"_a, "target_dy"_a, "intrinsic"_a, "extrinsic"_a,
+            "corresps"_a);
 
     // open3d.odometry.RGBDOdometryJacobianFromColorTerm: RGBDOdometryJacobian
     py::class_<RGBDOdometryJacobianFromColorTerm,
@@ -217,9 +217,8 @@ void pybind_odometry_methods(py::module &m) {
     m.def("compute_correspondence", &ComputeCorrespondence,
           py::call_guard<py::gil_scoped_release>(),
           "Function to estimate point to point correspondences from two depth "
-          "images"
-          "A vector of u_s, v_s, u_t, v_t which maps the 2d coordinates of "
-          "source to target",
+          "images. A vector of u_s, v_s, u_t, v_t which maps the 2d "
+          "coordinates of source to target.",
           "intrinsic_matrix"_a, "extrinsic"_a, "depth_s"_a, "depth_t"_a,
           "option"_a = OdometryOption());
     docstring::FunctionDocInject(

--- a/cpp/pybind/pipelines/odometry/odometry.cpp
+++ b/cpp/pybind/pipelines/odometry/odometry.cpp
@@ -127,6 +127,18 @@ void pybind_odometry_classes(py::module &m) {
                     m, "RGBDOdometryJacobian",
                     "Base class that computes Jacobian from two RGB-D images.");
 
+    jacobian.def("compute_jacobian_and_residual",
+                 &RGBDOdometryJacobian::ComputeJacobianAndResidual,
+                 py::call_guard<py::gil_scoped_release>(),
+                 "Function to compute i-th row of J and r"
+                 "the vector form of J_r is basically 6x1 matrix, but it can be"
+                 "easily extendable to 6xn matrix."
+                 "See RGBDOdometryJacobianFromHybridTerm for this case."
+                 "row"_a,
+                 "J_r"_a, "r"_a, "w"_a, "source"_a, "target"_a, "source_xyz"_a,
+                 "target_dx"_a, "target_dy"_a, "intrinsic"_a, "extrinsic"_a,
+                 "corresps"_a);
+
     // open3d.odometry.RGBDOdometryJacobianFromColorTerm: RGBDOdometryJacobian
     py::class_<RGBDOdometryJacobianFromColorTerm,
                PyRGBDOdometryJacobian<RGBDOdometryJacobianFromColorTerm>,
@@ -199,6 +211,25 @@ void pybind_odometry_methods(py::module &m) {
                      "RGBDOdometryJacobianFromHybridTerm()`` or "
                      "``RGBDOdometryJacobianFromColorTerm("
                      ").``"},
+                    {"option", "Odometry hyper parameters."},
+            });
+
+    m.def("compute_correspondence", &ComputeCorrespondence,
+          py::call_guard<py::gil_scoped_release>(),
+          "Function to estimate point to point correspondences from two depth "
+          "images"
+          "A vector of u_s, v_s, u_t, v_t which maps the 2d coordinates of "
+          "source to target",
+          "intrinsic_matrix"_a, "extrinsic"_a, "depth_s"_a, "depth_t"_a,
+          "option"_a = OdometryOption());
+    docstring::FunctionDocInject(
+            m, "compute_correspondence",
+            {
+                    {"intrinsic_matrix", "Camera intrinsic parameters."},
+                    {"extrinsic",
+                     "Estimation of transform from source to target."},
+                    {"depth_s", "Source depth image."},
+                    {"depth_t", "Target depth image."},
                     {"option", "Odometry hyper parameters."},
             });
 }


### PR DESCRIPTION
The use case for this is to be better able to tune the various odometery options as well as integrate the cost function(s) into different minimization frameworks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5611)
<!-- Reviewable:end -->
