### PR TITLE
Update the GLTF writer to support writing textured models

### DIFF
--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -1889,6 +1889,14 @@ else()
     set(BUILD_WEBRTC_COMMENT "//")
 endif()
 
+# tcb::span
+include(${Open3D_3RDPARTY_DIR}/tcbspan/tcbspan.cmake)
+open3d_import_3rdparty_library(3rdparty_tcbspan
+    INCLUDE_DIRS ${TCB_SPAN_INCLUDE_DIRS}
+    LIBRARIES    ${TCB_SPAN_LIBRARIES}
+)
+list(APPEND Open3D_3RDPARTY_PRIVATE_TARGETS_FROM_CUSTOM Open3D::3rdparty_tcbspan)
+
 # Compactify list of external modules.
 # This must be called after all dependencies are processed.
 list(REMOVE_DUPLICATES Open3D_3RDPARTY_EXTERNAL_MODULES)

--- a/3rdparty/tcbspan/CMakeLists.txt
+++ b/3rdparty/tcbspan/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.8)
+project(span LANGUAGES CXX)
+
+option(BUILD_RAYCAST_APP "If the raycast test app should be built" OFF)
+
+include(GNUInstallDirs)
+
+add_library(span INTERFACE)
+add_library(tcb::span ALIAS span)
+target_include_directories(span INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/tcb/>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/>
+)
+
+install(TARGETS span EXPORT tcbspan-targets)
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/include/tcb/span.hpp
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tcbspan/
+)
+
+install(EXPORT tcbspan-targets
+    FILE tcbspan-targets.cmake
+    NAMESPACE tcb::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/tcbspan/
+)
+
+install(FILES LICENSE_1_0.txt
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/tcbspan/
+)

--- a/3rdparty/tcbspan/tcbspan.cmake
+++ b/3rdparty/tcbspan/tcbspan.cmake
@@ -1,0 +1,24 @@
+include(ExternalProject)
+
+set(TCB_SPAN_LIB_NAME tcbspan)
+
+ExternalProject_Add(
+    ext_tcbspan
+    PREFIX tcbspan
+    GIT_REPOSITORY https://github.com/tcbrindle/span.git
+    GIT_TAG 836dc6a0efd9849cb194e88e4aa2387436bb079b
+    GIT_SHALLOW TRUE
+    DOWNLOAD_DIR "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/tcbspan"
+    UPDATE_COMMAND ""
+    PATCH_COMMAND ${CMAKE_COMMAND} -E copy
+        ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tcbspan/CMakeLists.txt <SOURCE_DIR>
+    CMAKE_ARGS
+        ${ExternalProject_CMAKE_ARGS_hidden}
+        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+)
+ExternalProject_Get_Property(ext_tcbspan DOWNLOAD_DIR)
+message(WARNING "TCBSpan source dir ${DOWNLOAD_DIR}")
+
+ExternalProject_Get_Property(ext_tcbspan INSTALL_DIR)
+set(TCB_SPAN_INCLUDE_DIRS ${INSTALL_DIR}/include/) # "/" is critical.
+set(STDGPU_LIBRARIES tcb::span)

