### PR TITLE
Add draw_web to CLI for remote visualization.

### DIFF
--- a/python/tools/cli.py
+++ b/python/tools/cli.py
@@ -202,7 +202,7 @@ def _example(parser, args):
 
 
 def _draw(parser, args):
-    if args.filename == None:
+    if args.filename is None:
         parser.print_help()
     elif not os.path.isfile(args.filename):
         print(f"Error: could not find file: {args.filename}")
@@ -214,6 +214,20 @@ def _draw(parser, args):
     app.main()
     sys.argv.insert(1, removed_arg)
     return 0
+
+
+def _draw_webrtc(parser, args):
+    if args.filename is None:
+        parser.print_help()
+    elif not os.path.isfile(args.filename):
+        print(f"Error: could not find file: {args.filename}")
+        parser.print_help()
+        parser.exit(2)
+    if args.bind_all:
+        os.environ['WEBRTC_IP'] = "0.0.0.0"
+    mesh = o3d.t.io.read_triangle_mesh(args.filename)
+    o3d.visualization.webrtc_server.enable_webrtc()
+    o3d.visualization.draw(mesh)
 
 
 def main():
@@ -315,6 +329,36 @@ def main():
                              action="help",
                              help="Show this help message and exit.")
     parser_draw.set_defaults(func=_draw)
+
+    draw_web_help = (
+        "Load and visualize a 3D model in a browser with WebRTC. Example usage:\n"
+        "# Visualize a 3D model file at http://localhost:8888 \n"
+        "  open3d draw_web path/to/model_file \n"
+        "# Visualize a 3D model file at http://hostname.domainname:8888 \n"
+        "  open3d draw_web --bind_all path/to/model_file")
+    parser_draw_web = subparsers.add_parser(
+        "draw_web",
+        description=draw_web_help,
+        help=draw_web_help,
+        add_help=False,
+        formatter_class=argparse.RawTextHelpFormatter)
+
+    parser_draw_web.add_argument("filename",
+                                 nargs="?",
+                                 help="Name of the mesh or point cloud file.")
+    parser_draw_web.add_argument(
+        "--bind_all",
+        required=False,
+        action="store_true",
+        dest="bind_all",
+        help="Listen for connections on all interfaces. "
+        "This is only secure in a private network and"
+        " with an encrypted tunnel.")
+    parser_draw_web.add_argument("-h",
+                                 "--help",
+                                 action="help",
+                                 help="Show this help message and exit.")
+    parser_draw_web.set_defaults(func=_draw_webrtc)
 
     args = main_parser.parse_args()
     if args.command in subparsers.choices.keys():

--- a/python/tools/cli.py
+++ b/python/tools/cli.py
@@ -37,8 +37,7 @@ import open3d.app as app
 class _Open3DArgumentParser(argparse.ArgumentParser):
 
     def error(self, message):
-        sys.stderr.write("Error: %s\n" % message)
-        self.print_help()
+        print(f"Error: {message}\n", file=sys.stderr)
         self.exit(2)
 
 
@@ -72,15 +71,17 @@ def _get_all_examples_dict():
 def _get_runnable_examples_dict():
     examples_dict = _get_all_examples_dict()
     categories_to_remove = [
-        "benchmark", "reconstruction_system", "t_reconstruction_system"
+        "benchmark",
+        "reconstruction_system",
+        "t_reconstruction_system",
     ]
     examples_to_remove = {
-        "io": ["realsense_io",],
+        "io": ["realsense_io"],
         "visualization": [
             "online_processing",
             "tensorboard_pytorch",
             "tensorboard_tensorflow",
-        ]
+        ],
     }
     for cat in categories_to_remove:
         examples_dict.pop(cat)
@@ -127,7 +128,9 @@ def _example_help_categories():
     msg = f"\ncategories:\n"
     for category in sorted(_get_example_categories()):
         msg += f"  {category}\n"
-    msg += "\nTo view the example in each category, run one of the following commands:\n"
+    msg += (
+        "\nTo view the example in each category, run one of the following commands:\n"
+    )
     for category in sorted(_get_example_categories()):
         msg += f"  open3d example --list {category}\n"
     return msg
@@ -135,7 +138,7 @@ def _example_help_categories():
 
 def _example(parser, args):
 
