### PR TITLE
Fix a bug of computing oriented bounding box in tensor 

### DIFF
--- a/cpp/open3d/t/geometry/BoundingVolume.cpp
+++ b/cpp/open3d/t/geometry/BoundingVolume.cpp
@@ -405,7 +405,7 @@ core::Tensor OrientedBoundingBox::GetMaxBound() const {
 core::Tensor OrientedBoundingBox::GetBoxPoints() const {
     const t::geometry::AxisAlignedBoundingBox aabb(GetExtent() * -0.5,
                                                    GetExtent() * 0.5);
-    return aabb.GetBoxPoints().Matmul(GetRotation()).Add(GetCenter());
+    return aabb.GetBoxPoints().Matmul(GetRotation().T()).Add(GetCenter());
 }
 
 OrientedBoundingBox &OrientedBoundingBox::Translate(

--- a/cpp/tests/t/geometry/OrientedBoundingBox.cpp
+++ b/cpp/tests/t/geometry/OrientedBoundingBox.cpp
@@ -226,8 +226,8 @@ TEST_P(OrientedBoundingBoxPermuteDevices, Scale) {
 TEST_P(OrientedBoundingBoxPermuteDevices, GetBoxPoints) {
     core::Device device = GetParam();
 
-    core::Tensor center = core::Tensor::Init<float>({-1, -1, -1}, device);
-    core::Tensor extent = core::Tensor::Init<float>({1.0, 1.0, 1.0}, device);
+    core::Tensor center = core::Tensor::Init<float>({-1., -1., -1.}, device);
+    core::Tensor extent = core::Tensor::Init<float>({0.0, 0.0, 1.0}, device);
     core::Tensor rotation = core::Tensor::Eye(3, core::Float32, device);
 
     t::geometry::OrientedBoundingBox obb(center, rotation, extent);
@@ -235,14 +235,14 @@ TEST_P(OrientedBoundingBoxPermuteDevices, GetBoxPoints) {
     auto box_points = obb.GetBoxPoints();
 
     EXPECT_TRUE(
-            box_points.AllClose(core::Tensor::Init<float>({{-1.5, -1.5, -1.5},
-                                                           {-0.5, -1.5, -1.5},
-                                                           {-1.5, -0.5, -1.5},
-                                                           {-1.5, -1.5, -0.5},
-                                                           {-0.5, -0.5, -0.5},
-                                                           {-1.5, -0.5, -0.5},
-                                                           {-0.5, -1.5, -0.5},
-                                                           {-0.5, -0.5, -1.5}},
+            box_points.AllClose(core::Tensor::Init<float>({{-1.0, -1.0, -1.5},
+                                                           {-1.0, -1.0, -1.5},
+                                                           {-1.0, -1.0, -1.5},
+                                                           {-1.0, -1.0, -0.5},
+                                                           {-1.0, -1.0, -0.5},
+                                                           {-1.0, -1.0, -0.5},
+                                                           {-1.0, -1.0, -0.5},
+                                                           {-1.0, -1.0, -1.5}},
                                                           device)));
 }
 


### PR DESCRIPTION
An error occurs in computing oriented bounding box became the operation is absence of matrix transpose.
Therefore, the obb will just like an inverted box hence the bunny's ear is out of bbx.

![An error](https://user-images.githubusercontent.com/20416823/230568570-a00d9fbe-6498-4830-a84f-a0958785812c.png)

As the unit test has used a cube, the error could not be detected by programme automatically.

After fixing, the bounding box will be in a right place.

![Unit test](https://user-images.githubusercontent.com/20416823/230567944-670a904b-77c0-4f6f-bbc6-0b1cfc970f18.png)

![Python usage](https://user-images.githubusercontent.com/20416823/230567947-d8572855-0438-485b-ba50-acfc68183384.png)
