### PR TITLE
Fix scrolling direction bug for TextEdit

### DIFF
--- a/cpp/open3d/visualization/gui/TextEdit.cpp
+++ b/cpp/open3d/visualization/gui/TextEdit.cpp
@@ -102,7 +102,7 @@ Size TextEdit::CalcPreferredSize(const LayoutContext &context,
 Widget::DrawResult TextEdit::Draw(const DrawContext &context) {
     auto &frame = GetFrame();
     ImGui::SetCursorScreenPos(
-            ImVec2(float(frame.x), float(frame.y) + ImGui::GetScrollY()));
+            ImVec2(float(frame.x), float(frame.y) - ImGui::GetScrollY()));
 
     ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding,
                         0.0);  // macOS doesn't round text editing


### PR DESCRIPTION
As discussed in #5095, the `TextEdit` control is moving into the opposite direction when added to a scrollable widget. This is due the addition of the `ImGui::GetScrollY()` value, instead of the subtraction as any other widget ([gui/NumberEdit.cpp](https://github.com/isl-org/Open3D/blob/ad1c3ade70dc52e7972db85670ff07a9bb31d2e2/cpp/open3d/visualization/gui/NumberEdit.cpp#L138-L139), [gui/Label.cpp](https://github.com/isl-org/Open3D/blob/ad1c3ade70dc52e7972db85670ff07a9bb31d2e2/cpp/open3d/visualization/gui/Label.cpp#L136-L137)).

This behaviour was added with the following commit: https://github.com/isl-org/Open3D/commit/14363b9f3f19f0550db94a92963e17e7c67e75a9

## Type
-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #5095
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Because it breaks the scrolling behaviour in any gui built with open3d.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

This changes the direction  of the scrolling for TextEdits.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/5887)
<!-- Reviewable:end -->