--- a/3rdparty/tinygltf/tinygltf.cmake
+++ b/3rdparty/tinygltf/tinygltf.cmake
@@ -3,8 +3,8 @@ include(ExternalProject)
 ExternalProject_Add(
     ext_tinygltf
     PREFIX tinygltf
-    URL https://github.com/syoyo/tinygltf/archive/72f4a55edd54742bca1a71ade8ac70afca1d3f07.tar.gz
-    URL_HASH SHA256=9e848dcf0ec7dcb352ced782aea32064a63a51b3c68ed14c68531e08632a2d90
+    URL https://github.com/syoyo/tinygltf/archive/refs/tags/v2.8.3.tar.gz
+    URL_HASH SHA256=fbef83ef47dbc6d1662103b54ea54f05a753ddff7a11d80b9fe0cd306ab5d4d2
     DOWNLOAD_DIR "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/tinygltf"
     UPDATE_COMMAND ""
     CONFIGURE_COMMAND ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fix raycasting scene: Allow setting of number of threads that are used for building a raycasting scene
 * Fix Python bindings for CUDA device synchronization, voxel grid saving (PR #5425)
 * Support msgpack versions without cmake
+* Changed TriangleMesh to store materials in a list so they can be accessed by the material index (PR #5938)
 
 ## 0.13
 

--- a/cpp/open3d/geometry/TriangleMesh.h
+++ b/cpp/open3d/geometry/TriangleMesh.h
@@ -853,7 +853,7 @@ public:
         std::unordered_map<std::string, Image> additionalMaps;
     };
 
-    std::unordered_map<std::string, Material> materials_;
+    std::vector<std::pair<std::string, Material>> materials_;
 
     /// List of material ids.
     std::vector<int> triangle_material_ids_;

--- a/cpp/open3d/io/ModelIO.cpp
+++ b/cpp/open3d/io/ModelIO.cpp
@@ -25,7 +25,8 @@ MeshWithPerVertexUVs(const geometry::TriangleMesh& mesh) {
         return {mesh, {}};
     }
     if (mesh.HasAdjacencyList()) {
-        utility::LogWarning("[MeshWithPerVertexUVs] This mesh contains "
+        utility::LogWarning(
+                "[MeshWithPerVertexUVs] This mesh contains "
                 "an adjacency list that are not handled in this function");
     }
     geometry::TriangleMesh out = mesh;
@@ -40,10 +41,11 @@ MeshWithPerVertexUVs(const geometry::TriangleMesh& mesh) {
             if (vertex_uvs[triangle(i)] == InvalidUV) {
                 vertex_uvs[triangle(i)] = out.triangle_uvs_[3 * tidx + i];
             } else {
-                if (vertex_uvs[triangle(i)] != out.triangle_uvs_[3 * tidx + i]){
+                if (vertex_uvs[triangle(i)] !=
+                    out.triangle_uvs_[3 * tidx + i]) {
                     assert(true);
                     if (vertex_remap.count(triangle(i))) {
-                        for (int remap_tidx: vertex_remap[(int)tidx]) {
+                        for (int remap_tidx : vertex_remap[(int)tidx]) {
                             if (vertex_uvs[remap_tidx] ==
                                 out.triangle_uvs_[3 * tidx + i]) {
                                 triangle(i) = remap_tidx;
@@ -51,7 +53,8 @@ MeshWithPerVertexUVs(const geometry::TriangleMesh& mesh) {
                             }
                         }
                     } else {
-                        vertex_uvs.emplace_back(out.triangle_uvs_[3 * tidx + 1]);
+                        vertex_uvs.emplace_back(
+                                out.triangle_uvs_[3 * tidx + 1]);
                         out.vertices_.emplace_back(out.vertices_[triangle(i)]);
                         if (mesh.HasVertexColors()) {
                             out.vertex_colors_.emplace_back(
@@ -63,7 +66,8 @@ MeshWithPerVertexUVs(const geometry::TriangleMesh& mesh) {
                         }
                         vertex_remap[triangle(i)].emplace_back(
                                 out.vertices_.size() - 1);
-                        triangle(i) = static_cast<int>(out.vertices_.size() - 1);
+                        triangle(i) =
+                                static_cast<int>(out.vertices_.size() - 1);
                     }
                 }
             }
@@ -73,7 +77,7 @@ MeshWithPerVertexUVs(const geometry::TriangleMesh& mesh) {
     return {out, vertex_uvs};
 }
 
-}  // namesapce detail
+}  // namespace detail
 
 bool ReadModelUsingAssimp(const std::string& filename,
                           visualization::rendering::TriangleMeshModel& model,
@@ -94,8 +98,8 @@ bool ReadTriangleModel(const std::string& filename,
 }
 
 bool HasPerVertexUVs(const geometry::TriangleMesh& mesh) {
-    std::vector<Eigen::Vector2d> vertex_uvs(
-            mesh.vertices_.size(), Eigen::Vector2d(-1, -1));
+    std::vector<Eigen::Vector2d> vertex_uvs(mesh.vertices_.size(),
+                                            Eigen::Vector2d(-1, -1));
     for (std::size_t tidx = 0; tidx < mesh.triangles_.size(); ++tidx) {
         const auto& triangle = mesh.triangles_[tidx];
         for (int i = 0; i < 3; ++i) {
@@ -112,24 +116,29 @@ bool HasPerVertexUVs(const geometry::TriangleMesh& mesh) {
     return true;
 }
 
-bool WriteTriangleModel(const std::string& filename,
-                        const visualization::rendering::TriangleMeshModel& model) {
+bool WriteTriangleModel(
+        const std::string& filename,
+        const visualization::rendering::TriangleMeshModel& model) {
     const std::string ext =
             utility::filesystem::GetFileExtensionInLowerCase(filename);
     // Validate model for output
-    for (const auto& mesh_info: model.meshes_) {
+    for (const auto& mesh_info : model.meshes_) {
         if (!HasPerVertexUVs(*mesh_info.mesh)) {
-            utility::LogWarning("Cannot export model because mesh {} needs "
+            utility::LogWarning(
+                    "Cannot export model because mesh {} needs "
                     "to be converted to have per-vertex uvs instead "
-                    "of per-triangle uvs", mesh_info.mesh_name);
+                    "of per-triangle uvs",
+                    mesh_info.mesh_name);
             return false;
         }
         auto mat_it = std::minmax_element(
                 mesh_info.mesh->triangle_material_ids_.begin(),
                 mesh_info.mesh->triangle_material_ids_.end());
         if (mat_it.first != mat_it.second) {
-            utility::LogWarning("Cannot export model because mesh {} has more "
-                    "than one material", mesh_info.mesh_name);
+            utility::LogWarning(
+                    "Cannot export model because mesh {} has more "
+                    "than one material",
+                    mesh_info.mesh_name);
             return false;
         }
     }
@@ -137,8 +146,10 @@ bool WriteTriangleModel(const std::string& filename,
     if (ext == "gltf" || ext == "glb") {
         return WriteTriangleModelToGLTF(filename, model);
     } else {
-        utility::LogWarning("Unsupported file format {}. "
-                "Currently only gltf and glb are supported", ext);
+        utility::LogWarning(
+                "Unsupported file format {}. "
+                "Currently only gltf and glb are supported",
+                ext);
         return false;
     }
 }

--- a/cpp/open3d/io/ModelIO.cpp
+++ b/cpp/open3d/io/ModelIO.cpp
@@ -19,6 +19,25 @@ namespace open3d {
 namespace io {
 namespace detail {
 
+bool HasPerVertexUVs(const geometry::TriangleMesh& mesh) {
+    std::vector<Eigen::Vector2d> vertex_uvs(mesh.vertices_.size(),
+                                            Eigen::Vector2d(-1, -1));
+    for (std::size_t tidx = 0; tidx < mesh.triangles_.size(); ++tidx) {
+        const auto& triangle = mesh.triangles_[tidx];
+        for (int i = 0; i < 3; ++i) {
+            const auto& tri_uv = mesh.triangle_uvs_[3 * tidx + i];
+            if (vertex_uvs[triangle(i)] == Eigen::Vector2d(-1, -1)) {
+                vertex_uvs[triangle(i)] = tri_uv;
+                continue;
+            }
+            if (vertex_uvs[triangle(i)] != tri_uv) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
 std::pair<geometry::TriangleMesh, std::vector<Eigen::Vector2d>>
 MeshWithPerVertexUVs(const geometry::TriangleMesh& mesh) {
     if (!mesh.HasTriangleUvs()) {
@@ -35,45 +54,53 @@ MeshWithPerVertexUVs(const geometry::TriangleMesh& mesh) {
     std::vector<Eigen::Vector2d> vertex_uvs;
     const Eigen::Vector2d InvalidUV(-1, -1);
     vertex_uvs.resize(out.vertices_.size(), InvalidUV);
+
+    // Code to remap a vertex
+    auto remap_vert = [&mesh, &out, &vertex_uvs,
+                       &vertex_remap](std::size_t tidx, int i){
+        Eigen::Vector3i& triangle = out.triangles_[tidx];
+        vertex_uvs.emplace_back(out.triangle_uvs_[3 * tidx + i]);
+        out.vertices_.emplace_back(out.vertices_[triangle(i)]);
+        if (mesh.HasVertexColors()) {
+            out.vertex_colors_.emplace_back(out.vertex_colors_[triangle(i)]);
+        }
+        if (mesh.HasVertexNormals()) {
+            out.vertex_normals_.emplace_back(out.vertex_normals_[triangle(i)]);
+        }
+        vertex_remap[triangle(i)].emplace_back(out.vertices_.size() - 1);
+        triangle(i) = static_cast<int>(out.vertices_.size() - 1);
+        assert(out.triangles_[tidx](i) == int(out.vertices_.size() - 1));
+    };
+
     for (std::size_t tidx = 0; tidx < out.triangles_.size(); ++tidx) {
         Eigen::Vector3i& triangle = out.triangles_[tidx];
         for (int i = 0; i < 3; ++i) {
             if (vertex_uvs[triangle(i)] == InvalidUV) {
                 vertex_uvs[triangle(i)] = out.triangle_uvs_[3 * tidx + i];
-            } else {
-                if (vertex_uvs[triangle(i)] !=
-                    out.triangle_uvs_[3 * tidx + i]) {
-                    assert(true);
-                    if (vertex_remap.count(triangle(i))) {
-                        for (int remap_tidx : vertex_remap[(int)tidx]) {
-                            if (vertex_uvs[remap_tidx] ==
-                                out.triangle_uvs_[3 * tidx + i]) {
-                                triangle(i) = remap_tidx;
-                                break;
-                            }
+            } else if (vertex_uvs[triangle(i)] !=
+                out.triangle_uvs_[3 * tidx + i]) {
+                if (vertex_remap.count(triangle(i)) > 0) {
+                    for (int remap_vidx : vertex_remap[triangle(i)]) {
+                        if (vertex_uvs[remap_vidx] ==
+                            out.triangle_uvs_[3 * tidx + i]) {
+                            triangle(i) = remap_vidx;
+                            break;
                         }
-                    } else {
-                        vertex_uvs.emplace_back(
-                                out.triangle_uvs_[3 * tidx + 1]);
-                        out.vertices_.emplace_back(out.vertices_[triangle(i)]);
-                        if (mesh.HasVertexColors()) {
-                            out.vertex_colors_.emplace_back(
-                                    out.vertex_colors_[triangle(i)]);
-                        }
-                        if (mesh.HasVertexNormals()) {
-                            out.vertex_normals_.emplace_back(
-                                    out.vertex_normals_[triangle(i)]);
-                        }
-                        vertex_remap[triangle(i)].emplace_back(
-                                out.vertices_.size() - 1);
-                        triangle(i) =
-                                static_cast<int>(out.vertices_.size() - 1);
+                        remap_vert(tidx, i);
                     }
+                } else {
+                    remap_vert(tidx, i);
                 }
             }
         }
     }
     assert(out.vertices_.size() == vertex_uvs.size());
+    for (std::size_t tidx = 0; tidx < out.triangles_.size(); ++tidx) {
+        for (int i = 0; i < 3; ++i) {
+            assert(out.triangle_uvs_[3 * tidx + i] ==
+                   vertex_uvs[out.triangles_[tidx](i)]);
+        }
+    }
     return {out, vertex_uvs};
 }
 
@@ -97,25 +124,6 @@ bool ReadTriangleModel(const std::string& filename,
     return ReadModelUsingAssimp(filename, model, params);
 }
 
-bool HasPerVertexUVs(const geometry::TriangleMesh& mesh) {
-    std::vector<Eigen::Vector2d> vertex_uvs(mesh.vertices_.size(),
-                                            Eigen::Vector2d(-1, -1));
-    for (std::size_t tidx = 0; tidx < mesh.triangles_.size(); ++tidx) {
-        const auto& triangle = mesh.triangles_[tidx];
-        for (int i = 0; i < 3; ++i) {
-            const auto& tri_uv = mesh.triangle_uvs_[3 * tidx + i];
-            if (vertex_uvs[triangle(i)] == Eigen::Vector2d(-1, -1)) {
-                vertex_uvs[triangle(i)] = tri_uv;
-                continue;
-            }
-            if (vertex_uvs[triangle(i)] != tri_uv) {
-                return false;
-            }
-        }
-    }
-    return true;
-}
-
 bool WriteTriangleModel(
         const std::string& filename,
         const visualization::rendering::TriangleMeshModel& model) {
@@ -123,14 +131,14 @@ bool WriteTriangleModel(
             utility::filesystem::GetFileExtensionInLowerCase(filename);
     // Validate model for output
     for (const auto& mesh_info : model.meshes_) {
-        if (!HasPerVertexUVs(*mesh_info.mesh)) {
-            utility::LogWarning(
-                    "Cannot export model because mesh {} needs "
-                    "to be converted to have per-vertex uvs instead "
-                    "of per-triangle uvs",
-                    mesh_info.mesh_name);
-            return false;
-        }
+//        if (!HasPerVertexUVs(*mesh_info.mesh)) {
+//            utility::LogWarning(
+//                    "Cannot export model because mesh {} needs "
+//                    "to be converted to have per-vertex uvs instead "
+//                    "of per-triangle uvs",
+//                    mesh_info.mesh_name);
+//            return false;
+//        }
         auto mat_it = std::minmax_element(
                 mesh_info.mesh->triangle_material_ids_.begin(),
                 mesh_info.mesh->triangle_material_ids_.end());

--- a/cpp/open3d/io/ModelIO.cpp
+++ b/cpp/open3d/io/ModelIO.cpp
@@ -134,7 +134,7 @@ bool WriteTriangleModel(
         auto mat_it = std::minmax_element(
                 mesh_info.mesh->triangle_material_ids_.begin(),
                 mesh_info.mesh->triangle_material_ids_.end());
-        if (mat_it.first != mat_it.second) {
+        if (*mat_it.first != *mat_it.second) {
             utility::LogWarning(
                     "Cannot export model because mesh {} has more "
                     "than one material",

--- a/cpp/open3d/io/ModelIO.cpp
+++ b/cpp/open3d/io/ModelIO.cpp
@@ -135,36 +135,13 @@ bool WriteTriangleModel(const std::string& filename,
     }
 
     if (ext == "gltf" || ext == "glb") {
-        return WriteTriangleMeshModelToGLTF(filename, model);
+        return WriteTriangleModelToGLTF(filename, model);
     } else {
         utility::LogWarning("Unsupported file format {}. "
                 "Currently only gltf and glb are supported", ext);
         return false;
     }
 }
-
-//bool WriteTriangleMeshModelToGLTF(
-//        const std::string& filename,
-//        const visualization::rendering::TriangleMeshModel& model) {
-//    // Validate model for output
-//    for (const auto& mesh_info: model.meshes_) {
-//        if (!HasPerVertexUVs(*mesh_info.mesh)) {
-//            utility::LogWarning("Cannot export model because mesh {} needs "
-//                    "to be converted to have per-vertex uvs instead "
-//                    "of per-triangle uvs", mesh_info.mesh_name);
-//            return false;
-//        }
-//        auto mat_it = std::minmax_element(
-//                mesh_info.mesh->triangle_material_ids_.begin(),
-//                mesh_info.mesh->triangle_material_ids_.end());
-//        if (mat_it.first != mat_it.second) {
-//            utility::LogWarning("Cannot export model because mesh {} has more "
-//                    "than one material", mesh_info.mesh_name);
-//            return false;
-//        }
-//    }
-//    return detail::WriteValidatedTriangleMeshModelToGLTF(filename, model);
-//}
 
 }  // namespace io
 }  // namespace open3d

--- a/cpp/open3d/io/ModelIO.cpp
+++ b/cpp/open3d/io/ModelIO.cpp
@@ -9,12 +9,71 @@
 
 #include <unordered_map>
 
+#include "open3d/geometry/TriangleMesh.h"
 #include "open3d/utility/FileSystem.h"
 #include "open3d/utility/Logging.h"
 #include "open3d/utility/ProgressBar.h"
+#include "open3d/visualization/rendering/Model.h"
 
 namespace open3d {
 namespace io {
+namespace detail {
+
+std::pair<geometry::TriangleMesh, std::vector<Eigen::Vector2d>>
+MeshWithPerVertexUVs(const geometry::TriangleMesh& mesh) {
+    if (!mesh.HasTriangleUvs()) {
+        return {mesh, {}};
+    }
+    if (mesh.HasAdjacencyList()) {
+        utility::LogWarning("[MeshWithPerVertexUVs] This mesh contains "
+                "an adjacency list that are not handled in this function");
+    }
+    geometry::TriangleMesh out = mesh;
+
+    std::unordered_map<int, std::vector<int>> vertex_remap;
+    std::vector<Eigen::Vector2d> vertex_uvs;
+    const Eigen::Vector2d InvalidUV(-1, -1);
+    vertex_uvs.resize(out.vertices_.size(), InvalidUV);
+    for (std::size_t tidx = 0; tidx < out.triangles_.size(); ++tidx) {
+        Eigen::Vector3i& triangle = out.triangles_[tidx];
+        for (int i = 0; i < 3; ++i) {
+            if (vertex_uvs[triangle(i)] == InvalidUV) {
+                vertex_uvs[triangle(i)] = out.triangle_uvs_[3 * tidx + i];
+            } else {
+                if (vertex_uvs[triangle(i)] != out.triangle_uvs_[3 * tidx + i]){
+                    assert(true);
+                    if (vertex_remap.count(triangle(i))) {
+                        for (int remap_tidx: vertex_remap[(int)tidx]) {
+                            if (vertex_uvs[remap_tidx] ==
+                                out.triangle_uvs_[3 * tidx + i]) {
+                                triangle(i) = remap_tidx;
+                                break;
+                            }
+                        }
+                    } else {
+                        vertex_uvs.emplace_back(out.triangle_uvs_[3 * tidx + 1]);
+                        out.vertices_.emplace_back(out.vertices_[triangle(i)]);
+                        if (mesh.HasVertexColors()) {
+                            out.vertex_colors_.emplace_back(
+                                    out.vertex_colors_[triangle(i)]);
+                        }
+                        if (mesh.HasVertexNormals()) {
+                            out.vertex_normals_.emplace_back(
+                                    out.vertex_normals_[triangle(i)]);
+                        }
+                        vertex_remap[triangle(i)].emplace_back(
+                                out.vertices_.size() - 1);
+                        triangle(i) = static_cast<int>(out.vertices_.size() - 1);
+                    }
+                }
+            }
+        }
+    }
+    assert(out.vertices_.size() == vertex_uvs.size());
+    return {out, vertex_uvs};
+}
+
+}  // namesapce detail
 
 bool ReadModelUsingAssimp(const std::string& filename,
                           visualization::rendering::TriangleMeshModel& model,
@@ -33,6 +92,79 @@ bool ReadTriangleModel(const std::string& filename,
     }
     return ReadModelUsingAssimp(filename, model, params);
 }
+
+bool HasPerVertexUVs(const geometry::TriangleMesh& mesh) {
+    std::vector<Eigen::Vector2d> vertex_uvs(
+            mesh.vertices_.size(), Eigen::Vector2d(-1, -1));
+    for (std::size_t tidx = 0; tidx < mesh.triangles_.size(); ++tidx) {
+        const auto& triangle = mesh.triangles_[tidx];
+        for (int i = 0; i < 3; ++i) {
+            const auto& tri_uv = mesh.triangle_uvs_[3 * tidx + i];
+            if (vertex_uvs[triangle(i)] == Eigen::Vector2d(-1, -1)) {
+                vertex_uvs[triangle(i)] = tri_uv;
+                continue;
+            }
+            if (vertex_uvs[triangle(i)] != tri_uv) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+bool WriteTriangleModel(const std::string& filename,
+                        const visualization::rendering::TriangleMeshModel& model) {
+    const std::string ext =
+            utility::filesystem::GetFileExtensionInLowerCase(filename);
+    // Validate model for output
+    for (const auto& mesh_info: model.meshes_) {
+        if (!HasPerVertexUVs(*mesh_info.mesh)) {
+            utility::LogWarning("Cannot export model because mesh {} needs "
+                    "to be converted to have per-vertex uvs instead "
+                    "of per-triangle uvs", mesh_info.mesh_name);
+            return false;
+        }
+        auto mat_it = std::minmax_element(
+                mesh_info.mesh->triangle_material_ids_.begin(),
+                mesh_info.mesh->triangle_material_ids_.end());
+        if (mat_it.first != mat_it.second) {
+            utility::LogWarning("Cannot export model because mesh {} has more "
+                    "than one material", mesh_info.mesh_name);
+            return false;
+        }
+    }
+
+    if (ext == "gltf" || ext == "glb") {
+        return WriteTriangleMeshModelToGLTF(filename, model);
+    } else {
+        utility::LogWarning("Unsupported file format {}. "
+                "Currently only gltf and glb are supported", ext);
+        return false;
+    }
+}
+
+//bool WriteTriangleMeshModelToGLTF(
+//        const std::string& filename,
+//        const visualization::rendering::TriangleMeshModel& model) {
+//    // Validate model for output
+//    for (const auto& mesh_info: model.meshes_) {
+//        if (!HasPerVertexUVs(*mesh_info.mesh)) {
+//            utility::LogWarning("Cannot export model because mesh {} needs "
+//                    "to be converted to have per-vertex uvs instead "
+//                    "of per-triangle uvs", mesh_info.mesh_name);
+//            return false;
+//        }
+//        auto mat_it = std::minmax_element(
+//                mesh_info.mesh->triangle_material_ids_.begin(),
+//                mesh_info.mesh->triangle_material_ids_.end());
+//        if (mat_it.first != mat_it.second) {
+//            utility::LogWarning("Cannot export model because mesh {} has more "
+//                    "than one material", mesh_info.mesh_name);
+//            return false;
+//        }
+//    }
+//    return detail::WriteValidatedTriangleMeshModelToGLTF(filename, model);
+//}
 
 }  // namespace io
 }  // namespace open3d

--- a/cpp/open3d/io/ModelIO.h
+++ b/cpp/open3d/io/ModelIO.h
@@ -26,12 +26,17 @@ namespace io {
 
 namespace detail {
 
+/**
+ * Creates a mesh with a texture coordinate per vertex for IO
+ * @note TriangleMesh's with adjacency lists are not supported by this function
+ * and the output mesh will not have any adjacency information transferred
+ * @param mesh The mesh with texture coordinaets to be converted
+ * @return A pair containing a new mesh, and a vector texture coordinates
+ * of the same length as the vector of vertices. The per face texture
+ * in the returned mesh have also been updated.
+ */
 std::pair<geometry::TriangleMesh, std::vector<Eigen::Vector2d>>
 MeshWithPerVertexUVs(const geometry::TriangleMesh& mesh);
-
-bool WriteValidatedTriangleMeshModelToGLTF(
-        const std::string& filename,
-        const visualization::rendering::TriangleMeshModel& model);
 
 }  // namespace detail
 
@@ -50,10 +55,11 @@ bool ReadTriangleModel(const std::string& filename,
                        visualization::rendering::TriangleMeshModel& model,
                        ReadTriangleModelOptions params = {});
 
-bool WriteTriangleMeshModel(const std::string& filename,
+bool WriteTriangleModel(const std::string& filename,
         const visualization::rendering::TriangleMeshModel& model);
 
-bool WriteTriangleMeshModelToGLTF(const std::string& filename,
+// Implemented in FileGLTF.cpp
+bool WriteTriangleModelToGLTF(const std::string& filename,
         const visualization::rendering::TriangleMeshModel& mesh_model);
 
 }  // namespace io

--- a/cpp/open3d/io/ModelIO.h
+++ b/cpp/open3d/io/ModelIO.h
@@ -37,6 +37,8 @@ namespace detail {
 std::pair<geometry::TriangleMesh, std::vector<Eigen::Vector2d>>
 MeshWithPerVertexUVs(const geometry::TriangleMesh& mesh);
 
+bool HasPerVertexUVs(const geometry::TriangleMesh& mesh);
+
 }  // namespace detail
 
 struct ReadTriangleModelOptions {

--- a/cpp/open3d/io/ModelIO.h
+++ b/cpp/open3d/io/ModelIO.h
@@ -7,10 +7,9 @@
 
 #pragma once
 
+#include <Eigen/Core>
 #include <functional>
 #include <string>
-
-#include <Eigen/Core>
 
 namespace open3d {
 namespace geometry {
@@ -55,11 +54,13 @@ bool ReadTriangleModel(const std::string& filename,
                        visualization::rendering::TriangleMeshModel& model,
                        ReadTriangleModelOptions params = {});
 
-bool WriteTriangleModel(const std::string& filename,
+bool WriteTriangleModel(
+        const std::string& filename,
         const visualization::rendering::TriangleMeshModel& model);
 
 // Implemented in FileGLTF.cpp
-bool WriteTriangleModelToGLTF(const std::string& filename,
+bool WriteTriangleModelToGLTF(
+        const std::string& filename,
         const visualization::rendering::TriangleMeshModel& mesh_model);
 
 }  // namespace io

--- a/cpp/open3d/io/ModelIO.h
+++ b/cpp/open3d/io/ModelIO.h
@@ -10,7 +10,12 @@
 #include <functional>
 #include <string>
 
+#include <Eigen/Core>
+
 namespace open3d {
+namespace geometry {
+class TriangleMesh;
+}  // namespace geometry
 namespace visualization {
 namespace rendering {
 struct TriangleMeshModel;
@@ -18,6 +23,17 @@ struct TriangleMeshModel;
 }  // namespace visualization
 
 namespace io {
+
+namespace detail {
+
+std::pair<geometry::TriangleMesh, std::vector<Eigen::Vector2d>>
+MeshWithPerVertexUVs(const geometry::TriangleMesh& mesh);
+
+bool WriteValidatedTriangleMeshModelToGLTF(
+        const std::string& filename,
+        const visualization::rendering::TriangleMeshModel& model);
+
+}  // namespace detail
 
 struct ReadTriangleModelOptions {
     /// Print progress to stdout about loading progress.
@@ -33,6 +49,12 @@ struct ReadTriangleModelOptions {
 bool ReadTriangleModel(const std::string& filename,
                        visualization::rendering::TriangleMeshModel& model,
                        ReadTriangleModelOptions params = {});
+
+bool WriteTriangleMeshModel(const std::string& filename,
+        const visualization::rendering::TriangleMeshModel& model);
+
+bool WriteTriangleMeshModelToGLTF(const std::string& filename,
+        const visualization::rendering::TriangleMeshModel& mesh_model);
 
 }  // namespace io
 }  // namespace open3d

--- a/cpp/open3d/io/file_format/FileASSIMP.cpp
+++ b/cpp/open3d/io/file_format/FileASSIMP.cpp
@@ -237,12 +237,13 @@ bool ReadTriangleMeshUsingASSIMP(
     }
 
     // Now load the materials
+    mesh.materials_.resize(scene->mNumMaterials);
     for (size_t i = 0; i < scene->mNumMaterials; ++i) {
         auto* mat = scene->mMaterials[i];
 
-        // create material structure to match this name
-        auto& mesh_material =
-                mesh.materials_[std::string(mat->GetName().C_Str())];
+        // Set the material structure to match this name
+        auto& mesh_material = mesh.materials_[i].second;
+        mesh.materials_[i].first = mat->GetName().C_Str();
 
         using MaterialParameter =
                 geometry::TriangleMesh::Material::MaterialParameter;
@@ -277,9 +278,9 @@ bool ReadTriangleMeshUsingASSIMP(
 
         // For legacy visualization support
         if (mesh_material.albedo) {
-            mesh.textures_.push_back(*mesh_material.albedo->FlipVertical());
+            mesh.textures_.emplace_back(*mesh_material.albedo->FlipVertical());
         } else {
-            mesh.textures_.push_back(geometry::Image());
+            mesh.textures_.emplace_back();
         }
     }
 

--- a/cpp/open3d/io/file_format/FileGLTF.cpp
+++ b/cpp/open3d/io/file_format/FileGLTF.cpp
@@ -801,7 +801,7 @@ bool WriteTriangleModelToGLTF(
         auto mat_it = std::minmax_element(
                 mesh_info.mesh->triangle_material_ids_.begin(),
                 mesh_info.mesh->triangle_material_ids_.end());
-        if (mat_it.first != mat_it.second) {
+        if (*mat_it.first != *mat_it.second) {
             utility::LogWarning(
                     "Cannot export model because mesh {} has more "
                     "than one material",

--- a/cpp/open3d/io/file_format/FileGLTF.cpp
+++ b/cpp/open3d/io/file_format/FileGLTF.cpp
@@ -790,7 +790,7 @@ void ConsolidateBuffers(tinygltf::Model& model) {
     model.buffers.erase(std::next(model.buffers.begin()), model.buffers.end());
 }
 
-bool WriteTriangleMeshModelToGLTF(
+bool WriteTriangleModelToGLTF(
         const std::string& filename,
         const visualization::rendering::TriangleMeshModel& mesh_model) {
     for (const auto& mesh_info: mesh_model.meshes_) {

--- a/cpp/open3d/io/file_format/FileGLTF.cpp
+++ b/cpp/open3d/io/file_format/FileGLTF.cpp
@@ -1045,9 +1045,12 @@ bool WriteTriangleModelToGLTF(
         // Write the material definition
         const auto& mat_rec = mesh_model.materials_[i];
         tinygltf::Material material = ConvertMaterial(mat_rec);
-        material.extensions = {
-            std::make_pair("KHR_materials_unlit", tinygltf::Value{})
-        };
+        const std::string lowercase_mat_name = utility::ToLower(mat_rec.name);
+        if (utility::ContainsString(lowercase_mat_name, "unlit")) {
+            material.extensions = {
+                    std::make_pair("KHR_materials_unlit", tinygltf::Value{})
+            };
+        }
 
         // Write the textures
         if (mat_rec.albedo_img && mat_rec.albedo_img->HasData()) {

--- a/cpp/open3d/io/file_format/FileGLTF.cpp
+++ b/cpp/open3d/io/file_format/FileGLTF.cpp
@@ -10,10 +10,14 @@
 #include <numeric>
 #include <vector>
 
+#include <tcbspan/span.hpp>
+
 #include "open3d/io/FileFormatIO.h"
 #include "open3d/io/TriangleMeshIO.h"
+#include "open3d/io/ModelIO.h"
 #include "open3d/utility/FileSystem.h"
 #include "open3d/utility/Logging.h"
+#include "open3d/visualization/rendering/Model.h"
 
 namespace open3d {
 namespace io {
@@ -577,7 +581,7 @@ bool WriteTriangleMeshToGLTF(const std::string& filename,
     if (filename_ext == "glb") {
         if (!loader.WriteGltfSceneToFile(&model, filename, false, true, true,
                                          true)) {
-            utility::LogWarning("Write GLTF failed.");
+            utility::LogWarning("Write GLB failed.");
             return false;
         }
     } else {
@@ -588,6 +592,454 @@ bool WriteTriangleMeshToGLTF(const std::string& filename,
         }
     }
 
+    return true;
+}
+
+std::string SanitizeStringForURI(const std::string& str) {
+    //  TODO
+    return str;
+}
+
+template <typename T>
+tcb::span<T, tcb::dynamic_extent> GetBufferSpan(
+        tinygltf::Buffer& buff,
+        const tinygltf::BufferView& view,
+        const tinygltf::Accessor& accessor) {
+    if (view.byteStride != 0 && view.byteStride != sizeof(T)) {
+        utility::LogError("Cannot get a strided buffer span");
+    }
+    // Make sure the buffer can hold that much data
+    buff.data.resize(view.byteOffset + view.byteLength);
+    // Create a span with the correct type aliasing the underlying data
+    return tcb::span<T, tcb::dynamic_extent>(
+            reinterpret_cast<T*>(buff.data.data() +
+                view.byteOffset + accessor.byteOffset),
+            accessor.count);
+}
+
+tinygltf::Material ConvertMaterial(const visualization::rendering::MaterialRecord& mat_rec) {
+    tinygltf::Material material;
+    material.name = mat_rec.name;
+    material.emissiveFactor = {{
+            mat_rec.emissive_color(0),
+            mat_rec.emissive_color(1),
+            mat_rec.emissive_color(2),
+    }};
+    material.alphaMode = mat_rec.has_alpha ? "BLEND" : "OPAQUE";
+
+    material.pbrMetallicRoughness.baseColorFactor = {{
+            mat_rec.base_color(0),
+            mat_rec.base_color(1),
+            mat_rec.base_color(2),
+            mat_rec.base_color(3),
+    }};
+    material.pbrMetallicRoughness.metallicFactor = mat_rec.base_metallic;
+    material.pbrMetallicRoughness.roughnessFactor = mat_rec.base_roughness;
+
+    if (mat_rec.thickness != 1.f || mat_rec.transmission != 1.f ||
+        mat_rec.absorption_color != Eigen::Vector3f::Ones() ||
+        mat_rec.absorption_distance != 1.f) {
+        utility::LogWarning("Refractive materials are not supported when "
+                "exporting to GLTF");
+    }
+
+    if (mat_rec.point_size != 3.f || mat_rec.line_width != 1.f) {
+        utility::LogWarning("Line and Point materials are not supported "
+                "when exporting to GLTF");
+    }
+
+    if (mat_rec.base_reflectance != 0.5f || mat_rec.reflectance_img) {
+        utility::LogWarning(
+                "Reflectance is not supported when exporting to GLTF");
+    }
+
+    if (mat_rec.base_clearcoat != 0.f ||
+        mat_rec.base_clearcoat_roughness != 0.f ||
+        mat_rec.clearcoat_img ||
+        mat_rec.clearcoat_roughness_img ||
+        mat_rec.ao_rough_metal_img) {
+        utility::LogWarning(
+                "Clearcoat is not supported when exporting to GLTF");
+    }
+
+    if (mat_rec.base_anisotropy != 0.f ||
+        mat_rec.anisotropy_img) {
+        utility::LogWarning(
+                "Anisotropy is not supported when exporting to GLTF");
+    }
+
+    if (mat_rec.ao_rough_metal_img) {
+        utility::LogWarning("Combined AO/Roughness is not supported "
+                "when exporting to GLTF");
+    }
+
+    if (mat_rec.gradient ||
+        mat_rec.scalar_min != 0.f ||
+        mat_rec.scalar_max != 1.f) {
+        utility::LogWarning("Gradient sampling is not supported "
+                "when exporting to GLTF");
+    }
+
+    for (const auto& kvpair: mat_rec.generic_params) {
+        utility::LogWarning("Skipping material property {}", kvpair.first);
+    }
+
+    for (const auto& kvpair: mat_rec.generic_imgs) {
+        utility::LogWarning("Skipping material texture {}", kvpair.first);
+    }
+    return material;
+}
+
+void SerializeTexture(tinygltf::Model& model,
+                      const geometry::Image& tex_img,
+                      std::size_t primitive_idx,
+                      const std::string& tex_name) {
+    tinygltf::Image image;
+    image.name = tex_img.GetName();
+    if (image.name.empty()) {
+        image.name = fmt::format("primitive-{}-{}", primitive_idx, tex_name);
+    }
+    image.mimeType = "image/jpeg";
+    image.width = tex_img.width_;
+    image.height = tex_img.height_;
+    image.component = tex_img.num_of_channels_;
+    image.bits = 8;
+    image.pixel_type = TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE;
+    // Copy the image data itself
+    if (tex_img.bytes_per_channel_ == 1) {
+        image.image = tex_img.data_;
+    } else if (tex_img.bytes_per_channel_ == 2) {
+        tcb::span<const std::uint16_t> input_span(
+                reinterpret_cast<const std::uint16_t*>(tex_img.data_.data()),
+                tex_img.data_.size() / 2);
+        image.image.resize(input_span.size());
+        tcb::span<std::uint8_t> output_span(
+                image.image.data(), image.image.size());
+        std::transform(input_span.begin(), input_span.end(),
+                       output_span.begin(), [](const auto& val){
+            return val;
+        });
+    } else {
+        utility::LogError("Primitive {} cannot export {} image for GLTF",
+                          primitive_idx, tex_name);
+    }
+    model.images.emplace_back(std::move(image));
+    model.textures.emplace_back();
+    model.textures.back().name = fmt::format(
+            "primitive-{}-{}", primitive_idx, tex_name);
+    model.textures.back().source =
+            static_cast<int>(model.images.size()) - 1;
+}
+
+bool WriteTriangleMeshModelToGLTF(
+        const std::string& filename,
+        const visualization::rendering::TriangleMeshModel& mesh_model) {
+    for (const auto& mesh_info: mesh_model.meshes_) {
+        auto mat_it = std::minmax_element(
+                mesh_info.mesh->triangle_material_ids_.begin(),
+                mesh_info.mesh->triangle_material_ids_.end());
+        if (mat_it.first != mat_it.second) {
+            utility::LogWarning("Cannot export model because mesh {} has more "
+                    "than one material", mesh_info.mesh_name);
+            return false;
+        }
+    }
+    std::string base_uri = utility::filesystem::GetFileNameWithoutDirectory(filename);
+    base_uri = utility::filesystem::GetFileNameWithoutExtension(base_uri);
+    base_uri = SanitizeStringForURI(base_uri);
+    tinygltf::Model model;
+    model.asset.generator = "Open3d";
+    model.asset.version = "2.0";
+    model.meshes.emplace_back();
+    model.meshes.back().name = base_uri;
+    model.nodes.emplace_back();
+    model.nodes.back().mesh = 0;
+    model.scenes.emplace_back();
+    model.scenes.back().nodes.emplace_back(0);
+    model.defaultScene = 0;
+
+    for (std::size_t i = 0; i < mesh_model.meshes_.size(); ++i) {
+        geometry::TriangleMesh mesh;
+        std::vector<Eigen::Vector2d> vertex_uvs;
+        std::tie(mesh, vertex_uvs) =
+                detail::MeshWithPerVertexUVs(*mesh_model.meshes_[i].mesh);
+        if (!mesh.HasTriangles()) {
+            utility::LogWarning("Invalid Mesh {}:{} has no triangles and will "
+                    "be skipped", i, mesh_model.meshes_[i].mesh_name);
+            continue;
+        }
+
+        model.meshes.back().primitives.emplace_back();
+        tinygltf::Primitive& primitive = model.meshes.back().primitives.back();
+        primitive.mode = TINYGLTF_MODE_TRIANGLES;
+
+        model.buffers.emplace_back();
+        tinygltf::Buffer& mesh_buffer = model.buffers.back();
+        mesh_buffer.name = fmt::format(
+                "primitive-{}-geometry-buffer", i);
+        mesh_buffer.uri = fmt::format(
+                "{}-primitive-{}.bin", base_uri, i);
+
+        // Store triangle indices
+        bool save_indices_as_uint16 = mesh.vertices_.size() <=
+            std::numeric_limits<std::uint16_t>::max();
+
+        model.bufferViews.emplace_back();
+        tinygltf::BufferView& indices_view = model.bufferViews.back();
+        indices_view.name = fmt::format("primitive-{}-index-buffview", i);
+        indices_view.target = TINYGLTF_TARGET_ELEMENT_ARRAY_BUFFER;
+        indices_view.buffer = static_cast<int>(model.buffers.size()) - 1;
+
+        tinygltf::Accessor indices_accaessor;
+        indices_accaessor.bufferView =
+                static_cast<int>(model.bufferViews.size()) - 1;
+        indices_accaessor.name = fmt::format("primitive-{}-indices", i);
+        indices_accaessor.type = TINYGLTF_TYPE_SCALAR;
+        indices_accaessor.componentType = save_indices_as_uint16 ?
+                TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT :
+                TINYGLTF_COMPONENT_TYPE_UNSIGNED_INT;
+        indices_accaessor.count = 3 * mesh.triangles_.size();
+        indices_accaessor.byteOffset = 0;
+        indices_accaessor.minValues = {0};
+        indices_accaessor.maxValues =
+                {static_cast<double>(mesh.vertices_.size()) - 1};
+
+        if (save_indices_as_uint16) {
+            indices_view.byteLength = indices_accaessor.count *
+                                      sizeof(std::uint16_t);
+            using OutType = std::array<std::uint16_t, 3>;
+            auto span = GetBufferSpan<OutType>(
+                    mesh_buffer, indices_view, indices_accaessor);
+            std::transform(mesh.triangles_.begin(), mesh.triangles_.end(),
+                    span.begin(), [](const Eigen::Vector3i& tri){
+                const auto tdat = tri.template cast<OutType::value_type>();
+                return OutType{tdat(0), tdat(1), tdat(2)};
+            });
+        } else {
+            if (mesh.vertices_.size() >
+                std::numeric_limits<std::uint32_t>::max()) {
+                utility::LogError("Number of vertices {} is unsupported "
+                        "by this writer", mesh.vertices_.size());
+            }
+            indices_view.byteLength = indices_accaessor.count *
+                                      sizeof(std::uint32_t);
+            using OutType = std::array<std::uint32_t, 3>;
+            auto span = GetBufferSpan<OutType>(
+                    mesh_buffer, indices_view, indices_accaessor);
+            std::transform(mesh.triangles_.begin(), mesh.triangles_.end(),
+                    span.begin(), [](const Eigen::Vector3i& tri){
+                const auto tdat = tri.template cast<OutType::value_type>();
+                return OutType{tdat(0), tdat(1), tdat(2)};
+            });
+        }
+        // Add the indices to the primitive
+        model.accessors.emplace_back(std::move(indices_accaessor));
+        primitive.indices = static_cast<int>(model.accessors.size()) - 1;
+
+        model.bufferViews.emplace_back();
+        tinygltf::BufferView& data_view_strided = model.bufferViews.back();
+        data_view_strided.name = fmt::format(
+                "primitive-{}-vertdata-buffview", i);
+        data_view_strided.target = TINYGLTF_TARGET_ARRAY_BUFFER;
+        data_view_strided.byteOffset = indices_view.byteLength;
+        data_view_strided.byteStride = 12;
+        data_view_strided.buffer = static_cast<int>(model.buffers.size()) - 1;
+        int data_view_idx = static_cast<int>(model.bufferViews.size()) - 1;
+
+        tinygltf::Accessor vertex_accessor;
+        vertex_accessor.name = fmt::format("primitive-{}-vertices", i);
+        vertex_accessor.type = TINYGLTF_TYPE_VEC3;
+        vertex_accessor.componentType = TINYGLTF_COMPONENT_TYPE_FLOAT;
+        vertex_accessor.count = mesh.vertices_.size();
+        vertex_accessor.bufferView = data_view_idx;
+        vertex_accessor.minValues = std::vector<double>(
+                3, std::numeric_limits<double>::max());
+        vertex_accessor.maxValues = std::vector<double>(
+                3, std::numeric_limits<double>::lowest());
+        vertex_accessor.byteOffset = data_view_strided.byteLength;
+        data_view_strided.byteLength += 3 * sizeof(float) * vertex_accessor.count;
+        {
+            using OutType = std::array<float, 3>;
+            auto span = GetBufferSpan<OutType>(
+                    mesh_buffer, data_view_strided, vertex_accessor);
+            std::transform(mesh.vertices_.begin(), mesh.vertices_.end(),
+                    span.begin(), [&vertex_accessor](const auto& vert){
+                auto vout = vert.template cast<OutType::value_type>();
+                // Change coordinates system
+                return OutType{vout(0), vout(2), -vout(1)};
+            });
+            std::for_each(span.begin(), span.end(),
+                          [&vertex_accessor](const auto& arr){
+                for (int i = 0; i < 3; ++i) {
+                    vertex_accessor.minValues[i] = std::min<double>(
+                            arr[i], vertex_accessor.minValues[i]);
+                    vertex_accessor.maxValues[i] = std::max<double>(
+                            arr[i], vertex_accessor.maxValues[i]);
+                }
+            });
+        }
+        // Register the positions accessor to the primitive
+        model.accessors.emplace_back(std::move(vertex_accessor));
+        primitive.attributes["POSITION"] =
+                static_cast<int>(model.accessors.size()) - 1;
+
+        if (mesh.HasVertexNormals()) {
+            tinygltf::Accessor normals_accessor;
+            normals_accessor.name = fmt::format("primitive-{}-normals", i);
+            normals_accessor.type = TINYGLTF_TYPE_VEC3;
+            normals_accessor.componentType = TINYGLTF_COMPONENT_TYPE_FLOAT;
+            normals_accessor.count = mesh.vertex_normals_.size();
+            normals_accessor.bufferView = data_view_idx;
+//            normals_accessor.minValues = std::vector<double>(3, double{-1});
+//            normals_accessor.maxValues = std::vector<double>(3, double{1});
+            normals_accessor.byteOffset = data_view_strided.byteLength;
+            data_view_strided.byteLength += 3 * sizeof(float) * normals_accessor.count;
+            {
+                using OutType = std::array<float, 3>;
+                auto span = GetBufferSpan<OutType>(
+                        mesh_buffer, data_view_strided, normals_accessor);
+                std::transform(mesh.vertex_normals_.begin(),
+                               mesh.vertex_normals_.end(),
+                               span.begin(), [](const auto& norm){
+                    auto nout = norm.template cast<OutType::value_type>();
+                    return OutType{nout(0), nout(1), nout(2)};
+                });
+            }
+            // Register the normals accessor to the primitive
+            model.accessors.emplace_back(std::move(normals_accessor));
+            primitive.attributes["NORMAL"] =
+                    static_cast<int>(model.accessors.size()) - 1;
+        }
+        
+        if (mesh.HasVertexColors()) {
+            tinygltf::Accessor colors_accessor;
+            colors_accessor.name = fmt::format("primitive-{}-colors", i);
+            colors_accessor.type = TINYGLTF_TYPE_VEC3;
+            colors_accessor.componentType = TINYGLTF_COMPONENT_TYPE_FLOAT;
+            colors_accessor.count = mesh.vertex_colors_.size();
+            colors_accessor.bufferView = data_view_idx;
+//            colors_accessor.minValues = std::vector<double>(3, double{0});
+//            colors_accessor.maxValues = std::vector<double>(3, double{1});
+            colors_accessor.byteOffset = data_view_strided.byteLength;
+            data_view_strided.byteLength += 3 * sizeof(float) * colors_accessor.count;
+            {
+                using OutType = std::array<float, 3>;
+                auto span = GetBufferSpan<OutType>(
+                        mesh_buffer, data_view_strided, colors_accessor);
+                std::transform(mesh.vertex_colors_.begin(),
+                               mesh.vertex_colors_.end(),
+                               span.begin(), [](const auto& color){
+                    auto cout = color.template cast<OutType::value_type>();
+                    return OutType{cout(0), cout(1), cout(2)};
+                });
+            }
+            // Register the colors accessor to the primitive
+            model.accessors.emplace_back(std::move(colors_accessor));
+            primitive.attributes["COLOR_0"] =
+                    static_cast<int>(model.accessors.size()) - 1;
+        }
+
+        if (mesh.HasTriangleNormals()) {
+            utility::LogWarning("Mesh {}:{} has per-triangle normals which "
+                    "are not supported and will be skipped",
+                    i, mesh_model.meshes_[i].mesh_name);
+        }
+
+        if (mesh.HasAdjacencyList()) {
+            utility::LogWarning("Mesh {}:{} has an adjacency list which "
+                    "is not supported and will be skipped",
+                    i, mesh_model.meshes_[i].mesh_name);
+        }
+
+        if (mesh.HasTriangleUvs()) {
+            model.bufferViews.emplace_back();
+            tinygltf::BufferView& uv_buffer_view = model.bufferViews.back();
+            uv_buffer_view.name = fmt::format(
+                    "primitive-{}-uvdata-buffview", i);
+            uv_buffer_view.target = TINYGLTF_TARGET_ARRAY_BUFFER;
+            uv_buffer_view.byteOffset =
+                    data_view_strided.byteOffset + data_view_strided.byteLength;
+            uv_buffer_view.byteStride = 8;
+            uv_buffer_view.buffer = static_cast<int>(model.buffers.size()) - 1;
+
+            tinygltf::Accessor uv_accessor;
+            uv_accessor.name = fmt::format("primitive-{}-uvs", i);
+            uv_accessor.type = TINYGLTF_TYPE_VEC2;
+            uv_accessor.componentType = TINYGLTF_COMPONENT_TYPE_FLOAT;
+            uv_accessor.count = vertex_uvs.size();
+            uv_accessor.bufferView =
+                    static_cast<int>(model.bufferViews.size()) - 1;
+//            uv_accessor.minValues = std::vector<double>(2, double{0});
+//            uv_accessor.maxValues = std::vector<double>(2, double{1});
+            uv_accessor.byteOffset = uv_buffer_view.byteLength;
+            uv_buffer_view.byteLength += 2 * sizeof(float) * uv_accessor.count;
+            {
+                using OutType = std::array<float, 2>;
+                auto span = GetBufferSpan<OutType>(
+                        mesh_buffer, uv_buffer_view, uv_accessor);
+                std::transform(vertex_uvs.begin(), vertex_uvs.end(),
+                               span.begin(), [](const auto& uvs){
+                    auto uvout = uvs.template cast<OutType::value_type>();
+                    return OutType{uvout(0), 1.f - uvout(1)};
+                });
+            }
+            // Register the uv accessor to the primitive
+            model.accessors.emplace_back(std::move(uv_accessor));
+            primitive.attributes["TEXCOORD_0"] =
+                    static_cast<int>(model.accessors.size()) - 1;
+        }
+
+        // Write the material definition
+        const auto& mat_rec = mesh_model.materials_[i];
+        tinygltf::Material material = ConvertMaterial(mat_rec);
+
+        // Write the textures
+        if (mat_rec.albedo_img && mat_rec.albedo_img->HasData()) {
+            SerializeTexture(model, *mat_rec.albedo_img, i, "albedo");
+            material.pbrMetallicRoughness.baseColorTexture.index =
+                    static_cast<int>(model.textures.size()) - 1;
+        }
+        if (mat_rec.roughness_img && mat_rec.roughness_img->HasData()) {
+            SerializeTexture(model, *mat_rec.roughness_img, i, "roughness");
+            material.pbrMetallicRoughness.metallicRoughnessTexture.index =
+                    static_cast<int>(model.textures.size()) - 1;
+        }
+        if (mat_rec.normal_img && mat_rec.normal_img->HasData()) {
+            SerializeTexture(model, *mat_rec.normal_img, i, "normals");
+            material.normalTexture.index =
+                    static_cast<int>(model.textures.size()) - 1;
+        }
+        if (mat_rec.ao_img && mat_rec.ao_img->HasData()) {
+            SerializeTexture(model, *mat_rec.ao_img, i, "ao");
+            material.occlusionTexture.index =
+                    static_cast<int>(model.textures.size()) - 1;
+        }
+        model.materials.emplace_back(std::move(material));
+        primitive.material = static_cast<int>(model.materials.size()) - 1;
+    }
+
+    tinygltf::TinyGLTF loader;
+    std::string filename_ext =
+            utility::filesystem::GetFileExtensionInLowerCase(filename);
+    if (filename_ext == "glb") {
+        for (auto& buffer: model.buffers) {
+            buffer.uri.clear();
+        }
+        for (auto& image: model.images) {
+            image.uri.clear();
+        }
+        if (!loader.WriteGltfSceneToFile(
+                    &model, filename, true, true, true, true)) {
+            utility::LogWarning("Write GLB failed.");
+            return false;
+        }
+    } else {
+        if (!loader.WriteGltfSceneToFile(
+                    &model, filename, false, false, true, false)) {
+            utility::LogWarning("Write GLTF failed.");
+            return false;
+        }
+    }
     return true;
 }
 

--- a/cpp/open3d/io/file_format/FileGLTF.cpp
+++ b/cpp/open3d/io/file_format/FileGLTF.cpp
@@ -694,7 +694,8 @@ void SerializeTexture(tinygltf::Model& model,
     if (image.name.empty()) {
         image.name = fmt::format("primitive-{}-{}", primitive_idx, tex_name);
     }
-    image.mimeType = "image/jpeg";
+    image.uri = image.name + ".png";
+    image.mimeType = "image/png";
     image.width = tex_img.width_;
     image.height = tex_img.height_;
     image.component = tex_img.num_of_channels_;
@@ -758,6 +759,7 @@ void WriteImagesToBuffers(tinygltf::Model& model) {
             utility::LogError("Unsupported mime-type for image {}", image.name);
         }
         image.image.clear();
+        image.uri.clear();
         image.bufferView = static_cast<int>(model.bufferViews.size()) - 1;
         image.as_is = true;
         img_buff_view.byteLength = img_buff.data.size();
@@ -814,6 +816,8 @@ bool WriteTriangleMeshModelToGLTF(
     model.scenes.emplace_back();
     model.scenes.back().nodes.emplace_back(0);
     model.defaultScene = 0;
+
+    model.extensionsUsed = {"KHR_materials_unlit"};
 
     for (std::size_t i = 0; i < mesh_model.meshes_.size(); ++i) {
         geometry::TriangleMesh mesh;
@@ -1041,6 +1045,9 @@ bool WriteTriangleMeshModelToGLTF(
         // Write the material definition
         const auto& mat_rec = mesh_model.materials_[i];
         tinygltf::Material material = ConvertMaterial(mat_rec);
+        material.extensions = {
+            std::make_pair("KHR_materials_unlit", tinygltf::Value{})
+        };
 
         // Write the textures
         if (mat_rec.albedo_img && mat_rec.albedo_img->HasData()) {

--- a/cpp/open3d/io/file_format/FileGLTF.cpp
+++ b/cpp/open3d/io/file_format/FileGLTF.cpp
@@ -597,11 +597,16 @@ bool WriteTriangleMeshToGLTF(const std::string& filename,
 template <typename T>
 tcb::span<T, tcb::dynamic_extent> GetBufferSpan(
         tinygltf::Buffer& buff,
-        const tinygltf::BufferView& view,
+        tinygltf::BufferView& view,
         const tinygltf::Accessor& accessor) {
     if (view.byteStride != 0 && view.byteStride != sizeof(T)) {
         utility::LogError("Cannot get a strided buffer span");
     }
+
+    if (view.byteLength % 4 != 0) {
+        view.byteLength += 4 - (view.byteLength % 4);
+    }
+
     // Make sure the buffer can hold that much data
     buff.data.resize(view.byteOffset + view.byteLength);
     // Create a span with the correct type aliasing the underlying data

--- a/cpp/open3d/io/file_format/FileOBJ.cpp
+++ b/cpp/open3d/io/file_format/FileOBJ.cpp
@@ -140,8 +140,11 @@ bool ReadTriangleMeshFromOBJ(const std::string& filename,
     using MaterialParameter =
             geometry::TriangleMesh::Material::MaterialParameter;
 
-    for (auto& material : materials) {
-        auto& meshMaterial = mesh.materials_[material.name];
+    mesh.materials_.resize(materials.size());
+    for (std::size_t i = 0; i < materials.size(); ++i) {
+        auto& material = materials[i];
+        mesh.materials_[i].first = material.name;
+        auto& meshMaterial = mesh.materials_[i].second;
 
         meshMaterial.baseColor = MaterialParameter::CreateRGB(
                 material.diffuse[0], material.diffuse[1], material.diffuse[2]);

--- a/cpp/open3d/t/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/t/geometry/TriangleMesh.cpp
@@ -409,7 +409,9 @@ open3d::geometry::TriangleMesh TriangleMesh::ToLegacy() const {
     // Convert material if the t geometry has a valid one
     auto &tmat = GetMaterial();
     if (tmat.IsValid()) {
-        auto &legacy_mat = mesh_legacy.materials_["Mat1"];
+        mesh_legacy.materials_.emplace_back();
+        mesh_legacy.materials_.front().first = "Mat1";
+        auto &legacy_mat = mesh_legacy.materials_.front().second;
         // Convert scalar properties
         if (tmat.HasBaseColor()) {
             legacy_mat.baseColor.f4[0] = tmat.GetBaseColor().x();

--- a/cpp/open3d/visualization/CMakeLists.txt
+++ b/cpp/open3d/visualization/CMakeLists.txt
@@ -44,6 +44,7 @@ target_sources(visualization PRIVATE
 
 target_sources(visualization PRIVATE
     rendering/Material.cpp  # For RPC serialization
+    rendering/Model.cpp  # For Mesh IO
 )
 
 if (BUILD_GUI)

--- a/cpp/open3d/visualization/rendering/Model.cpp
+++ b/cpp/open3d/visualization/rendering/Model.cpp
@@ -30,20 +30,6 @@ namespace open3d {
 namespace visualization {
 namespace rendering {
 
-bool StringStartsWith(const std::string& str, const std::string& prefix) {
-#ifdef __cpp_lib_starts_ends_with
-    return str.starts_with(prefix);
-#else
-    if (prefix.size() >= str.size()) {
-        return std::equal(str.begin(), str.end(),
-                          prefix.begin(), prefix.end());
-    } else {
-        return std::equal(prefix.begin(), prefix.end(),
-                          str.begin(), str.end());
-    }
-#endif
-}
-
 MaterialRecord ConvertMaterial(
         const geometry::TriangleMesh::Material& mat,
         const std::string& name = "Material") {

--- a/cpp/open3d/visualization/rendering/Model.cpp
+++ b/cpp/open3d/visualization/rendering/Model.cpp
@@ -1,27 +1,8 @@
 // ----------------------------------------------------------------------------
 // -                        Open3D: www.open3d.org                            -
 // ----------------------------------------------------------------------------
-// The MIT License (MIT)
-//
-// Copyright (c) 2018-2021 www.open3d.org
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-// IN THE SOFTWARE.
+// Copyright (c) 2018-2023 www.open3d.org
+// SPDX-License-Identifier: MIT
 // ----------------------------------------------------------------------------
 
 #include "open3d/visualization/rendering/Model.h"
@@ -30,9 +11,8 @@ namespace open3d {
 namespace visualization {
 namespace rendering {
 
-MaterialRecord ConvertMaterial(
-        const geometry::TriangleMesh::Material& mat,
-        const std::string& name = "Material") {
+MaterialRecord ConvertMaterial(const geometry::TriangleMesh::Material& mat,
+                               const std::string& name = "Material") {
     MaterialRecord out;
     out.name = name;
     // Base attributes
@@ -54,11 +34,10 @@ MaterialRecord ConvertMaterial(
     out.clearcoat_roughness_img = mat.clearCoatRoughness;
     out.anisotropy_img = mat.anisotropy;
     // Dictionary attributes
-    for (const auto& kvpair: mat.floatParameters) {
-        out.generic_params[kvpair.first] =
-                Eigen::Vector4f(kvpair.second.f4);
+    for (const auto& kvpair : mat.floatParameters) {
+        out.generic_params[kvpair.first] = Eigen::Vector4f(kvpair.second.f4);
     }
-    for (const auto& kvpair: mat.additionalMaps) {
+    for (const auto& kvpair : mat.additionalMaps) {
         out.generic_imgs[kvpair.first] = kvpair.second;
     }
     return out;
@@ -66,9 +45,7 @@ MaterialRecord ConvertMaterial(
 
 // Split mesh into components based on material id
 geometry::TriangleMesh GetComponentForMaterial(
-        const geometry::TriangleMesh& mesh,
-        int mat_idx) {
-
+        const geometry::TriangleMesh& mesh, int mat_idx) {
     geometry::TriangleMesh component;
     for (std::size_t tidx = 0; tidx < mesh.triangles_.size(); ++tidx) {
         if (mesh.triangle_material_ids_[tidx] != mat_idx) {
@@ -77,8 +54,7 @@ geometry::TriangleMesh GetComponentForMaterial(
         // Copy over per-triangle attributes
         component.triangles_.emplace_back(mesh.triangles_[tidx]);
         if (mesh.HasTriangleUvs()) {
-            component.triangle_uvs_.emplace_back(
-                    mesh.triangle_uvs_[tidx]);
+            component.triangle_uvs_.emplace_back(mesh.triangle_uvs_[tidx]);
         }
         if (mesh.HasTriangleNormals()) {
             component.triangle_normals_.emplace_back(
@@ -87,11 +63,10 @@ geometry::TriangleMesh GetComponentForMaterial(
     }
     // Create a mapping of old indices to new indices
     std::unordered_map<int, int> vidx_remap;
-    for (const Eigen::Vector3i& tri: component.triangles_) {
+    for (const Eigen::Vector3i& tri : component.triangles_) {
         for (int i = 0; i < 3; ++i) {
             if (vidx_remap.count(tri(i)) == 0) {
-                vidx_remap[tri(i)] =
-                        static_cast<int>(vidx_remap.size());
+                vidx_remap[tri(i)] = static_cast<int>(vidx_remap.size());
             }
         }
     }
@@ -103,9 +78,8 @@ geometry::TriangleMesh GetComponentForMaterial(
         component.vertex_colors_.resize(vidx_remap.size());
     }
     // Remap per-vertex data
-    for (std::pair<int, int> remap: vidx_remap) {
-        component.vertices_[remap.second] =
-                mesh.vertices_[remap.first];
+    for (std::pair<int, int> remap : vidx_remap) {
+        component.vertices_[remap.second] = mesh.vertices_[remap.first];
         if (mesh.HasVertexNormals()) {
             component.vertex_normals_[remap.second] =
                     mesh.vertex_normals_[remap.first];
@@ -123,25 +97,22 @@ geometry::TriangleMesh GetComponentForMaterial(
     return component;
 }
 
-void TriangleMeshModel::AddMesh(
-        const geometry::TriangleMesh &mesh,
-        const std::string &name) {
+void TriangleMeshModel::AddMesh(const geometry::TriangleMesh& mesh,
+                                const std::string& name) {
     // Reused code
-    auto add_mesh_with_material =
-            [this](const geometry::TriangleMesh& mesh,
-                   const std::string& mesh_name,
-                   const geometry::TriangleMesh::Material& material,
-                   const std::string& material_name){
-        MeshInfo mesh_info{
-                std::make_shared<geometry::TriangleMesh>(mesh),
-                mesh_name + " " + std::to_string(meshes_.size()),
-                static_cast<unsigned int>(materials_.size())
-        };
+    auto add_mesh_with_material = [this](const geometry::TriangleMesh& mesh,
+                                         const std::string& mesh_name,
+                                         const geometry::TriangleMesh::Material&
+                                                 material,
+                                         const std::string& material_name) {
+        MeshInfo mesh_info{std::make_shared<geometry::TriangleMesh>(mesh),
+                           mesh_name + " " + std::to_string(meshes_.size()),
+                           static_cast<unsigned int>(materials_.size())};
         meshes_.emplace_back(std::move(mesh_info));
         // Remove references to other materials
         auto& added_mesh = meshes_.back().mesh;
-        added_mesh->triangle_material_ids_ = std::vector<int>(
-                added_mesh->triangles_.size(), 0);
+        added_mesh->triangle_material_ids_ =
+                std::vector<int>(added_mesh->triangles_.size(), 0);
         added_mesh->materials_ = {std::make_pair(material_name, material)};
         added_mesh->textures_ = {*material.albedo->FlipVertical()};
         materials_.emplace_back(ConvertMaterial(material, material_name));
@@ -149,45 +120,44 @@ void TriangleMeshModel::AddMesh(
 
     if (mesh.HasTriangleMaterialIds()) {
         // Check if all the material IDs are the same
-        auto minmax_iters = std::minmax_element(
-                mesh.triangle_material_ids_.begin(),
-                mesh.triangle_material_ids_.end());
+        auto minmax_iters =
+                std::minmax_element(mesh.triangle_material_ids_.begin(),
+                                    mesh.triangle_material_ids_.end());
         if (*minmax_iters.first == *minmax_iters.second) {
             const auto& mat = mesh.materials_[*minmax_iters.first];
             add_mesh_with_material(mesh, name, mat.second, mat.first);
         } else {
             // Split the mesh into components, one for each material
             std::unordered_set<int> unique_material_indices;
-            unique_material_indices.insert(
-                    mesh.triangle_material_ids_.begin(),
-                    mesh.triangle_material_ids_.end());
-            for (int mat_idx: unique_material_indices) {
-                const auto& mat =
-                        mesh.materials_[mat_idx];
+            unique_material_indices.insert(mesh.triangle_material_ids_.begin(),
+                                           mesh.triangle_material_ids_.end());
+            for (int mat_idx : unique_material_indices) {
+                const auto& mat = mesh.materials_[mat_idx];
                 const std::string component_name =
                         name + " " + std::to_string(mat_idx);
-                add_mesh_with_material(
-                        mesh, component_name, mat.second, mat.first);
+                add_mesh_with_material(mesh, component_name, mat.second,
+                                       mat.first);
             }
         }
     } else {
         if (mesh.materials_.empty()) {
-            utility::LogWarning("No material found for triangle mesh, "
+            utility::LogWarning(
+                    "No material found for triangle mesh, "
                     "creating default material");
         } else {
             // Search for Texture or DefaultMaterial
             // otherwise use the first material
-            auto material_it = std::find_if(
-                    mesh.materials_.begin(), mesh.materials_.end(),
-                    [](const auto& mat_name_pair){
-                return mat_name_pair.first == "Texture";
-            });
+            auto material_it =
+                    std::find_if(mesh.materials_.begin(), mesh.materials_.end(),
+                                 [](const auto& mat_name_pair) {
+                                     return mat_name_pair.first == "Texture";
+                                 });
             if (material_it == mesh.materials_.end()) {
                 material_it = std::find_if(
                         mesh.materials_.begin(), mesh.materials_.end(),
-                        [](const auto& mat_name_pair){
-                    return mat_name_pair.first == "DefaultMaterial";
-                });
+                        [](const auto& mat_name_pair) {
+                            return mat_name_pair.first == "DefaultMaterial";
+                        });
                 if (material_it == mesh.materials_.end()) {
                     material_it = mesh.materials_.begin();
                 }
@@ -199,8 +169,7 @@ void TriangleMeshModel::AddMesh(
 }
 
 TriangleMeshModel TriangleMeshModel::FromTriangleMesh(
-        const geometry::TriangleMesh &mesh,
-        const std::string &name) {
+        const geometry::TriangleMesh& mesh, const std::string& name) {
     TriangleMeshModel out;
     out.AddMesh(mesh, name);
     return out;

--- a/cpp/open3d/visualization/rendering/Model.cpp
+++ b/cpp/open3d/visualization/rendering/Model.cpp
@@ -114,7 +114,9 @@ void TriangleMeshModel::AddMesh(const geometry::TriangleMesh& mesh,
         added_mesh->triangle_material_ids_ =
                 std::vector<int>(added_mesh->triangles_.size(), 0);
         added_mesh->materials_ = {std::make_pair(material_name, material)};
-        added_mesh->textures_ = {*material.albedo->FlipVertical()};
+        if (material.albedo) {
+            added_mesh->textures_ = {*material.albedo->FlipVertical()};
+        }
         materials_.emplace_back(ConvertMaterial(material, material_name));
     };
 

--- a/cpp/open3d/visualization/rendering/Model.cpp
+++ b/cpp/open3d/visualization/rendering/Model.cpp
@@ -153,8 +153,7 @@ void TriangleMeshModel::AddMesh(
                 mesh.triangle_material_ids_.begin(),
                 mesh.triangle_material_ids_.end());
         if (*minmax_iters.first == *minmax_iters.second) {
-            std::pair<std::string, geometry::TriangleMesh::Material> mat =
-                    mesh.materials_[*minmax_iters.first];
+            const auto& mat = mesh.materials_[*minmax_iters.first];
             add_mesh_with_material(mesh, name, mat.second, mat.first);
         } else {
             // Split the mesh into components, one for each material
@@ -163,7 +162,7 @@ void TriangleMeshModel::AddMesh(
                     mesh.triangle_material_ids_.begin(),
                     mesh.triangle_material_ids_.end());
             for (int mat_idx: unique_material_indices) {
-                std::pair<std::string, geometry::TriangleMesh::Material> mat =
+                const auto& mat =
                         mesh.materials_[mat_idx];
                 const std::string component_name =
                         name + " " + std::to_string(mat_idx);
@@ -193,8 +192,7 @@ void TriangleMeshModel::AddMesh(
                     material_it = mesh.materials_.begin();
                 }
             }
-            std::pair<std::string, geometry::TriangleMesh::Material> mat =
-                    *material_it;
+            const auto& mat = *material_it;
             add_mesh_with_material(mesh, name, mat.second, mat.first);
         }
     }

--- a/cpp/open3d/visualization/rendering/Model.cpp
+++ b/cpp/open3d/visualization/rendering/Model.cpp
@@ -1,0 +1,227 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "open3d/visualization/rendering/Model.h"
+
+namespace open3d {
+namespace visualization {
+namespace rendering {
+
+bool StringStartsWith(const std::string& str, const std::string& prefix) {
+#ifdef __cpp_lib_starts_ends_with
+    return str.starts_with(prefix);
+#else
+    if (prefix.size() >= str.size()) {
+        return std::equal(str.begin(), str.end(),
+                          prefix.begin(), prefix.end());
+    } else {
+        return std::equal(prefix.begin(), prefix.end(),
+                          str.begin(), str.end());
+    }
+#endif
+}
+
+MaterialRecord ConvertMaterial(
+        const geometry::TriangleMesh::Material& mat,
+        const std::string& name = "Material") {
+    MaterialRecord out;
+    out.name = name;
+    // Base attributes
+    out.base_color = Eigen::Vector4f(mat.baseColor.f4);
+    out.base_metallic = mat.baseMetallic;
+    out.base_roughness = mat.baseRoughness;
+    out.base_reflectance = mat.baseReflectance;
+    out.base_clearcoat = mat.baseClearCoat;
+    out.base_clearcoat_roughness = mat.baseClearCoatRoughness;
+    out.base_anisotropy = mat.baseAnisotropy;
+    // Image attributes
+    out.albedo_img = mat.albedo;
+    out.normal_img = mat.normalMap;
+    out.ao_img = mat.ambientOcclusion;
+    out.metallic_img = mat.metallic;
+    out.roughness_img = mat.roughness;
+    out.reflectance_img = mat.reflectance;
+    out.clearcoat_img = mat.clearCoat;
+    out.clearcoat_roughness_img = mat.clearCoatRoughness;
+    out.anisotropy_img = mat.anisotropy;
+    // Dictionary attributes
+    for (const auto& kvpair: mat.floatParameters) {
+        out.generic_params[kvpair.first] =
+                Eigen::Vector4f(kvpair.second.f4);
+    }
+    for (const auto& kvpair: mat.additionalMaps) {
+        out.generic_imgs[kvpair.first] = kvpair.second;
+    }
+    return out;
+}
+
+// Split mesh into components based on material id
+geometry::TriangleMesh GetComponentForMaterial(
+        const geometry::TriangleMesh& mesh,
+        int mat_idx) {
+
+    geometry::TriangleMesh component;
+    for (std::size_t tidx = 0; tidx < mesh.triangles_.size(); ++tidx) {
+        if (mesh.triangle_material_ids_[tidx] != mat_idx) {
+            continue;
+        }
+        // Copy over per-triangle attributes
+        component.triangles_.emplace_back(mesh.triangles_[tidx]);
+        if (mesh.HasTriangleUvs()) {
+            component.triangle_uvs_.emplace_back(
+                    mesh.triangle_uvs_[tidx]);
+        }
+        if (mesh.HasTriangleNormals()) {
+            component.triangle_normals_.emplace_back(
+                    mesh.triangle_normals_[tidx]);
+        }
+    }
+    // Create a mapping of old indices to new indices
+    std::unordered_map<int, int> vidx_remap;
+    for (const Eigen::Vector3i& tri: component.triangles_) {
+        for (int i = 0; i < 3; ++i) {
+            if (vidx_remap.count(tri(i)) == 0) {
+                vidx_remap[tri(i)] =
+                        static_cast<int>(vidx_remap.size());
+            }
+        }
+    }
+    component.vertices_.resize(vidx_remap.size());
+    if (mesh.HasVertexNormals()) {
+        component.vertex_normals_.resize(vidx_remap.size());
+    }
+    if (mesh.HasVertexColors()) {
+        component.vertex_colors_.resize(vidx_remap.size());
+    }
+    // Remap per-vertex data
+    for (std::pair<int, int> remap: vidx_remap) {
+        component.vertices_[remap.second] =
+                mesh.vertices_[remap.first];
+        if (mesh.HasVertexNormals()) {
+            component.vertex_normals_[remap.second] =
+                    mesh.vertex_normals_[remap.first];
+        }
+        if (mesh.HasVertexColors()) {
+            component.vertex_colors_[remap.second] =
+                    mesh.vertex_colors_[remap.first];
+        }
+    }
+    for (auto& triangle : component.triangles_) {
+        for (int i = 0; i < 3; ++i) {
+            triangle(i) = vidx_remap[triangle(i)];
+        }
+    }
+    return component;
+}
+
+void TriangleMeshModel::AddMesh(
+        const geometry::TriangleMesh &mesh,
+        const std::string &name) {
+    // Reused code
+    auto add_mesh_with_material =
+            [this](const geometry::TriangleMesh& mesh,
+                   const std::string& mesh_name,
+                   const geometry::TriangleMesh::Material& material,
+                   const std::string& material_name){
+        MeshInfo mesh_info{
+                std::make_shared<geometry::TriangleMesh>(mesh),
+                mesh_name + " " + std::to_string(meshes_.size()),
+                static_cast<unsigned int>(materials_.size())
+        };
+        meshes_.emplace_back(std::move(mesh_info));
+        // Remove references to other materials
+        auto& added_mesh = meshes_.back().mesh;
+        added_mesh->triangle_material_ids_ = std::vector<int>(
+                added_mesh->triangles_.size(), 0);
+        added_mesh->materials_ = {std::make_pair(material_name, material)};
+        added_mesh->textures_ = {*material.albedo->FlipVertical()};
+        materials_.emplace_back(ConvertMaterial(material, material_name));
+    };
+
+    if (mesh.HasTriangleMaterialIds()) {
+        // Check if all the material IDs are the same
+        auto minmax_iters = std::minmax_element(
+                mesh.triangle_material_ids_.begin(),
+                mesh.triangle_material_ids_.end());
+        if (*minmax_iters.first == *minmax_iters.second) {
+            std::pair<std::string, geometry::TriangleMesh::Material> mat =
+                    mesh.materials_[*minmax_iters.first];
+            add_mesh_with_material(mesh, name, mat.second, mat.first);
+        } else {
+            // Split the mesh into components, one for each material
+            std::unordered_set<int> unique_material_indices;
+            unique_material_indices.insert(
+                    mesh.triangle_material_ids_.begin(),
+                    mesh.triangle_material_ids_.end());
+            for (int mat_idx: unique_material_indices) {
+                std::pair<std::string, geometry::TriangleMesh::Material> mat =
+                        mesh.materials_[mat_idx];
+                const std::string component_name =
+                        name + " " + std::to_string(mat_idx);
+                add_mesh_with_material(
+                        mesh, component_name, mat.second, mat.first);
+            }
+        }
+    } else {
+        if (mesh.materials_.empty()) {
+            utility::LogWarning("No material found for triangle mesh, "
+                    "creating default material");
+        } else {
+            // Search for Texture or DefaultMaterial
+            // otherwise use the first material
+            auto material_it = std::find_if(
+                    mesh.materials_.begin(), mesh.materials_.end(),
+                    [](const auto& mat_name_pair){
+                return mat_name_pair.first == "Texture";
+            });
+            if (material_it == mesh.materials_.end()) {
+                material_it = std::find_if(
+                        mesh.materials_.begin(), mesh.materials_.end(),
+                        [](const auto& mat_name_pair){
+                    return mat_name_pair.first == "DefaultMaterial";
+                });
+                if (material_it == mesh.materials_.end()) {
+                    material_it = mesh.materials_.begin();
+                }
+            }
+            std::pair<std::string, geometry::TriangleMesh::Material> mat =
+                    *material_it;
+            add_mesh_with_material(mesh, name, mat.second, mat.first);
+        }
+    }
+}
+
+TriangleMeshModel TriangleMeshModel::FromTriangleMesh(
+        const geometry::TriangleMesh &mesh,
+        const std::string &name) {
+    TriangleMeshModel out;
+    out.AddMesh(mesh, name);
+    return out;
+}
+
+}  // namespace rendering
+}  // namespace visualization
+}  // namespace open3d

--- a/cpp/open3d/visualization/rendering/Model.h
+++ b/cpp/open3d/visualization/rendering/Model.h
@@ -23,6 +23,12 @@ struct TriangleMeshModel {
 
     std::vector<MeshInfo> meshes_;
     std::vector<visualization::rendering::MaterialRecord> materials_;
+
+    void AddMesh(const geometry::TriangleMesh& mesh, const std::string& name);
+
+    static TriangleMeshModel FromTriangleMesh(
+            const geometry::TriangleMesh& mesh,
+            const std::string& name = "Mesh");
 };
 
 }  // namespace rendering

--- a/cpp/open3d/visualization/rendering/Model.h
+++ b/cpp/open3d/visualization/rendering/Model.h
@@ -24,8 +24,26 @@ struct TriangleMeshModel {
     std::vector<MeshInfo> meshes_;
     std::vector<visualization::rendering::MaterialRecord> materials_;
 
+    /**
+     * Breaks a mesh into separate #MeshInfo structures and add them to the
+     * TriangleMeshModel based on the material assigned to each triangle using
+     * the mesh's geometry::TriangleMesh#triangle_matrial_ids_. A
+     * geometry::TriangleMesh where
+     * geometry::TriangleMesh#triangle_material_ids_ is empty will just be
+     * copied
+     * @param mesh The mesh to be broken apart and added to the model
+     * @param name The base name of the mesh to be used for the generated
+     * #MeshInfo objects
+     */
     void AddMesh(const geometry::TriangleMesh& mesh, const std::string& name);
 
+    /**
+     * Helper function to create a TriangleMeshModel from a TriangleMesh
+     * @see AddMesh()
+     * @param mesh The mesh to break apart from
+     * @param name The name of the mesh to be used in the #MeshInfo struct
+     * @return The constructed TriangleMeshModel struct
+     */
     static TriangleMeshModel FromTriangleMesh(
             const geometry::TriangleMesh& mesh,
             const std::string& name = "Mesh");

--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
@@ -941,11 +941,24 @@ struct O3DVisualizer::Impl {
 
             // Finally assign material properties if geometry is a triangle mesh
             if (tmesh && tmesh->materials_.size() > 0) {
-                // Only a single material is supported for TriangleMesh so we
-                // just grab the first one we find. Users should be using
-                // TriangleMeshModel if they have a model with multiple
-                // materials.
-                auto &mesh_material = tmesh->materials_.begin()->second;
+                std::size_t material_index;
+                if (tmesh->HasTriangleMaterialIds()) {
+                    auto minmax_it = std::minmax_element(
+                            tmesh->triangle_material_ids_.begin(),
+                            tmesh->triangle_material_ids_.end());
+                    if (*minmax_it.first != *minmax_it.second) {
+                        utility::LogWarning(
+                                "Only a single material is "
+                                "supported for TriangleMesh visualization, "
+                                "only the first referenced material will be "
+                                "used. Use TriangleMeshModel if more than one "
+                                "material is required.");
+                    }
+                    material_index = *minmax_it.first;
+                } else {
+                    material_index = 0;
+                }
+                auto &mesh_material = tmesh->materials_[material_index].second;
                 mat.base_color = {mesh_material.baseColor.r(),
                                   mesh_material.baseColor.g(),
                                   mesh_material.baseColor.b(),

--- a/cpp/pybind/io/class_io.cpp
+++ b/cpp/pybind/io/class_io.cpp
@@ -245,6 +245,17 @@ void pybind_class_io(py::module &m_io) {
     docstring::FunctionDocInject(m_io, "read_triangle_model",
                                  map_shared_argument_docstrings);
 
+    m_io.def(
+            "write_triangle_model",
+            [](const std::string &filename,
+               const geometry::TriangleMesh &mesh) {
+                py::gil_scoped_release release;
+                return WriteTriangleMesh(filename, mesh, );
+            },
+            "Function to write TriangleMesh to file", "filename"_a, "mesh"_a);
+    docstring::FunctionDocInject(m_io, "write_triangle_mesh",
+                                 map_shared_argument_docstrings);
+
     // open3d::geometry::VoxelGrid
     m_io.def(
             "read_voxel_grid",

--- a/cpp/pybind/visualization/rendering/rendering.cpp
+++ b/cpp/pybind/visualization/rendering/rendering.cpp
@@ -389,6 +389,13 @@ void pybind_rendering_classes(py::module &m) {
     tri_model.def(py::init<>())
             .def_readwrite("meshes", &TriangleMeshModel::meshes_)
             .def_readwrite("materials", &TriangleMeshModel::materials_);
+    tri_model.def("add_mesh", &TriangleMeshModel::AddMesh,
+                  "Adds a mesh to an existing model and breaks it into "
+                  "separate meshes based on the material index per triangle");
+    tri_model.def_static("from_triangle_mesh",
+                         &TriangleMeshModel::FromTriangleMesh,
+                         "Creates a model by splitting a mesh apart based on "
+                         "the material index per triangle");
 
     // ---- ColorGradingParams ---
     py::class_<ColorGradingParams> color_grading(

--- a/cpp/tests/t/geometry/TriangleMesh.cpp
+++ b/cpp/tests/t/geometry/TriangleMesh.cpp
@@ -500,11 +500,8 @@ TEST_P(TriangleMeshPermuteDevices, ToLegacy) {
                                   Pointwise(FloatEq(), {1.0, 1.1})}));
 
     auto mat_iterator = std::find_if(
-            legacy_mesh.materials_.begin(),
-            legacy_mesh.materials_.end(),
-            [](const auto& pair)->bool{
-                return pair.first == "Mat1";
-    });
+            legacy_mesh.materials_.begin(), legacy_mesh.materials_.end(),
+            [](const auto& pair) -> bool { return pair.first == "Mat1"; });
     EXPECT_TRUE(mat_iterator != legacy_mesh.materials_.end());
     auto& mat = mat_iterator->second;
     EXPECT_TRUE(Eigen::Vector4f(mat.baseColor.f4) ==

--- a/cpp/tests/t/geometry/TriangleMesh.cpp
+++ b/cpp/tests/t/geometry/TriangleMesh.cpp
@@ -394,7 +394,9 @@ TEST_P(TriangleMeshPermuteDevices, FromLegacy) {
             Eigen::Vector2d(0.4, 0.5), Eigen::Vector2d(0.6, 0.7),
             Eigen::Vector2d(0.8, 0.9), Eigen::Vector2d(1.0, 1.1)};
 
-    auto& mat = legacy_mesh.materials_["Mat1"];
+    legacy_mesh.materials_.emplace_back();
+    legacy_mesh.materials_.front().first = "Mat1";
+    auto& mat = legacy_mesh.materials_.front().second;
     mat.baseColor = mat.baseColor.CreateRGB(1, 1, 1);
 
     core::Dtype float_dtype = core::Float32;
@@ -497,8 +499,14 @@ TEST_P(TriangleMeshPermuteDevices, ToLegacy) {
                                   Pointwise(FloatEq(), {0.8, 0.9}),
                                   Pointwise(FloatEq(), {1.0, 1.1})}));
 
-    EXPECT_TRUE(legacy_mesh.materials_.count("Mat1") > 0);
-    auto& mat = legacy_mesh.materials_["Mat1"];
+    auto mat_iterator = std::find_if(
+            legacy_mesh.materials_.begin(),
+            legacy_mesh.materials_.end(),
+            [](const auto& pair)->bool{
+                return pair.first == "Mat1";
+    });
+    EXPECT_TRUE(mat_iterator != legacy_mesh.materials_.end());
+    auto& mat = mat_iterator->second;
     EXPECT_TRUE(Eigen::Vector4f(mat.baseColor.f4) ==
                 Eigen::Vector4f(1, 1, 1, 1));
     EXPECT_TRUE(mat.baseMetallic == 0.0);

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -27,6 +27,8 @@ macro(open3d_add_example EXAMPLE_CPP_NAME)
     list(APPEND EXAMPLE_TARGETS ${EXAMPLE_CPP_NAME})
 endmacro()
 
+open3d_add_example(TestGLTF)
+
 open3d_add_example(CameraPoseTrajectory)
 open3d_add_example(ColorMapOptimization)
 open3d_add_example(DepthCapture)

--- a/examples/cpp/TestGLTF.cpp
+++ b/examples/cpp/TestGLTF.cpp
@@ -1,0 +1,17 @@
+//
+// Created by Daniel Simon on 2/27/23.
+//
+
+#include <open3d/Open3D.h>
+#include <open3d/io/ModelIO.h>
+
+int main(int argc, char** argv) {
+    open3d::utility::SetVerbosityLevel(open3d::utility::VerbosityLevel::Debug);
+    open3d::visualization::rendering::TriangleMeshModel mesh_model;
+    if (!open3d::io::ReadTriangleModel(argv[1], mesh_model, {})) {
+        open3d::utility::LogError("Could not read {}", argv[1]);
+    }
+    if (!open3d::io::WriteTriangleMeshModelToGLTF(argv[2], mesh_model)) {
+        open3d::utility::LogError("Could not write {}", argv[2]);
+    }
+}

--- a/examples/cpp/TestGLTF.cpp
+++ b/examples/cpp/TestGLTF.cpp
@@ -11,7 +11,7 @@ int main(int argc, char** argv) {
     if (!open3d::io::ReadTriangleModel(argv[1], mesh_model, {})) {
         open3d::utility::LogError("Could not read {}", argv[1]);
     }
-    if (!open3d::io::WriteTriangleMeshModelToGLTF(argv[2], mesh_model)) {
+    if (!open3d::io::WriteTriangleModelToGLTF(argv[2], mesh_model)) {
         open3d::utility::LogError("Could not write {}", argv[2]);
     }
 }


### PR DESCRIPTION
The GLTF exporter does not currently support textured meshes. This is because Open3d's per triangle UV coordinates makes the task non-trivial. This change set adds that feature.
Note: this depends on #5938 which changes how textures are stored in an `open3d::geometry::TriangleMesh`

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [x] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

The current GLTF exporter does not support textured meshes. This PR adds an exporter for TriangleMeshModels. Currently there is only a reader. It does not add support to the existing writer.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->

Code was added to create TriangleMeshModels from a TriangleMesh. This isn't a simple conversion because TriangleMesh's support multiple materials, assigned on a per triangle basis. However TriangleMeshModels are supposed to only have one material per mesh. There is a similar issue for the export of the meshes. TriangleMesh's store texture coordinates on a per triangle basis. This is to support seams where the same vertex has different texture coordinates. However GLTF requires texture coordinates to be stored on a per vertex basis. So this PR adds a function to convert a mesh to have per-vertex texture coordinates. Currently this function is in a detail namespace but could be moved to a public API.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/6101)
<!-- Reviewable:end -->
