### PR TITLE
Address issue #5697

### DIFF
--- a/examples/python/visualization/mouse_and_point_coord.py
+++ b/examples/python/visualization/mouse_and_point_coord.py
@@ -100,7 +100,7 @@ class ExampleApp:
                     text = ""
                 else:
                     world = self.widget3d.scene.camera.unproject(
-                        event.x, event.y, depth, self.widget3d.frame.width,
+                        x, y, depth, self.widget3d.frame.width,
                         self.widget3d.frame.height)
                     text = "({:.3f}, {:.3f}, {:.3f})".format(
                         world[0], world[1], world[2])


### PR DESCRIPTION
Feed the unproject method of camera with the x, y view-coordinates instead of the x, y window-coordinates to transform into world-coordinates.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5701)
<!-- Reviewable:end -->
