### PR TITLE
Update github actions CI workflow versions

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,5 +1,13 @@
 # Running workflows on GitHub Actions
 
+## OS versions
+
+Use the oldest available OS version (e.g. ubuntu-18.04, macos-11, windows-2019)
+for each workflow to ensure created binary artifacts are as widely compatible as
+possible. For jobs that use docker, or auxiliary jobs (e.g. uploading artifacts
+to google cloud), use ubuntu-latest to avoid changing the version on GitHub
+actions updates. On macOS and Windows, using Ubuntu reduces CI cost.
+
 ## Documentation deployment
 
 ### Directory structure

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,21 +4,22 @@
 
 ### Directory structure
 
-- `.github/workflows/documentation.yml`: Github Actions workflow file to
-  create and deploy documentation. Documentation is created for every branch
-  as a CI test, but deployed only for `master`.
-- `util/ci_utils.sh:build_docs()`: Called by GitHub Actions to build documentation.
-- `unpack_docs.sh`: Called by the documentation server to deploy the docs into
-  the website.
+-   `.github/workflows/documentation.yml`: Github Actions workflow file to
+    create and deploy documentation. Documentation is created for every branch
+    as a CI test, but deployed only for `master`.
+-   `util/ci_utils.sh:build_docs()`: Called by GitHub Actions to build documentation.
+-   `unpack_docs.sh`: Called by the documentation server to deploy the docs into
+    the website.
 
 ### Setting up the docs deployment
 
 #### Step 1: Google Cloud
 
