### PR TITLE
add voting and ray jitter to compute the inside outside

### DIFF
--- a/cpp/open3d/t/geometry/RaycastingScene.cpp
+++ b/cpp/open3d/t/geometry/RaycastingScene.cpp
@@ -774,14 +774,12 @@ core::Tensor VoteInsideOutside(RaycastingScene& scene,
                        // results.
     size_t num_query_points = shape.NumElements();
 
+    // Use local RNG here to generate rays with a similar direction in a
+    // deterministic manner.
+    std::mt19937 gen(42);
+    std::uniform_real_distribution<float> dist(-0.001, 0.001);
     Eigen::MatrixXf ray_dirs(3, num_votes);
-    for (int i = 0; i < num_votes; ++i) {
-        ray_dirs.col(i) =
-                Eigen::Vector3f::Ones() +
-                0.001f * Eigen::Vector3f(std::cos((i + 1) * 12815.349f),
-                                         std::cos((i + 1) * 85381.575f),
-                                         std::cos((i + 1) * 46031.538f));
-    }
+    ray_dirs = ray_dirs.unaryExpr([&](float) { return 1 + dist(gen); });
 
     auto query_points_ = query_points.Contiguous();
     Eigen::Map<Eigen::MatrixXf> query_points_map(

--- a/cpp/open3d/t/geometry/RaycastingScene.cpp
+++ b/cpp/open3d/t/geometry/RaycastingScene.cpp
@@ -774,10 +774,14 @@ core::Tensor VoteInsideOutside(RaycastingScene& scene,
                        // results.
     size_t num_query_points = shape.NumElements();
 
-    std::mt19937 gen(42);
-    std::uniform_real_distribution<float> dist(-0.001, 0.001);
     Eigen::MatrixXf ray_dirs(3, num_votes);
-    ray_dirs = ray_dirs.unaryExpr([&](float) { return 1 + dist(gen); });
+    for (int i = 0; i < num_votes; ++i) {
+        ray_dirs.col(i) =
+                Eigen::Vector3f::Ones() +
+                0.001f * Eigen::Vector3f(std::cos((i + 1) * 12815.349f),
+                                         std::cos((i + 1) * 85381.575f),
+                                         std::cos((i + 1) * 46031.538f));
+    }
 
     auto query_points_ = query_points.Contiguous();
     Eigen::Map<Eigen::MatrixXf> query_points_map(

--- a/cpp/open3d/t/geometry/RaycastingScene.cpp
+++ b/cpp/open3d/t/geometry/RaycastingScene.cpp
@@ -832,13 +832,13 @@ core::Tensor VoteInsideOutside(RaycastingScene& scene,
 core::Tensor RaycastingScene::ComputeSignedDistance(
         const core::Tensor& query_points,
         const int nthreads,
-        const int samples) {
+        const int nsamples) {
     AssertTensorDtypeLastDimDeviceMinNDim<float>(query_points, "query_points",
                                                  3, impl_->tensor_device_);
 
-    if (samples < 1 || (samples % 2) != 1) {
-        open3d::utility::LogError("samples must be odd and >= 1 but is {}",
-                                  samples);
+    if (nsamples < 1 || (nsamples % 2) != 1) {
+        open3d::utility::LogError("nsamples must be odd and >= 1 but is {}",
+                                  nsamples);
     }
     auto shape = query_points.GetShape();
     shape.pop_back();  // Remove last dim, we want to use this shape for the
@@ -850,7 +850,7 @@ core::Tensor RaycastingScene::ComputeSignedDistance(
                                              num_query_points);
 
     auto inside_outside =
-            VoteInsideOutside(*this, data, nthreads, samples, -1, 1);
+            VoteInsideOutside(*this, data, nthreads, nsamples, -1, 1);
     Eigen::Map<Eigen::VectorXi> inside_outside_map(
             inside_outside.GetDataPtr<int>(), num_query_points);
     distance_map.array() *= inside_outside_map.array().cast<float>();
@@ -859,16 +859,16 @@ core::Tensor RaycastingScene::ComputeSignedDistance(
 
 core::Tensor RaycastingScene::ComputeOccupancy(const core::Tensor& query_points,
                                                const int nthreads,
-                                               const int samples) {
+                                               const int nsamples) {
     AssertTensorDtypeLastDimDeviceMinNDim<float>(query_points, "query_points",
                                                  3, impl_->tensor_device_);
 
-    if (samples < 1 || (samples % 2) != 1) {
+    if (nsamples < 1 || (nsamples % 2) != 1) {
         open3d::utility::LogError("samples must be odd and >= 1 but is {}",
-                                  samples);
+                                  nsamples);
     }
 
-    auto result = VoteInsideOutside(*this, query_points, nthreads, samples);
+    auto result = VoteInsideOutside(*this, query_points, nthreads, nsamples);
     return result.To(core::Float32);
 }
 

--- a/cpp/open3d/t/geometry/RaycastingScene.cpp
+++ b/cpp/open3d/t/geometry/RaycastingScene.cpp
@@ -761,60 +761,115 @@ core::Tensor RaycastingScene::ComputeDistance(const core::Tensor& query_points,
     return distance;
 }
 
-core::Tensor RaycastingScene::ComputeSignedDistance(
-        const core::Tensor& query_points, const int nthreads) {
-    AssertTensorDtypeLastDimDeviceMinNDim<float>(query_points, "query_points",
-                                                 3, impl_->tensor_device_);
+namespace {
+// Helper function to determine the inside and outside with voting.
+core::Tensor VoteInsideOutside(RaycastingScene& scene,
+                               const core::Tensor& query_points,
+                               const int nthreads = 0,
+                               const int num_votes = 3,
+                               const int inside_val = 1,
+                               const int outside_val = 0) {
     auto shape = query_points.GetShape();
     shape.pop_back();  // Remove last dim, we want to use this shape for the
                        // results.
     size_t num_query_points = shape.NumElements();
 
+    std::mt19937 gen(42);
+    std::uniform_real_distribution<float> dist(-0.001, 0.001);
+    Eigen::MatrixXf ray_dirs(3, num_votes);
+    ray_dirs = ray_dirs.unaryExpr([&](float) { return 1 + dist(gen); });
+
+    auto query_points_ = query_points.Contiguous();
+    Eigen::Map<Eigen::MatrixXf> query_points_map(
+            query_points_.GetDataPtr<float>(), 3, num_query_points);
+
+    core::Tensor rays({int64_t(num_votes * num_query_points), 6},
+                      core::Float32);
+    Eigen::Map<Eigen::MatrixXf> rays_map(rays.GetDataPtr<float>(), 6,
+                                         num_votes * num_query_points);
+    if (num_votes > 1) {
+        for (size_t i = 0; i < num_query_points; ++i) {
+            for (int j = 0; j < num_votes; ++j) {
+                rays_map.col(i * num_votes + j).topRows<3>() =
+                        query_points_map.col(i);
+                rays_map.col(i * num_votes + j).bottomRows<3>() =
+                        ray_dirs.col(j);
+            }
+        }
+    } else {
+        for (size_t i = 0; i < num_query_points; ++i) {
+            rays_map.col(i).topRows<3>() = query_points_map.col(i);
+            rays_map.col(i).bottomRows<3>() = ray_dirs;
+        }
+    }
+
+    auto intersections = scene.CountIntersections(rays, nthreads);
+    Eigen::Map<Eigen::MatrixXi> intersections_map(
+            intersections.GetDataPtr<int>(), num_votes, num_query_points);
+
+    if (num_votes > 1) {
+        core::Tensor result({int64_t(num_query_points)}, core::Int32);
+        Eigen::Map<Eigen::VectorXi> result_map(result.GetDataPtr<int>(),
+                                               num_query_points);
+        result_map =
+                intersections_map.unaryExpr([&](const int x) { return x % 2; })
+                        .colwise()
+                        .sum()
+                        .unaryExpr([&](const int x) {
+                            return (x > num_votes / 2) ? inside_val
+                                                       : outside_val;
+                        });
+        return result.Reshape(shape);
+    } else {
+        intersections_map = intersections_map.unaryExpr([&](const int x) {
+            return (x % 2) ? inside_val : outside_val;
+        });
+        return intersections.Reshape(shape);
+    }
+}
+}  // namespace
+
+core::Tensor RaycastingScene::ComputeSignedDistance(
+        const core::Tensor& query_points,
+        const int nthreads,
+        const int samples) {
+    AssertTensorDtypeLastDimDeviceMinNDim<float>(query_points, "query_points",
+                                                 3, impl_->tensor_device_);
+
+    if (samples < 1 || (samples % 2) != 1) {
+        open3d::utility::LogError("samples must be odd and >= 1 but is {}",
+                                  samples);
+    }
+    auto shape = query_points.GetShape();
+    shape.pop_back();  // Remove last dim, we want to use this shape for the
+                       // results.
+    size_t num_query_points = shape.NumElements();
     auto data = query_points.Contiguous();
     auto distance = ComputeDistance(data, nthreads);
-    core::Tensor rays({int64_t(num_query_points), 6}, core::Float32);
-    rays.SetItem({core::TensorKey::Slice(0, num_query_points, 1),
-                  core::TensorKey::Slice(0, 3, 1)},
-                 data.Reshape({int64_t(num_query_points), 3}));
-    rays.SetItem({core::TensorKey::Slice(0, num_query_points, 1),
-                  core::TensorKey::Slice(3, 6, 1)},
-                 core::Tensor::Ones({1}, core::Float32, impl_->tensor_device_)
-                         .Expand({int64_t(num_query_points), 3}));
-    auto intersections = CountIntersections(rays, nthreads);
-
     Eigen::Map<Eigen::VectorXf> distance_map(distance.GetDataPtr<float>(),
                                              num_query_points);
-    Eigen::Map<Eigen::VectorXi> intersections_map(
-            intersections.GetDataPtr<int>(), num_query_points);
-    intersections_map = intersections_map.unaryExpr(
-            [](const int x) { return (x % 2) ? -1 : 1; });
-    distance_map.array() *= intersections_map.array().cast<float>();
+
+    auto inside_outside =
+            VoteInsideOutside(*this, data, nthreads, samples, -1, 1);
+    Eigen::Map<Eigen::VectorXi> inside_outside_map(
+            inside_outside.GetDataPtr<int>(), num_query_points);
+    distance_map.array() *= inside_outside_map.array().cast<float>();
     return distance;
 }
 
 core::Tensor RaycastingScene::ComputeOccupancy(const core::Tensor& query_points,
-                                               const int nthreads) {
+                                               const int nthreads,
+                                               const int samples) {
     AssertTensorDtypeLastDimDeviceMinNDim<float>(query_points, "query_points",
                                                  3, impl_->tensor_device_);
-    auto shape = query_points.GetShape();
-    shape.pop_back();  // Remove last dim, we want to use this shape for the
-                       // results.
-    size_t num_query_points = shape.NumElements();
 
-    core::Tensor rays({int64_t(num_query_points), 6}, core::Float32);
-    rays.SetItem({core::TensorKey::Slice(0, num_query_points, 1),
-                  core::TensorKey::Slice(0, 3, 1)},
-                 query_points.Reshape({int64_t(num_query_points), 3}));
-    rays.SetItem({core::TensorKey::Slice(0, num_query_points, 1),
-                  core::TensorKey::Slice(3, 6, 1)},
-                 core::Tensor::Ones({1}, core::Float32, impl_->tensor_device_)
-                         .Expand({int64_t(num_query_points), 3}));
-    auto intersections = CountIntersections(rays, nthreads);
-    Eigen::Map<Eigen::VectorXi> intersections_map(
-            intersections.GetDataPtr<int>(), num_query_points);
-    intersections_map =
-            intersections_map.unaryExpr([](const int x) { return x % 2; });
-    return intersections.To(core::Float32).Reshape(shape);
+    if (samples < 1 || (samples % 2) != 1) {
+        open3d::utility::LogError("samples must be odd and >= 1 but is {}",
+                                  samples);
+    }
+
+    auto result = VoteInsideOutside(*this, query_points, nthreads, samples);
+    return result.To(core::Float32);
 }
 
 core::Tensor RaycastingScene::CreateRaysPinhole(

--- a/cpp/open3d/t/geometry/RaycastingScene.h
+++ b/cpp/open3d/t/geometry/RaycastingScene.h
@@ -170,15 +170,17 @@ public:
     /// shape can be {depth, height, width, 3}. The last dimension must be 3 and
     /// has the format [x, y, z].
     /// \param nthreads The number of threads to use. Set to 0 for automatic.
-    /// \param samples The number of rays used for determining the inside.
-    /// This must be an odd number. The default is 1.
+    /// \param nsamples The number of rays used for determining the inside.
+    /// This must be an odd number. The default is 1. Use a higher value if you
+    /// notice sign flipping, which can occur when rays hit exactly an edge or
+    /// vertex in the scene.
     ///
     /// \return A tensor with the signed distances to
     /// the surface. The shape is
     /// {..}. Negative distances mean a point is inside a closed surface.
     core::Tensor ComputeSignedDistance(const core::Tensor &query_points,
                                        const int nthreads = 0,
-                                       const int samples = 1);
+                                       const int nsamples = 1);
 
     /// \brief Computes the occupancy at the query point positions.
     ///
@@ -195,14 +197,16 @@ public:
     /// {depth, height, width, 3}.
     /// The last dimension must be 3 and has the format [x, y, z].
     /// \param nthreads The number of threads to use. Set to 0 for automatic.
-    /// \param samples The number of rays used for determining the inside.
-    /// This must be an odd number. The default is 1.
+    /// \param nsamples The number of rays used for determining the inside.
+    /// This must be an odd number. The default is 1. Use a higher value if you
+    /// notice errors in the occupancy values. Errors can occur when rays hit
+    /// exactly an edge or vertex in the scene.
     ///
     /// \return A tensor with the occupancy values. The shape is {..}. Values
     /// are either 0 or 1. A point is occupied or inside if the value is 1.
     core::Tensor ComputeOccupancy(const core::Tensor &query_points,
                                   const int nthreads = 0,
-                                  const int samples = 1);
+                                  const int nsamples = 1);
 
     /// \brief Creates rays for the given camera parameters.
     ///

--- a/cpp/open3d/t/geometry/RaycastingScene.h
+++ b/cpp/open3d/t/geometry/RaycastingScene.h
@@ -170,11 +170,15 @@ public:
     /// shape can be {depth, height, width, 3}. The last dimension must be 3 and
     /// has the format [x, y, z].
     /// \param nthreads The number of threads to use. Set to 0 for automatic.
+    /// \param samples The number of rays used for determining the inside.
+    /// This must be an odd number. The default is 1.
+    ///
     /// \return A tensor with the signed distances to
     /// the surface. The shape is
     /// {..}. Negative distances mean a point is inside a closed surface.
     core::Tensor ComputeSignedDistance(const core::Tensor &query_points,
-                                       const int nthreads = 0);
+                                       const int nthreads = 0,
+                                       const int samples = 1);
 
     /// \brief Computes the occupancy at the query point positions.
     ///
@@ -191,10 +195,14 @@ public:
     /// {depth, height, width, 3}.
     /// The last dimension must be 3 and has the format [x, y, z].
     /// \param nthreads The number of threads to use. Set to 0 for automatic.
+    /// \param samples The number of rays used for determining the inside.
+    /// This must be an odd number. The default is 1.
+    ///
     /// \return A tensor with the occupancy values. The shape is {..}. Values
     /// are either 0 or 1. A point is occupied or inside if the value is 1.
     core::Tensor ComputeOccupancy(const core::Tensor &query_points,
-                                  const int nthreads = 0);
+                                  const int nthreads = 0,
+                                  const int samples = 1);
 
     /// \brief Creates rays for the given camera parameters.
     ///

--- a/cpp/pybind/t/geometry/raycasting_scene.cpp
+++ b/cpp/pybind/t/geometry/raycasting_scene.cpp
@@ -253,9 +253,9 @@ Returns:
     A tensor with the distances to the surface. The shape is {..}.
 )doc");
 
-    raycasting_scene.def("compute_signed_distance",
-                         &RaycastingScene::ComputeSignedDistance,
-                         "query_points"_a, "nthreads"_a = 0, R"doc(
+    raycasting_scene.def(
+            "compute_signed_distance", &RaycastingScene::ComputeSignedDistance,
+            "query_points"_a, "nthreads"_a = 0, "samples"_a = 1, R"doc(
 Computes the signed distance to the surface of the scene.
 
 This function computes the signed distance to the meshes in the scene.
@@ -274,6 +274,9 @@ Args:
 
     nthreads (int): The number of threads to use. Set to 0 for automatic.
 
+    samples (int): The number of rays used for determining the inside.
+        This must be an odd number. The default is 1.
+
 Returns:
     A tensor with the signed distances to the surface. The shape is {..}.
     Negative distances mean a point is inside a closed surface.
@@ -281,7 +284,7 @@ Returns:
 
     raycasting_scene.def("compute_occupancy",
                          &RaycastingScene::ComputeOccupancy, "query_points"_a,
-                         "nthreads"_a = 0,
+                         "nthreads"_a = 0, "samples"_a = 1,
                          R"doc(
 Computes the occupancy at the query point positions.
 
@@ -300,6 +303,9 @@ Args:
         The last dimension must be 3 and has the format [x, y, z].
 
     nthreads (int): The number of threads to use. Set to 0 for automatic.
+
+    samples (int): The number of rays used for determining the inside.
+        This must be an odd number. The default is 1.
 
 Returns:
     A tensor with the occupancy values. The shape is {..}. Values are either 0

--- a/cpp/pybind/t/geometry/raycasting_scene.cpp
+++ b/cpp/pybind/t/geometry/raycasting_scene.cpp
@@ -255,7 +255,7 @@ Returns:
 
     raycasting_scene.def(
             "compute_signed_distance", &RaycastingScene::ComputeSignedDistance,
-            "query_points"_a, "nthreads"_a = 0, "samples"_a = 1, R"doc(
+            "query_points"_a, "nthreads"_a = 0, "nsamples"_a = 1, R"doc(
 Computes the signed distance to the surface of the scene.
 
 This function computes the signed distance to the meshes in the scene.
@@ -274,8 +274,10 @@ Args:
 
     nthreads (int): The number of threads to use. Set to 0 for automatic.
 
-    samples (int): The number of rays used for determining the inside.
-        This must be an odd number. The default is 1.
+    nsamples (int): The number of rays used for determining the inside.
+        This must be an odd number. The default is 1. Use a higher value if you
+        notice sign flipping, which can occur when rays hit exactly an edge or 
+        vertex in the scene.
 
 Returns:
     A tensor with the signed distances to the surface. The shape is {..}.
@@ -284,7 +286,7 @@ Returns:
 
     raycasting_scene.def("compute_occupancy",
                          &RaycastingScene::ComputeOccupancy, "query_points"_a,
-                         "nthreads"_a = 0, "samples"_a = 1,
+                         "nthreads"_a = 0, "nsamples"_a = 1,
                          R"doc(
 Computes the occupancy at the query point positions.
 
@@ -304,8 +306,10 @@ Args:
 
     nthreads (int): The number of threads to use. Set to 0 for automatic.
 
-    samples (int): The number of rays used for determining the inside.
-        This must be an odd number. The default is 1.
+    nsamples (int): The number of rays used for determining the inside.
+        This must be an odd number. The default is 1. Use a higher value if you
+        notice errors in the occupancy values. Errors can occur when rays hit
+        exactly an edge or vertex in the scene.
 
 Returns:
     A tensor with the occupancy values. The shape is {..}. Values are either 0

--- a/python/test/t/geometry/test_raycasting_scene.py
+++ b/python/test/t/geometry/test_raycasting_scene.py
@@ -285,3 +285,48 @@ def test_output_shapes(shape):
             v.shape
         ) == expected_shape, 'shape mismatch: expected {} but got {} for {}'.format(
             expected_shape, list(v.shape), k)
+
+
+def test_sphere_wrong_occupancy():
+    # This test checks a specific scenario where the old implementation
+    # without ray jitter produced wrong results for a sphere because some
+    # rays miss hitting exactly a vertex or an edge.
+    mesh = o3d.geometry.TriangleMesh.create_sphere(0.8)
+    mesh = o3d.t.geometry.TriangleMesh.from_legacy(mesh)
+
+    scene = o3d.t.geometry.RaycastingScene()
+    scene.add_triangles(mesh)
+
+    min_bound = mesh.vertex.positions.min(0).numpy() * 1.1
+    max_bound = mesh.vertex.positions.max(0).numpy() * 1.1
+
+    xyz_range = np.linspace(min_bound, max_bound, num=6)
+    query_points = np.stack(np.meshgrid(*xyz_range.T),
+                            axis=-1).astype(np.float32)
+
+    occupancy = scene.compute_occupancy(query_points)
+    expected = np.array(
+        [[[0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+          [0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+          [0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]],
+         [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0, 1.0, 0.0, 0.0],
+          [0.0, 1.0, 1.0, 1.0, 1.0, 0.0], [0.0, 1.0, 1.0, 1.0, 1.0, 0.0],
+          [0.0, 0.0, 1.0, 1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]],
+         [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 1.0, 1.0, 1.0, 1.0, 0.0],
+          [0.0, 1.0, 1.0, 1.0, 1.0, 0.0], [0.0, 1.0, 1.0, 1.0, 1.0, 0.0],
+          [0.0, 1.0, 1.0, 1.0, 1.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]],
+         [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 1.0, 1.0, 1.0, 1.0, 0.0],
+          [0.0, 1.0, 1.0, 1.0, 1.0, 0.0], [0.0, 1.0, 1.0, 1.0, 1.0, 0.0],
+          [0.0, 1.0, 1.0, 1.0, 1.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]],
+         [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0, 1.0, 0.0, 0.0],
+          [0.0, 1.0, 1.0, 1.0, 1.0, 0.0], [0.0, 1.0, 1.0, 1.0, 1.0, 0.0],
+          [0.0, 0.0, 1.0, 1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]],
+         [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+          [0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+          [0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]],
+        dtype=np.float32)
+    np.testing.assert_equal(occupancy.numpy(), expected)
+
+    # we should get the same result with more samples
+    occupancy_3samples = scene.compute_occupancy(query_points, samples=3)
+    np.testing.assert_equal(occupancy_3samples.numpy(), expected)

--- a/python/test/t/geometry/test_raycasting_scene.py
+++ b/python/test/t/geometry/test_raycasting_scene.py
@@ -328,5 +328,5 @@ def test_sphere_wrong_occupancy():
     np.testing.assert_equal(occupancy.numpy(), expected)
 
     # we should get the same result with more samples
-    occupancy_3samples = scene.compute_occupancy(query_points, samples=3)
+    occupancy_3samples = scene.compute_occupancy(query_points, nsamples=3)
     np.testing.assert_equal(occupancy_3samples.numpy(), expected)


### PR DESCRIPTION
This PR addresses #5669

Functions like ComputeOccupancy and ComputeSignedDistance have a new argument `samples` for using multiple rays to determine the inside/outside.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d/5797)
<!-- Reviewable:end -->
