### PR TITLE
Changed usage of TensorFlow Status API

### DIFF
--- a/cpp/open3d/ml/tensorflow/continuous_conv/ContinuousConvBackpropFilterOps.cpp
+++ b/cpp/open3d/ml/tensorflow/continuous_conv/ContinuousConvBackpropFilterOps.cpp
@@ -147,7 +147,7 @@ REGISTER_OP("Open3DContinuousConvBackpropFilter")
             }
 
             c->set_output(0, filters_shape);
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc(
 Computes the backprop for the filter of the ContinuousConv

--- a/cpp/open3d/ml/tensorflow/continuous_conv/ContinuousConvOps.cpp
+++ b/cpp/open3d/ml/tensorflow/continuous_conv/ContinuousConvOps.cpp
@@ -139,7 +139,7 @@ REGISTER_OP("Open3DContinuousConv")
                     c->MakeShape({output_first_dim, output_channel_dim});
 
             c->set_output(0, output_shape);
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc(
 Continuous convolution of two pointclouds.

--- a/cpp/open3d/ml/tensorflow/continuous_conv/ContinuousConvTransposeBackpropFilterOps.cpp
+++ b/cpp/open3d/ml/tensorflow/continuous_conv/ContinuousConvTransposeBackpropFilterOps.cpp
@@ -166,7 +166,7 @@ REGISTER_OP("Open3DContinuousConvTransposeBackpropFilter")
             }
 
             c->set_output(0, filters_shape);
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc(
 Computes the backrop for the filter of the ContinuousConvTranspose

--- a/cpp/open3d/ml/tensorflow/continuous_conv/ContinuousConvTransposeOps.cpp
+++ b/cpp/open3d/ml/tensorflow/continuous_conv/ContinuousConvTransposeOps.cpp
@@ -168,7 +168,7 @@ REGISTER_OP("Open3DContinuousConvTranspose")
                     c->MakeShape({output_first_dim, output_channel_dim});
 
             c->set_output(0, output_shape);
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc(
 Continuous tranpose convolution of two pointclouds.

--- a/cpp/open3d/ml/tensorflow/misc/BuildSpatialHashTableOps.cpp
+++ b/cpp/open3d/ml/tensorflow/misc/BuildSpatialHashTableOps.cpp
@@ -52,7 +52,7 @@ REGISTER_OP("Open3DBuildSpatialHashTable")
             hash_table_splits_shape = MakeShapeHandle(c, batch_size + 1);
             c->set_output(2, hash_table_splits_shape);
 
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc(
 Creates a spatial hash table meant as input for fixed_radius_search

--- a/cpp/open3d/ml/tensorflow/misc/FixedRadiusSearchOps.cpp
+++ b/cpp/open3d/ml/tensorflow/misc/FixedRadiusSearchOps.cpp
@@ -79,7 +79,7 @@ REGISTER_OP("Open3DFixedRadiusSearch")
                 neighbors_distance_shape = c->MakeShape({0});
             c->set_output(2, neighbors_distance_shape);
 
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc(
 Computes the indices of all neighbors within a radius.

--- a/cpp/open3d/ml/tensorflow/misc/InvertNeighborsListOps.cpp
+++ b/cpp/open3d/ml/tensorflow/misc/InvertNeighborsListOps.cpp
@@ -58,7 +58,7 @@ REGISTER_OP("Open3DInvertNeighborsList")
 
             // the attributes will have the same shape
             c->set_output(2, inp_neighbors_attributes);
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc(
 Inverts a neighbors list made of neighbors_index and neighbors_row_splits.

--- a/cpp/open3d/ml/tensorflow/misc/KnnSearchOps.cpp
+++ b/cpp/open3d/ml/tensorflow/misc/KnnSearchOps.cpp
@@ -67,7 +67,7 @@ REGISTER_OP("Open3DKnnSearch")
                 neighbors_distance_shape = c->MakeShape({0});
             c->set_output(2, neighbors_distance_shape);
 
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc(
 Computes the indices of k nearest neighbors.

--- a/cpp/open3d/ml/tensorflow/misc/NmsOps.cpp
+++ b/cpp/open3d/ml/tensorflow/misc/NmsOps.cpp
@@ -34,7 +34,7 @@ REGISTER_OP("Open3DNms")
 
             keep_indices = c->MakeShape({c->UnknownDim()});
             c->set_output(0, keep_indices);
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc(
 Performs non-maximum suppression of bounding boxes.

--- a/cpp/open3d/ml/tensorflow/misc/RadiusSearchOps.cpp
+++ b/cpp/open3d/ml/tensorflow/misc/RadiusSearchOps.cpp
@@ -69,7 +69,7 @@ REGISTER_OP("Open3DRadiusSearch")
                 neighbors_distance_shape = c->MakeShape({0});
             c->set_output(2, neighbors_distance_shape);
 
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc(
 Computes the indices and distances of all neighbours within a radius.

--- a/cpp/open3d/ml/tensorflow/misc/ReduceSubarraysSumOps.cpp
+++ b/cpp/open3d/ml/tensorflow/misc/ReduceSubarraysSumOps.cpp
@@ -33,7 +33,7 @@ REGISTER_OP("Open3DReduceSubarraysSum")
             sums_shape = c->MakeShape({sums_size});
             c->set_output(0, sums_shape);
 
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc(
 Computes the sum for each subarray in a flat vector of arrays.

--- a/cpp/open3d/ml/tensorflow/misc/VoxelPoolingOps.cpp
+++ b/cpp/open3d/ml/tensorflow/misc/VoxelPoolingOps.cpp
@@ -53,7 +53,7 @@ REGISTER_OP("Open3DVoxelPooling")
                         c->WithValue(c->Dim(positions_shape, -1), 3, &d));
             }
 
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc(
 Spatial pooling for point clouds by combining points that fall into the same voxel bin.
@@ -202,7 +202,7 @@ REGISTER_OP("Open3DVoxelPoolingGrad")
                         c->Dim(pooled_positions_shape, -1), 3, &d));
             }
 
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc(
 Gradient for features in VoxelPooling. For internal use only.

--- a/cpp/open3d/ml/tensorflow/misc/VoxelizeOps.cpp
+++ b/cpp/open3d/ml/tensorflow/misc/VoxelizeOps.cpp
@@ -58,7 +58,7 @@ REGISTER_OP("Open3DVoxelize")
             voxel_batch_splits = c->MakeShape({c->UnknownDim()});
             c->set_output(3, voxel_batch_splits);
 
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc(
 Voxelization for point clouds.

--- a/cpp/open3d/ml/tensorflow/pointnet/BallQueryOps.cpp
+++ b/cpp/open3d/ml/tensorflow/pointnet/BallQueryOps.cpp
@@ -32,6 +32,6 @@ REGISTER_OP("Open3DBallQuery")
             ::tensorflow::shape_inference::ShapeHandle output =
                     c->MakeShape({c->Dim(dims1, 0), c->Dim(dims1, 1), nsample});
             c->set_output(0, output);
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc( TODO )doc");

--- a/cpp/open3d/ml/tensorflow/pointnet/InterpolateOps.cpp
+++ b/cpp/open3d/ml/tensorflow/pointnet/InterpolateOps.cpp
@@ -30,7 +30,7 @@ REGISTER_OP("Open3DThreeNN")
                     c->MakeShape({c->Dim(dims1, 0), c->Dim(dims1, 1), 3});
             c->set_output(0, output);
             c->set_output(1, output);
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc( TODO )doc");
 
@@ -50,7 +50,7 @@ REGISTER_OP("Open3DThreeInterpolate")
             ::tensorflow::shape_inference::ShapeHandle output = c->MakeShape(
                     {c->Dim(dims1, 0), c->Dim(dims1, 1), c->Dim(dims2, 1)});
             c->set_output(0, output);
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc( TODO )doc");
 
@@ -70,6 +70,6 @@ REGISTER_OP("Open3DThreeInterpolateGrad")
                     c->MakeShape({c->Dim(dims1, 0), c->Dim(dims1, 1), M});
             c->set_output(0, output);
             c->set_output(1, output);
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc( TODO )doc");

--- a/cpp/open3d/ml/tensorflow/pointnet/RoiPoolOps.cpp
+++ b/cpp/open3d/ml/tensorflow/pointnet/RoiPoolOps.cpp
@@ -42,6 +42,6 @@ REGISTER_OP("Open3DRoiPool")
             ::tensorflow::shape_inference::ShapeHandle output2 =
                     c->MakeShape({c->Dim(dims1, 0), c->Dim(dims1, 1)});
             c->set_output(1, output2);
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc( TODO )doc");

--- a/cpp/open3d/ml/tensorflow/pointnet/SamplingOps.cpp
+++ b/cpp/open3d/ml/tensorflow/pointnet/SamplingOps.cpp
@@ -30,6 +30,6 @@ REGISTER_OP("Open3DFurthestPointSampling")
             ::tensorflow::shape_inference::ShapeHandle output =
                     c->MakeShape({c->Dim(dims1, 0), npoint});
             c->set_output(0, output);
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc( TODO )doc");

--- a/cpp/open3d/ml/tensorflow/pvcnn/TrilinearDevoxelizeOps.cpp
+++ b/cpp/open3d/ml/tensorflow/pvcnn/TrilinearDevoxelizeOps.cpp
@@ -51,7 +51,7 @@ REGISTER_OP("Open3DTrilinearDevoxelize")
             c->set_output(1, out2);
             c->set_output(2, out2);
 
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc(
 Trilinear Devoxelize.
@@ -167,7 +167,7 @@ REGISTER_OP("Open3DTrilinearDevoxelizeGrad")
 
             c->set_output(0, out);
 
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc(
 Gradient function for Trilinear Devoxelize op.

--- a/cpp/open3d/ml/tensorflow/sparse_conv/SparseConvBackpropFilterOps.cpp
+++ b/cpp/open3d/ml/tensorflow/sparse_conv/SparseConvBackpropFilterOps.cpp
@@ -66,7 +66,7 @@ REGISTER_OP("Open3DSparseConvBackpropFilter")
             CHECK_SHAPE_HANDLE(c, out_features_gradient, num_out, out_channels);
 
             c->set_output(0, filters);
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc(
 Computes the backprop for the filter of the SparseConv

--- a/cpp/open3d/ml/tensorflow/sparse_conv/SparseConvOps.cpp
+++ b/cpp/open3d/ml/tensorflow/sparse_conv/SparseConvOps.cpp
@@ -66,7 +66,7 @@ REGISTER_OP("Open3DSparseConv")
             ShapeHandle out_features_shape =
                     MakeShapeHandle(c, num_out, out_channels);
             c->set_output(0, out_features_shape);
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc(
 General sparse convolution.

--- a/cpp/open3d/ml/tensorflow/sparse_conv/SparseConvTransposeBackpropFilterOps.cpp
+++ b/cpp/open3d/ml/tensorflow/sparse_conv/SparseConvTransposeBackpropFilterOps.cpp
@@ -71,7 +71,7 @@ REGISTER_OP("Open3DSparseConvTransposeBackpropFilter")
             CHECK_SHAPE_HANDLE(c, out_features_gradient, num_out, out_channels);
 
             c->set_output(0, filters);
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc(
 Computes the backrop for the filter of the SparseConvTranspose

--- a/cpp/open3d/ml/tensorflow/sparse_conv/SparseConvTransposeOps.cpp
+++ b/cpp/open3d/ml/tensorflow/sparse_conv/SparseConvTransposeOps.cpp
@@ -75,7 +75,7 @@ REGISTER_OP("Open3DSparseConvTranspose")
             ShapeHandle out_features_shape =
                     MakeShapeHandle(c, num_out, out_channels);
             c->set_output(0, out_features_shape);
-            return Status::OK();
+            return Status();
         })
         .Doc(R"doc(
 Sparse tranpose convolution of two pointclouds.

--- a/cpp/open3d/ml/tensorflow/tf_subsampling/tf_batch_subsampling.cpp
+++ b/cpp/open3d/ml/tensorflow/tf_subsampling/tf_batch_subsampling.cpp
@@ -47,7 +47,7 @@ REGISTER_OP("Open3DBatchGridSubsampling")
             TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 2, &input0_shape));
             c->set_output(0, input0_shape);
             c->set_output(1, c->input(1));
-            return Status::OK();
+            return Status();
         });
 
 class BatchGridSubsamplingOp : public OpKernel {

--- a/cpp/open3d/ml/tensorflow/tf_subsampling/tf_subsampling.cpp
+++ b/cpp/open3d/ml/tensorflow/tf_subsampling/tf_subsampling.cpp
@@ -44,7 +44,7 @@ REGISTER_OP("Open3DGridSubsampling")
             ::tensorflow::shape_inference::ShapeHandle input;
             TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 2, &input));
             c->set_output(0, input);
-            return Status::OK();
+            return Status();
         });
 
 class GridSubsamplingOp : public OpKernel {

--- a/cpp/open3d/t/geometry/TensorMap.cpp
+++ b/cpp/open3d/t/geometry/TensorMap.cpp
@@ -56,7 +56,7 @@ void TensorMap::AssertSizeSynchronized() const {
             if (kv.first != primary_key_ &&
                 kv.second.GetLength() != primary_size) {
                 ss << fmt::format("    > Tensor \"{}\" has size {}.\n",
-                            kv.first, kv.second.GetLength());
+                                  kv.first, kv.second.GetLength());
             }
         }
         utility::LogError("{}", ss.str());

--- a/cpp/open3d/t/geometry/TensorMap.cpp
+++ b/cpp/open3d/t/geometry/TensorMap.cpp
@@ -55,8 +55,8 @@ void TensorMap::AssertSizeSynchronized() const {
         for (auto& kv : *this) {
             if (kv.first != primary_key_ &&
                 kv.second.GetLength() != primary_size) {
-                fmt::format("    > Tensor \"{}\" has size {}.\n", kv.first,
-                            kv.second.GetLength());
+                ss << fmt::format("    > Tensor \"{}\" has size {}.\n",
+                            kv.first, kv.second.GetLength());
             }
         }
         utility::LogError("{}", ss.str());


### PR DESCRIPTION
## Type

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

In TensorFlow 2.11 and later, `tsensorflow::Status::OK()` has been removed.
This causes build errors.
Changing to `tensorflow::Status()` will maintain compatibility with previous versions and fix build errors.

## Checklist:


-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

If not corrected, the following build error will occur with TensorFlow v2.12.
```bash
error: 'OK' is not a member of 'tsl::Status'
  150 |             return Status::OK();
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/6091)
<!-- Reviewable:end -->
