### PR TITLE
add add_voxel in pybind for VoxelGrid::AddVoxel

### DIFF
--- a/cpp/open3d/geometry/VoxelGrid.cpp
+++ b/cpp/open3d/geometry/VoxelGrid.cpp
@@ -197,6 +197,10 @@ void VoxelGrid::AddVoxel(const Voxel &voxel) {
     voxels_[voxel.grid_index_] = voxel;
 }
 
+void VoxelGrid::RemoveVoxel(const Eigen::Vector3i &idx) {
+    voxels_.erase(idx);
+}
+
 std::vector<bool> VoxelGrid::CheckIfIncluded(
         const std::vector<Eigen::Vector3d> &queries) {
     std::vector<bool> output;

--- a/cpp/open3d/geometry/VoxelGrid.cpp
+++ b/cpp/open3d/geometry/VoxelGrid.cpp
@@ -197,9 +197,7 @@ void VoxelGrid::AddVoxel(const Voxel &voxel) {
     voxels_[voxel.grid_index_] = voxel;
 }
 
-void VoxelGrid::RemoveVoxel(const Eigen::Vector3i &idx) {
-    voxels_.erase(idx);
-}
+void VoxelGrid::RemoveVoxel(const Eigen::Vector3i &idx) { voxels_.erase(idx); }
 
 std::vector<bool> VoxelGrid::CheckIfIncluded(
         const std::vector<Eigen::Vector3d> &queries) {

--- a/cpp/open3d/geometry/VoxelGrid.h
+++ b/cpp/open3d/geometry/VoxelGrid.h
@@ -123,7 +123,7 @@ public:
     /// Add a voxel with specified grid index and color.
     void AddVoxel(const Voxel &voxel);
 
-    /// Remove a voxel with specified grid index
+    /// Remove a voxel with specified grid index.
     void RemoveVoxel(const Eigen::Vector3i &idx);
 
     /// Return a vector of 3D coordinates that define the indexed voxel cube.

--- a/cpp/open3d/geometry/VoxelGrid.h
+++ b/cpp/open3d/geometry/VoxelGrid.h
@@ -123,6 +123,9 @@ public:
     /// Add a voxel with specified grid index and color.
     void AddVoxel(const Voxel &voxel);
 
+    /// Remove a voxel with specified grid index
+    void RemoveVoxel(const Eigen::Vector3i &idx);
+
     /// Return a vector of 3D coordinates that define the indexed voxel cube.
     std::vector<Eigen::Vector3d> GetVoxelBoundingPoints(
             const Eigen::Vector3i &index) const;

--- a/cpp/pybind/geometry/voxelgrid.cpp
+++ b/cpp/pybind/geometry/voxelgrid.cpp
@@ -161,8 +161,9 @@ void pybind_voxelgrid(py::module &m) {
                                     {{"point", "The query point."}});
     docstring::ClassMethodDocInject(m, "VoxelGrid", "add_voxel",
                                     {{"Voxel", "A new voxel."}});
-    docstring::ClassMethodDocInject(m, "VoxelGrid", "remove_voxel",
-                                    {{"idx", "The grid index of the target voxel."}});
+    docstring::ClassMethodDocInject(
+            m, "VoxelGrid", "remove_voxel",
+            {{"idx", "The grid index of the target voxel."}});
     docstring::ClassMethodDocInject(
             m, "VoxelGrid", "check_if_included",
             {{"query", "a list of voxel indices to check."}});

--- a/cpp/pybind/geometry/voxelgrid.cpp
+++ b/cpp/pybind/geometry/voxelgrid.cpp
@@ -79,6 +79,8 @@ void pybind_voxelgrid(py::module &m) {
                  "Returns voxel index given query point.")
             .def("add_voxel", &VoxelGrid::AddVoxel, "voxel"_a,
                  "Add a new voxel into the VoxelGrid.")
+            .def("remove_voxel", &VoxelGrid::RemoveVoxel, "idx"_a,
+                 "Remove a voxel given index.")
             .def("check_if_included", &VoxelGrid::CheckIfIncluded, "queries"_a,
                  "Element-wise check if a query in the list is included in "
                  "the VoxelGrid. Queries are double precision and "
@@ -159,6 +161,8 @@ void pybind_voxelgrid(py::module &m) {
                                     {{"point", "The query point."}});
     docstring::ClassMethodDocInject(m, "VoxelGrid", "add_voxel",
                                     {{"Voxel", "A new voxel."}});
+    docstring::ClassMethodDocInject(m, "VoxelGrid", "remove_voxel",
+                                    {{"idx", "The grid index of the target voxel."}});
     docstring::ClassMethodDocInject(
             m, "VoxelGrid", "check_if_included",
             {{"query", "a list of voxel indices to check."}});

--- a/cpp/pybind/geometry/voxelgrid.cpp
+++ b/cpp/pybind/geometry/voxelgrid.cpp
@@ -77,6 +77,8 @@ void pybind_voxelgrid(py::module &m) {
                  "Returns ``True`` if the voxel grid contains voxels.")
             .def("get_voxel", &VoxelGrid::GetVoxel, "point"_a,
                  "Returns voxel index given query point.")
+            .def("add_voxel", &VoxelGrid::AddVoxel, "voxel"_a,
+                 "Add a new voxel into the VoxelGrid.")
             .def("check_if_included", &VoxelGrid::CheckIfIncluded, "queries"_a,
                  "Element-wise check if a query in the list is included in "
                  "the VoxelGrid. Queries are double precision and "
@@ -155,6 +157,8 @@ void pybind_voxelgrid(py::module &m) {
     docstring::ClassMethodDocInject(m, "VoxelGrid", "has_voxels");
     docstring::ClassMethodDocInject(m, "VoxelGrid", "get_voxel",
                                     {{"point", "The query point."}});
+    docstring::ClassMethodDocInject(m, "VoxelGrid", "add_voxel",
+                                    {{"Voxel", "A new voxel."}});
     docstring::ClassMethodDocInject(
             m, "VoxelGrid", "check_if_included",
             {{"query", "a list of voxel indices to check."}});


### PR DESCRIPTION
I hope this update doesn't make any conflict with other features.
Regarding issues https://github.com/isl-org/Open3D/issues/2660, https://github.com/isl-org/Open3D/issues/1101, and https://github.com/isl-org/Open3D/issues/3133, there are needs for people to manually control voxels in VoxelGrid. Although it is already implemented in c++, there are no corresponding lines in pybind.

```import numpy as np
import open3d as o3d

print('input')
N = 2000

armadillo = o3d.data.ArmadilloMesh()
mesh = o3d.io.read_triangle_mesh(armadillo.path)
pcd = mesh.sample_points_poisson_disk(N)
# fit to unit cube
pcd.scale(1 / np.max(pcd.get_max_bound() - pcd.get_min_bound()),
          center=pcd.get_center())
pcd.colors = o3d.utility.Vector3dVector(np.random.uniform(0, 1, size=(N, 3)))
# o3d.visualization.draw_geometries([pcd])

print('voxelization')
voxel_grid = o3d.geometry.VoxelGrid.create_from_point_cloud(pcd,
                                                            voxel_size=0.05)
o3d.visualization.draw_geometries([voxel_grid])
voxel_grid.add_voxel(o3d.geometry.Voxel([20,0,13], [1.0,0.0,0.0]))
o3d.visualization.draw_geometries([voxel_grid])


```
![image](https://user-images.githubusercontent.com/19196641/226949725-2d89728e-14dc-415b-b50c-abd892427a73.png)



More discussions
- Is AddVoxel a profer name? Since the voxel can be overwritten several times with the function, the name could be something else e.g. "SetVoxel"
- EraseVoxel(or RemoveVoxel) function would be useful. It must not be hard work with 'std::unordered_map::erase'.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/6023)
<!-- Reviewable:end -->
