### PR TITLE
Fix Wstringop-owerflow compilation error for GCC

### DIFF
--- a/cpp/tools/GLInfo.cpp
+++ b/cpp/tools/GLInfo.cpp
@@ -41,6 +41,10 @@ void TryGLVersion(int major,
     std::string forwardCompatStr =
             (forwardCompat ? "GLFW_OPENGL_FORWARD_COMPAT " : "");
     std::string profileStr = "UnknownProfile";
+    // Some versions of GCC reports Wstringop-overflow error if string storage
+    // is not reserved. This might be related to a bug reported here:
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96963
+    profileStr.reserve(32);
 #define OPEN3D_CHECK_PROFILESTR(p) \
     if (profileId == p) {          \
         profileStr = #p;           \


### PR DESCRIPTION
I am using GCC 12.2 and have not tried with GCC 11 or older to check if this is really a regression described in here https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96963 or at least related, but simple `std::string::reserve()` is enough to fix that compilation error in my case.