### PR TITLE
Github Actions: link libomp so that cmake finds it

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew install ccache pkg-config
+          brew link --force libomp  # needed for cmake to find OpenMP
           ccache -M 2G  # See .github/workflows/readme.md for ccache strategy.
       - name: Config and build
         run: |


### PR DESCRIPTION
In Github actions macOS runner, libomp is installed with brew, but not linked. cmake does not find it, though clang is able to find and use it when building. The PR #5663 set WITH_OPENMP=OFF if cmake is not able to find OpenMP, and hence macOS is built without OpenMP on Github. This PR links libomp, so that both cmake and clang can find it.

GHA run with this branch: 
https://github.com/isl-org/Open3D/actions/runs/3430223624/jobs/5716910302#step:6:12210
libomp location: 
https://github.com/isl-org/Open3D/actions/runs/3430223624/jobs/5716910302#step:6:12210

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5668)
<!-- Reviewable:end -->
