### PR TITLE
ignore filament compilation warning (macos)

### DIFF
--- a/3rdparty/filament/filament_build.cmake
+++ b/3rdparty/filament/filament_build.cmake
@@ -43,6 +43,12 @@ set(lib_byproducts ${filament_LIBRARIES})
 list(TRANSFORM lib_byproducts PREPEND ${FILAMENT_ROOT}/${lib_dir}/${CMAKE_STATIC_LIBRARY_PREFIX})
 list(TRANSFORM lib_byproducts APPEND ${CMAKE_STATIC_LIBRARY_SUFFIX})
 
+set(filament_cxx_flags "${CMAKE_CXX_FLAGS} -Wno-deprecated")
+if(NOT WIN32)
+    # Issue Open3D#1909, filament#2146
+    set(filament_cxx_flags "${filament_cxx_flags} -fno-builtin")
+endif()
+
 ExternalProject_Add(
     ext_filament
     PREFIX filament
@@ -59,7 +65,7 @@ ExternalProject_Add(
         -DCMAKE_CXX_COMPILER=${FILAMENT_CXX_COMPILER}
         -DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}
         -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
-        $<$<NOT:$<PLATFORM_ID:Windows>>:-DCMAKE_CXX_FLAGS="-fno-builtin">  # Issue Open3D#1909, filament#2146
+        -DCMAKE_CXX_FLAGS:STRING=${filament_cxx_flags}
         -DCMAKE_INSTALL_PREFIX=${FILAMENT_ROOT}
         -DUSE_STATIC_CRT=${STATIC_WINDOWS_RUNTIME}
         -DUSE_STATIC_LIBCXX=ON


### PR DESCRIPTION
System info:

```bash
(open3d) ➜  ~/repo/Open3D/build (master) clang --version
Apple clang version 14.0.0 (clang-1400.0.29.202)
Target: arm64-apple-darwin22.1.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin

(open3d) ➜  ~/repo/Open3D/build (master) pkgutil --pkg-info=com.apple.pkg.CLTools_Executables
package-id: com.apple.pkg.CLTools_Executables
version: 14.1.0.0.1.1666437224
volume: /
location: /
install-time: 1667393287
groups: com.apple.FindSystemFiles.pkg-group 

(open3d) ➜  ~/repo/Open3D/build (master) sw_vers
ProductName:            macOS
ProductVersion:         13.0
BuildVersion:           22A380

```

Fixes the following error on M1 Macs:

```bash
In file included from /Users/yixing/repo/Open3D/build/filament/src/ext_filament/third_party/spirv-tools/source/opt/scalar_replacement_pass.cpp:15:
/Users/yixing/repo/Open3D/build/filament/src/ext_filament/third_party/spirv-tools/source/opt/scalar_replacement_pass.h:42:5: error: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations]
    sprintf(&name_[strlen(name_)], "%d", max_num_elements_);
    ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.0.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.0.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
1 error generated.
make[5]: *** [third_party/spirv-tools/source/opt/CMakeFiles/SPIRV-Tools-opt.dir/scalar_replacement_pass.cpp.o] Error 1
make[5]: *** Waiting for unfinished jobs....
In file included from /Users/yixing/repo/Open3D/build/filament/src/ext_filament/third_party/spirv-tools/source/opt/optimizer.cpp:28:
In file included from /Users/yixing/repo/Open3D/build/filament/src/ext_filament/third_party/spirv-tools/source/opt/passes.h:70:
/Users/yixing/repo/Open3D/build/filament/src/ext_filament/third_party/spirv-tools/source/opt/scalar_replacement_pass.h:42:5: error: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations]
    sprintf(&name_[strlen(name_)], "%d", max_num_elements_);
    ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.0.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.0.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
1 error generated.
make[5]: *** [third_party/spirv-tools/source/opt/CMakeFiles/SPIRV-Tools-opt.dir/optimizer.cpp.o] Error 1
make[4]: *** [third_party/spirv-tools/source/opt/CMakeFiles/SPIRV-Tools-opt.dir/all] Error 2
make[3]: *** [all] Error 2
make[2]: *** [filament/src/ext_filament-stamp/ext_filament-build] Error 2
make[1]: *** [CMakeFiles/ext_f
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5673)
<!-- Reviewable:end -->
