### PR TITLE
remove normals from assimp importer

### DIFF
--- a/cpp/open3d/io/file_format/FileASSIMP.cpp
+++ b/cpp/open3d/io/file_format/FileASSIMP.cpp
@@ -257,6 +257,9 @@ bool ReadTriangleMeshUsingASSIMP(
         current_vidx += assimp_mesh->mNumVertices;
     }
 
+    // Compute triangle normals independent from assimp
+    mesh.ComputeTriangleNormals();
+
     // Now load the materials
     for (size_t i = 0; i < scene->mNumMaterials; ++i) {
         auto* mat = scene->mMaterials[i];
@@ -410,6 +413,9 @@ bool ReadModelUsingAssimp(const std::string& filename,
                 mesh->vertex_colors_.push_back({c.r, c.g, c.b});
             }
         }
+
+        // Compute triangle normals independent from assimp
+        mesh->ComputeTriangleNormals();
 
         // Add the mesh to the model
         model.meshes_.push_back({mesh, std::string(assimp_mesh->mName.C_Str()),

--- a/cpp/open3d/io/file_format/FileASSIMP.cpp
+++ b/cpp/open3d/io/file_format/FileASSIMP.cpp
@@ -225,12 +225,14 @@ bool ReadTriangleMeshUsingASSIMP(
             mesh.triangle_material_ids_.push_back(assimp_mesh->mMaterialIndex);
         }
 
+/*
         if (assimp_mesh->mNormals) {
             for (size_t nidx = 0; nidx < assimp_mesh->mNumVertices; ++nidx) {
                 auto& normal = assimp_mesh->mNormals[nidx];
                 mesh.vertex_normals_.push_back({normal.x, normal.y, normal.z});
             }
         }
+*/
 
         // NOTE: only support a single UV channel
         if (assimp_mesh->HasTextureCoords(0)) {
@@ -257,8 +259,8 @@ bool ReadTriangleMeshUsingASSIMP(
         current_vidx += assimp_mesh->mNumVertices;
     }
 
-    // Compute triangle normals independent from assimp
-    mesh.ComputeTriangleNormals();
+    // Compute vertex normals independent from assimp
+    mesh.ComputeVertexNormals();
 
     // Now load the materials
     for (size_t i = 0; i < scene->mNumMaterials; ++i) {
@@ -386,12 +388,14 @@ bool ReadModelUsingAssimp(const std::string& filename,
             mesh->triangles_.push_back(facet);
         }
 
+/*
         if (assimp_mesh->mNormals) {
             for (size_t nidx = 0; nidx < assimp_mesh->mNumVertices; ++nidx) {
                 auto& normal = assimp_mesh->mNormals[nidx];
                 mesh->vertex_normals_.push_back({normal.x, normal.y, normal.z});
             }
         }
+*/
 
         // NOTE: only use the first UV channel
         if (assimp_mesh->HasTextureCoords(0)) {
@@ -414,8 +418,8 @@ bool ReadModelUsingAssimp(const std::string& filename,
             }
         }
 
-        // Compute triangle normals independent from assimp
-        mesh->ComputeTriangleNormals();
+        // Compute vertex normals independent from assimp
+        mesh->ComputeVertexNormals();
 
         // Add the mesh to the model
         model.meshes_.push_back({mesh, std::string(assimp_mesh->mName.C_Str()),

--- a/cpp/open3d/io/file_format/FileASSIMP.cpp
+++ b/cpp/open3d/io/file_format/FileASSIMP.cpp
@@ -59,7 +59,7 @@ const unsigned int kPostProcessFlags_compulsory =
         aiProcess_JoinIdenticalVertices;
 
 const unsigned int kPostProcessFlags_fast =
-        aiProcessPreset_TargetRealtime_Fast |
+        (aiProcessPreset_TargetRealtime_Fast & ~aiProcess_GenNormals) |
         aiProcess_RemoveRedundantMaterials | aiProcess_OptimizeMeshes |
         aiProcess_PreTransformVertices;
 

--- a/cpp/open3d/io/file_format/FileASSIMP.cpp
+++ b/cpp/open3d/io/file_format/FileASSIMP.cpp
@@ -340,8 +340,11 @@ bool ReadModelUsingAssimp(const std::string& filename,
     // is silent on this salient point).
     importer.SetProgressHandler(
             new AssimpProgress(params, readfile_total / progress_total));
+    unsigned int post_process_flags = kPostProcessFlags_fast;
+    importer.SetPropertyInteger(AI_CONFIG_PP_RVC_FLAGS, aiComponent_NORMALS);
+    post_process_flags |= aiProcess_RemoveComponent;
     const auto* scene =
-            importer.ReadFile(filename.c_str(), kPostProcessFlags_fast);
+            importer.ReadFile(filename.c_str(), post_process_flags);
     if (!scene) {
         utility::LogWarning("Unable to load file {} with ASSIMP", filename);
         return false;

--- a/cpp/open3d/io/file_format/FileASSIMP.cpp
+++ b/cpp/open3d/io/file_format/FileASSIMP.cpp
@@ -184,6 +184,8 @@ bool ReadTriangleMeshUsingASSIMP(
         post_process_flags = kPostProcessFlags_fast;
     }
 
+    importer.SetPropertyInteger(AI_CONFIG_PP_RVC_FLAGS, aiComponent_NORMALS);
+    post_process_flags |= aiProcess_RemoveComponent;
     const auto* scene = importer.ReadFile(filename.c_str(), post_process_flags);
     if (!scene) {
         utility::LogWarning("Unable to load file {} with ASSIMP", filename);


### PR DESCRIPTION
## symptom

https://www.dropbox.com/s/7f0g474xf9nb5wm/teapot.stl

with this patch:

```
python3 -c 'import open3d,sys; mesh=open3d.io.read_triangle_mesh(sys.argv[1], enable_post_processing=True); print("triangles=%d, vertices=%d"%(len(mesh.triangles),len(mesh.vertices))); mesh=mesh.compute_vertex_normals(); mesh=mesh.simplify_quadric_decimation(target_number_of_triangles=400); open3d.io.write_triangle_mesh("out.stl", mesh)' ~/Downloads/teapot.stl 
triangles=894, vertices=480
```

https://www.dropbox.com/s/ad75o4vegilsvsb/out_patch.stl

without this patch:

```
python3 -c 'import open3d,sys; mesh=open3d.io.read_triangle_mesh(sys.argv[1], enable_post_processing=True); print("triangles=%d, vertices=%d"%(len(mesh.triangles),len(mesh.vertices))); mesh=mesh.compute_vertex_normals(); mesh=mesh.simplify_quadric_decimation(target_number_of_triangles=400); open3d.io.write_triangle_mesh("out.stl", mesh)' ~/Downloads/teapot.stl 
triangles=894, vertices=2310
```

https://www.dropbox.com/s/5xv1odt7bd610d4/out_nopatch.stl

In latter state, simplify_quadric_decimation gives broken mesh.

## method

The core issue is that aiProcess_JoinIdenticalVertices does not work well if the stl has normals because JoinIdenticalVertices considers the normals value as vertex normals while assimp STLLoader loads triangle normals. According to https://github.com/assimp/assimp/issues/407 , we need to remove normals component during import.

Also aiProcess_GenNormals (from aiProcessPreset_TargetRealtime_Fast) saves normal before running aiProcess_JoinIdenticalVertices, so it has to be removed as well.

As we dropped aiProcess_GenNormals, we ensure normals by calling ComputeVertexNormals.

/cc @jerasman @RunqiuBao

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5761)
<!-- Reviewable:end -->
