### PR TITLE
Add loading colors and uvs in tgeometry TriangleMesh IO

### DIFF
--- a/cpp/open3d/t/io/file_format/FileASSIMP.cpp
+++ b/cpp/open3d/t/io/file_format/FileASSIMP.cpp
@@ -81,9 +81,11 @@ bool ReadTriangleMeshUsingASSIMP(
     std::vector<core::Tensor> mesh_vertices;
     std::vector<core::Tensor> mesh_vertex_normals;
     std::vector<core::Tensor> mesh_faces;
+    std::vector<core::Tensor> mesh_vertex_colors;
 
     size_t current_vidx = 0;
     size_t count_mesh_with_normals = 0;
+    size_t count_mesh_with_colors = 0;
 
     // Merge individual meshes in aiScene into a single TriangleMesh
     for (size_t midx = 0; midx < scene->mNumMeshes; ++midx) {
@@ -92,24 +94,35 @@ bool ReadTriangleMeshUsingASSIMP(
         core::Tensor vertices = core::Tensor::Empty(
                 {assimp_mesh->mNumVertices, 3}, core::Dtype::Float32);
         auto vertices_ptr = vertices.GetDataPtr<float>();
+        std::memcpy(vertices_ptr, assimp_mesh->mVertices,
+                3 * assimp_mesh->mNumVertices * sizeof(float));
+        mesh_vertices.push_back(vertices);
 
         core::Tensor vertex_normals;
+        core::Tensor vertex_colors;
         if (assimp_mesh->mNormals) {
             // Loop fusion for performance optimization.
             vertex_normals = core::Tensor::Empty({assimp_mesh->mNumFaces, 3},
                                                  core::Dtype::Float32);
-            auto vertex_normals_ptr = vertices.GetDataPtr<float>();
-            std::memcpy(vertices_ptr, assimp_mesh->mVertices,
-                        3 * assimp_mesh->mNumVertices * sizeof(float));
+            auto vertex_normals_ptr = vertex_normals.GetDataPtr<float>();
             std::memcpy(vertex_normals_ptr, assimp_mesh->mNormals,
                         3 * assimp_mesh->mNumVertices * sizeof(float));
             mesh_vertex_normals.push_back(vertex_normals);
             count_mesh_with_normals++;
-        } else {
-            std::memcpy(vertices_ptr, assimp_mesh->mVertices,
-                        3 * assimp_mesh->mNumVertices * sizeof(float));
         }
-        mesh_vertices.push_back(vertices);
+
+        if (assimp_mesh->HasVertexColors(0)) {
+            vertex_colors = core::Tensor::Empty({assimp_mesh->mNumVertices, 3},
+                    core::Dtype::Float32);
+            auto vertex_colors_ptr = vertex_colors.GetDataPtr<float>();
+            for (unsigned int i = 0; i < assimp_mesh->mNumVertices; ++i) {
+                *vertex_colors_ptr++ = assimp_mesh->mColors[0][i].r;
+                *vertex_colors_ptr++ = assimp_mesh->mColors[0][i].g;
+                *vertex_colors_ptr++ = assimp_mesh->mColors[0][i].b;
+            }
+            mesh_vertex_colors.push_back(vertex_colors);
+            count_mesh_with_colors++;
+        }
 
         core::Tensor faces = core::Tensor::Empty({assimp_mesh->mNumFaces, 3},
                                                  core::Dtype::Int64);
@@ -136,11 +149,17 @@ bool ReadTriangleMeshUsingASSIMP(
         if (count_mesh_with_normals == scene->mNumMeshes) {
             mesh.SetVertexNormals(core::Concatenate(mesh_vertex_normals));
         }
+        if (count_mesh_with_colors == scene->mNumMeshes) {
+            mesh.SetVertexColors(core::Concatenate(mesh_vertex_colors));
+        }
     } else {
         mesh.SetVertexPositions(mesh_vertices[0]);
         mesh.SetTriangleIndices(mesh_faces[0]);
         if (count_mesh_with_normals) {
             mesh.SetVertexNormals(mesh_vertex_normals[0]);
+        }
+        if (count_mesh_with_colors) {
+            mesh.SetVertexColors(mesh_vertex_colors[0]);
         }
     }
 

--- a/cpp/open3d/t/io/file_format/FileASSIMP.cpp
+++ b/cpp/open3d/t/io/file_format/FileASSIMP.cpp
@@ -97,7 +97,7 @@ bool ReadTriangleMeshUsingASSIMP(
                 {assimp_mesh->mNumVertices, 3}, core::Dtype::Float32);
         auto vertices_ptr = vertices.GetDataPtr<float>();
         std::memcpy(vertices_ptr, assimp_mesh->mVertices,
-                3 * assimp_mesh->mNumVertices * sizeof(float));
+                    3 * assimp_mesh->mNumVertices * sizeof(float));
         mesh_vertices.push_back(vertices);
 
         core::Tensor vertex_normals;
@@ -116,7 +116,7 @@ bool ReadTriangleMeshUsingASSIMP(
 
         if (assimp_mesh->HasVertexColors(0)) {
             vertex_colors = core::Tensor::Empty({assimp_mesh->mNumVertices, 3},
-                    core::Dtype::Float32);
+                                                core::Dtype::Float32);
             auto vertex_colors_ptr = vertex_colors.GetDataPtr<float>();
             for (unsigned int i = 0; i < assimp_mesh->mNumVertices; ++i) {
                 *vertex_colors_ptr++ = assimp_mesh->mColors[0][i].r;
@@ -142,8 +142,8 @@ bool ReadTriangleMeshUsingASSIMP(
         mesh_faces.push_back(faces);
 
         if (assimp_mesh->HasTextureCoords(0)) {
-            auto vertex_uvs = core::Tensor::Empty({assimp_mesh->mNumVertices, 2},
-                    core::Dtype::Float32);
+            auto vertex_uvs = core::Tensor::Empty(
+                    {assimp_mesh->mNumVertices, 2}, core::Dtype::Float32);
             auto uvs_ptr = vertex_uvs.GetDataPtr<float>();
             // NOTE: Can't just memcpy because ASSIMP UVs are 3 element and
             // TriangleMesh wants 2 element UVs.

--- a/cpp/open3d/t/io/file_format/FileASSIMP.cpp
+++ b/cpp/open3d/t/io/file_format/FileASSIMP.cpp
@@ -153,10 +153,10 @@ bool ReadTriangleMeshUsingASSIMP(
             }
             triangle_uvs = vertex_uvs.IndexGet({faces});
             mesh_uvs.push_back(triangle_uvs);
+            count_mesh_with_uvs++;
         }
         // Adjust face indices to index into combined mesh vertex array
         current_vidx += static_cast<int>(assimp_mesh->mNumVertices);
-        count_mesh_with_uvs++;
     }
 
     mesh.Clear();


### PR DESCRIPTION
Adds loading of colors and uvs when using tgeometry IO function `read_triangle_mesh` with file types loaded by ASSIMP (obj, stl, off, gltf/glb, fbx). Test with following script:

```
import open3d as o3d

dataset = o3d.data.MonkeyModel()
mesh = o3d.t.io.read_triangle_mesh(dataset.path)
mesh.material.material_name = 'defaultLit'
mesh.material.texture_maps['albedo'] = o3d.t.io.read_image(dataset.path_map['albedo'])

print(mesh)
o3d.visualization.draw(mesh)
```

![2022-10-30-201809_1024x768_scrot](https://user-images.githubusercontent.com/3722407/198909181-a0e5ffe2-7f93-46ff-a712-3864a048581a.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5632)
<!-- Reviewable:end -->