-1. Setup `gcloud`
-    - [Install `gcloud`](https://cloud.google.com/sdk/install)
-    - `gcloud init` and login with admin's google account on the web
-2. Create storage bucket
+1.  Setup `gcloud`
+    -   [Install `gcloud`](https://cloud.google.com/sdk/install)
+    -   `gcloud init` and login with admin's google account on the web
+2.  Create storage bucket
+
     ```bash
     # Create with uniform bucket-level access: `-b`
     # https://cloud.google.com/storage/docs/creating-buckets#storage-create-bucket-gsutil
@@ -38,19 +39,19 @@
     documentation server fetches the latest docs from `master` branch every hour.
     If the documentation server fails to fetch the docs matching the `master`
     commit id, the last successfully fetched docs will be displayed.
-3. Create service account
+3.  Create service account
     ```bash
     gcloud iam service-accounts create open3d-ci-sa \
         --description="Service account for Open3D CI" \
         --display-name="open3d-ci-sa"
     ```
-4. Grant `objectAdmin` to the service account
+4.  Grant `objectAdmin` to the service account
     ```bash
     gsutil iam ch \
         serviceAccount:open3d-ci-sa@isl-buckets.iam.gserviceaccount.com:objectAdmin \
         gs://open3d-docs
     ```
-5. Create key for service account
+5.  Create key for service account
     ```bash
     gcloud iam service-accounts keys create ~/open3d-ci-sa-key.json \
     --iam-account open3d-ci-sa@isl-buckets.iam.gserviceaccount.com
@@ -60,12 +61,12 @@ Now `~/open3d-ci-sa-key.json` should have been created.
 
 #### Step 2: GitHub
 
-1. Encode the private key json file with `base64 ~/open3d-ci-sa-key.json` and
+1.  Encode the private key json file with `base64 ~/open3d-ci-sa-key.json` and
     add the output text to the
     [GitHub repository secrets](https://github.com/isl-org/Open3D/settings/secrets)
     with name `GCE_SA_KEY_DOCS_CI`
 
-2. Also add secret `GCE_DOCS_PROJECT: isl-buckets`
+2.  Also add secret `GCE_DOCS_PROJECT: isl-buckets`
 
 ## Google compute engine setup for GPU CI
 
@@ -73,18 +74,18 @@ Now `~/open3d-ci-sa-key.json` should have been created.
 
 The GCE CI workflow `.github/workflows/gce-ubuntu-docker.yml` performs these steps:
 
-- Clone the repository
-- Build docker image, starting with a an NVIDIA base devel image with CUDA and
-  cuDNN.
-- Push image to Google container registry.
-- On Google Compute Engine (GCE), in parallel (up to GPU quota limit - currently
-  4):
-- Create a new VM instance with a custom OS image
-- Run docker image on GCE (Google Compute Engine) with environment variables
-  set for specific build config.
-- The docker image entrypoint is the `run-ci.sh` script: build, install, run
-  tests and uninstall.
-- Delete the VM instance.
+-   Clone the repository
+-   Build docker image, starting with a an NVIDIA base devel image with CUDA and
+    cuDNN.
+-   Push image to Google container registry.
+-   On Google Compute Engine (GCE), in parallel (up to GPU quota limit - currently
+    4):
+-   Create a new VM instance with a custom OS image
+-   Run docker image on GCE (Google Compute Engine) with environment variables
+    set for specific build config.
+-   The docker image entrypoint is the `run-ci.sh` script: build, install, run
+    tests and uninstall.
+-   Delete the VM instance.
 
 A separate VM instance is created for each commit and build option. The VM
 instances are named according to the commit hash and build config ID used. We
@@ -95,21 +96,21 @@ either due to lack of resources or GPU quota exhaustion.
 
 #### Step 1: Google Cloud: Create service account and key
 
-1. Create service account
+1.  Create service account
     ```bash
     gcloud iam service-accounts create open3d-ci-sa \
         --description="Service account for Open3D CI" \
         --display-name="open3d-ci-sa"    \
         --project open3d-dev
     ```
-2. Grant `Compute Instance Admin (beta)` to the service account
+2.  Grant `Compute Instance Admin (beta)` to the service account
     ```bash
     gcloud projects add-iam-policy-binding open3d-dev \
         --member=serviceAccount:open3d-ci-sa-gpu@open3d-dev.iam.gserviceaccount.com \
         --role=roles/compute.instanceAdmin \
         --project open3d-dev
     ```
-3. Create key for service account
+3.  Create key for service account
     ```bash
     gcloud iam service-accounts keys create ~/open3d-ci-sa-key.json \
         --iam-account open3d-ci-sa@open3d-dev.iam.gserviceaccount.com \
@@ -138,39 +139,42 @@ used for running CI.
 
 ## Ccache strategy
 
-- Typically, a build generates ~500MB cache. A build with Filament compiled from
-  source generates ~600MB cache.
-- Typically, regular X86 Ubuntu and macOS builds take about 40 mins without
-  caching.
-- The bottleneck of the CI is in the ARM build since it runs on a simulator.
-  When building Filament from source, the build time can exceed GitHub's 6-hour
-  limit if caching is not properly activated. With proper caching and good cache
-  hit rate, the ARM build job can run within 1 hour.
-- Both Ubuntu and macOS have a max cache setting of 2GB each out of a total
-  cache limit of 5GB for the whole repository. Windows MSVC does not use
-  caching at present since `ccache` does not officially support MSVC.
-- ARM64 cache (limit 1.5GB) is stored on Google cloud bucket
-  (`open3d-ci-cache` in the `isl-buckets` project). The bucket is world
-  readable, but needs the `open3d-ci-sa` service account for writing. Every
-  ARM64 build downloads the cache contents before build. Only `master` branch
-  builds use `gsutil rsync` to update the cache in GCS. Cache transfer only
-  takes a few minutes, but reduces ARM64 CI time to about 1:15 hours.
+-   Typically, a build generates ~500MB cache. A build with Filament compiled from
+    source generates ~600MB cache.
+-   Typically, regular X86 Ubuntu and macOS builds take about 40 mins without
+    caching.
+-   The bottleneck of the CI is in the ARM build since it runs on a simulator.
+    When building Filament from source, the build time can exceed GitHub's 6-hour
+    limit if caching is not properly activated. With proper caching and good cache
+    hit rate, the ARM build job can run within 1 hour.
+-   Both Ubuntu and macOS have a max cache setting of 2GB each out of a total
+    cache limit of 10GB for the whole repository. Windows MSVC does not use
+    caching at present since `cmake + ccache` requires Ninja instead of MSBuild.
+    Most users use MSVC / MSBuild instead of Ninja and this would make resolving
+    user issues harder.
+-   ARM64 cache (limit 1.5GB) is stored on Google cloud bucket
+    (`open3d-ci-cache` in the `isl-buckets` project). The bucket is world
+    readable, but needs the `open3d-ci-sa` service account for writing. Every
+    ARM64 build downloads the cache contents before build. Only `master` branch
+    builds use `gsutil rsync` to update the cache in GCS. Cache transfer only
+    takes a few minutes, but reduces ARM64 CI time to about 1:15 hours.
 
-## Development wheels for user testing
+## Development wheels and binary archives for user testing
 
-`master` branch Python wheels are uploaded to a world readable GCS bucket for
-users to try out development wheels.
+`master` branch Python wheels and binary archives are uploaded to a world
+readable GCS bucket in `open3d-releases-master/{python-wheels,devel}` for users
+to try out development wheels.
 
 ### Google Cloud storage
 
 Follow instructions in A. Documentation deployment to setup a Google cloud
 bucket with:
 
-- Project: open3d-dev
-- Service account: open3d-ci-sa-gpu
-- Bucket name: open3d-ci-sa-gpu
-- Public read permissions
-- One week object lifecycle
+-   Project: open3d-dev
+-   Service account: open3d-ci-sa-gpu
+-   Bucket name: open3d-ci-sa-gpu
+-   Public read permissions
+-   One month (30 days) object lifecycle
 
 ```bash
 gsutil mb -p open3d-dev -c STANDARD -l US -b on gs://open3d-releases-master

--- a/.github/workflows/clean-gcloud-profiles.yml
+++ b/.github/workflows/clean-gcloud-profiles.yml
@@ -31,15 +31,19 @@ env:
 
 jobs:
   clean-gcloud-profiles:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     steps:
+      - name: GCloud CLI auth
+        uses: 'google-github-actions/auth@v1'
+        with:
+          project_id: ${{ secrets.GCE_PROJECT }}
+          credentials_json: '${{ secrets.GCE_SA_KEY_GPU_CI }}'
       - name: GCloud CLI setup
-        uses: google-github-actions/setup-gcloud@v1.1.0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
-          service_account_key: ${{ secrets.GCE_SA_KEY_GPU_CI }}
           project_id: ${{ secrets.GCE_PROJECT }}
       - name: Delete GCloud login profiles manually
         run: |

--- a/.github/workflows/clean-gcloud-profiles.yml
+++ b/.github/workflows/clean-gcloud-profiles.yml
@@ -27,7 +27,7 @@ on:
 
 env:
   GCE_GPU_CI_SA: ${{ secrets.GCE_GPU_CI_SA }}
-  GCE_CLI_GHA_VERSION: '302.0.0' # Fixed to avoid dependency on API changes
+  GCE_CLI_GHA_VERSION: '416.0.0' # Fixed to avoid dependency on API changes
 
 jobs:
   clean-gcloud-profiles:
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
     steps:
       - name: GCloud CLI setup
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v1.1.0
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
           service_account_key: ${{ secrets.GCE_SA_KEY_GPU_CI }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -59,13 +59,16 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.7'
+      - name: GCloud CLI auth
+        uses: 'google-github-actions/auth@v1'
+        with:
+          project_id: ${{ secrets.GCE_PROJECT }}
+          credentials_json: '${{ secrets.GCE_SA_KEY_GPU_CI }}'
       - name: GCloud CLI setup
-        uses: google-github-actions/setup-gcloud@v1.1.0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
-          service_account_key: ${{ secrets.GCE_SA_KEY_DOCS_CI }}
-          project_id: ${{ secrets.GCE_DOCS_PROJECT }}
-          export_default_credentials: true
+          project_id: ${{ secrets.GCE_PROJECT }}
 
       - name: Install dependencies
         env:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,18 +18,18 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GCE_CLI_GHA_VERSION: '302.0.0'      # Fixed to avoid dependency on API changes
+  GCE_CLI_GHA_VERSION: '416.0.0'      # Fixed to avoid dependency on API changes
 
 jobs:
   headless-docs:
     # Build headless and docs
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest  # Warn about build issues in new versions
     env:
       OPEN3D_ML_ROOT: ${{ github.workspace }}/Open3D-ML
       DEVELOPER_BUILD: ${{ github.event.inputs.developer_build || 'ON' }}
     steps:
       - name: Checkout Open3D source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Maximize build space
         run: |
@@ -37,13 +37,13 @@ jobs:
           maximize_ubuntu_github_actions_build_space
 
       - name: Checkout Open3D-ML source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: isl-org/Open3D-ML
           path: ${{ env.OPEN3D_ML_ROOT }}
 
       - name: Setup cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           # Ref: https://github.com/apache/incubator-mxnet/pull/18459/files
           path: ~/.ccache
@@ -56,11 +56,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-ccache
       - name: Set up Python version
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: '3.7'
       - name: GCloud CLI setup
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v1.1.0
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
           service_account_key: ${{ secrets.GCE_SA_KEY_DOCS_CI }}
@@ -88,7 +88,7 @@ jobs:
           ccache -s
 
       - name: Upload docs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: open3d_docs
           path: docs/_out/html

--- a/.github/workflows/gcs.lifecycle.json
+++ b/.github/workflows/gcs.lifecycle.json
@@ -1,9 +1,12 @@
 {
-    "rule":
-    [
-      {
-        "action": {"type": "Delete"},
-        "condition": {"age": 7}
+  "rule": [
+    {
+      "action": {
+        "type": "Delete"
+      },
+      "condition": {
+        "age": 7
       }
-    ]
+    }
+  ]
 }

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -92,15 +92,18 @@ jobs:
           path: build/package/${{ env.DEVEL_PKG_NAME }}
           if-no-files-found: error
 
+      - name: GCloud CLI auth
+        if: ${{ github.ref == 'refs/heads/master' && env.BUILD_SHARED_LIBS == 'ON' }}
+        uses: 'google-github-actions/auth@v1'
+        with:
+          project_id: ${{ secrets.GCE_PROJECT }}
+          credentials_json: '${{ secrets.GCE_SA_KEY_GPU_CI }}'
       - name: GCloud CLI setup
         if: ${{ github.ref == 'refs/heads/master' && env.BUILD_SHARED_LIBS == 'ON' }}
-        # https://github.com/GoogleCloudPlatform/github-actions/issues/100#issuecomment-650798308
-        uses: google-github-actions/setup-gcloud@v1.1.0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
-          service_account_key: ${{ secrets.GCE_SA_KEY_GPU_CI }}
-          project_id: ${{ secrets.GCE_DOCS_PROJECT }}
-          export_default_credentials: true
+          project_id: ${{ secrets.GCE_PROJECT }}
 
       - name: Upload package to GCS bucket
         if: ${{ github.ref == 'refs/heads/master' && env.BUILD_SHARED_LIBS == 'ON' }}
@@ -201,14 +204,18 @@ jobs:
           path: build/lib/python_package/pip_package/${{ env.PIP_PKG_NAME }}
           if-no-files-found: error
 
+      - name: GCloud CLI auth
+        if: ${{ github.ref == 'refs/heads/master' }}
+        uses: 'google-github-actions/auth@v1'
+        with:
+          project_id: ${{ secrets.GCE_PROJECT }}
+          credentials_json: '${{ secrets.GCE_SA_KEY_GPU_CI }}'
       - name: GCloud CLI setup
         if: ${{ github.ref == 'refs/heads/master' }}
-        uses: google-github-actions/setup-gcloud@v1.1.0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
-          service_account_key: ${{ secrets.GCE_SA_KEY_GPU_CI }}
-          project_id: ${{ secrets.GCE_DOCS_PROJECT }}
-          export_default_credentials: true
+          project_id: ${{ secrets.GCE_PROJECT }}
 
       - name: Upload wheel to GCS bucket
         if: ${{ github.ref == 'refs/heads/master' }}
@@ -277,17 +284,20 @@ jobs:
   ready-docs:
     name: Ready docs archive
     # no need to run on macOS
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/master' }}
     needs: [build-wheel, MacOS]
     steps:
+      - name: GCloud CLI auth
+        uses: 'google-github-actions/auth@v1'
+        with:
+          project_id: ${{ secrets.GCE_PROJECT }}
+          credentials_json: '${{ secrets.GCE_SA_KEY_GPU_CI }}'
       - name: GCloud CLI setup
-        uses: google-github-actions/setup-gcloud@v1.1.0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
-          service_account_key: ${{ secrets.GCE_SA_KEY_GPU_CI }}
-          project_id: ${{ secrets.GCE_DOCS_PROJECT }}
-          export_default_credentials: true
+          project_id: ${{ secrets.GCE_PROJECT }}
       - name: Check wheels and ready documentation archive
         run: |
             touch marker_file

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -38,9 +38,9 @@ jobs:
       LOW_MEM_USAGE: ON
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           # Ref: https://github.com/apache/incubator-mxnet/pull/18459/files
           path: ~/.ccache
@@ -53,7 +53,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-ccache
       - name: Set up Python version
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - name: Install dependencies
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload package
         if: ${{ env.BUILD_SHARED_LIBS == 'ON' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: open3d-devel-macosx
           path: build/package/${{ env.DEVEL_PKG_NAME }}
@@ -95,7 +95,7 @@ jobs:
       - name: GCloud CLI setup
         if: ${{ github.ref == 'refs/heads/master' && env.BUILD_SHARED_LIBS == 'ON' }}
         # https://github.com/GoogleCloudPlatform/github-actions/issues/100#issuecomment-650798308
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v1.1.0
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
           service_account_key: ${{ secrets.GCE_SA_KEY_GPU_CI }}
@@ -109,7 +109,7 @@ jobs:
           echo "Download devel package at: https://storage.googleapis.com/open3d-releases-master/devel/${{ env.DEVEL_PKG_NAME }}"
 
       - name: Upload Open3D viewer app
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ env.BUILD_SHARED_LIBS == 'OFF' }}
         with:
           name: open3d-app-macosx-10_15
@@ -139,16 +139,16 @@ jobs:
       OPEN3D_ML_ROOT: ${{ github.workspace }}/Open3D-ML
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Checkout Open3D-ML source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: isl-org/Open3D-ML
           path: ${{ env.OPEN3D_ML_ROOT }}
 
       - name: Setup cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           # Ref: https://github.com/apache/incubator-mxnet/pull/18459/files
           path: ~/.ccache
@@ -162,7 +162,7 @@ jobs:
             ${{ runner.os }}-ccache
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python_version }}
 
@@ -195,7 +195,7 @@ jobs:
           echo "PIP_PKG_NAME=$PIP_PKG_NAME" >> $GITHUB_ENV
 
       - name: Upload wheel
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: open3d_macosx_x86_64_wheels
           path: build/lib/python_package/pip_package/${{ env.PIP_PKG_NAME }}
@@ -203,7 +203,7 @@ jobs:
 
       - name: GCloud CLI setup
         if: ${{ github.ref == 'refs/heads/master' }}
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v1.1.0
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
           service_account_key: ${{ secrets.GCE_SA_KEY_GPU_CI }}
@@ -241,23 +241,23 @@ jobs:
       OPEN3D_ML_ROOT: ${{ github.workspace }}/Open3D-ML
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Checkout Open3D-ML source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: isl-org/Open3D-ML
           path: ${{ env.OPEN3D_ML_ROOT }}
 
       - name: Download wheels
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         # See https://github.com/dawidd6/action-download-artifact for more
         # flexible artifact download options
         with:
           name: open3d_macosx_x86_64_wheels
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python_version }}
 
@@ -282,7 +282,7 @@ jobs:
     needs: [build-wheel, MacOS]
     steps:
       - name: GCloud CLI setup
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v1.1.0
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
           service_account_key: ${{ secrets.GCE_SA_KEY_GPU_CI }}

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   style-check:
-    runs-on: ubuntu-20.04     # No need for cmake repo
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-20.04     # No need for cmake repo
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python version
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.7'
       - name: Install dependencies

--- a/.github/workflows/ubuntu-cuda.yml
+++ b/.github/workflows/ubuntu-cuda.yml
@@ -34,10 +34,10 @@ jobs:
         run: |
           if [ "${GITHUB_REPOSITORY}" == "isl-org/Open3D" ] && [ -n "${GCE_GPU_CI_SA}" ] ; then
             echo "Secrets available: performing GCE test"
-            echo "::set-output name=skip::no"
+            echo "skip=no" >> $GITHUB_OUTPUT
           else
             echo "Secrets not available: skipping GCE test"
-            echo "::set-output name=skip::yes"
+            echo "skip=yes" >> $GITHUB_OUTPUT
           fi
 
   build-and-run-docker:

--- a/.github/workflows/ubuntu-cuda.yml
+++ b/.github/workflows/ubuntu-cuda.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   skip-check:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     name: Skip job for forks
     outputs:
       skip: ${{ steps.check.outputs.skip }}
@@ -42,7 +42,7 @@ jobs:
 
   build-and-run-docker:
     name: Build and run
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: [skip-check]
     if: needs.skip-check.outputs.skip == 'no'
     strategy:
@@ -72,11 +72,15 @@ jobs:
           cd "${GITHUB_WORKSPACE}/.."
           tar -czvf Open3D.tar.gz Open3D
           ls -alh
+      - name: GCloud CLI auth
+        uses: 'google-github-actions/auth@v1'
+        with:
+          project_id: ${{ secrets.GCE_PROJECT }}
+          credentials_json: '${{ secrets.GCE_SA_KEY_GPU_CI }}'
       - name: GCloud CLI setup
-        uses: google-github-actions/setup-gcloud@v1.1.0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
-          service_account_key: ${{ secrets.GCE_SA_KEY_GPU_CI }}
           project_id: ${{ secrets.GCE_PROJECT }}
       - name: VM create
         run: |

--- a/.github/workflows/ubuntu-cuda.yml
+++ b/.github/workflows/ubuntu-cuda.yml
@@ -19,7 +19,7 @@ concurrency:
 
 env:
   GCE_GPU_CI_SA: ${{ secrets.GCE_GPU_CI_SA }}
-  GCE_CLI_GHA_VERSION: "302.0.0"
+  GCE_CLI_GHA_VERSION: "416.0.0"
   DEVELOPER_BUILD: ${{ github.event.inputs.developer_build || 'ON' }}
 
 jobs:
@@ -63,7 +63,7 @@ jobs:
       CCACHE_TAR_NAME    : open3d-ci-${{ matrix.CI_CONFIG }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: 'false'
       - name: Package code
@@ -73,7 +73,7 @@ jobs:
           tar -czvf Open3D.tar.gz Open3D
           ls -alh
       - name: GCloud CLI setup
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v1.1.0
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
           service_account_key: ${{ secrets.GCE_SA_KEY_GPU_CI }}
@@ -145,7 +145,7 @@ jobs:
 
       - name: Upload package
         if: ${{ env.BUILD_PACKAGE == 'true' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: open3d-devel-linux-x86_64-cuda
           path: open3d-devel-linux*.tar.xz

--- a/.github/workflows/ubuntu-openblas.yml
+++ b/.github/workflows/ubuntu-openblas.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   GCE_GPU_CI_SA: ${{ secrets.GCE_GPU_CI_SA }}
-  GCE_CLI_GHA_VERSION: '302.0.0'      # Fixed to avoid dependency on API changes
+  GCE_CLI_GHA_VERSION: '416.0.0'      # Fixed to avoid dependency on API changes
 
 jobs:
   openblas-amd64:
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Maximize build space
         run: |
           source util/ci_utils.sh
@@ -32,7 +32,7 @@ jobs:
         run: |
           docker/docker_build.sh openblas-amd64-py310-dev
       - name: GCloud CLI setup
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v1.1.0
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
           service_account_key: ${{ secrets.GCE_SA_KEY_DOCS_CI }}
@@ -73,7 +73,7 @@ jobs:
       GCE_INSTANCE_PREFIX: open3d-ci-openblas-arm64-py310-dev
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Package code
         run: |
           # GITHUB_WORKSPACE: /home/runner/work/Open3D/Open3D
@@ -81,7 +81,7 @@ jobs:
           tar -czvf Open3D.tar.gz Open3D
           ls -alh
       - name: GCloud CLI setup
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v1.1.0
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
           service_account_key: ${{ secrets.GCE_SA_KEY_GPU_CI }}

--- a/.github/workflows/ubuntu-openblas.yml
+++ b/.github/workflows/ubuntu-openblas.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   openblas-amd64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     steps:
@@ -31,20 +31,23 @@ jobs:
       - name: Docker build
         run: |
           docker/docker_build.sh openblas-amd64-py310-dev
+      - name: GCloud CLI auth
+        uses: 'google-github-actions/auth@v1'
+        with:
+          project_id: ${{ secrets.GCE_PROJECT }}
+          credentials_json: '${{ secrets.GCE_SA_KEY_GPU_CI }}'
       - name: GCloud CLI setup
-        uses: google-github-actions/setup-gcloud@v1.1.0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
-          service_account_key: ${{ secrets.GCE_SA_KEY_DOCS_CI }}
-          project_id: ${{ secrets.GCE_DOCS_PROJECT }}
-          export_default_credentials: true
+          project_id: ${{ secrets.GCE_PROJECT }}
       - name: Docker test
         run: |
           docker/docker_test.sh openblas-amd64-py310-dev
 
   # With forked repo, the GitHub secret is not available.
   skip-arm64-check-on-fork:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Skip job for forks
     outputs:
       skip: ${{ steps.check.outputs.skip }}
@@ -54,14 +57,14 @@ jobs:
         run: |
           if [ "${GITHUB_REPOSITORY}" == "isl-org/Open3D" ] && [ -n "${GCE_GPU_CI_SA}" ] ; then
             echo "Secrets available: performing GCE test"
-            echo "::set-output name=skip::no"
+            echo "skip=no" >> $GITHUB_OUTPUT
           else
             echo "Secrets not available: skipping GCE test"
-            echo "::set-output name=skip::yes"
+            echo "skip=yes" >> $GITHUB_OUTPUT
           fi
 
   openblas-arm64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [skip-arm64-check-on-fork]
     if: needs.skip-arm64-check-on-fork.outputs.skip == 'no'
     strategy:
@@ -80,11 +83,15 @@ jobs:
           cd "${GITHUB_WORKSPACE}/.."
           tar -czvf Open3D.tar.gz Open3D
           ls -alh
+      - name: GCloud CLI auth
+        uses: 'google-github-actions/auth@v1'
+        with:
+          project_id: ${{ secrets.GCE_PROJECT }}
+          credentials_json: '${{ secrets.GCE_SA_KEY_GPU_CI }}'
       - name: GCloud CLI setup
-        uses: google-github-actions/setup-gcloud@v1.1.0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
-          service_account_key: ${{ secrets.GCE_SA_KEY_GPU_CI }}
           project_id: ${{ secrets.GCE_PROJECT }}
       - name: VM create
         run: |

--- a/.github/workflows/ubuntu-sycl.yml
+++ b/.github/workflows/ubuntu-sycl.yml
@@ -13,7 +13,7 @@ concurrency:
 
 env:
   NPROC: 2
-  GCE_CLI_GHA_VERSION: "302.0.0"
+  GCE_CLI_GHA_VERSION: "416.0.0"
 
 jobs:
   ubuntu-sycl:
@@ -24,7 +24,7 @@ jobs:
         BUILD_SHARED_LIBS: [ON, OFF]
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Maximize build space
         run: |
           source util/ci_utils.sh
@@ -45,7 +45,7 @@ jobs:
           fi
       - name: GCloud CLI setup
         if: ${{ github.ref == 'refs/heads/master' }}
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v1.1.0
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
           service_account_key: ${{ secrets.GCE_SA_KEY_DOCS_CI }}

--- a/.github/workflows/ubuntu-sycl.yml
+++ b/.github/workflows/ubuntu-sycl.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   ubuntu-sycl:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -43,14 +43,16 @@ jobs:
           else
             docker/docker_test.sh sycl-static
           fi
+      - name: GCloud CLI auth
+        uses: 'google-github-actions/auth@v1'
+        with:
+          project_id: ${{ secrets.GCE_PROJECT }}
+          credentials_json: '${{ secrets.GCE_SA_KEY_GPU_CI }}'
       - name: GCloud CLI setup
-        if: ${{ github.ref == 'refs/heads/master' }}
-        uses: google-github-actions/setup-gcloud@v1.1.0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
-          service_account_key: ${{ secrets.GCE_SA_KEY_DOCS_CI }}
-          project_id: ${{ secrets.GCE_DOCS_PROJECT }}
-          export_default_credentials: true
+          project_id: ${{ secrets.GCE_PROJECT }}
       - name: Upload ccache to GCS
         if: ${{ github.ref == 'refs/heads/master' }}
         run: |

--- a/.github/workflows/ubuntu-wheel.yml
+++ b/.github/workflows/ubuntu-wheel.yml
@@ -41,7 +41,7 @@ jobs:
       OPEN3D_CPU_RENDERING: true
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Maximize build space
         run: |
           source util/ci_utils.sh
@@ -70,14 +70,14 @@ jobs:
           PIP_PKG_NAME="$(basename ${GITHUB_WORKSPACE}/open3d*.whl)"
           echo "PIP_PKG_NAME=$PIP_PKG_NAME" >> $GITHUB_ENV
       - name: Upload wheel to GitHub artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: open3d_linux_x86_64_wheels
           path: ${{ env.PIP_PKG_NAME }}
           if-no-files-found: error
       - name: GCloud CLI setup (GCE_SA_KEY_DOCS_CI)
         if: ${{ github.ref == 'refs/heads/master' }}
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v1.1.0
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
           service_account_key: ${{ secrets.GCE_SA_KEY_DOCS_CI }}
@@ -89,7 +89,7 @@ jobs:
           gsutil cp ${GITHUB_WORKSPACE}/${{ env.CCACHE_TAR_NAME }}.tar.gz gs://open3d-ci-cache/
       - name: GCloud CLI setup (GCE_SA_KEY_GPU_CI)
         if: ${{ github.ref == 'refs/heads/master' }}
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v1.1.0
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
           service_account_key: ${{ secrets.GCE_SA_KEY_GPU_CI }}
@@ -122,22 +122,22 @@ jobs:
       OPEN3D_ML_ROOT: ${{ github.workspace }}/Open3D-ML
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Maximize build space
         run: |
           source util/ci_utils.sh
           maximize_ubuntu_github_actions_build_space
       - name: Checkout Open3D-ML source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: isl-org/Open3D-ML
           path: ${{ env.OPEN3D_ML_ROOT }}
       - name: Download wheels
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: open3d_linux_x86_64_wheels
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python_version }}
       - name: Test Python package
@@ -159,7 +159,7 @@ jobs:
     needs: [build-wheel]
     steps:
       - name: GCloud CLI setup
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v1.1.0
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
           service_account_key: ${{ secrets.GCE_SA_KEY_GPU_CI }}

--- a/.github/workflows/ubuntu-wheel.yml
+++ b/.github/workflows/ubuntu-wheel.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   build-wheel:
     name: Build wheel
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -75,26 +75,22 @@ jobs:
           name: open3d_linux_x86_64_wheels
           path: ${{ env.PIP_PKG_NAME }}
           if-no-files-found: error
-      - name: GCloud CLI setup (GCE_SA_KEY_DOCS_CI)
+      - name: GCloud CLI auth
         if: ${{ github.ref == 'refs/heads/master' }}
-        uses: google-github-actions/setup-gcloud@v1.1.0
+        uses: 'google-github-actions/auth@v1'
+        with:
+          project_id: ${{ secrets.GCE_PROJECT }}
+          credentials_json: '${{ secrets.GCE_SA_KEY_GPU_CI }}'
+      - name: GCloud CLI setup
+        if: ${{ github.ref == 'refs/heads/master' }}
+        uses: google-github-actions/setup-gcloud@v1
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
-          service_account_key: ${{ secrets.GCE_SA_KEY_DOCS_CI }}
-          project_id: ${{ secrets.GCE_DOCS_PROJECT }}
-          export_default_credentials: true
+          project_id: ${{ secrets.GCE_PROJECT }}
       - name: Upload ccache to GCS
         if: ${{ github.ref == 'refs/heads/master' }}
         run: |
           gsutil cp ${GITHUB_WORKSPACE}/${{ env.CCACHE_TAR_NAME }}.tar.gz gs://open3d-ci-cache/
-      - name: GCloud CLI setup (GCE_SA_KEY_GPU_CI)
-        if: ${{ github.ref == 'refs/heads/master' }}
-        uses: google-github-actions/setup-gcloud@v1.1.0
-        with:
-          version: ${{ env.GCE_CLI_GHA_VERSION }}
-          service_account_key: ${{ secrets.GCE_SA_KEY_GPU_CI }}
-          project_id: ${{ secrets.GCE_DOCS_PROJECT }}
-          export_default_credentials: true
       - name: Upload wheel to GCS
         if: ${{ github.ref == 'refs/heads/master' }}
         run: |
@@ -154,17 +150,22 @@ jobs:
 
   ready-docs:
     name: Ready docs archive
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/master' }}
     needs: [build-wheel]
     steps:
+      - name: GCloud CLI auth
+        if: ${{ github.ref == 'refs/heads/master' }}
+        uses: 'google-github-actions/auth@v1'
+        with:
+          project_id: ${{ secrets.GCE_PROJECT }}
+          credentials_json: '${{ secrets.GCE_SA_KEY_GPU_CI }}'
       - name: GCloud CLI setup
-        uses: google-github-actions/setup-gcloud@v1.1.0
+        if: ${{ github.ref == 'refs/heads/master' }}
+        uses: google-github-actions/setup-gcloud@v1
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
-          service_account_key: ${{ secrets.GCE_SA_KEY_GPU_CI }}
-          project_id: ${{ secrets.GCE_DOCS_PROJECT }}
-          export_default_credentials: true
+          project_id: ${{ secrets.GCE_PROJECT }}
       - name: Check wheels and ready documentation archive
         run: |
             touch marker_file

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -19,7 +19,7 @@ concurrency:
 
 env:
   NPROC: 2
-  GCE_CLI_GHA_VERSION: "302.0.0"
+  GCE_CLI_GHA_VERSION: "416.0.0"
 
 jobs:
   ubuntu:
@@ -41,7 +41,7 @@ jobs:
       OPEN3D_CPU_RENDERING: true
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Maximize build space
         run: |
           source util/ci_utils.sh
@@ -74,7 +74,7 @@ jobs:
           fi
       - name: Upload package to GitHub artifacts
         if: ${{ env.BUILD_SHARED_LIBS == 'ON' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: open3d-devel-linux-x86_64
           path: open3d-devel-*.tar.xz
@@ -82,7 +82,7 @@ jobs:
       - name: GCloud CLI setup
         if: ${{ github.ref == 'refs/heads/master' && env.BUILD_SHARED_LIBS == 'ON' }}
         # https://github.com/GoogleCloudPlatform/github-actions/issues/100#issuecomment-650798308
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v1.1.0
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
           service_account_key: ${{ secrets.GCE_SA_KEY_GPU_CI }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   ubuntu:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -79,15 +79,18 @@ jobs:
           name: open3d-devel-linux-x86_64
           path: open3d-devel-*.tar.xz
           if-no-files-found: error
+      - name: GCloud CLI auth
+        if: ${{ github.ref == 'refs/heads/master' }}
+        uses: 'google-github-actions/auth@v1'
+        with:
+          project_id: ${{ secrets.GCE_PROJECT }}
+          credentials_json: '${{ secrets.GCE_SA_KEY_GPU_CI }}'
       - name: GCloud CLI setup
-        if: ${{ github.ref == 'refs/heads/master' && env.BUILD_SHARED_LIBS == 'ON' }}
-        # https://github.com/GoogleCloudPlatform/github-actions/issues/100#issuecomment-650798308
-        uses: google-github-actions/setup-gcloud@v1.1.0
+        if: ${{ github.ref == 'refs/heads/master' }}
+        uses: google-github-actions/setup-gcloud@v1
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
-          service_account_key: ${{ secrets.GCE_SA_KEY_GPU_CI }}
-          project_id: ${{ secrets.GCE_DOCS_PROJECT }}
-          export_default_credentials: true
+          project_id: ${{ secrets.GCE_PROJECT }}
       - name: Upload package to GCS bucket
         if: ${{ github.ref == 'refs/heads/master' && env.BUILD_SHARED_LIBS == 'ON' }}
         run: |

--- a/.github/workflows/vtk_packages.yml
+++ b/.github/workflows/vtk_packages.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: CMake configure
         run: |
           mkdir build
@@ -24,7 +24,7 @@ jobs:
           make -j$(nproc)
           cmake -E sha256sum vtk*.tar.gz > checksum_linux.txt
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: vtk_linux
           path: |
@@ -52,7 +52,7 @@ jobs:
       - name: Disk space used
         run: Get-PSDrive
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Config
         # Move build directory to C: https://github.com/actions/virtual-environments/issues/1341
         run: |
@@ -74,7 +74,7 @@ jobs:
           ls
           cmake -E sha256sum (get-item vtk*.tar.gz).Name > checksum_win_${{matrix.configuration}}.txt
       - name: Upload package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: vtk_windows_${{matrix.configuration}}
           path: |
@@ -89,7 +89,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: CMake configure
         run: |
           mkdir build
@@ -101,7 +101,7 @@ jobs:
           make -j2
           cmake -E sha256sum vtk*.tar.gz > checksum_macos.txt
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: vtk_macos
           path: |

--- a/.github/workflows/webrtc.yml
+++ b/.github/workflows/webrtc.yml
@@ -27,13 +27,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macOS 10.15 build does not work on macOS 10.14 due to this issue:
-        # https://openradar.appspot.com/FB7647406
-        # macOS 10.14 build works on both 10.14 and 10.15
-        os: [ubuntu-18.04, macos-12]
+        os: [ubuntu-18.04, macos-11]
         GLIBCXX_USE_CXX11_ABI: [0, 1]
         exclude:
-          - os: macos-12
+          - os: macos-11
             GLIBCXX_USE_CXX11_ABI: 0
     env:
       GLIBCXX_USE_CXX11_ABI: ${{ matrix.GLIBCXX_USE_CXX11_ABI }}
@@ -74,7 +71,7 @@ jobs:
 
   Windows:
     # https://chromium.googlesource.com/chromium/src/+/HEAD/docs/windows_build_instructions.md
-    runs-on: windows-latest
+    runs-on: windows-2019
     env:
       WORK_DIR: "C:\\WebRTC"  # Not enough space in D:
       OPEN3D_DIR: "D:\\a\\open3d\\open3d"

--- a/.github/workflows/webrtc.yml
+++ b/.github/workflows/webrtc.yml
@@ -40,10 +40,10 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python version
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 
@@ -64,7 +64,7 @@ jobs:
           build_webrtc
 
       - name: Upload WebRTC
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: webrtc_release
           path: |
@@ -84,10 +84,10 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python version
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
 
@@ -170,7 +170,7 @@ jobs:
           cmake -E sha256sum webrtc_${env:WEBRTC_COMMIT_SHORT}_win.zip | Tee-Object -FilePath checksum_win.txt
 
       - name: Upload WebRTC
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: webrtc_release
           path: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -95,10 +95,10 @@ jobs:
           echo "$CUDA_PATH\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python version
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 
@@ -151,7 +151,7 @@ jobs:
 
       - name: Upload package
         if: ${{ matrix.BUILD_SHARED_LIBS == 'ON' && matrix.BUILD_CUDA_MODULE == 'OFF' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: open3d-devel-windows
           path: ${{ env.BUILD_DIR }}/package/${{ env.DEVEL_PKG_NAME }}
@@ -160,7 +160,7 @@ jobs:
       - name: GCloud CLI setup
         if: ${{ github.ref == 'refs/heads/master' && matrix.BUILD_SHARED_LIBS == 'ON' && matrix.BUILD_CUDA_MODULE == 'OFF' }}
         # https://github.com/GoogleCloudPlatform/github-actions/issues/100#issuecomment-650798308
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v1.1.0
         env:
           CLOUDSDK_PYTHON: ${{env.PYTHON_EXECUTABLE}}
         with:
@@ -241,7 +241,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Windows SDK
         uses: GuillaumeFalourd/setup-windows10-sdk-action@v1.7
@@ -249,7 +249,7 @@ jobs:
           sdk-version: 19041
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python_version }}
 
@@ -296,7 +296,7 @@ jobs:
           echo "PYTHON_EXECUTABLE=$PYTHON_EXECUTABLE"  | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Upload wheel
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: open3d_win_amd64_wheels
           path: ${{ env.BUILD_DIR }}/lib/python_package/pip_package/${{ env.PIP_PKG_NAME }}
@@ -305,7 +305,7 @@ jobs:
       - name: GCloud CLI setup
         if: ${{ github.ref == 'refs/heads/master' }}
         # https://github.com/GoogleCloudPlatform/github-actions/issues/100#issuecomment-650798308
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v1.1.0
         env:
           CLOUDSDK_PYTHON: ${{env.PYTHON_EXECUTABLE}}
         with:
@@ -349,17 +349,17 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download wheels
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         # See https://github.com/dawidd6/action-download-artifact for more
         # flexible artifact download options
         with:
           name: open3d_win_amd64_wheels
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python_version }}
 
@@ -408,7 +408,7 @@ jobs:
     needs: [build-wheel, windows]
     steps:
       - name: GCloud CLI setup
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v1.1.0
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
           service_account_key: ${{ secrets.GCE_SA_KEY_GPU_CI }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -403,17 +403,22 @@ jobs:
   ready-docs:
     name: Ready docs archive
     # no need to run on Windows
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/master' }}
     needs: [build-wheel, windows]
     steps:
+      - name: GCloud CLI auth
+        if: ${{ github.ref == 'refs/heads/master' }}
+        uses: 'google-github-actions/auth@v1'
+        with:
+          project_id: ${{ secrets.GCE_PROJECT }}
+          credentials_json: '${{ secrets.GCE_SA_KEY_GPU_CI }}'
       - name: GCloud CLI setup
-        uses: google-github-actions/setup-gcloud@v1.1.0
+        if: ${{ github.ref == 'refs/heads/master' }}
+        uses: google-github-actions/setup-gcloud@v1
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}
-          service_account_key: ${{ secrets.GCE_SA_KEY_GPU_CI }}
-          project_id: ${{ secrets.GCE_DOCS_PROJECT }}
-          export_default_credentials: true
+          project_id: ${{ secrets.GCE_PROJECT }}
       - name: Check wheels and ready documentation archive
         run: |
             touch marker_file

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,7 +27,7 @@ env:
   SCIPY_VER: "1.7.3"
   JEDI_VER: "0.17.2"  # https://github.com/ipython/ipython/issues/12740
   IDNA_VER: "2.8"  # https://github.com/psf/requests/issues/5710
-  TENSORBOARD_VER: "2.5"
+  TENSORBOARD_VER: "2.8"
   SRC_DIR: "D:\\a\\open3d\\open3d"
   BUILD_DIR: "C:\\Open3D\\build"
   NPROC: 2
@@ -57,7 +57,7 @@ jobs:
         run: Get-PSDrive
 
       - name: Setup Windows SDK
-        uses: GuillaumeFalourd/setup-windows10-sdk-action@v1.7
+        uses: GuillaumeFalourd/setup-windows10-sdk-action@v1.11
         with:
           sdk-version: 19041
 
@@ -244,7 +244,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Windows SDK
-        uses: GuillaumeFalourd/setup-windows10-sdk-action@v1.7
+        uses: GuillaumeFalourd/setup-windows10-sdk-action@v1.11
         with:
           sdk-version: 19041
 


### PR DESCRIPTION
Prevent deprecation warnings that will turn into errors later.
**Future**: Github cache allowance is now 10GB (up from 5GB earlier). We can add caching to Windows builds, but cmake + ccache doesn't work with msbuild, ninja is needed.

- Github actions: Checkout, cache, setup python
- Others: Gcloud SDK, Windows SDK version.
- Update OS: ubuntu-latest for docker and aux (e.g. artifact upload) actions, oldest supported for others.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/5890)
<!-- Reviewable:end -->
