### PR TITLE
Fix Mac build issue with ASSIMP

### DIFF
--- a/3rdparty/assimp/assimp.cmake
+++ b/3rdparty/assimp/assimp.cmake
@@ -17,8 +17,8 @@ endif()
 ExternalProject_Add(
     ext_assimp
     PREFIX assimp
-    GIT_REPOSITORY https://github.com/assimp/assimp
-    GIT_TAG 9a5d6282322de3085474ca8f9f4a4a8f84756394
+    URL https://github.com/assimp/assimp/archive/cfed74516b46a7c2bdf19c1643c448363bd90ad7.tar.gz
+    URL_HASH SHA256=b2f1c9450609f3bf201aa63b0b16023073d0ebb1c6e9ae5a832441f1e43c634c
     DOWNLOAD_DIR "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/assimp"
     UPDATE_COMMAND ""
     CMAKE_ARGS

--- a/3rdparty/assimp/assimp.cmake
+++ b/3rdparty/assimp/assimp.cmake
@@ -17,8 +17,8 @@ endif()
 ExternalProject_Add(
     ext_assimp
     PREFIX assimp
-    URL https://github.com/assimp/assimp/archive/refs/tags/v5.1.6.tar.gz # Jan 2022
-    URL_HASH SHA256=52ad3a3776ce320c8add531dbcb2d3b93f2e1f10fcff5ac30178b09ba934d084
+    GIT_REPOSITORY https://github.com/assimp/assimp
+    GIT_TAG 9a5d6282322de3085474ca8f9f4a4a8f84756394
     DOWNLOAD_DIR "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/assimp"
     UPDATE_COMMAND ""
     CMAKE_ARGS


### PR DESCRIPTION
Fixes two issues:

1. MacOS 13.0 SDK deprecates `vsprintf` and `sprintf` which causes warnings/errors building ASSIMP. This PR pulls a version of ASSIMP that uses the recommended `vsnprintf` and `snprintf` alternatives.
2. Changes glTF importer to use normal flow control instead of exceptions for flow control. On Apple Silicon the exception was not being caught starting with `clang` 14.0 and loading glTF 2.0 models always caused a crash.

Note: No ASSIMP release currently incorporates these two changes therefore this PR clones a specific commit. Once ASSIMP produces a stable release incorporating these changes a new PR will be necessary to reference the release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5646)
<!-- Reviewable:end -->
