### PR TITLE
Fix the pybind reference bug of get_view_control()

### DIFF
--- a/cpp/open3d/visualization/visualizer/Visualizer.h
+++ b/cpp/open3d/visualization/visualizer/Visualizer.h
@@ -173,7 +173,6 @@ public:
 
     /// Function to retrieve the associated ViewControl
     ViewControl &GetViewControl() { return *view_control_ptr_; }
-    const ViewControl &GetViewControl() const { return *view_control_ptr_; }
     /// Function to retrieve the associated RenderOption.
     RenderOption &GetRenderOption() { return *render_option_ptr_; }
     /// \brief Function to capture screen and store RGB in a float buffer.

--- a/cpp/pybind/visualization/visualizer.cpp
+++ b/cpp/pybind/visualization/visualizer.cpp
@@ -93,11 +93,9 @@ void pybind_visualizer(py::module &m) {
                  "reset_bounding_box"_a = true)
             .def("clear_geometries", &Visualizer::ClearGeometries,
                  "Function to clear geometries from the visualizer")
-            .def(
-                    "get_view_control",
-                    [](Visualizer &vis) { return vis.GetViewControl(); },
-                    "Function to retrieve the associated ``ViewControl``",
-                    py::return_value_policy::reference_internal)
+            .def("get_view_control", &Visualizer::GetViewControl,
+                 "Function to retrieve the associated ``ViewControl``",
+                 py::return_value_policy::reference_internal)
             .def("get_render_option", &Visualizer::GetRenderOption,
                  "Function to retrieve the associated ``RenderOption``",
                  py::return_value_policy::reference_internal)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #6009 
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

Resolves the issue reported in #6009  that `Visualizer.get_view_control()` is expected to return a reference but it actually returns a copy, this problem does not exist in older versions of Open3D.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description
Updated the pybind code and fixed the reference issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/6116)
<!-- Reviewable:end -->
