### PR TITLE
New feature: minimal bounding box for a given point cloud

### DIFF
--- a/cpp/open3d/geometry/BoundingVolume.cpp
+++ b/cpp/open3d/geometry/BoundingVolume.cpp
@@ -210,63 +210,38 @@ OrientedBoundingBox OrientedBoundingBox::CreateFromPoints(
 
 OrientedBoundingBox OrientedBoundingBox::CreateFromPointsMinimal(
         const std::vector<Eigen::Vector3d>& points, bool robust) {
-    std::cout << "OrientedBoundingBox::CreateFromPointsMinimal()" << std::endl;
-    PointCloud hull_pcd;
-    std::vector<size_t> hull_point_indices;
     std::shared_ptr<TriangleMesh> mesh;
-    std::tie(mesh, hull_point_indices) =
-            Qhull::ComputeConvexHull(points, robust);
-    auto triangles = mesh->triangles_;
+    std::tie(mesh, std::ignore) = Qhull::ComputeConvexHull(points, robust);
     double min_vol = -1;
     OrientedBoundingBox min_box;
-    for (auto &triangle : triangles) {
+    PointCloud hull_pcd;
+    for (auto &tri : mesh->triangles_) {
         hull_pcd.points_ = mesh->vertices_;
-        Eigen::Vector3d a = mesh->vertices_[triangle(0)];
-        Eigen::Vector3d b = mesh->vertices_[triangle(1)];
-        Eigen::Vector3d c = mesh->vertices_[triangle(2)];
+        Eigen::Vector3d a = mesh->vertices_[tri(0)];
+        Eigen::Vector3d b = mesh->vertices_[tri(1)];
+        Eigen::Vector3d c = mesh->vertices_[tri(2)];
         Eigen::Vector3d u = b - a;
         Eigen::Vector3d v = c - a;
         Eigen::Vector3d w = u.cross(v);
         v = w.cross(u);
         u = u / u.norm();
         v = v / v.norm();
-        w = u.cross(v);
-        Eigen::Matrix4d matrix_from = Eigen::Matrix4d::Identity();
-        Eigen::Matrix4d matrix_to = Eigen::Matrix4d::Identity();
-        matrix_to.col(0) = Eigen::Vector4d{u[0], u[1], u[2], 0};
-        matrix_to.col(1) = Eigen::Vector4d{v[0], v[1], v[2], 0};
-        matrix_to.col(2) = Eigen::Vector4d{w[0], w[1], w[2], 0};
-        matrix_to.col(3) = Eigen::Vector4d{a[0], a[1], a[2], 1};
-        Eigen::Matrix4d matrix_trans = matrix_to.inverse() * matrix_from;
-        hull_pcd.Transform(matrix_trans);
+        w = w / w.norm();
+        Eigen::Matrix3d m_rot;
+        m_rot << u[0], v[0], w[0],
+                 u[1], v[1], w[1],
+                 u[2], v[2], w[2];
+        hull_pcd.Rotate(m_rot.inverse(), a);
+
         const auto aabox = hull_pcd.GetAxisAlignedBoundingBox();
         double volume = aabox.Volume();
-        std::cout << "aabox.Volume() = " << volume << std::endl;
         if (min_vol==-1. || volume < min_vol) {
             min_vol = volume;
-            min_box.center_ = aabox.GetCenter();
-            min_box.extent_ = aabox.GetExtent();
-            Eigen::Matrix3d matrix_rot;
-            Eigen::Matrix4d m = matrix_trans.inverse();
-            std::cout << "m = " << m << std::endl;
-            matrix_rot.col(0) = m.col(0).head(3);
-            matrix_rot.col(1) = m.col(1).head(3);
-            matrix_rot.col(2) = m.col(2).head(3);
-            Eigen::Vector3d vec_trans = m.col(3).head(3);
-            min_box.Rotate(matrix_rot, Eigen::Vector3d{0,0,0});
-            min_box.Translate(vec_trans);
-            //min_box.Transform(matrix_trans.inverse());
+            min_box = aabox.GetOrientedBoundingBox();
+            min_box.Rotate(m_rot, a);
         }
-//        Eigen::Vector3d v01 = vertices_[triangle(1)] - vertices_[triangle(0)];
-//        Eigen::Vector3d v02 = vertices_[triangle(2)] - vertices_[triangle(0)];
     }
     return min_box;
-    //std::cout << "mesh->vertices_ = " << mesh->vertices_ << std::endl;
-    //std::cout << "mesh->triangles_ = " << mesh->triangles_ << std::endl;
-    //std::cout << "mesh->ComputeTriangleNormals() = " << mesh->ComputeTriangleNormals() << std::endl;
-    //std::cout << "mesh->GetNonManifoldEdges(true) = " << mesh->GetNonManifoldEdges(true) << std::endl;
-    //std::cout << "mesh->GetTrianglePlane(0) = " << mesh->GetTrianglePlane(0) << std::endl;
-    //std::cout << "mesh->CreateCoordinateFrame() = " << mesh->CreateCoordinateFrame() << std::endl;
 }
 
 AxisAlignedBoundingBox& AxisAlignedBoundingBox::Clear() {

--- a/cpp/open3d/geometry/BoundingVolume.cpp
+++ b/cpp/open3d/geometry/BoundingVolume.cpp
@@ -34,8 +34,6 @@
 #include "open3d/geometry/TriangleMesh.h"
 #include "open3d/utility/Logging.h"
 
-#include<iostream>
-
 namespace open3d {
 namespace geometry {
 
@@ -153,7 +151,6 @@ OrientedBoundingBox OrientedBoundingBox::CreateFromAxisAlignedBoundingBox(
 
 OrientedBoundingBox OrientedBoundingBox::CreateFromPoints(
         const std::vector<Eigen::Vector3d>& points, bool robust) {
-    std::cout << "OrientedBoundingBox::CreateFromPoints()" << std::endl;
     PointCloud hull_pcd;
     std::vector<size_t> hull_point_indices;
     {
@@ -210,7 +207,6 @@ OrientedBoundingBox OrientedBoundingBox::CreateFromPoints(
 
 OrientedBoundingBox OrientedBoundingBox::CreateFromPointsMinimal(
         const std::vector<Eigen::Vector3d>& points, bool robust) {
-    std::cout << "OrientedBoundingBox::CreateFromPointsMinimal()" << std::endl;
     std::shared_ptr<TriangleMesh> mesh;
     std::tie(mesh, std::ignore) = Qhull::ComputeConvexHull(points, robust);
     double min_vol = -1;
@@ -236,7 +232,6 @@ OrientedBoundingBox OrientedBoundingBox::CreateFromPointsMinimal(
 
         const auto aabox = hull_pcd.GetAxisAlignedBoundingBox();
         double volume = aabox.Volume();
-        std::cout << "aabox.Volume() = " << volume << std::endl;
         if (min_vol==-1. || volume < min_vol) {
             min_vol = volume;
             min_box = aabox.GetOrientedBoundingBox();

--- a/cpp/open3d/geometry/BoundingVolume.cpp
+++ b/cpp/open3d/geometry/BoundingVolume.cpp
@@ -67,7 +67,8 @@ OrientedBoundingBox OrientedBoundingBox::GetOrientedBoundingBox(bool) const {
     return *this;
 }
 
-OrientedBoundingBox OrientedBoundingBox::GetMinimalOrientedBoundingBox(bool) const {
+OrientedBoundingBox OrientedBoundingBox::GetMinimalOrientedBoundingBox(
+        bool) const {
     return *this;
 }
 
@@ -212,7 +213,7 @@ OrientedBoundingBox OrientedBoundingBox::CreateFromPointsMinimal(
     double min_vol = -1;
     OrientedBoundingBox min_box;
     PointCloud hull_pcd;
-    for (auto &tri : mesh->triangles_) {
+    for (auto& tri : mesh->triangles_) {
         hull_pcd.points_ = mesh->vertices_;
         Eigen::Vector3d a = mesh->vertices_[tri(0)];
         Eigen::Vector3d b = mesh->vertices_[tri(1)];
@@ -225,14 +226,12 @@ OrientedBoundingBox OrientedBoundingBox::CreateFromPointsMinimal(
         v = v / v.norm();
         w = w / w.norm();
         Eigen::Matrix3d m_rot;
-        m_rot << u[0], v[0], w[0],
-                 u[1], v[1], w[1],
-                 u[2], v[2], w[2];
+        m_rot << u[0], v[0], w[0], u[1], v[1], w[1], u[2], v[2], w[2];
         hull_pcd.Rotate(m_rot.inverse(), a);
 
         const auto aabox = hull_pcd.GetAxisAlignedBoundingBox();
         double volume = aabox.Volume();
-        if (min_vol==-1. || volume < min_vol) {
+        if (min_vol == -1. || volume < min_vol) {
             min_vol = volume;
             min_box = aabox.GetOrientedBoundingBox();
             min_box.Rotate(m_rot, a);

--- a/cpp/open3d/geometry/BoundingVolume.cpp
+++ b/cpp/open3d/geometry/BoundingVolume.cpp
@@ -210,6 +210,7 @@ OrientedBoundingBox OrientedBoundingBox::CreateFromPoints(
 
 OrientedBoundingBox OrientedBoundingBox::CreateFromPointsMinimal(
         const std::vector<Eigen::Vector3d>& points, bool robust) {
+    std::cout << "OrientedBoundingBox::CreateFromPointsMinimal()" << std::endl;
     std::shared_ptr<TriangleMesh> mesh;
     std::tie(mesh, std::ignore) = Qhull::ComputeConvexHull(points, robust);
     double min_vol = -1;
@@ -235,6 +236,7 @@ OrientedBoundingBox OrientedBoundingBox::CreateFromPointsMinimal(
 
         const auto aabox = hull_pcd.GetAxisAlignedBoundingBox();
         double volume = aabox.Volume();
+        std::cout << "aabox.Volume() = " << volume << std::endl;
         if (min_vol==-1. || volume < min_vol) {
             min_vol = volume;
             min_box = aabox.GetOrientedBoundingBox();

--- a/cpp/open3d/geometry/BoundingVolume.h
+++ b/cpp/open3d/geometry/BoundingVolume.h
@@ -76,6 +76,8 @@ public:
     virtual AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
     virtual OrientedBoundingBox GetOrientedBoundingBox(
             bool robust) const override;
+    virtual OrientedBoundingBox GetMinimalOrientedBoundingBox(
+            bool robust) const override;
     virtual OrientedBoundingBox& Transform(
             const Eigen::Matrix4d& transformation) override;
     virtual OrientedBoundingBox& Translate(const Eigen::Vector3d& translation,
@@ -133,6 +135,9 @@ public:
     static OrientedBoundingBox CreateFromPoints(
             const std::vector<Eigen::Vector3d>& points, bool robust = false);
 
+    static OrientedBoundingBox CreateFromPointsMinimal(
+            const std::vector<Eigen::Vector3d>& points, bool robust = false);
+
 public:
     /// The center point of the bounding box.
     Eigen::Vector3d center_;
@@ -182,6 +187,8 @@ public:
     virtual Eigen::Vector3d GetCenter() const override;
     virtual AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
     virtual OrientedBoundingBox GetOrientedBoundingBox(
+            bool robust = false) const override;
+    virtual OrientedBoundingBox GetMinimalOrientedBoundingBox(
             bool robust = false) const override;
     virtual AxisAlignedBoundingBox& Transform(
             const Eigen::Matrix4d& transformation) override;

--- a/cpp/open3d/geometry/BoundingVolume.h
+++ b/cpp/open3d/geometry/BoundingVolume.h
@@ -73,11 +73,19 @@ public:
     virtual Eigen::Vector3d GetMinBound() const override;
     virtual Eigen::Vector3d GetMaxBound() const override;
     virtual Eigen::Vector3d GetCenter() const override;
+
+    /// Creates an axis-aligned bounding box around the
+    /// points (corners) of the object.
     virtual AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
+
+    /// Returns the object itself
     virtual OrientedBoundingBox GetOrientedBoundingBox(
             bool robust) const override;
+
+    /// Returns the object itself
     virtual OrientedBoundingBox GetMinimalOrientedBoundingBox(
             bool robust) const override;
+
     virtual OrientedBoundingBox& Transform(
             const Eigen::Matrix4d& transformation) override;
     virtual OrientedBoundingBox& Translate(const Eigen::Vector3d& translation,
@@ -195,9 +203,17 @@ public:
     virtual Eigen::Vector3d GetMinBound() const override;
     virtual Eigen::Vector3d GetMaxBound() const override;
     virtual Eigen::Vector3d GetCenter() const override;
+
+    /// Returns the object itself
     virtual AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
+
+    /// Returns an oriented bounding box with the same dimensions
+    /// and orientation as the object
     virtual OrientedBoundingBox GetOrientedBoundingBox(
             bool robust = false) const override;
+
+    /// Returns an oriented bounding box with the same dimensions
+    /// and orientation as the object
     virtual OrientedBoundingBox GetMinimalOrientedBoundingBox(
             bool robust = false) const override;
     virtual AxisAlignedBoundingBox& Transform(

--- a/cpp/open3d/geometry/BoundingVolume.h
+++ b/cpp/open3d/geometry/BoundingVolume.h
@@ -135,6 +135,16 @@ public:
     static OrientedBoundingBox CreateFromPoints(
             const std::vector<Eigen::Vector3d>& points, bool robust = false);
 
+    /// Creates the oriented bounding box with the smallest volume.
+    /// The algorithm makes use of the fact that at least one edge of
+    /// the convex hull must be collinear with an edge of the minimum
+    /// bounding box: for each triangle in the convex hull, calculate
+    /// the minimal axis aligned box in the frame of that triangle.
+    /// at the end, return the box with the smallest volume
+    /// \param points The input points
+    /// \param robust If set to true uses a more robust method which works
+    ///               in degenerate cases but introduces noise to the points
+    ///               coordinates.
     static OrientedBoundingBox CreateFromPointsMinimal(
             const std::vector<Eigen::Vector3d>& points, bool robust = false);
 

--- a/cpp/open3d/geometry/Geometry3D.h
+++ b/cpp/open3d/geometry/Geometry3D.h
@@ -74,6 +74,8 @@ public:
     ///               coordinates.
     virtual OrientedBoundingBox GetOrientedBoundingBox(
             bool robust = false) const = 0;
+    virtual OrientedBoundingBox GetMinimalOrientedBoundingBox(
+            bool robust = false) const = 0;
     /// \brief Apply transformation (4x4 matrix) to the geometry coordinates.
     virtual Geometry3D& Transform(const Eigen::Matrix4d& transformation) = 0;
 

--- a/cpp/open3d/geometry/Geometry3D.h
+++ b/cpp/open3d/geometry/Geometry3D.h
@@ -63,19 +63,28 @@ public:
     virtual Eigen::Vector3d GetMaxBound() const = 0;
     /// Returns the center of the geometry coordinates.
     virtual Eigen::Vector3d GetCenter() const = 0;
-    /// Returns an axis-aligned bounding box of the geometry.
+
+    /// Creates the axis-aligned bounding box around the points of the object.
+    /// Further details in AxisAlignedBoundingBox::CreateFromPoints()
     virtual AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const = 0;
 
-    /// Computes the oriented bounding box based on the PCA of the convex hull.
-    /// The returned bounding box is an approximation to the minimal bounding
-    /// box.
+    /// Creates an oriented bounding box around the points of the object.
+    /// Further details in OrientedBoundingBox::CreateFromPoints()
     /// \param robust If set to true uses a more robust method which works
     ///               in degenerate cases but introduces noise to the points
     ///               coordinates.
     virtual OrientedBoundingBox GetOrientedBoundingBox(
             bool robust = false) const = 0;
+
+    /// Creates the minimal oriented bounding box around the points of the
+    /// object. Further details in
+    /// OrientedBoundingBox::CreateFromPointsMinimal()
+    /// \param robust If set to true uses a more robust method which works
+    ///               in degenerate cases but introduces noise to the points
+    ///               coordinates.
     virtual OrientedBoundingBox GetMinimalOrientedBoundingBox(
             bool robust = false) const = 0;
+
     /// \brief Apply transformation (4x4 matrix) to the geometry coordinates.
     virtual Geometry3D& Transform(const Eigen::Matrix4d& transformation) = 0;
 

--- a/cpp/open3d/geometry/LineSet.cpp
+++ b/cpp/open3d/geometry/LineSet.cpp
@@ -60,6 +60,10 @@ OrientedBoundingBox LineSet::GetOrientedBoundingBox(bool robust) const {
     return OrientedBoundingBox::CreateFromPoints(points_, robust);
 }
 
+OrientedBoundingBox LineSet::GetMinimalOrientedBoundingBox(bool robust) const {
+    return OrientedBoundingBox::CreateFromPointsMinimal(points_, robust);
+}
+
 LineSet &LineSet::Transform(const Eigen::Matrix4d &transformation) {
     TransformPoints(transformation, points_);
     return *this;

--- a/cpp/open3d/geometry/LineSet.h
+++ b/cpp/open3d/geometry/LineSet.h
@@ -68,11 +68,28 @@ public:
     Eigen::Vector3d GetMinBound() const override;
     Eigen::Vector3d GetMaxBound() const override;
     Eigen::Vector3d GetCenter() const override;
+
+    /// Creates the axis-aligned bounding box around the points of the object.
+    /// Further details in AxisAlignedBoundingBox::CreateFromPoints()
     AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
+
+    /// Creates an oriented bounding box around the points of the object.
+    /// Further details in OrientedBoundingBox::CreateFromPoints()
+    /// \param robust If set to true uses a more robust method which works
+    ///               in degenerate cases but introduces noise to the points
+    ///               coordinates.
     OrientedBoundingBox GetOrientedBoundingBox(
             bool robust = false) const override;
+
+    /// Creates the minimal oriented bounding box around the points of the
+    /// object. Further details in
+    /// OrientedBoundingBox::CreateFromPointsMinimal()
+    /// \param robust If set to true uses a more robust method which works
+    ///               in degenerate cases but introduces noise to the points
+    ///               coordinates.
     OrientedBoundingBox GetMinimalOrientedBoundingBox(
             bool robust = false) const override;
+
     LineSet &Transform(const Eigen::Matrix4d &transformation) override;
     LineSet &Translate(const Eigen::Vector3d &translation,
                        bool relative = true) override;

--- a/cpp/open3d/geometry/LineSet.h
+++ b/cpp/open3d/geometry/LineSet.h
@@ -71,6 +71,8 @@ public:
     AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
     OrientedBoundingBox GetOrientedBoundingBox(
             bool robust = false) const override;
+    OrientedBoundingBox GetMinimalOrientedBoundingBox(
+            bool robust = false) const override;
     LineSet &Transform(const Eigen::Matrix4d &transformation) override;
     LineSet &Translate(const Eigen::Vector3d &translation,
                        bool relative = true) override;

--- a/cpp/open3d/geometry/MeshBase.cpp
+++ b/cpp/open3d/geometry/MeshBase.cpp
@@ -69,6 +69,10 @@ OrientedBoundingBox MeshBase::GetOrientedBoundingBox(bool robust) const {
     return OrientedBoundingBox::CreateFromPoints(vertices_, robust);
 }
 
+OrientedBoundingBox MeshBase::GetMinimalOrientedBoundingBox(bool robust) const {
+    return OrientedBoundingBox::CreateFromPoints(vertices_, robust);
+}
+
 MeshBase &MeshBase::Transform(const Eigen::Matrix4d &transformation) {
     TransformPoints(transformation, vertices_);
     TransformNormals(transformation, vertex_normals_);

--- a/cpp/open3d/geometry/MeshBase.h
+++ b/cpp/open3d/geometry/MeshBase.h
@@ -88,6 +88,8 @@ public:
     virtual AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
     virtual OrientedBoundingBox GetOrientedBoundingBox(
             bool robust = false) const override;
+    virtual OrientedBoundingBox GetMinimalOrientedBoundingBox(
+            bool robust = false) const override;
     virtual MeshBase &Transform(const Eigen::Matrix4d &transformation) override;
     virtual MeshBase &Translate(const Eigen::Vector3d &translation,
                                 bool relative = true) override;

--- a/cpp/open3d/geometry/MeshBase.h
+++ b/cpp/open3d/geometry/MeshBase.h
@@ -85,11 +85,28 @@ public:
     virtual Eigen::Vector3d GetMinBound() const override;
     virtual Eigen::Vector3d GetMaxBound() const override;
     virtual Eigen::Vector3d GetCenter() const override;
+
+    /// Creates the axis-aligned bounding box around the vertices of the object.
+    /// Further details in AxisAlignedBoundingBox::CreateFromPoints()
     virtual AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
+
+    /// Creates an oriented bounding box around the vertices of the object.
+    /// Further details in OrientedBoundingBox::CreateFromPoints()
+    /// \param robust If set to true uses a more robust method which works
+    ///               in degenerate cases but introduces noise to the points
+    ///               coordinates.
     virtual OrientedBoundingBox GetOrientedBoundingBox(
             bool robust = false) const override;
+
+    /// Creates the minimal oriented bounding box around the vertices of the
+    /// object. Further details in
+    /// OrientedBoundingBox::CreateFromPointsMinimal()
+    /// \param robust If set to true uses a more robust method which works
+    ///               in degenerate cases but introduces noise to the points
+    ///               coordinates.
     virtual OrientedBoundingBox GetMinimalOrientedBoundingBox(
             bool robust = false) const override;
+
     virtual MeshBase &Transform(const Eigen::Matrix4d &transformation) override;
     virtual MeshBase &Translate(const Eigen::Vector3d &translation,
                                 bool relative = true) override;

--- a/cpp/open3d/geometry/Octree.cpp
+++ b/cpp/open3d/geometry/Octree.cpp
@@ -534,6 +534,11 @@ OrientedBoundingBox Octree::GetOrientedBoundingBox(bool robust) const {
             GetAxisAlignedBoundingBox());
 }
 
+OrientedBoundingBox Octree::GetMinimalOrientedBoundingBox(bool robust) const {
+    return OrientedBoundingBox::CreateFromAxisAlignedBoundingBox(
+            GetAxisAlignedBoundingBox());
+}
+
 Octree& Octree::Transform(const Eigen::Matrix4d& transformation) {
     utility::LogError("Not implemented");
     return *this;

--- a/cpp/open3d/geometry/Octree.h
+++ b/cpp/open3d/geometry/Octree.h
@@ -300,6 +300,8 @@ public:
     AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
     OrientedBoundingBox GetOrientedBoundingBox(
             bool robust = false) const override;
+    OrientedBoundingBox GetMinimalOrientedBoundingBox(
+            bool robust = false) const override;
     Octree& Transform(const Eigen::Matrix4d& transformation) override;
     Octree& Translate(const Eigen::Vector3d& translation,
                       bool relative = true) override;

--- a/cpp/open3d/geometry/Octree.h
+++ b/cpp/open3d/geometry/Octree.h
@@ -297,11 +297,21 @@ public:
     Eigen::Vector3d GetMinBound() const override;
     Eigen::Vector3d GetMaxBound() const override;
     Eigen::Vector3d GetCenter() const override;
+
+    /// Creates the axis-aligned bounding box around the object.
+    /// Further details in AxisAlignedBoundingBox::AxisAlignedBoundingBox()
     AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
+
+    /// Creates an oriented bounding box that is identical to the
+    /// axis-aligned bounding from GetAxisAlignedBoundingBox().
     OrientedBoundingBox GetOrientedBoundingBox(
             bool robust = false) const override;
+
+    /// Creates an oriented bounding box that is identical to the
+    /// axis-aligned bounding from GetAxisAlignedBoundingBox().
     OrientedBoundingBox GetMinimalOrientedBoundingBox(
             bool robust = false) const override;
+
     Octree& Transform(const Eigen::Matrix4d& transformation) override;
     Octree& Translate(const Eigen::Vector3d& translation,
                       bool relative = true) override;

--- a/cpp/open3d/geometry/PointCloud.cpp
+++ b/cpp/open3d/geometry/PointCloud.cpp
@@ -71,6 +71,10 @@ OrientedBoundingBox PointCloud::GetOrientedBoundingBox(bool robust) const {
     return OrientedBoundingBox::CreateFromPoints(points_, robust);
 }
 
+OrientedBoundingBox PointCloud::GetMinimalOrientedBoundingBox(bool robust) const {
+    return OrientedBoundingBox::CreateFromPointsMinimal(points_, robust);
+}
+
 PointCloud &PointCloud::Transform(const Eigen::Matrix4d &transformation) {
     TransformPoints(transformation, points_);
     TransformNormals(transformation, normals_);

--- a/cpp/open3d/geometry/PointCloud.cpp
+++ b/cpp/open3d/geometry/PointCloud.cpp
@@ -71,7 +71,8 @@ OrientedBoundingBox PointCloud::GetOrientedBoundingBox(bool robust) const {
     return OrientedBoundingBox::CreateFromPoints(points_, robust);
 }
 
-OrientedBoundingBox PointCloud::GetMinimalOrientedBoundingBox(bool robust) const {
+OrientedBoundingBox PointCloud::GetMinimalOrientedBoundingBox(
+        bool robust) const {
     return OrientedBoundingBox::CreateFromPointsMinimal(points_, robust);
 }
 

--- a/cpp/open3d/geometry/PointCloud.h
+++ b/cpp/open3d/geometry/PointCloud.h
@@ -72,6 +72,8 @@ public:
     AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
     OrientedBoundingBox GetOrientedBoundingBox(
             bool robust = false) const override;
+    OrientedBoundingBox GetMinimalOrientedBoundingBox(
+            bool robust = false) const override;
     PointCloud &Transform(const Eigen::Matrix4d &transformation) override;
     PointCloud &Translate(const Eigen::Vector3d &translation,
                           bool relative = true) override;

--- a/cpp/open3d/geometry/VoxelGrid.cpp
+++ b/cpp/open3d/geometry/VoxelGrid.cpp
@@ -109,6 +109,11 @@ OrientedBoundingBox VoxelGrid::GetOrientedBoundingBox(bool) const {
             GetAxisAlignedBoundingBox());
 }
 
+OrientedBoundingBox VoxelGrid::GetMinimalOrientedBoundingBox(bool) const {
+    return OrientedBoundingBox::CreateFromAxisAlignedBoundingBox(
+            GetAxisAlignedBoundingBox());
+}
+
 VoxelGrid &VoxelGrid::Transform(const Eigen::Matrix4d &transformation) {
     utility::LogError("VoxelGrid::Transform is not supported");
     return *this;

--- a/cpp/open3d/geometry/VoxelGrid.h
+++ b/cpp/open3d/geometry/VoxelGrid.h
@@ -93,6 +93,8 @@ public:
     AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
     OrientedBoundingBox GetOrientedBoundingBox(
             bool robust = false) const override;
+    OrientedBoundingBox GetMinimalOrientedBoundingBox(
+            bool robust = false) const override;
     VoxelGrid &Transform(const Eigen::Matrix4d &transformation) override;
     VoxelGrid &Translate(const Eigen::Vector3d &translation,
                          bool relative = true) override;

--- a/cpp/open3d/geometry/VoxelGrid.h
+++ b/cpp/open3d/geometry/VoxelGrid.h
@@ -90,11 +90,21 @@ public:
     Eigen::Vector3d GetMinBound() const override;
     Eigen::Vector3d GetMaxBound() const override;
     Eigen::Vector3d GetCenter() const override;
+
+    /// Creates the axis-aligned bounding box around the object.
+    /// Further details in AxisAlignedBoundingBox::AxisAlignedBoundingBox()
     AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
+
+    /// Creates an oriented bounding box that is identical to the
+    /// axis-aligned bounding from GetAxisAlignedBoundingBox().
     OrientedBoundingBox GetOrientedBoundingBox(
             bool robust = false) const override;
+
+    /// Creates an oriented bounding box that is identical to the
+    /// axis-aligned bounding from GetAxisAlignedBoundingBox().
     OrientedBoundingBox GetMinimalOrientedBoundingBox(
             bool robust = false) const override;
+
     VoxelGrid &Transform(const Eigen::Matrix4d &transformation) override;
     VoxelGrid &Translate(const Eigen::Vector3d &translation,
                          bool relative = true) override;

--- a/cpp/open3d/visualization/utility/PointCloudPicker.cpp
+++ b/cpp/open3d/visualization/utility/PointCloudPicker.cpp
@@ -87,6 +87,17 @@ geometry::OrientedBoundingBox PointCloudPicker::GetOrientedBoundingBox(
     }
 }
 
+geometry::OrientedBoundingBox PointCloudPicker::GetMinimalOrientedBoundingBox(
+        bool robust) const {
+    if (pointcloud_ptr_) {
+        return geometry::OrientedBoundingBox::CreateFromPointsMinimal(
+                ((const geometry::PointCloud&)(*pointcloud_ptr_)).points_,
+                robust);
+    } else {
+        return geometry::OrientedBoundingBox();
+    }
+}
+
 PointCloudPicker& PointCloudPicker::Transform(
         const Eigen::Matrix4d& /*transformation*/) {
     // Do nothing

--- a/cpp/open3d/visualization/utility/PointCloudPicker.h
+++ b/cpp/open3d/visualization/utility/PointCloudPicker.h
@@ -52,11 +52,33 @@ public:
     Eigen::Vector3d GetMinBound() const final;
     Eigen::Vector3d GetMaxBound() const final;
     Eigen::Vector3d GetCenter() const final;
+
+    /// If point cloud does not exist, creates an axis-aligned bounding box
+    /// form its default constructor. If point cloud exists, creates the
+    /// axis-aligned bounding box around it. Further details in
+    /// AxisAlignedBoundingBox::CreateFromPoints()
     geometry::AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const final;
+
+    /// If point cloud does not exist, creates an oriented bounding box
+    /// form its default constructor. If point cloud exists, creates the
+    /// oriented bounding box around it. Further details in
+    /// OrientedBoundingBox::CreateFromPoints()
+    /// \param robust If set to true uses a more robust method which works
+    ///               in degenerate cases but introduces noise to the points
+    ///               coordinates.
     geometry::OrientedBoundingBox GetOrientedBoundingBox(
             bool robust = false) const final;
+
+    /// If point cloud does not exist, creates an oriented bounding box
+    /// form its default constructor. If point cloud exists, creates the minimal
+    /// oriented bounding box around it.
+    /// Further details in OrientedBoundingBox::CreateFromPointsMinimal()
+    /// \param robust If set to true uses a more robust method which works
+    ///               in degenerate cases but introduces noise to the points
+    ///               coordinates.
     geometry::OrientedBoundingBox GetMinimalOrientedBoundingBox(
             bool robust = false) const final;
+
     PointCloudPicker& Transform(const Eigen::Matrix4d& transformation) override;
     PointCloudPicker& Translate(const Eigen::Vector3d& translation,
                                 bool relative = true) override;

--- a/cpp/open3d/visualization/utility/PointCloudPicker.h
+++ b/cpp/open3d/visualization/utility/PointCloudPicker.h
@@ -55,6 +55,8 @@ public:
     geometry::AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const final;
     geometry::OrientedBoundingBox GetOrientedBoundingBox(
             bool robust = false) const final;
+    geometry::OrientedBoundingBox GetMinimalOrientedBoundingBox(
+            bool robust = false) const final;
     PointCloudPicker& Transform(const Eigen::Matrix4d& transformation) override;
     PointCloudPicker& Translate(const Eigen::Vector3d& translation,
                                 bool relative = true) override;

--- a/cpp/pybind/geometry/geometry.cpp
+++ b/cpp/pybind/geometry/geometry.cpp
@@ -123,7 +123,24 @@ Returns:
 )doc")
             .def("get_minimal_oriented_bounding_box",
                  &Geometry3D::GetMinimalOrientedBoundingBox, "robust"_a = false,
-                 "Returns the minimal oriented bounding box of the geometry.")
+                 R"doc(
+Returns the minimal oriented bounding box for the geometry.
+
+Creates the oriented bounding box with the smallest volume.
+The algorithm makes use of the fact that at least one edge of
+the convex hull must be collinear with an edge of the minimum
+bounding box: for each triangle in the convex hull, calculate
+the minimal axis aligned box in the frame of that triangle.
+at the end, return the box with the smallest volume
+
+Args:
+     robust (bool): If set to true uses a more robust method which works in
+          degenerate cases but introduces noise to the points coordinates.
+
+Returns:
+     open3d.geometry.OrientedBoundingBox: The oriented bounding box. The
+     bounding box is oriented such that its volume is minimized.
+)doc")
             .def("transform", &Geometry3D::Transform,
                  "Apply transformation (4x4 matrix) to the geometry "
                  "coordinates.")

--- a/cpp/pybind/geometry/geometry.cpp
+++ b/cpp/pybind/geometry/geometry.cpp
@@ -121,6 +121,9 @@ Returns:
      bounding box is oriented such that the axes are ordered with respect to
      the principal components.
 )doc")
+            .def("get_minimal_oriented_bounding_box",
+                 &Geometry3D::GetMinimalOrientedBoundingBox, "robust"_a = false,
+                 "Returns the minimal oriented bounding box of the geometry.")
             .def("transform", &Geometry3D::Transform,
                  "Apply transformation (4x4 matrix) to the geometry "
                  "coordinates.")

--- a/cpp/pybind/geometry/geometry_trampoline.h
+++ b/cpp/pybind/geometry/geometry_trampoline.h
@@ -70,6 +70,10 @@ public:
             bool robust = false) const override {
         PYBIND11_OVERLOAD_PURE(OrientedBoundingBox, Geometry3DBase, robust);
     }
+    OrientedBoundingBox GetMinimalOrientedBoundingBox(
+            bool robust = false) const override {
+        PYBIND11_OVERLOAD_PURE(OrientedBoundingBox, Geometry3DBase, robust);
+    }
     Geometry3DBase& Transform(const Eigen::Matrix4d& transformation) override {
         PYBIND11_OVERLOAD_PURE(Geometry3DBase&, Geometry3DBase, transformation);
     }

--- a/cpp/tests/geometry/PointCloud.cpp
+++ b/cpp/tests/geometry/PointCloud.cpp
@@ -279,7 +279,8 @@ TEST(PointCloud, GetMinimalOrientedBoundingBox) {
                                 {0.744, 0.182, 0.052},
                                 {0.019, 0.525, 0.699},
                                 {0.722, 0.134, 0.668}});
-    geometry::OrientedBoundingBox mobb = pcd.GetMinimalOrientedBoundingBox();;
+    geometry::OrientedBoundingBox mobb = pcd.GetMinimalOrientedBoundingBox();
+    ;
     obb = pcd.GetOrientedBoundingBox();
     geometry::AxisAlignedBoundingBox aabb = pcd.GetAxisAlignedBoundingBox();
     EXPECT_GT(obb.Volume(), mobb.Volume());

--- a/cpp/tests/geometry/PointCloud.cpp
+++ b/cpp/tests/geometry/PointCloud.cpp
@@ -210,6 +210,82 @@ TEST(PointCloud, GetOrientedBoundingBox) {
     EXPECT_GT(obb.R_.determinant(), 0.999);
 }
 
+TEST(PointCloud, GetMinimalOrientedBoundingBox) {
+    geometry::PointCloud pcd;
+    geometry::OrientedBoundingBox obb;
+
+    // Empty (GetOrientedBoundingBox requires >=4 points)
+    pcd = geometry::PointCloud();
+    EXPECT_ANY_THROW(pcd.GetMinimalOrientedBoundingBox());
+
+    // Point
+    pcd = geometry::PointCloud({{0, 0, 0}});
+    EXPECT_ANY_THROW(pcd.GetMinimalOrientedBoundingBox());
+    pcd = geometry::PointCloud({{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}});
+    EXPECT_ANY_THROW(pcd.GetMinimalOrientedBoundingBox());
+    EXPECT_NO_THROW(pcd.GetMinimalOrientedBoundingBox(true));
+
+    // Line
+    pcd = geometry::PointCloud({{0, 0, 0}, {1, 1, 1}});
+    EXPECT_ANY_THROW(pcd.GetMinimalOrientedBoundingBox());
+    pcd = geometry::PointCloud({{0, 0, 0}, {1, 1, 1}, {2, 2, 2}, {3, 3, 3}});
+    EXPECT_ANY_THROW(pcd.GetMinimalOrientedBoundingBox());
+    EXPECT_NO_THROW(pcd.GetMinimalOrientedBoundingBox(true));
+
+    // Plane
+    pcd = geometry::PointCloud({{0, 0, 0}, {0, 0, 1}, {0, 1, 0}, {0, 1, 1}});
+    EXPECT_ANY_THROW(pcd.GetMinimalOrientedBoundingBox());
+    EXPECT_NO_THROW(pcd.GetMinimalOrientedBoundingBox(true));
+
+    // Valid 4 points
+    pcd = geometry::PointCloud({{0, 0, 0}, {0, 0, 1}, {0, 1, 0}, {1, 1, 1}});
+    pcd.GetMinimalOrientedBoundingBox();
+
+    // 8 points with known ground truth
+    pcd = geometry::PointCloud({{0, 0, 0},
+                                {0, 0, 1},
+                                {0, 2, 0},
+                                {0, 2, 1},
+                                {3, 0, 0},
+                                {3, 0, 1},
+                                {3, 2, 0},
+                                {3, 2, 1}});
+    obb = pcd.GetMinimalOrientedBoundingBox();
+    EXPECT_EQ(obb.center_, Eigen::Vector3d(1.5, 1, 0.5));
+    EXPECT_EQ(obb.extent_, Eigen::Vector3d(3, 2, 1));
+    EXPECT_EQ(obb.color_, Eigen::Vector3d(1, 1, 1));
+    ExpectEQ(Sort(obb.GetBoxPoints()),
+             Sort(std::vector<Eigen::Vector3d>({{0, 0, 0},
+                                                {0, 0, 1},
+                                                {0, 2, 0},
+                                                {0, 2, 1},
+                                                {3, 0, 0},
+                                                {3, 0, 1},
+                                                {3, 2, 0},
+                                                {3, 2, 1}})));
+
+    // Check for a bug where the OBB rotation contained a reflection for this
+    // example.
+    pcd = geometry::PointCloud({{0, 2, 4}, {7, 9, 1}, {5, 2, 0}, {3, 8, 7}});
+    obb = pcd.GetMinimalOrientedBoundingBox();
+    EXPECT_GT(obb.R_.determinant(), 0.999);
+
+    // should always be equal/smaller than axis aligned- & oriented bounding box
+    pcd = geometry::PointCloud({{0.866, 0.474, 0.659},
+                                {0.943, 0.025, 0.789},
+                                {0.386, 0.264, 0.691},
+                                {0.938, 0.588, 0.496},
+                                {0.221, 0.116, 0.257},
+                                {0.744, 0.182, 0.052},
+                                {0.019, 0.525, 0.699},
+                                {0.722, 0.134, 0.668}});
+    geometry::OrientedBoundingBox mobb = pcd.GetMinimalOrientedBoundingBox();;
+    obb = pcd.GetOrientedBoundingBox();
+    geometry::AxisAlignedBoundingBox aabb = pcd.GetAxisAlignedBoundingBox();
+    EXPECT_GT(obb.Volume(), mobb.Volume());
+    EXPECT_GT(aabb.Volume(), mobb.Volume());
+}
+
 TEST(PointCloud, Transform) {
     std::vector<Eigen::Vector3d> points = {
             {0, 0, 0},


### PR DESCRIPTION
Introduced new function that calculates the minimal bounding box for a given point cloud. So far, only the minimal axis aligned and the object-oriented bounding box are implemented.
 I have created a feature request here: [https://github.com/isl-org/Open3D/issues/5856](https://github.com/isl-org/Open3D/issues/5856).
I used the same algorithm as the library 'compas' [https://github.com/compas-dev/compas/blob/main/src/compas/geometry/bbox/bbox_numpy.py](https://github.com/compas-dev/compas/blob/main/src/compas/geometry/bbox/bbox_numpy.py)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/5857)
<!-- Reviewable:end -->
