### PR TITLE
SimplifyQuadricDecimation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fix raycasting scene: Allow setting of number of threads that are used for building a raycasting scene
 * Fix Python bindings for CUDA device synchronization, voxel grid saving (PR #5425)
 * Support msgpack versions without cmake
+* Fix some bad triangle generation in TriangleMesh::SimplifyQuadricDecimation
 
 ## 0.13
 

--- a/cpp/open3d/geometry/TriangleMeshSimplification.cpp
+++ b/cpp/open3d/geometry/TriangleMeshSimplification.cpp
@@ -311,6 +311,11 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SimplifyQuadricDecimation(
         AddPerpPlaneQuadric(tria(2), tria(0), tria(1), area);
     }
 
+    // Clear the unused vectors to save some memory
+    triangle_areas.clear();
+    triangle_planes.clear();
+    edge_triangle_count.clear();
+
     // Get valid edges and compute cost
     // Note: We could also select all vertex pairs as edges with dist < eps
     std::unordered_map<Eigen::Vector2i, Eigen::Vector3d,

--- a/cpp/open3d/geometry/TriangleMeshSimplification.cpp
+++ b/cpp/open3d/geometry/TriangleMeshSimplification.cpp
@@ -400,10 +400,8 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SimplifyQuadricDecimation(
         // avoid flip of triangle normal and creation of degenerate triangles
         bool creates_invalid_triangle = false;
         const double degenerate_ratio_threshold = 0.001;
-        std::unordered_set<Eigen::Vector2i,
-                           utility::hash_eigen<Eigen::Vector2i>>
-                edges{};
-        for (int vidx : {vidx0, vidx1}) {
+        std::unordered_map<int, int> edges{};
+        for (int vidx : {vidx1, vidx0}) {
             for (int tidx : vert_to_triangles[vidx]) {
                 if (triangles_deleted[tidx]) {
                     continue;
@@ -418,34 +416,26 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SimplifyQuadricDecimation(
                     continue;
                 }
 
-                Eigen::Vector3d vert0 = mesh->vertices_[tria(0)];
-                Eigen::Vector3d vert1 = mesh->vertices_[tria(1)];
-                Eigen::Vector3d vert2 = mesh->vertices_[tria(2)];
+                Eigen::Vector3d verts[3] = {mesh->vertices_[tria(0)],
+                                            mesh->vertices_[tria(1)],
+                                            mesh->vertices_[tria(2)]};
                 Eigen::Vector3d norm_before =
-                        (vert1 - vert0).cross(vert2 - vert0);
+                        (verts[1] - verts[0]).cross(verts[2] - verts[0]);
                 const double area_before = 0.5 * norm_before.norm();
                 norm_before /= norm_before.norm();
 
-                auto sort_edges = [](auto a, auto b) {
-                    const auto minmax = std::minmax(a, b);
-                    return Eigen::Vector2i(std::get<0>(minmax),
-                                           std::get<1>(minmax));
-                };
-                const std::size_t old_edges_size = edges.size();
-                if (vidx == tria(0)) {
-                    vert0 = vbar;
-                    edges.insert(sort_edges(tria(1), tria(2)));
-                } else if (vidx == tria(1)) {
-                    vert1 = vbar;
-                    edges.insert(sort_edges(tria(0), tria(2)));
-                } else if (vidx == tria(2)) {
-                    vert2 = vbar;
-                    edges.insert(sort_edges(tria(0), tria(1)));
+                for (auto i = 0; i < 3; ++i) {
+                    if (tria(i) == vidx) {
+                        verts[i] = vbar;
+                        continue;
+                    }
+                    auto& vert_count = edges[tria(i)];
+                    creates_invalid_triangle |= vert_count >= 2;
+                    vert_count += 1;
                 }
-                creates_invalid_triangle |= edges.size() == old_edges_size;
 
                 Eigen::Vector3d norm_after =
-                        (vert1 - vert0).cross(vert2 - vert0);
+                        (verts[1] - verts[0]).cross(verts[2] - verts[0]);
                 const double area_after = 0.5 * norm_after.norm();
                 norm_after /= norm_after.norm();
                 // Disallow flipping the triangle normal


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
The existing Quadric Error Decimation code could create some faulty meshes under certain circumstances
- Flipped Triangles - There is a check to prevent flipped triangles but it doesnt apply to all the relevant triangles
- Degenerate Triangles - Triangles with 3 colinear points can be created, particularly when the existing vertices are arranged in a grid
- Non-manifold edges - In some circumstances an edge collapse could create two equal triangles with opposite normals (ie back to back).

This PR fixes these three issues and clears a few vectors once they are finished being used to save a little memory.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/6163)
<!-- Reviewable:end -->
