### PR TITLE
fixed a bug in CreateFromTriangleMeshWithinBounds

### DIFF
--- a/cpp/open3d/geometry/VoxelGridFactory.cpp
+++ b/cpp/open3d/geometry/VoxelGridFactory.cpp
@@ -141,9 +141,7 @@ std::shared_ptr<VoxelGrid> VoxelGrid::CreateFromTriangleMeshWithinBounds(
     for (int widx = 0; widx < num_w; widx++) {
         for (int hidx = 0; hidx < num_h; hidx++) {
             for (int didx = 0; didx < num_d; didx++) {
-                const Eigen::Vector3d box_center =
-                        min_bound + 
-                        Eigen::Vector3d(widx, hidx, didx) * voxel_size + box_half_size;
+                const Eigen::Vector3d box_center = min_bound + box_half_size + Eigen::Vector3d(widx, hidx, didx) * voxel_size;
                 for (const Eigen::Vector3i &tria : input.triangles_) {
                     const Eigen::Vector3d &v0 = input.vertices_[tria(0)];
                     const Eigen::Vector3d &v1 = input.vertices_[tria(1)];

--- a/cpp/open3d/geometry/VoxelGridFactory.cpp
+++ b/cpp/open3d/geometry/VoxelGridFactory.cpp
@@ -141,10 +141,9 @@ std::shared_ptr<VoxelGrid> VoxelGrid::CreateFromTriangleMeshWithinBounds(
     for (int widx = 0; widx < num_w; widx++) {
         for (int hidx = 0; hidx < num_h; hidx++) {
             for (int didx = 0; didx < num_d; didx++) {
-                const Eigen::Vector3d box_center = 
-                  min_bound + 
-                  box_half_size + 
-                  Eigen::Vector3d(widx, hidx, didx) * voxel_size;
+                const Eigen::Vector3d box_center =
+                        min_bound + box_half_size +
+                        Eigen::Vector3d(widx, hidx, didx) * voxel_size;
                 for (const Eigen::Vector3i &tria : input.triangles_) {
                     const Eigen::Vector3d &v0 = input.vertices_[tria(0)];
                     const Eigen::Vector3d &v1 = input.vertices_[tria(1)];

--- a/cpp/open3d/geometry/VoxelGridFactory.cpp
+++ b/cpp/open3d/geometry/VoxelGridFactory.cpp
@@ -142,8 +142,8 @@ std::shared_ptr<VoxelGrid> VoxelGrid::CreateFromTriangleMeshWithinBounds(
         for (int hidx = 0; hidx < num_h; hidx++) {
             for (int didx = 0; didx < num_d; didx++) {
                 const Eigen::Vector3d box_center =
-                        min_bound +
-                        Eigen::Vector3d(widx, hidx, didx) * voxel_size;
+                        min_bound + 
+                        Eigen::Vector3d(widx, hidx, didx) * voxel_size + box_half_size;
                 for (const Eigen::Vector3i &tria : input.triangles_) {
                     const Eigen::Vector3d &v0 = input.vertices_[tria(0)];
                     const Eigen::Vector3d &v1 = input.vertices_[tria(1)];

--- a/cpp/open3d/geometry/VoxelGridFactory.cpp
+++ b/cpp/open3d/geometry/VoxelGridFactory.cpp
@@ -141,9 +141,10 @@ std::shared_ptr<VoxelGrid> VoxelGrid::CreateFromTriangleMeshWithinBounds(
     for (int widx = 0; widx < num_w; widx++) {
         for (int hidx = 0; hidx < num_h; hidx++) {
             for (int didx = 0; didx < num_d; didx++) {
-                const Eigen::Vector3d box_center = min_bound 
-                  + box_half_size 
-                  + Eigen::Vector3d(widx, hidx, didx) * voxel_size;
+                const Eigen::Vector3d box_center = 
+                  min_bound + 
+                  box_half_size + 
+                  Eigen::Vector3d(widx, hidx, didx) * voxel_size;
                 for (const Eigen::Vector3i &tria : input.triangles_) {
                     const Eigen::Vector3d &v0 = input.vertices_[tria(0)];
                     const Eigen::Vector3d &v1 = input.vertices_[tria(1)];

--- a/cpp/open3d/geometry/VoxelGridFactory.cpp
+++ b/cpp/open3d/geometry/VoxelGridFactory.cpp
@@ -141,7 +141,9 @@ std::shared_ptr<VoxelGrid> VoxelGrid::CreateFromTriangleMeshWithinBounds(
     for (int widx = 0; widx < num_w; widx++) {
         for (int hidx = 0; hidx < num_h; hidx++) {
             for (int didx = 0; didx < num_d; didx++) {
-                const Eigen::Vector3d box_center = min_bound + box_half_size + Eigen::Vector3d(widx, hidx, didx) * voxel_size;
+                const Eigen::Vector3d box_center = min_bound 
+                  + box_half_size 
+                  + Eigen::Vector3d(widx, hidx, didx) * voxel_size;
                 for (const Eigen::Vector3i &tria : input.triangles_) {
                     const Eigen::Vector3d &v0 = input.vertices_[tria(0)];
                     const Eigen::Vector3d &v1 = input.vertices_[tria(1)];


### PR DESCRIPTION
The box_center calculation was wrong. it gave the corner of a voxel, instead of the center of the box. shifting by half box  size should fix it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5759)
<!-- Reviewable:end -->