-    if args.category_example == None:
+    if args.category_example is None:
         if args.list:
             for category in _get_example_categories():
                 print("examples in " + category + ": ")
@@ -150,13 +153,12 @@ def _example(parser, args):
     try:
         category = args.category_example.split("/")[0]
         example = args.category_example.split("/")[1]
-    except:
+    except IndexError:
         category = args.category_example
         example = ""
 
     if category not in _get_example_categories():
-        print("Error: invalid category provided: " + category)
-        parser.print_help()
+        print("Error: invalid category provided: " + category, file=sys.stderr)
         parser.exit(2)
 
     if args.list:
@@ -169,13 +171,17 @@ def _example(parser, args):
             print("  open3d example --list\n")
             return 0
         else:
-            print("Error: invalid category provided: " + args.category_example)
-            parser.print_help()
+            print(
+                "Error: invalid category provided: " + args.category_example,
+                file=sys.stderr,
+            )
             parser.exit(2)
 
     if args.category_example not in _get_all_examples():
-        print("Error: invalid example name provided: " + args.category_example)
-        parser.print_help()
+        print(
+            "Error: invalid example name provided: " + args.category_example,
+            file=sys.stderr,
+        )
         parser.exit(2)
 
     examples_dir = _get_examples_dir()
@@ -205,8 +211,7 @@ def _draw(parser, args):
     if args.filename is None:
         parser.print_help()
     elif not os.path.isfile(args.filename):
-        print(f"Error: could not find file: {args.filename}")
-        parser.print_help()
+        print(f"Error: could not find file: {args.filename}", file=sys.stderr)
         parser.exit(2)
 
     removed_arg = sys.argv[1]
@@ -220,11 +225,10 @@ def _draw_webrtc(parser, args):
     if args.filename is None:
         parser.print_help()
     elif not os.path.isfile(args.filename):
-        print(f"Error: could not find file: {args.filename}")
-        parser.print_help()
+        print(f"Error: could not find file: {args.filename}", file=sys.stderr)
         parser.exit(2)
     if args.bind_all:
-        os.environ['WEBRTC_IP'] = "0.0.0.0"
+        os.environ["WEBRTC_IP"] = "0.0.0.0"
     mesh = o3d.t.io.read_triangle_mesh(args.filename)
     o3d.visualization.webrtc_server.enable_webrtc()
     o3d.visualization.draw(mesh)
@@ -242,12 +246,15 @@ def main():
     main_parser = _Open3DArgumentParser(
         description="Open3D commad-line tools",
         add_help=False,
-        formatter_class=argparse.RawTextHelpFormatter)
-    main_parser.add_argument("-V",
-                             "--version",
-                             action="version",
-                             version="Open3D " + o3d.__version__,
-                             help="Show program's version number and exit.")
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    main_parser.add_argument(
+        "-V",
+        "--version",
+        action="version",
+        version="Open3D " + o3d.__version__,
+        help="Show program's version number and exit.",
+    )
     main_parser.add_argument("-h",
                              "--help",
                              action="help",
@@ -270,13 +277,15 @@ def main():
         add_help=False,
         description=example_help + _example_help_categories(),
         help=example_help,
-        formatter_class=argparse.RawTextHelpFormatter)
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
     parser_example.add_argument(
         "category_example",
         nargs="?",
         help=
         "Category/example_name of an example (supports .py extension too)\n",
-        type=_support_choice_with_dot_py)
+        type=_support_choice_with_dot_py,
+    )
     parser_example.add_argument("example_args",
                                 nargs="*",
                                 help="Arguments for the example to be run\n")
@@ -291,7 +300,8 @@ def main():
         "  open3d example --list \n"
         "  open3d example --list [category]\n"
         "e.g.:\n"
