### PR TITLE
Add IO for NPZ files for Tensor-based TriangleMeshes

### DIFF
--- a/cpp/open3d/t/io/TriangleMeshIO.cpp
+++ b/cpp/open3d/t/io/TriangleMeshIO.cpp
@@ -263,7 +263,7 @@ bool WriteTriangleMeshToNPZ(const std::string &filename,
 
     // Output texture maps
     if (mesh.GetMaterial().IsValid()) {
-        for (auto& tex : mesh.GetMaterial().GetTextureMaps()) {
+        for (auto &tex : mesh.GetMaterial().GetTextureMaps()) {
             std::string key = std::string("tex_") + tex.first;
             mesh_attributes[key] = tex.second.AsTensor();
         }

--- a/cpp/open3d/t/io/TriangleMeshIO.cpp
+++ b/cpp/open3d/t/io/TriangleMeshIO.cpp
@@ -172,7 +172,7 @@ bool ReadTriangleMeshFromNPZ(
             mesh.SetVertexColors(attr.second);
         } else if (attr.first == "triangle_colors") {
             mesh.SetTriangleColors(attr.second);
-        } else if (attr.first == "uvmap") {
+        } else if (attr.first == "triangle_texture_uvs") {
             mesh.SetTriangleAttr("texture_uvs", attr.second);
         } else if (attr.first.find("tex_") != std::string::npos) {
             // Get texture map
@@ -255,7 +255,7 @@ bool WriteTriangleMeshToNPZ(const std::string &filename,
         mesh_attributes["triangle_colors"] = mesh.GetTriangleColors();
     }
     if (mesh.HasTriangleAttr("texture_uvs")) {
-        mesh_attributes["uvmap"] = mesh.GetTriangleAttr("texture_uvs");
+        mesh_attributes["triangle_texture_uvs"] = mesh.GetTriangleAttr("texture_uvs");
     }
 
     // Add "generic" attributes

--- a/cpp/open3d/t/io/TriangleMeshIO.cpp
+++ b/cpp/open3d/t/io/TriangleMeshIO.cpp
@@ -199,9 +199,10 @@ bool ReadTriangleMeshFromNPZ(
             if (!mesh.GetMaterial().IsValid()) {
                 mesh.GetMaterial().SetDefaultProperties();
             }
-            const uint8_t* str_ptr = attr.second.GetDataPtr<uint8_t>();
+            const uint8_t *str_ptr = attr.second.GetDataPtr<uint8_t>();
             std::string mat_name(attr.second.GetShape().GetLength(), 'a');
-            std::memcpy((void*)mat_name.data(), str_ptr, attr.second.GetShape().GetLength());
+            std::memcpy((void *)mat_name.data(), str_ptr,
+                        attr.second.GetShape().GetLength());
             mesh.GetMaterial().SetMaterialName(mat_name);
         }
     }
@@ -277,9 +278,10 @@ bool WriteTriangleMeshToNPZ(const std::string &filename,
 
     // Output texture maps
     if (mesh.GetMaterial().IsValid()) {
-        auto& mat = mesh.GetMaterial();
+        auto &mat = mesh.GetMaterial();
         // Get material name in Tensor form
-        std::vector<uint8_t> mat_name_vec({mat.GetMaterialName().begin(), mat.GetMaterialName().end()});
+        std::vector<uint8_t> mat_name_vec(
+                {mat.GetMaterialName().begin(), mat.GetMaterialName().end()});
         core::Tensor mat_name_tensor(std::move(mat_name_vec));
         mesh_attributes["material_name"] = mat_name_tensor;
         for (auto &tex : mat.GetTextureMaps()) {

--- a/cpp/open3d/t/io/TriangleMeshIO.cpp
+++ b/cpp/open3d/t/io/TriangleMeshIO.cpp
@@ -255,7 +255,8 @@ bool WriteTriangleMeshToNPZ(const std::string &filename,
         mesh_attributes["triangle_colors"] = mesh.GetTriangleColors();
     }
     if (mesh.HasTriangleAttr("texture_uvs")) {
-        mesh_attributes["triangle_texture_uvs"] = mesh.GetTriangleAttr("texture_uvs");
+        mesh_attributes["triangle_texture_uvs"] =
+                mesh.GetTriangleAttr("texture_uvs");
     }
 
     // Add "generic" attributes

--- a/cpp/open3d/t/io/TriangleMeshIO.cpp
+++ b/cpp/open3d/t/io/TriangleMeshIO.cpp
@@ -174,6 +174,21 @@ bool ReadTriangleMeshFromNPZ(
             mesh.SetTriangleColors(attr.second);
         } else if (attr.first == "uvmap") {
             mesh.SetTriangleAttr("texture_uvs", attr.second);
+        } else if (attr.first.find("tex_") != std::string::npos) {
+            // Get texture map
+            auto key = attr.first.substr(4);
+            if (!mesh.GetMaterial().IsValid()) {
+                mesh.GetMaterial().SetDefaultProperties();
+            }
+            mesh.GetMaterial().SetTextureMap(key, geometry::Image(attr.second));
+        } else if (attr.first.find("vertex_") != std::string::npos) {
+            // Generic vertex attribute
+            auto key = attr.first.substr(7);
+            mesh.SetVertexAttr(key, attr.second);
+        } else if (attr.first.find("triangle_") != std::string::npos) {
+            // Generic triangle attribute
+            auto key = attr.first.substr(9);
+            mesh.SetTriangleAttr(key, attr.second);
         }
     }
 
@@ -245,6 +260,15 @@ bool WriteTriangleMeshToNPZ(const std::string &filename,
         key_name += attr.first;
         mesh_attributes[key_name] = attr.second;
     }
+
+    // Output texture maps
+    if (mesh.GetMaterial().IsValid()) {
+        for (auto& tex : mesh.GetMaterial().GetTextureMaps()) {
+            std::string key = std::string("tex_") + tex.first;
+            mesh_attributes[key] = tex.second.AsTensor();
+        }
+    }
+
     WriteNpz(filename, mesh_attributes);
 
     return true;

--- a/cpp/open3d/t/io/TriangleMeshIO.h
+++ b/cpp/open3d/t/io/TriangleMeshIO.h
@@ -54,6 +54,19 @@ bool ReadTriangleMeshUsingASSIMP(
         geometry::TriangleMesh &mesh,
         const open3d::io::ReadTriangleMeshOptions &params);
 
+bool ReadTriangleMeshFromNPZ(const std::string &filename,
+                             geometry::TriangleMesh &mesh,
+                             const open3d::io::ReadTriangleMeshOptions &params);
+
+bool WriteTriangleMeshToNPZ(const std::string &filename,
+                            const geometry::TriangleMesh &mesh,
+                            const bool write_ascii,
+                            const bool compressed,
+                            const bool write_vertex_normals,
+                            const bool write_vertex_colors,
+                            const bool write_triangle_uvs,
+                            const bool print_progress);
+
 }  // namespace io
 }  // namespace t
 }  // namespace open3d

--- a/cpp/tests/t/io/TriangleMeshIO.cpp
+++ b/cpp/tests/t/io/TriangleMeshIO.cpp
@@ -79,8 +79,10 @@ TEST(TriangleMeshIO, ReadWriteTriangleMeshNPZ) {
     EXPECT_TRUE(t::io::WriteTriangleMesh(filename, cube_mesh));
     t::geometry::TriangleMesh mesh;
     EXPECT_TRUE(t::io::ReadTriangleMesh(filename, mesh));
-    EXPECT_TRUE(mesh.GetVertexPositions().AllClose(cube_mesh.GetVertexPositions()));
-    EXPECT_TRUE(mesh.GetTriangleIndices().AllClose(cube_mesh.GetTriangleIndices()));
+    EXPECT_TRUE(
+            mesh.GetVertexPositions().AllClose(cube_mesh.GetVertexPositions()));
+    EXPECT_TRUE(
+            mesh.GetTriangleIndices().AllClose(cube_mesh.GetTriangleIndices()));
 }
 
 // TODO: Add tests for triangle_uvs, materials, triangle_material_ids and

--- a/cpp/tests/t/io/TriangleMeshIO.cpp
+++ b/cpp/tests/t/io/TriangleMeshIO.cpp
@@ -71,6 +71,18 @@ TEST(TriangleMeshIO, ReadWriteTriangleMeshOBJ) {
     EXPECT_TRUE(mesh.GetTriangleIndices().AllClose(triangles));
 }
 
+TEST(TriangleMeshIO, ReadWriteTriangleMeshNPZ) {
+    auto cube_mesh = t::geometry::TriangleMesh::CreateBox();
+
+    const std::string filename =
+            utility::filesystem::GetTempDirectoryPath() + "/cube.npz";
+    EXPECT_TRUE(t::io::WriteTriangleMesh(filename, cube_mesh));
+    t::geometry::TriangleMesh mesh;
+    EXPECT_TRUE(t::io::ReadTriangleMesh(filename, mesh));
+    EXPECT_TRUE(mesh.GetVertexPositions().AllClose(cube_mesh.GetVertexPositions()));
+    EXPECT_TRUE(mesh.GetTriangleIndices().AllClose(cube_mesh.GetTriangleIndices()));
+}
+
 // TODO: Add tests for triangle_uvs, materials, triangle_material_ids and
 // textures once these are supported.
 TEST(TriangleMeshIO, TriangleMeshLegecyCompatibility) {


### PR DESCRIPTION
The following script tests the basic functionality:
```
import open3d as o3d

# Load OBJ file
d = o3d.data.MonkeyModel()
mesh = o3d.t.io.read_triangle_mesh(d.path)
print(mesh)
o3d.visualization.draw(mesh)

# Save mesh as NPZ and reload it
o3d.t.io.write_triangle_mesh('monkey.npz', mesh)
mesh_npz = o3d.t.io.read_triangle_mesh('monkey.npz')
print(mesh_npz)

# Verify it looks correct
o3d.visualization.draw(mesh_npz)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/6019)
<!-- Reviewable:end -->
