### PR TITLE
Fix multi-device CUDA switching bug

### DIFF
--- a/cpp/open3d/core/CUDAUtils.h
+++ b/cpp/open3d/core/CUDAUtils.h
@@ -225,6 +225,19 @@ int GetCUDACurrentDeviceTextureAlignment();
 
 /// Returns the size of total global memory for the current device.
 size_t GetCUDACurrentTotalMemSize();
+
+#else
+
+/// When CUDA is not enabled, this is a dummy class.
+class CUDAScopedDevice {
+public:
+    explicit CUDAScopedDevice(int device_id) {}
+    explicit CUDAScopedDevice(const Device& device) {}
+    ~CUDAScopedDevice() {}
+    CUDAScopedDevice(const CUDAScopedDevice&) = delete;
+    CUDAScopedDevice& operator=(const CUDAScopedDevice&) = delete;
+};
+
 #endif
 
 namespace cuda {

--- a/cpp/open3d/core/hashmap/CUDA/StdGPUHashBackend.h
+++ b/cpp/open3d/core/hashmap/CUDA/StdGPUHashBackend.h
@@ -186,16 +186,19 @@ StdGPUHashBackend<Key, Hash, Eq>::StdGPUHashBackend(
         const std::vector<int64_t>& value_dsizes,
         const Device& device)
     : DeviceHashBackend(init_capacity, key_dsize, value_dsizes, device) {
+    CUDAScopedDevice scoped_device(this->device_);
     Allocate(init_capacity);
 }
 
 template <typename Key, typename Hash, typename Eq>
 StdGPUHashBackend<Key, Hash, Eq>::~StdGPUHashBackend() {
+    CUDAScopedDevice scoped_device(this->device_);
     Free();
 }
 
 template <typename Key, typename Hash, typename Eq>
 int64_t StdGPUHashBackend<Key, Hash, Eq>::Size() const {
+    CUDAScopedDevice scoped_device(this->device_);
     return impl_.size();
 }
 
@@ -222,6 +225,7 @@ void StdGPUHashBackend<Key, Hash, Eq>::Find(const void* input_keys,
                                             buf_index_t* output_buf_indices,
                                             bool* output_masks,
                                             int64_t count) {
+    CUDAScopedDevice scoped_device(this->device_);
     uint32_t threads = 128;
     uint32_t blocks = (count + threads - 1) / threads;
 
@@ -260,6 +264,7 @@ template <typename Key, typename Hash, typename Eq>
 void StdGPUHashBackend<Key, Hash, Eq>::Erase(const void* input_keys,
                                              bool* output_masks,
                                              int64_t count) {
+    CUDAScopedDevice scoped_device(this->device_);
     uint32_t threads = 128;
     uint32_t blocks = (count + threads - 1) / threads;
 
@@ -285,6 +290,7 @@ struct ValueExtractor {
 template <typename Key, typename Hash, typename Eq>
 int64_t StdGPUHashBackend<Key, Hash, Eq>::GetActiveIndices(
         buf_index_t* output_indices) {
+    CUDAScopedDevice scoped_device(this->device_);
     auto range = impl_.device_range();
 
     thrust::transform(range.begin(), range.end(), output_indices,
@@ -295,25 +301,31 @@ int64_t StdGPUHashBackend<Key, Hash, Eq>::GetActiveIndices(
 
 template <typename Key, typename Hash, typename Eq>
 void StdGPUHashBackend<Key, Hash, Eq>::Clear() {
+    CUDAScopedDevice scoped_device(this->device_);
     impl_.clear();
     this->buffer_->ResetHeap();
 }
 
 template <typename Key, typename Hash, typename Eq>
-void StdGPUHashBackend<Key, Hash, Eq>::Reserve(int64_t capacity) {}
+void StdGPUHashBackend<Key, Hash, Eq>::Reserve(int64_t capacity) {
+    CUDAScopedDevice scoped_device(this->device_);
+}
 
 template <typename Key, typename Hash, typename Eq>
 int64_t StdGPUHashBackend<Key, Hash, Eq>::GetBucketCount() const {
+    CUDAScopedDevice scoped_device(this->device_);
     return impl_.bucket_count();
 }
 
 template <typename Key, typename Hash, typename Eq>
 std::vector<int64_t> StdGPUHashBackend<Key, Hash, Eq>::BucketSizes() const {
+    CUDAScopedDevice scoped_device(this->device_);
     utility::LogError("Unimplemented");
 }
 
 template <typename Key, typename Hash, typename Eq>
 float StdGPUHashBackend<Key, Hash, Eq>::LoadFactor() const {
+    CUDAScopedDevice scoped_device(this->device_);
     return impl_.load_factor();
 }
 
@@ -378,6 +390,7 @@ void StdGPUHashBackend<Key, Hash, Eq>::Insert(
         buf_index_t* output_buf_indices,
         bool* output_masks,
         int64_t count) {
+    CUDAScopedDevice scoped_device(this->device_);
     uint32_t threads = 128;
     uint32_t blocks = (count + threads - 1) / threads;
 
@@ -402,6 +415,7 @@ void StdGPUHashBackend<Key, Hash, Eq>::Insert(
 
 template <typename Key, typename Hash, typename Eq>
 void StdGPUHashBackend<Key, Hash, Eq>::Allocate(int64_t capacity) {
+    CUDAScopedDevice scoped_device(this->device_);
     this->capacity_ = capacity;
 
     // Allocate buffer for key values.
@@ -424,6 +438,7 @@ void StdGPUHashBackend<Key, Hash, Eq>::Allocate(int64_t capacity) {
 
 template <typename Key, typename Hash, typename Eq>
 void StdGPUHashBackend<Key, Hash, Eq>::Free() {
+    CUDAScopedDevice scoped_device(this->device_);
     // Buffer is automatically handled by the smart pointer.
     buffer_accessor_.Shutdown(this->device_);
 

--- a/cpp/open3d/core/kernel/ArangeCUDA.cu
+++ b/cpp/open3d/core/kernel/ArangeCUDA.cu
@@ -24,6 +24,7 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/core/Dispatch.h"
 #include "open3d/core/ParallelFor.h"
 #include "open3d/core/Tensor.h"
@@ -37,6 +38,7 @@ void ArangeCUDA(const Tensor& start,
                 const Tensor& stop,
                 const Tensor& step,
                 Tensor& dst) {
+    CUDAScopedDevice scoped_device(start.GetDevice());
     Dtype dtype = start.GetDtype();
     DISPATCH_DTYPE_TO_TEMPLATE(dtype, [&]() {
         scalar_t sstart = start.Item<scalar_t>();

--- a/cpp/open3d/core/kernel/IndexGetSetCUDA.cu
+++ b/cpp/open3d/core/kernel/IndexGetSetCUDA.cu
@@ -68,6 +68,7 @@ void IndexGetCUDA(const Tensor& src,
                   const std::vector<Tensor>& index_tensors,
                   const SizeVector& indexed_shape,
                   const SizeVector& indexed_strides) {
+    CUDAScopedDevice scoped_device(src.GetDevice());
     Dtype dtype = src.GetDtype();
     AdvancedIndexer ai(src, dst, index_tensors, indexed_shape, indexed_strides,
                        AdvancedIndexer::AdvancedIndexerMode::GET);
@@ -96,6 +97,7 @@ void IndexSetCUDA(const Tensor& src,
                   const std::vector<Tensor>& index_tensors,
                   const SizeVector& indexed_shape,
                   const SizeVector& indexed_strides) {
+    CUDAScopedDevice scoped_device(src.GetDevice());
     Dtype dtype = src.GetDtype();
     AdvancedIndexer ai(src, dst, index_tensors, indexed_shape, indexed_strides,
                        AdvancedIndexer::AdvancedIndexerMode::SET);

--- a/cpp/open3d/core/kernel/NonZeroCUDA.cu
+++ b/cpp/open3d/core/kernel/NonZeroCUDA.cu
@@ -29,6 +29,7 @@
 #include <thrust/for_each.h>
 #include <thrust/iterator/zip_iterator.h>
 
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/core/Indexer.h"
 #include "open3d/core/kernel/NonZero.h"
 
@@ -75,6 +76,7 @@ protected:
 };
 
 Tensor NonZeroCUDA(const Tensor& src) {
+    CUDAScopedDevice scoped_device(src.GetDevice());
     Tensor src_contiguous = src.Contiguous();
     const int64_t num_elements = src_contiguous.NumElements();
     const int64_t num_bytes =

--- a/cpp/open3d/core/linalg/AddMM.cpp
+++ b/cpp/open3d/core/linalg/AddMM.cpp
@@ -28,6 +28,8 @@
 
 #include <unordered_map>
 
+#include "open3d/core/CUDAUtils.h"
+
 namespace open3d {
 namespace core {
 
@@ -110,8 +112,9 @@ void AddMM(const Tensor& A,
 
     if (device.IsCUDA()) {
 #ifdef BUILD_CUDA_MODULE
+        CUDAScopedDevice scoped_device(device);
         AddMMCUDA(B_data, A_data, C_data, n, k, m, alpha, beta, transB, transA,
-                  ldb, lda, ldc, dtype);
+                  ldb, lda, ldc, dtype, device);
 #else
         utility::LogError("Unimplemented device.");
 #endif

--- a/cpp/open3d/core/linalg/AddMM.h
+++ b/cpp/open3d/core/linalg/AddMM.h
@@ -53,7 +53,8 @@ void AddMMCUDA(void* A_data,
                int lda,
                int ldb,
                int ldc,
-               Dtype dtype);
+               Dtype dtype,
+               const Device& device);
 #endif
 
 void AddMMCPU(void* A_data,

--- a/cpp/open3d/core/linalg/AddMMCUDA.cpp
+++ b/cpp/open3d/core/linalg/AddMMCUDA.cpp
@@ -45,8 +45,9 @@ void AddMMCUDA(void* A_data,
                int lda,
                int ldb,
                int ldc,
-               Dtype dtype) {
-    cublasHandle_t handle = CuBLASContext::GetInstance()->GetHandle();
+               Dtype dtype,
+               const Device& device) {
+    cublasHandle_t handle = CuBLASContext::GetInstance().GetHandle(device);
     DISPATCH_LINALG_DTYPE_TO_TEMPLATE(dtype, [&]() {
         scalar_t alpha_ = scalar_t(alpha);
         scalar_t beta_ = scalar_t(beta);

--- a/cpp/open3d/core/linalg/Inverse.cpp
+++ b/cpp/open3d/core/linalg/Inverse.cpp
@@ -28,6 +28,7 @@
 
 #include <unordered_map>
 
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/core/linalg/LinalgHeadersCPU.h"
 
 namespace open3d {
@@ -57,6 +58,7 @@ void Inverse(const Tensor &A, Tensor &output) {
 
     if (device.IsCUDA()) {
 #ifdef BUILD_CUDA_MODULE
+        CUDAScopedDevice scoped_device(device);
         Tensor ipiv = Tensor::Zeros({n}, core::Int32, device);
         void *ipiv_data = ipiv.GetDataPtr();
 

--- a/cpp/open3d/core/linalg/InverseCUDA.cpp
+++ b/cpp/open3d/core/linalg/InverseCUDA.cpp
@@ -38,7 +38,8 @@ void InverseCUDA(void* A_data,
                  int64_t n,
                  Dtype dtype,
                  const Device& device) {
-    cusolverDnHandle_t handle = CuSolverContext::GetInstance()->GetHandle();
+    cusolverDnHandle_t handle =
+            CuSolverContext::GetInstance().GetHandle(device);
 
     DISPATCH_LINALG_DTYPE_TO_TEMPLATE(dtype, [&]() {
         int len;

--- a/cpp/open3d/core/linalg/LU.cpp
+++ b/cpp/open3d/core/linalg/LU.cpp
@@ -26,6 +26,7 @@
 
 #include "open3d/core/linalg/LU.h"
 
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/core/linalg/LUImpl.h"
 #include "open3d/core/linalg/LinalgHeadersCPU.h"
 #include "open3d/core/linalg/Tri.h"
@@ -108,6 +109,7 @@ void LUIpiv(const Tensor& A, Tensor& ipiv, Tensor& output) {
     // matrix was interchanged with row IPIV(i).
     if (device.IsCUDA()) {
 #ifdef BUILD_CUDA_MODULE
+        CUDAScopedDevice scoped_device(device);
         int64_t ipiv_len = std::min(rows, cols);
         ipiv = core::Tensor::Empty({ipiv_len}, core::Int32, device);
         void* ipiv_data = ipiv.GetDataPtr();

--- a/cpp/open3d/core/linalg/LUCUDA.cpp
+++ b/cpp/open3d/core/linalg/LUCUDA.cpp
@@ -37,7 +37,8 @@ void LUCUDA(void* A_data,
             int64_t cols,
             Dtype dtype,
             const Device& device) {
-    cusolverDnHandle_t handle = CuSolverContext::GetInstance()->GetHandle();
+    cusolverDnHandle_t handle =
+            CuSolverContext::GetInstance().GetHandle(device);
     DISPATCH_LINALG_DTYPE_TO_TEMPLATE(dtype, [&]() {
         int len;
         OPEN3D_CUSOLVER_CHECK(

--- a/cpp/open3d/core/linalg/LeastSquares.cpp
+++ b/cpp/open3d/core/linalg/LeastSquares.cpp
@@ -28,6 +28,8 @@
 
 #include <unordered_map>
 
+#include "open3d/core/CUDAUtils.h"
+
 namespace open3d {
 namespace core {
 
@@ -76,6 +78,7 @@ void LeastSquares(const Tensor &A, const Tensor &B, Tensor &X) {
 
     if (device.IsCUDA()) {
 #ifdef BUILD_CUDA_MODULE
+        CUDAScopedDevice scoped_device(device);
         LeastSquaresCUDA(A_data, B_data, m, n, k, dtype, device);
 #else
         utility::LogError("Unimplemented device.");

--- a/cpp/open3d/core/linalg/LeastSquaresCUDA.cpp
+++ b/cpp/open3d/core/linalg/LeastSquaresCUDA.cpp
@@ -48,8 +48,9 @@ void LeastSquaresCUDA(void* A_data,
                       Dtype dtype,
                       const Device& device) {
     cusolverDnHandle_t cusolver_handle =
-            CuSolverContext::GetInstance()->GetHandle();
-    cublasHandle_t cublas_handle = CuBLASContext::GetInstance()->GetHandle();
+            CuSolverContext::GetInstance().GetHandle(device);
+    cublasHandle_t cublas_handle =
+            CuBLASContext::GetInstance().GetHandle(device);
 
     DISPATCH_LINALG_DTYPE_TO_TEMPLATE(dtype, [&]() {
         int len_geqrf, len_ormqr, len;

--- a/cpp/open3d/core/linalg/LinalgUtils.h
+++ b/cpp/open3d/core/linalg/LinalgUtils.h
@@ -26,9 +26,9 @@
 
 #pragma once
 
-#include <memory>
 #include <string>
 
+#include "open3d/core/Device.h"
 #include "open3d/core/Dtype.h"
 #include "open3d/core/MemoryManager.h"
 #include "open3d/core/linalg/LinalgHeadersCPU.h"
@@ -93,31 +93,32 @@ inline void OPEN3D_CUSOLVER_CHECK_WITH_DINFO(cusolverStatus_t status,
 
 class CuSolverContext {
 public:
-    static std::shared_ptr<CuSolverContext> GetInstance();
-    CuSolverContext();
+    static CuSolverContext& GetInstance();
+
+    CuSolverContext(const CuSolverContext&) = delete;
+    CuSolverContext& operator=(const CuSolverContext&) = delete;
     ~CuSolverContext();
 
-    cusolverDnHandle_t& GetHandle() { return handle_; }
+    cusolverDnHandle_t& GetHandle(const Device& device);
 
 private:
-    cusolverDnHandle_t handle_;
-
-    static std::shared_ptr<CuSolverContext> instance_;
+    CuSolverContext();
+    std::unordered_map<Device, cusolverDnHandle_t> map_device_to_handle_;
 };
 
 class CuBLASContext {
 public:
-    static std::shared_ptr<CuBLASContext> GetInstance();
+    static CuBLASContext& GetInstance();
 
-    CuBLASContext();
+    CuBLASContext(const CuBLASContext&) = delete;
+    CuBLASContext& operator=(const CuBLASContext&) = delete;
     ~CuBLASContext();
 
-    cublasHandle_t& GetHandle() { return handle_; }
+    cublasHandle_t& GetHandle(const Device& device);
 
 private:
-    cublasHandle_t handle_;
-
-    static std::shared_ptr<CuBLASContext> instance_;
+    CuBLASContext();
+    std::unordered_map<Device, cublasHandle_t> map_device_to_handle_;
 };
 #endif
 }  // namespace core

--- a/cpp/open3d/core/linalg/Matmul.cpp
+++ b/cpp/open3d/core/linalg/Matmul.cpp
@@ -28,6 +28,8 @@
 
 #include <unordered_map>
 
+#include "open3d/core/CUDAUtils.h"
+
 namespace open3d {
 namespace core {
 
@@ -84,7 +86,8 @@ void Matmul(const Tensor& A, const Tensor& B, Tensor& output) {
 
     if (device.IsCUDA()) {
 #ifdef BUILD_CUDA_MODULE
-        MatmulCUDA(B_data, A_data, C_data, n, k, m, dtype);
+        CUDAScopedDevice scoped_device(device);
+        MatmulCUDA(B_data, A_data, C_data, n, k, m, dtype, device);
 #else
         utility::LogError("Unimplemented device.");
 #endif

--- a/cpp/open3d/core/linalg/Matmul.h
+++ b/cpp/open3d/core/linalg/Matmul.h
@@ -41,7 +41,8 @@ void MatmulCUDA(void* A_data,
                 int64_t m,
                 int64_t k,
                 int64_t n,
-                Dtype dtype);
+                Dtype dtype,
+                const Device& device);
 #endif
 void MatmulCPU(void* A_data,
                void* B_data,

--- a/cpp/open3d/core/linalg/MatmulCUDA.cpp
+++ b/cpp/open3d/core/linalg/MatmulCUDA.cpp
@@ -38,8 +38,9 @@ void MatmulCUDA(void* A_data,
                 int64_t m,
                 int64_t k,
                 int64_t n,
-                Dtype dtype) {
-    cublasHandle_t handle = CuBLASContext::GetInstance()->GetHandle();
+                Dtype dtype,
+                const Device& device) {
+    cublasHandle_t handle = CuBLASContext::GetInstance().GetHandle(device);
     DISPATCH_LINALG_DTYPE_TO_TEMPLATE(dtype, [&]() {
         scalar_t alpha = 1, beta = 0;
         OPEN3D_CUBLAS_CHECK(

--- a/cpp/open3d/core/linalg/SVD.cpp
+++ b/cpp/open3d/core/linalg/SVD.cpp
@@ -28,6 +28,8 @@
 
 #include <unordered_map>
 
+#include "open3d/core/CUDAUtils.h"
+
 namespace open3d {
 namespace core {
 
@@ -67,6 +69,7 @@ void SVD(const Tensor &A, Tensor &U, Tensor &S, Tensor &VT) {
 
     if (device.IsCUDA()) {
 #ifdef BUILD_CUDA_MODULE
+        CUDAScopedDevice scoped_device(device);
         SVDCUDA(A_data, U_data, S_data, VT_data, superb_data, m, n, dtype,
                 device);
 #else

--- a/cpp/open3d/core/linalg/SVDCUDA.cpp
+++ b/cpp/open3d/core/linalg/SVDCUDA.cpp
@@ -41,7 +41,8 @@ void SVDCUDA(const void* A_data,
              int64_t n,
              Dtype dtype,
              const Device& device) {
-    cusolverDnHandle_t handle = CuSolverContext::GetInstance()->GetHandle();
+    cusolverDnHandle_t handle =
+            CuSolverContext::GetInstance().GetHandle(device);
 
     DISPATCH_LINALG_DTYPE_TO_TEMPLATE(dtype, [&]() {
         int len;

--- a/cpp/open3d/core/linalg/Solve.cpp
+++ b/cpp/open3d/core/linalg/Solve.cpp
@@ -32,6 +32,7 @@
 
 #include <unordered_map>
 
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/core/linalg/LinalgHeadersCPU.h"
 
 namespace open3d {
@@ -80,6 +81,7 @@ void Solve(const Tensor &A, const Tensor &B, Tensor &X) {
 
     if (device.IsCUDA()) {
 #ifdef BUILD_CUDA_MODULE
+        CUDAScopedDevice scoped_device(device);
         Tensor ipiv = Tensor::Empty({n}, core::Int32, device);
         void *ipiv_data = ipiv.GetDataPtr();
 

--- a/cpp/open3d/core/linalg/SolveCUDA.cpp
+++ b/cpp/open3d/core/linalg/SolveCUDA.cpp
@@ -43,7 +43,8 @@ void SolveCUDA(void* A_data,
                int64_t k,
                Dtype dtype,
                const Device& device) {
-    cusolverDnHandle_t handle = CuSolverContext::GetInstance()->GetHandle();
+    cusolverDnHandle_t handle =
+            CuSolverContext::GetInstance().GetHandle(device);
 
     DISPATCH_LINALG_DTYPE_TO_TEMPLATE(dtype, [&]() {
         int len;

--- a/cpp/open3d/core/linalg/Tri.cpp
+++ b/cpp/open3d/core/linalg/Tri.cpp
@@ -26,6 +26,7 @@
 
 #include "open3d/core/linalg/Tri.h"
 
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/core/Tensor.h"
 #include "open3d/core/linalg/TriImpl.h"
 
@@ -56,6 +57,7 @@ void Triu(const Tensor& A, Tensor& output, const int diagonal) {
     output = core::Tensor::Zeros(A.GetShape(), A.GetDtype(), device);
     if (device.IsCUDA()) {
 #ifdef BUILD_CUDA_MODULE
+        CUDAScopedDevice scoped_device(device);
         TriuCUDA(A.Contiguous(), output, diagonal);
 #else
         utility::LogError("Unimplemented device.");
@@ -71,6 +73,7 @@ void Tril(const Tensor& A, Tensor& output, const int diagonal) {
     output = core::Tensor::Zeros(A.GetShape(), A.GetDtype(), device);
     if (device.IsCUDA()) {
 #ifdef BUILD_CUDA_MODULE
+        CUDAScopedDevice scoped_device(device);
         TrilCUDA(A.Contiguous(), output, diagonal);
 #else
         utility::LogError("Unimplemented device.");
@@ -87,6 +90,7 @@ void Triul(const Tensor& A, Tensor& upper, Tensor& lower, const int diagonal) {
     lower = core::Tensor::Zeros(A.GetShape(), A.GetDtype(), device);
     if (device.IsCUDA()) {
 #ifdef BUILD_CUDA_MODULE
+        CUDAScopedDevice scoped_device(device);
         TriulCUDA(A.Contiguous(), upper, lower, diagonal);
 #else
         utility::LogError("Unimplemented device.");

--- a/cpp/open3d/core/nns/FixedRadiusSearchOps.cu
+++ b/cpp/open3d/core/nns/FixedRadiusSearchOps.cu
@@ -25,6 +25,7 @@
 // ----------------------------------------------------------------------------
 //
 
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/core/Tensor.h"
 #include "open3d/core/nns/FixedRadiusIndex.h"
 #include "open3d/core/nns/FixedRadiusSearchImpl.cuh"
@@ -42,6 +43,7 @@ void BuildSpatialHashTableCUDA(const Tensor& points,
                                const Tensor& hash_table_splits,
                                Tensor& hash_table_index,
                                Tensor& hash_table_cell_splits) {
+    CUDAScopedDevice scoped_device(points.GetDevice());
     const cudaStream_t stream = 0;
     int texture_alignment = 512;
 
@@ -90,6 +92,7 @@ void FixedRadiusSearchCUDA(const Tensor& points,
                            Tensor& neighbors_index,
                            Tensor& neighbors_row_splits,
                            Tensor& neighbors_distance) {
+    CUDAScopedDevice scoped_device(points.GetDevice());
     const cudaStream_t stream = 0;
     int texture_alignment = 512;
 
@@ -189,6 +192,7 @@ void HybridSearchCUDA(const Tensor& points,
                       Tensor& neighbors_index,
                       Tensor& neighbors_count,
                       Tensor& neighbors_distance) {
+    CUDAScopedDevice scoped_device(points.GetDevice());
     const cudaStream_t stream = 0;
 
     Device device = points.GetDevice();

--- a/cpp/open3d/core/nns/KnnSearchOps.cu
+++ b/cpp/open3d/core/nns/KnnSearchOps.cu
@@ -52,6 +52,7 @@ void KnnSearchCUDABruteForce(const Tensor& points,
                              int knn,
                              OUTPUT_ALLOCATOR& output_allocator,
                              Tensor& query_neighbors_row_splits) {
+    CUDAScopedDevice scoped_device(points.GetDevice());
     const cudaStream_t stream = cuda::GetStream();
     int num_points = points.GetShape(0);
     int num_queries = queries.GetShape(0);
@@ -117,6 +118,7 @@ void KnnSearchCUDAOptimized(const Tensor& points,
                             int knn,
                             OUTPUT_ALLOCATOR& output_allocator,
                             Tensor& query_neighbors_row_splits) {
+    CUDAScopedDevice scoped_device(points.GetDevice());
     int num_points = points.GetShape(0);
     int num_queries = queries.GetShape(0);
     int dim = points.GetShape(1);
@@ -241,6 +243,7 @@ void KnnSearchCUDA(const Tensor& points,
                    Tensor& neighbors_index,
                    Tensor& neighbors_row_splits,
                    Tensor& neighbors_distance) {
+    CUDAScopedDevice scoped_device(points.GetDevice());
     int num_points = points.GetShape(0);
     int num_queries = queries.GetShape(0);
     Device device = points.GetDevice();

--- a/cpp/open3d/t/geometry/kernel/NPPImage.cpp
+++ b/cpp/open3d/t/geometry/kernel/NPPImage.cpp
@@ -80,6 +80,13 @@ static NppStreamContext MakeNPPContext() {
 }
 
 void RGBToGray(const core::Tensor &src_im, core::Tensor &dst_im) {
+    if (src_im.GetDevice() != dst_im.GetDevice()) {
+        utility::LogError(
+                "src_im and dst_im are not on the same device, got {} and {}.",
+                src_im.GetDevice().ToString(), dst_im.GetDevice().ToString());
+    }
+    core::CUDAScopedDevice scoped_device(src_im.GetDevice());
+
     NppiSize size_ROI = {static_cast<int>(dst_im.GetShape(1)),
                          static_cast<int>(dst_im.GetShape(0))};
 
@@ -109,6 +116,13 @@ void RGBToGray(const core::Tensor &src_im, core::Tensor &dst_im) {
 void Resize(const open3d::core::Tensor &src_im,
             open3d::core::Tensor &dst_im,
             t::geometry::Image::InterpType interp_type) {
+    if (src_im.GetDevice() != dst_im.GetDevice()) {
+        utility::LogError(
+                "src_im and dst_im are not on the same device, got {} and {}.",
+                src_im.GetDevice().ToString(), dst_im.GetDevice().ToString());
+    }
+    core::CUDAScopedDevice scoped_device(src_im.GetDevice());
+
     // Supported device and datatype checking happens in calling code and will
     // result in an exception if there are errors.
     NppiSize src_size = {static_cast<int>(src_im.GetShape(1)),
@@ -180,6 +194,12 @@ void Resize(const open3d::core::Tensor &src_im,
 }
 
 void Dilate(const core::Tensor &src_im, core::Tensor &dst_im, int kernel_size) {
+    if (src_im.GetDevice() != dst_im.GetDevice()) {
+        utility::LogError(
+                "src_im and dst_im are not on the same device, got {} and {}.",
+                src_im.GetDevice().ToString(), dst_im.GetDevice().ToString());
+    }
+    core::CUDAScopedDevice scoped_device(src_im.GetDevice());
     // Supported device and datatype checking happens in calling code and will
     // result in an exception if there are errors.
 
@@ -244,6 +264,13 @@ void Dilate(const core::Tensor &src_im, core::Tensor &dst_im, int kernel_size) {
 void Filter(const open3d::core::Tensor &src_im,
             open3d::core::Tensor &dst_im,
             const open3d::core::Tensor &kernel) {
+    if (src_im.GetDevice() != dst_im.GetDevice()) {
+        utility::LogError(
+                "src_im and dst_im are not on the same device, got {} and {}.",
+                src_im.GetDevice().ToString(), dst_im.GetDevice().ToString());
+    }
+    core::CUDAScopedDevice scoped_device(src_im.GetDevice());
+
     // Supported device and datatype checking happens in calling code and will
     // result in an exception if there are errors.
     NppiSize src_size = {static_cast<int>(src_im.GetShape(1)),
@@ -312,6 +339,13 @@ void FilterBilateral(const core::Tensor &src_im,
                      int kernel_size,
                      float value_sigma,
                      float distance_sigma) {
+    if (src_im.GetDevice() != dst_im.GetDevice()) {
+        utility::LogError(
+                "src_im and dst_im are not on the same device, got {} and {}.",
+                src_im.GetDevice().ToString(), dst_im.GetDevice().ToString());
+    }
+    core::CUDAScopedDevice scoped_device(src_im.GetDevice());
+
     // Supported device and datatype checking happens in calling code and will
     // result in an exception if there are errors.
     NppiSize src_size = {static_cast<int>(src_im.GetShape(1)),
@@ -363,6 +397,13 @@ void FilterGaussian(const core::Tensor &src_im,
                     core::Tensor &dst_im,
                     int kernel_size,
                     float sigma) {
+    if (src_im.GetDevice() != dst_im.GetDevice()) {
+        utility::LogError(
+                "src_im and dst_im are not on the same device, got {} and {}.",
+                src_im.GetDevice().ToString(), dst_im.GetDevice().ToString());
+    }
+    core::CUDAScopedDevice scoped_device(src_im.GetDevice());
+
     // Generate separable kernel weights given the sigma value.
     core::Tensor dist =
             core::Tensor::Arange(static_cast<float>(-kernel_size / 2),
@@ -384,6 +425,16 @@ void FilterSobel(const core::Tensor &src_im,
                  core::Tensor &dst_im_dx,
                  core::Tensor &dst_im_dy,
                  int kernel_size) {
+    if (src_im.GetDevice() != dst_im_dx.GetDevice() ||
+        src_im.GetDevice() != dst_im_dy.GetDevice()) {
+        utility::LogError(
+                "src_im, dst_im_dx, and dst_im_dy are not on the same device, "
+                "got {}, {} and {}.",
+                src_im.GetDevice().ToString(), dst_im_dx.GetDevice().ToString(),
+                dst_im_dy.GetDevice().ToString());
+    }
+    core::CUDAScopedDevice scoped_device(src_im.GetDevice());
+
     // Supported device and datatype checking happens in calling code and will
     // result in an exception if there are errors.
     NppiSize src_size = {static_cast<int>(src_im.GetShape(1)),

--- a/cpp/open3d/t/pipelines/kernel/Feature.cpp
+++ b/cpp/open3d/t/pipelines/kernel/Feature.cpp
@@ -26,6 +26,7 @@
 
 #include "open3d/t/pipelines/kernel/Feature.h"
 
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/core/TensorCheck.h"
 
 namespace open3d {
@@ -47,6 +48,7 @@ void ComputeFPFHFeature(const core::Tensor &points,
         ComputeFPFHFeatureCPU(points_d, normals_d, indices, distance2, counts_d,
                               fpfhs);
     } else {
+        core::CUDAScopedDevice scoped_device(points.GetDevice());
         CUDA_CALL(ComputeFPFHFeatureCUDA, points_d, normals_d, indices,
                   distance2, counts_d, fpfhs);
     }

--- a/cpp/open3d/t/pipelines/kernel/FillInLinearSystem.cpp
+++ b/cpp/open3d/t/pipelines/kernel/FillInLinearSystem.cpp
@@ -26,6 +26,7 @@
 
 #include "open3d/t/pipelines/kernel/FillInLinearSystem.h"
 
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/core/TensorCheck.h"
 
 namespace open3d {
@@ -72,6 +73,7 @@ void FillInRigidAlignmentTerm(core::Tensor &AtA,
 
     } else if (AtA.IsCUDA()) {
 #ifdef BUILD_CUDA_MODULE
+        core::CUDAScopedDevice scoped_device(AtA.GetDevice());
         FillInRigidAlignmentTermCUDA(AtA, Atb, residual, Ti_ps, Tj_qs,
                                      Ri_normal_ps, i, j, threshold);
 
@@ -133,6 +135,7 @@ void FillInSLACAlignmentTerm(core::Tensor &AtA,
 
     } else if (AtA.IsCUDA()) {
 #ifdef BUILD_CUDA_MODULE
+        core::CUDAScopedDevice scoped_device(AtA.GetDevice());
         FillInSLACAlignmentTermCUDA(AtA, Atb, residual, Ti_ps, Tj_qs, normal_ps,
                                     Ri_normal_ps, RjT_Ri_normal_ps,
                                     cgrid_idx_ps, cgrid_idx_qs, cgrid_ratio_ps,
@@ -173,6 +176,7 @@ void FillInSLACRegularizerTerm(core::Tensor &AtA,
 
     } else if (AtA.IsCUDA()) {
 #ifdef BUILD_CUDA_MODULE
+        core::CUDAScopedDevice scoped_device(AtA.GetDevice());
         FillInSLACRegularizerTermCUDA(
                 AtA, Atb, residual, grid_idx, grid_nbs_idx, grid_nbs_mask,
                 positions_init, positions_curr, weight, n, anchor_idx);

--- a/cpp/open3d/t/pipelines/kernel/RGBDOdometry.cpp
+++ b/cpp/open3d/t/pipelines/kernel/RGBDOdometry.cpp
@@ -72,6 +72,7 @@ void ComputeOdometryResultPointToPlane(
                 intrinsics_d, trans_d, delta, inlier_residual, inlier_count,
                 depth_outlier_trunc, depth_huber_delta);
     } else if (device.IsCUDA()) {
+        core::CUDAScopedDevice scoped_device(source_vertex_map.GetDevice());
         CUDA_CALL(ComputeOdometryResultPointToPlaneCUDA, source_vertex_map,
                   target_vertex_map, target_normal_map, intrinsics_d, trans_d,
                   delta, inlier_residual, inlier_count, depth_outlier_trunc,
@@ -130,6 +131,7 @@ void ComputeOdometryResultIntensity(const core::Tensor &source_depth,
                 intrinsics_d, trans_d, delta, inlier_residual, inlier_count,
                 depth_outlier_trunc, intensity_huber_delta);
     } else if (device.IsCUDA()) {
+        core::CUDAScopedDevice scoped_device(source_depth.GetDevice());
         CUDA_CALL(ComputeOdometryResultIntensityCUDA, source_depth,
                   target_depth, source_intensity, target_intensity,
                   target_intensity_dx, target_intensity_dy, source_vertex_map,
@@ -197,6 +199,7 @@ void ComputeOdometryResultHybrid(const core::Tensor &source_depth,
                 delta, inlier_residual, inlier_count, depth_outlier_trunc,
                 depth_huber_delta, intensity_huber_delta);
     } else if (device.IsCUDA()) {
+        core::CUDAScopedDevice scoped_device(source_depth.GetDevice());
         CUDA_CALL(ComputeOdometryResultHybridCUDA, source_depth, target_depth,
                   source_intensity, target_intensity, target_depth_dx,
                   target_depth_dy, target_intensity_dx, target_intensity_dy,

--- a/cpp/open3d/t/pipelines/kernel/RGBDOdometryCUDA.cu
+++ b/cpp/open3d/t/pipelines/kernel/RGBDOdometryCUDA.cu
@@ -112,6 +112,8 @@ void ComputeOdometryResultPointToPlaneCUDA(
         int& inlier_count,
         const float depth_outlier_trunc,
         const float depth_huber_delta) {
+    core::CUDAScopedDevice scoped_device(source_vertex_map.GetDevice());
+
     NDArrayIndexer source_vertex_indexer(source_vertex_map, 2);
     NDArrayIndexer target_vertex_indexer(target_vertex_map, 2);
     NDArrayIndexer target_normal_indexer(target_normal_map, 2);
@@ -211,6 +213,8 @@ void ComputeOdometryResultIntensityCUDA(
         int& inlier_count,
         const float depth_outlier_trunc,
         const float intensity_huber_delta) {
+    core::CUDAScopedDevice scoped_device(source_depth.GetDevice());
+
     NDArrayIndexer source_depth_indexer(source_depth, 2);
     NDArrayIndexer target_depth_indexer(target_depth, 2);
 
@@ -328,6 +332,8 @@ void ComputeOdometryResultHybridCUDA(const core::Tensor& source_depth,
                                      const float depth_outlier_trunc,
                                      const float depth_huber_delta,
                                      const float intensity_huber_delta) {
+    core::CUDAScopedDevice scoped_device(source_depth.GetDevice());
+
     NDArrayIndexer source_depth_indexer(source_depth, 2);
     NDArrayIndexer target_depth_indexer(target_depth, 2);
 

--- a/cpp/open3d/t/pipelines/kernel/Registration.cpp
+++ b/cpp/open3d/t/pipelines/kernel/Registration.cpp
@@ -54,6 +54,7 @@ core::Tensor ComputePosePointToPlane(const core::Tensor &source_points,
                 correspondence_indices.Contiguous(), pose, residual,
                 inlier_count, source_points.GetDtype(), device, kernel);
     } else if (source_points.IsCUDA()) {
+        core::CUDAScopedDevice scoped_device(source_points.GetDevice());
         CUDA_CALL(ComputePosePointToPlaneCUDA, source_points.Contiguous(),
                   target_points.Contiguous(), target_normals.Contiguous(),
                   correspondence_indices.Contiguous(), pose, residual,
@@ -94,6 +95,7 @@ core::Tensor ComputePoseColoredICP(const core::Tensor &source_points,
                 inlier_count, source_points.GetDtype(), device, kernel,
                 lambda_geometric);
     } else if (source_points.IsCUDA()) {
+        core::CUDAScopedDevice scoped_device(source_points.GetDevice());
         CUDA_CALL(ComputePoseColoredICPCUDA, source_points.Contiguous(),
                   source_colors.Contiguous(), target_points.Contiguous(),
                   target_normals.Contiguous(), target_colors.Contiguous(),
@@ -130,6 +132,7 @@ std::tuple<core::Tensor, core::Tensor> ComputeRtPointToPoint(
                 source_points.GetDtype(), device);
     } else if (source_points.IsCUDA()) {
 #ifdef BUILD_CUDA_MODULE
+        core::CUDAScopedDevice scoped_device(source_points.GetDevice());
         // TODO: Implement optimized CUDA reduction kernel.
         core::Tensor valid = correspondence_indices.Ne(-1).Reshape({-1});
         // correpondence_set : (i, corres[i]).
@@ -198,6 +201,7 @@ core::Tensor ComputeInformationMatrix(
                 target_points.Contiguous(), correspondence_indices.Contiguous(),
                 information_matrix, target_points.GetDtype(), device);
     } else if (target_points.IsCUDA()) {
+        core::CUDAScopedDevice scoped_device(target_points.GetDevice());
         CUDA_CALL(ComputeInformationMatrixCUDA, target_points.Contiguous(),
                   correspondence_indices.Contiguous(), information_matrix,
                   target_points.GetDtype(), device);

--- a/cpp/open3d/t/pipelines/kernel/RegistrationCUDA.cu
+++ b/cpp/open3d/t/pipelines/kernel/RegistrationCUDA.cu
@@ -107,6 +107,7 @@ void ComputePosePointToPlaneCUDA(const core::Tensor &source_points,
                                  const core::Dtype &dtype,
                                  const core::Device &device,
                                  const registration::RobustKernel &kernel) {
+    core::CUDAScopedDevice scoped_device(source_points.GetDevice());
     int n = source_points.GetLength();
 
     core::Tensor global_sum = core::Tensor::Zeros({29}, dtype, device);
@@ -211,6 +212,7 @@ void ComputePoseColoredICPCUDA(const core::Tensor &source_points,
                                const core::Device &device,
                                const registration::RobustKernel &kernel,
                                const double &lambda_geometric) {
+    core::CUDAScopedDevice scoped_device(source_points.GetDevice());
     int n = source_points.GetLength();
 
     core::Tensor global_sum = core::Tensor::Zeros({29}, dtype, device);
@@ -295,6 +297,7 @@ void ComputeInformationMatrixCUDA(const core::Tensor &target_points,
                                   core::Tensor &information_matrix,
                                   const core::Dtype &dtype,
                                   const core::Device &device) {
+    core::CUDAScopedDevice scoped_device(target_points.GetDevice());
     int n = correspondence_indices.GetLength();
 
     core::Tensor global_sum = core::Tensor::Zeros({21}, dtype, device);

--- a/cpp/open3d/t/pipelines/kernel/TransformationConverter.cpp
+++ b/cpp/open3d/t/pipelines/kernel/TransformationConverter.cpp
@@ -28,6 +28,7 @@
 
 #include <cmath>
 
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/core/Dispatch.h"
 #include "open3d/core/Tensor.h"
 #include "open3d/core/TensorCheck.h"
@@ -77,6 +78,7 @@ static void PoseToTransformationDevice(
         PoseToTransformationImpl<scalar_t>(transformation_ptr, pose_ptr);
     } else if (device_type == core::Device::DeviceType::CUDA) {
 #ifdef BUILD_CUDA_MODULE
+        core::CUDAScopedDevice scoped_device(transformation.GetDevice());
         PoseToTransformationCUDA<scalar_t>(transformation_ptr, pose_ptr);
 #else
         utility::LogError("Not compiled with CUDA, but CUDA device is used.");

--- a/cpp/tests/core/CoreTest.cpp
+++ b/cpp/tests/core/CoreTest.cpp
@@ -55,8 +55,14 @@ std::vector<core::Device> PermuteDevices::TestCases() {
     if (!cpu_devices.empty()) {
         devices.push_back(cpu_devices[0]);
     }
-    if (!cuda_devices.empty()) {
+
+    // Test 0, 1, or 2 CUDA devices.
+    // Testing 2 CUDA devices is necessary for testing device switching.
+    if (cuda_devices.size() == 1) {
         devices.push_back(cuda_devices[0]);
+    } else if (cuda_devices.size() == 2) {
+        devices.push_back(cuda_devices[0]);
+        devices.push_back(cuda_devices[1]);
     }
 
     return devices;


### PR DESCRIPTION
- Enable two CUDA devices in `tests::PermuteDevices::TestCases()`, when there are two CUDA GPUs
  - This exposes various bugs of device switching in the core and geometry code, e.g. illegal memory access when running on `CUDA:1`. For example:
    ![image](https://user-images.githubusercontent.com/1501945/201357967-8bd5d01b-4afc-4d3c-b1fe-fc9fdd3e3b1e.png)

- Fixes for the following tests:
```
- Linalg/LinalgPermuteDevices.Matmul
- Linalg/LinalgPermuteDevices.AddMM
- Linalg/LinalgPermuteDevices.LU
- Linalg/LinalgPermuteDevices.LUIpiv
- Linalg/LinalgPermuteDevices.Triu
- Linalg/LinalgPermuteDevices.Tril
- Linalg/LinalgPermuteDevices.Triul
- Linalg/LinalgPermuteDevices.Inverse
- Linalg/LinalgPermuteDevices.SVD
- Linalg/LinalgPermuteDevices.Solve
- Linalg/LinalgPermuteDevices.LeastSquares

- HashMap/HashMapPermuteDevices.SimpleInit
- HashMap/HashMapPermuteDevices.Find
- HashMap/HashMapPermuteDevices.Insert
- HashMap/HashMapPermuteDevices.Erase
- HashMap/HashMapPermuteDevices.Reserve
- HashMap/HashMapPermuteDevices.Clear
- HashMap/HashMapPermuteDevices.InsertComplexKeys
- HashMap/HashMapPermuteDevices.MultivalueInsertion
- HashMap/HashMapPermuteDevices.HashSet
- HashMap/HashMapPermuteDevices.HashMapIO

- NearestNeighborSearch/NNSPermuteDevices.KnnSearch
- NearestNeighborSearch/NNSPermuteDevices.FixedRadiusSearch
- NearestNeighborSearch/NNSPermuteDevices.HybridSearch

- All image functions using NPP

- Tensor
  - Arrange
  - IndexGetSet
  - NonZero

- Almost all custom geometry kernels
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5675)
<!-- Reviewable:end -->
