### PR TITLE
Enable picking points from TriangleMeshModels in O3D Visualizer

### DIFF
--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
@@ -2029,7 +2029,7 @@ struct O3DVisualizer::Impl {
         // Count number of meshes stored in TriangleMeshModels
         size_t model_mesh_count = 0;
         size_t model_count = 0;
-        for (auto &o: objects_) {
+        for (auto &o : objects_) {
             if (!IsGeometryVisible(o)) {
                 continue;
             }
@@ -2038,17 +2038,19 @@ struct O3DVisualizer::Impl {
                 model_mesh_count += o.model.get()->meshes_.size();
             }
         }
-        pickable.reserve(objects_.size()+model_mesh_count-model_count);
+        pickable.reserve(objects_.size() + model_mesh_count - model_count);
         for (auto &o : objects_) {
             if (!IsGeometryVisible(o)) {
                 continue;
             }
             if (o.model.get()) {
                 for (auto &g : o.model->meshes_) {
-                    pickable.emplace_back(o.name, g.mesh.get(), o.tgeometry.get());
+                    pickable.emplace_back(o.name, g.mesh.get(),
+                                          o.tgeometry.get());
                 }
             } else {
-                pickable.emplace_back(o.name, o.geometry.get(), o.tgeometry.get());
+                pickable.emplace_back(o.name, o.geometry.get(),
+                                      o.tgeometry.get());
             }
         }
         selections_->SetSelectableGeometry(pickable);

--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
@@ -2026,12 +2026,30 @@ struct O3DVisualizer::Impl {
 
     void UpdateSelectableGeometry() {
         std::vector<SceneWidget::PickableGeometry> pickable;
-        pickable.reserve(objects_.size());
+        // Count number of meshes stored in TriangleMeshModels
+        size_t model_mesh_count = 0;
+        size_t model_count = 0;
+        for (auto &o: objects_) {
+            if (!IsGeometryVisible(o)) {
+                continue;
+            }
+            if (o.model.get()) {
+                model_count++;
+                model_mesh_count += o.model.get()->meshes_.size();
+            }
+        }
+        pickable.reserve(objects_.size()+model_mesh_count-model_count);
         for (auto &o : objects_) {
             if (!IsGeometryVisible(o)) {
                 continue;
             }
-            pickable.emplace_back(o.name, o.geometry.get(), o.tgeometry.get());
+            if (o.model.get()) {
+                for (auto &g : o.model->meshes_) {
+                    pickable.emplace_back(o.name, g.mesh.get(), o.tgeometry.get());
+                }
+            } else {
+                pickable.emplace_back(o.name, o.geometry.get(), o.tgeometry.get());
+            }
         }
         selections_->SetSelectableGeometry(pickable);
     }

--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
@@ -2045,7 +2045,7 @@ struct O3DVisualizer::Impl {
             }
             if (o.model.get()) {
                 for (auto &g : o.model->meshes_) {
-                    pickable.emplace_back(o.name, g.mesh.get(),
+                    pickable.emplace_back(g.mesh_name, g.mesh.get(),
                                           o.tgeometry.get());
                 }
             } else {


### PR DESCRIPTION
## Description

Add ability to select points from a `TriangleMeshModel` in O3D Visualizer (e.g., draw.py). Previously, attempting to do so caused a crash with a cryptic message.

The following script demonstrates the new capability:
```py
import open3d as o3d
monkey = o3d.data.MonkeyModel()
m = o3d.io.read_triangle_model(monkey.path)
o3d.visualization.draw(m, show_ui=True, actions=[["Print selection", lambda o3dvis: print(o3dvis.get_selection_sets())]])
```
Output:
```py
[Open3D WARNING] Geometry Object 1 has already been added to scene graph.
[{'Object 1': {{ index: 47335, order: 5, point: (5.42036, -0.955666, -2.12278) }, { index: 49813, order: 3, point: (-1.15616, -0.0953989, -1.86053) }, { index: 53731, order: 4, point: (-0.625896, -0.964231, -6.8371) }, { index: 40037, order: 1, point: (-4.25987, -0.402343, -1.95247) }, { index: 57889, order: 2, point: (-4.27602, -0.404048, -1.47792) }, { index: 40561, order: 0, point: (-1.6692, -0.834914, -2.62355) }}}]
```
Select the "Selection" tab at the top right. Previously, selection the tab would cause a crash. Now, you can Ctrl-click to select points from the Monkey model.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/5978)
<!-- Reviewable:end -->
