### PR TITLE
Fix unresolved symbol in python package (Apple Silicon)

### DIFF
--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -1599,9 +1599,11 @@ else() # if(OPEN3D_USE_ONEAPI_PACKAGES)
                 # On ARM64 Ubuntu and ARM64 macOS, libgfortran.a is compiled with `-fPIC`.
                 find_library(gfortran_lib NAMES libgfortran.a PATHS ${gfortran_lib_dirs} REQUIRED)
                 find_library(gcc_lib      NAMES libgcc.a      PATHS ${gfortran_lib_dirs} REQUIRED)
+                find_library(quadmath_lib NAMES libquadmath.a PATHS ${gfortran_lib_dirs} REQUIRED)
                 target_link_libraries(3rdparty_blas INTERFACE
                     ${gfortran_lib}
                     ${gcc_lib}
+                    ${quadmath_lib}
                 )
                 if(APPLE_AARCH64)
                     # Suppress Apple compiler warnigns.


### PR DESCRIPTION
Resolves issue with unresolved symbol `__quadmath_snprintf` with M1 Python package build.