-        "  open3d example --list geometry\n ")
+        "  open3d example --list geometry\n ",
+    )
     parser_example.add_argument(
         "-s",
         "--show",
@@ -302,7 +312,8 @@ def main():
         "usage:\n"
         "  open3d example --show [category]/[example_name]\n"
         "e.g.:\n"
-        "  open3d example --show geometry/triangle_mesh_deformation\n ")
+        "  open3d example --show geometry/triangle_mesh_deformation\n",
+    )
     parser_example.add_argument("-h",
                                 "--help",
                                 action="help",
@@ -312,14 +323,15 @@ def main():
     draw_help = (
         "Load and visualize a 3D model. Example usage:\n"
         "  open3d draw                                            # Start a blank Open3D viewer\n"
-        "  open3d draw path/to/model_file                         # Visualize a 3D model file\n"
+        "  open3d draw path/to/model_file                         # Visualize a 3D model file\n\n"
     )
     parser_draw = subparsers.add_parser(
         "draw",
         description=draw_help,
         help=draw_help,
         add_help=False,
-        formatter_class=argparse.RawTextHelpFormatter)
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
 
     parser_draw.add_argument("filename",
                              nargs="?",
@@ -331,17 +343,20 @@ def main():
     parser_draw.set_defaults(func=_draw)
 
     draw_web_help = (
-        "Load and visualize a 3D model in a browser with WebRTC. Example usage:\n"
-        "# Visualize a 3D model file at http://localhost:8888 \n"
-        "  open3d draw_web path/to/model_file \n"
-        "# Visualize a 3D model file at http://hostname.domainname:8888 \n"
-        "  open3d draw_web --bind_all path/to/model_file")
+        "Load and visualize a 3D model in a browser with WebRTC. Optionally, you can\n"
+        "customize the serving IP address and port with WEBRTC_IP and WEBRTC_PORT\n"
+        "environment variables. Example usage:\n"
+        "  open3d draw_web path/to/model_file            # Visualize at http://localhost:8888\n"
+        "  open3d draw_web --bind_all path/to/model_file # Serve to the entire local network\n"
+        "                                                # at http://hostname.domainname:8888\n"
+    )
     parser_draw_web = subparsers.add_parser(
         "draw_web",
         description=draw_web_help,
         help=draw_web_help,
         add_help=False,
-        formatter_class=argparse.RawTextHelpFormatter)
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
 
     parser_draw_web.add_argument("filename",
                                  nargs="?",
@@ -351,9 +366,9 @@ def main():
         required=False,
         action="store_true",
         dest="bind_all",
-        help="Listen for connections on all interfaces. "
-        "This is only secure in a private network and"
-        " with an encrypted tunnel.")
+        help="Listen for connections on all interfaces in the local network.\n"
+        "Note: There is no encryption.",
+    )
     parser_draw_web.add_argument("-h",
                                  "--help",
                                  action="help",

--- a/python/tools/cli.py
+++ b/python/tools/cli.py
@@ -229,9 +229,16 @@ def _draw_webrtc(parser, args):
         parser.exit(2)
     if args.bind_all:
         os.environ["WEBRTC_IP"] = "0.0.0.0"
-    mesh = o3d.t.io.read_triangle_mesh(args.filename)
+    filetype = o3d.io.read_file_geometry_type(args.filename)
+    if (filetype & o3d.io.CONTAINS_TRIANGLES):
+        geometry = o3d.io.read_triangle_model(args.filename)
+    else:
+        geometry = o3d.t.io.read_point_cloud(args.filename)
+        if 'normals' not in geometry.point and 'colors' not in geometry.point:
+            geometry.estimate_normals()
+            geometry.normalize_normals()
     o3d.visualization.webrtc_server.enable_webrtc()
-    o3d.visualization.draw(mesh)
+    o3d.visualization.draw(geometry)
 
 
 def main():


### PR DESCRIPTION
```$ open3d draw_web -h
***************************************************
* Open3D: A Modern Library for 3D Data Processing *
*                                                 *
* Version 0.16.0+7862ccd51                        *
* Docs    http://www.open3d.org/docs              *
* Code    https://github.com/isl-org/Open3D       *
***************************************************
usage: open3d draw_web [--bind_all] [-h] [filename]

Load and visualize a 3D model in a browser with WebRTC. Optionally, you can
customize the serving IP address and port with WEBRTC_IP and WEBRTC_PORT
environment variables. Example usage:
  open3d draw_web path/to/model_file            # Visualize at http://localhost:8888
  open3d draw_web --bind_all path/to/model_file # Serve to the entire local network
                                                # at http://hostname.domainname:8888

positional arguments:
  filename    Name of the mesh or point cloud file.

optional arguments:
  --bind_all  Listen for connections on all interfaces in the local network.
              Note: There is no encryption.
  -h, --help  Show this help message and exit.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5707)
<!-- Reviewable:end -->
