### PR TITLE
Update imgui to latest version

### DIFF
--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -1135,6 +1135,7 @@ if(BUILD_GUI)
             SOURCES
                 imgui_demo.cpp
                 imgui_draw.cpp
+                imgui_tables.cpp
                 imgui_widgets.cpp
                 imgui.cpp
             DEPENDS

--- a/3rdparty/imgui/imgui.cmake
+++ b/3rdparty/imgui/imgui.cmake
@@ -3,8 +3,8 @@ include(ExternalProject)
 ExternalProject_Add(
     ext_imgui
     PREFIX imgui
-    URL https://github.com/ocornut/imgui/archive/refs/tags/v1.74.tar.gz
-    URL_HASH SHA256=2f5f2b789edb00260aa71f03189da5f21cf4b5617c4fbba709e9fbcfc76a2f1e
+    URL https://github.com/ocornut/imgui/archive/refs/tags/v1.88.tar.gz
+    URL_HASH SHA256=9f14c788aee15b777051e48f868c5d4d959bd679fc5050e3d2a29de80d8fd32e
     DOWNLOAD_DIR "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/imgui"
     UPDATE_COMMAND ""
     CONFIGURE_COMMAND ""

--- a/cpp/open3d/visualization/gui/Layout.cpp
+++ b/cpp/open3d/visualization/gui/Layout.cpp
@@ -476,7 +476,7 @@ Widget::DrawResult CollapsableVert::Draw(const DrawContext& context) {
     ImGui::PushStyleColor(ImGuiCol_HeaderActive,
                           colorToImgui(context.theme.button_active_color));
 
-    ImGui::SetNextTreeNodeOpen(impl_->is_open_);
+    ImGui::SetNextItemOpen(impl_->is_open_);
     ImGui::PushFont((ImFont*)context.fonts.GetFont(impl_->font_id_));
     bool node_clicked = ImGui::TreeNode(impl_->id_.c_str());
     ImGui::PopFont();

--- a/cpp/open3d/visualization/gui/Window.cpp
+++ b/cpp/open3d/visualization/gui/Window.cpp
@@ -1109,7 +1109,7 @@ void Window::OnMouseEvent(const MouseEvent& e) {
         ImGuiContext* context = ImGui::GetCurrentContext();
         for (auto* w : context->Windows) {
             if (w->Flags & ImGuiWindowFlags_Popup &&
-                ImGui::IsPopupOpen(w->PopupId)) {
+                ImGui::IsPopupOpen(w->PopupId, 0)) {
                 Rect r(int(w->Pos.x), int(w->Pos.y), int(w->Size.x),
                        int(w->Size.y));
                 if (r.Contains(e.x, e.y)) {


### PR DESCRIPTION
Open3D is mostly compatible with the latest ImGui release, except for a very small change.

**EDIT**: *two* small changes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5644)
<!-- Reviewable:end -->
