### PR TITLE
Document support for Python 3.10 wheels

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For more, please visit the [Open3D documentation](http://www.open3d.org/docs).
 ## Python quick start
 
 Pre-built pip packages support Ubuntu 18.04+, macOS 10.15+ and Windows 10+
-(64-bit) with Python 3.6-3.9.
+(64-bit) with Python 3.6-3.10.
 
 ```bash
 # Install


### PR DESCRIPTION

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5614)
<!-- Reviewable:end -->

3.10 wheels are included for 0.16.0:

- https://pypi.org/project/open3d/0.16.0/#files