### PR TITLE
Fix build issue on Apple M1

### DIFF
--- a/3rdparty/filament/filament_build.cmake
+++ b/3rdparty/filament/filament_build.cmake
@@ -66,5 +66,7 @@ ExternalProject_Add(
         -DFILAMENT_SUPPORTS_VULKAN=OFF
         -DFILAMENT_SKIP_SAMPLES=ON
         -DFILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB=20 # to support many small entities
+        -DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT}
+
     BUILD_BYPRODUCTS ${lib_byproducts}
 )


### PR DESCRIPTION
Xcode CommandLine Tools 14.1 includes SDK13.0 as the default SDK. Numerous APIs are deprecated in 13.0 which causes warnings. On Apple Silicon systems Open3D builds Filament from scratch and one of its subprojects unconditionally adds `-Werror` to the compiler flags which causes a handful for deprecation warnings to become errors. A quick workaround is to build against SDK12. This PR ensures that if Open3D is configured with a user set `OSX_SYSROOT` that Filament is configured with the same value.