### PR TITLE
Normal orientation issues in complex geometries

### DIFF
--- a/cpp/open3d/geometry/EstimateNormals.cpp
+++ b/cpp/open3d/geometry/EstimateNormals.cpp
@@ -8,7 +8,6 @@
 #include <Eigen/Eigenvalues>
 #include <queue>
 #include <tuple>
-#include <iostream>
 
 #include "open3d/geometry/KDTreeFlann.h"
 #include "open3d/geometry/PointCloud.h"
@@ -519,7 +518,6 @@ void PointCloud::OrientNormalsConsistentTangentPlane(size_t k, const double lamb
             n1 *= -1;
         }
     };
-    std::cout << "Procedo con tangenti NUOVE open3D" << std::endl;
     TestAndOrientNormal(Eigen::Vector3d(0, 0, -1), normals_[v0]);
     while (!traversal_queue.empty()) {
         v0 = traversal_queue.front();

--- a/cpp/open3d/geometry/EstimateNormals.cpp
+++ b/cpp/open3d/geometry/EstimateNormals.cpp
@@ -496,13 +496,15 @@ void PointCloud::OrientNormalsConsistentTangentPlane(size_t k, const double lamb
     }
 
     // find start node for tree traversal
-    // init with node that maximizes z
-    double max_z = std::numeric_limits<double>::lowest();
+    // init with node that maximizes z 
+
+    //change minimize instead of maximize
+    double min_z = std::numeric_limits<double>::max();
     size_t v0 = 0;
     for (size_t vidx = 0; vidx < points_.size(); ++vidx) {
         const Eigen::Vector3d &v = points_[vidx];
-        if (v(2) > max_z) {
-            max_z = v(2);
+        if (v(2) < min_z) {
+            min_z = v(2);
             v0 = vidx;
         }
     }
@@ -518,7 +520,7 @@ void PointCloud::OrientNormalsConsistentTangentPlane(size_t k, const double lamb
         }
     };
     std::cout << "Procedo con tangenti NUOVE open3D" << std::endl;
-    TestAndOrientNormal(Eigen::Vector3d(0, 0, 1), normals_[v0]);
+    TestAndOrientNormal(Eigen::Vector3d(0, 0, -1), normals_[v0]);
     while (!traversal_queue.empty()) {
         v0 = traversal_queue.front();
         traversal_queue.pop();

--- a/cpp/open3d/geometry/PointCloud.h
+++ b/cpp/open3d/geometry/PointCloud.h
@@ -251,7 +251,7 @@ public:
     ///
     /// \param k k nearest neighbour for graph reconstruction for normal
     /// propagation.
-    void OrientNormalsConsistentTangentPlane(size_t k);
+    void OrientNormalsConsistentTangentPlane(size_t k, const double lambda = 0, const double cos_alpha_tol = 1);
 
     /// \brief Function to compute the point to point distances between point
     /// clouds.

--- a/cpp/open3d/geometry/PointCloud.h
+++ b/cpp/open3d/geometry/PointCloud.h
@@ -248,10 +248,18 @@ public:
     /// \brief Function to consistently orient estimated normals based on
     /// consistent tangent planes as described in Hoppe et al., "Surface
     /// Reconstruction from Unorganized Points", 1992.
+    /// Further details on parameters are described in
+    /// Piazza, Valentini, Varetti, "Mesh Reconstruction from Point Cloud",
+    /// 2023.
     ///
     /// \param k k nearest neighbour for graph reconstruction for normal
     /// propagation.
-    void OrientNormalsConsistentTangentPlane(size_t k, const double lambda = 0.0, const double cos_alpha_tol = 1.0);
+    /// \param lambda penalty constant on the distance of a point from the
+    /// tangent plane \param cos_alpha_tol treshold that defines the amplitude
+    /// of the cone spanned by the reference normal
+    void OrientNormalsConsistentTangentPlane(size_t k,
+                                             const double lambda = 0.0,
+                                             const double cos_alpha_tol = 1.0);
 
     /// \brief Function to compute the point to point distances between point
     /// clouds.

--- a/cpp/open3d/geometry/PointCloud.h
+++ b/cpp/open3d/geometry/PointCloud.h
@@ -251,7 +251,7 @@ public:
     ///
     /// \param k k nearest neighbour for graph reconstruction for normal
     /// propagation.
-    void OrientNormalsConsistentTangentPlane(size_t k, const double lambda = 0, const double cos_alpha_tol = 1);
+    void OrientNormalsConsistentTangentPlane(size_t k, const double lambda = 0.0, const double cos_alpha_tol = 1.0);
 
     /// \brief Function to compute the point to point distances between point
     /// clouds.

--- a/cpp/open3d/t/geometry/PointCloud.cpp
+++ b/cpp/open3d/t/geometry/PointCloud.cpp
@@ -695,12 +695,15 @@ void PointCloud::OrientNormalsTowardsCameraLocation(
     }
 }
 
-void PointCloud::OrientNormalsConsistentTangentPlane(size_t k) {
+void PointCloud::OrientNormalsConsistentTangentPlane(
+        size_t k,
+        const double lambda /* = 0.0*/,
+        const double cos_alpha_tol /* = 1.0*/) {
     PointCloud tpcd(GetPointPositions());
     tpcd.SetPointNormals(GetPointNormals());
 
     open3d::geometry::PointCloud lpcd = tpcd.ToLegacy();
-    lpcd.OrientNormalsConsistentTangentPlane(k);
+    lpcd.OrientNormalsConsistentTangentPlane(k, lambda, cos_alpha_tol);
 
     SetPointNormals(core::eigen_converter::EigenVector3dVectorToTensor(
             lpcd.normals_, GetPointPositions().GetDtype(), GetDevice()));

--- a/cpp/open3d/t/geometry/PointCloud.h
+++ b/cpp/open3d/t/geometry/PointCloud.h
@@ -517,10 +517,18 @@ public:
     /// \brief Function to consistently orient estimated normals based on
     /// consistent tangent planes as described in Hoppe et al., "Surface
     /// Reconstruction from Unorganized Points", 1992.
+    /// Further details on parameters are described in
+    /// Piazza, Valentini, Varetti, "Mesh Reconstruction from Point Cloud",
+    /// 2023.
     ///
     /// \param k k nearest neighbour for graph reconstruction for normal
     /// propagation.
-    void OrientNormalsConsistentTangentPlane(size_t k);
+    /// \param lambda penalty constant on the distance of a point from the
+    /// tangent plane \param cos_alpha_tol treshold that defines the amplitude
+    /// of the cone spanned by the reference normal
+    void OrientNormalsConsistentTangentPlane(size_t k,
+                                             const double lambda = 0.0,
+                                             const double cos_alpha_tol = 1.0);
 
     /// \brief Function to compute point color gradients. If radius is provided,
     /// then HybridSearch is used, otherwise KNN-Search is used.

--- a/cpp/pybind/geometry/pointcloud.cpp
+++ b/cpp/pybind/geometry/pointcloud.cpp
@@ -139,9 +139,7 @@ void pybind_pointcloud(py::module &m) {
                  &PointCloud::OrientNormalsConsistentTangentPlane,
                  "Function to orient the normals with respect to consistent "
                  "tangent planes",
-                 "k"_a,
-                 "lambda"_a = 0.0,
-                 "cos_alpha_tol"_a = 1.0)
+                 "k"_a, "lambda"_a = 0.0, "cos_alpha_tol"_a = 1.0)
             .def("compute_point_cloud_distance",
                  &PointCloud::ComputePointCloudDistance,
                  "For each point in the source point cloud, compute the "

--- a/cpp/pybind/geometry/pointcloud.cpp
+++ b/cpp/pybind/geometry/pointcloud.cpp
@@ -139,7 +139,9 @@ void pybind_pointcloud(py::module &m) {
                  &PointCloud::OrientNormalsConsistentTangentPlane,
                  "Function to orient the normals with respect to consistent "
                  "tangent planes",
-                 "k"_a,"lambda"_a,"cos_alpha_tol"_a)
+                 "k"_a,
+                 "lambda"_a = 0.0,
+                 "cos_alpha_tol"_a = 1.0)
             .def("compute_point_cloud_distance",
                  &PointCloud::ComputePointCloudDistance,
                  "For each point in the source point cloud, compute the "

--- a/cpp/pybind/geometry/pointcloud.cpp
+++ b/cpp/pybind/geometry/pointcloud.cpp
@@ -139,7 +139,7 @@ void pybind_pointcloud(py::module &m) {
                  &PointCloud::OrientNormalsConsistentTangentPlane,
                  "Function to orient the normals with respect to consistent "
                  "tangent planes",
-                 "k"_a,"lamda"_a,"cos_alpha_tol"_a)
+                 "k"_a,"lambda"_a,"cos_alpha_tol"_a)
             .def("compute_point_cloud_distance",
                  &PointCloud::ComputePointCloudDistance,
                  "For each point in the source point cloud, compute the "

--- a/cpp/pybind/geometry/pointcloud.cpp
+++ b/cpp/pybind/geometry/pointcloud.cpp
@@ -139,7 +139,7 @@ void pybind_pointcloud(py::module &m) {
                  &PointCloud::OrientNormalsConsistentTangentPlane,
                  "Function to orient the normals with respect to consistent "
                  "tangent planes",
-                 "k"_a)
+                 "k"_a,"lamda"_a,"cos_alpha_tol"_a)
             .def("compute_point_cloud_distance",
                  &PointCloud::ComputePointCloudDistance,
                  "For each point in the source point cloud, compute the "

--- a/cpp/pybind/t/geometry/pointcloud.cpp
+++ b/cpp/pybind/t/geometry/pointcloud.cpp
@@ -304,21 +304,37 @@ Return:
             "orient_normals_consistent_tangent_plane",
             &PointCloud::OrientNormalsConsistentTangentPlane, "k"_a,
             "lambda"_a = 0.0, "cos_alpha_tol"_a = 1.0,
-            R"(Function to consistently orient the normals of a point cloud based on tangent planes
-                   as described in Hoppe et al., "Surface Reconstruction from Unorganized Points", 1992. 
-                   Additional information about the choice of lambda and cos_alpha_tol for complex point clouds
-                   can be found in Piazza, Valentini, Varetti, "Mesh Reconstruction from Point Cloud", 2023 (https://eugeniovaretti.github.io/meshreco/Piazza_Valentini_Varetti_MeshReconstructionFromPointCloud_2023.pdf).
+            R"(Function to consistently orient the normals of a point cloud based on tangent planes.
+
+The algorithm is described in Hoppe et al., "Surface Reconstruction from Unorganized Points", 1992. 
+Additional information about the choice of lambda and cos_alpha_tol for complex
+point clouds can be found in Piazza, Valentini, Varetti, "Mesh Reconstruction from Point Cloud", 2023 
+(https://eugeniovaretti.github.io/meshreco/Piazza_Valentini_Varetti_MeshReconstructionFromPointCloud_2023.pdf).
+
 Args:
-    k. Number of neighbors to use for tangent plane estimation.
-    lambda. A non-negative real parameter that influences the distance metric used to identify the true neighbors of a point in complex geometries. It penalizes the distance between a point and the tangent plane defined by the reference point and its normal vector, helping to mitigate misclassification issues encountered with traditional Euclidean distance metrics.
-    cos_alpha_tol. Cosine threshold angle used to determine the inclusion boundary of neighbors based on the direction of the normal vector.
+    k (int): Number of neighbors to use for tangent plane estimation.
+    lambda (float): A non-negative real parameter that influences the distance 
+        metric used to identify the true neighbors of a point in complex 
+        geometries. It penalizes the distance between a point and the tangent 
+        plane defined by the reference point and its normal vector, helping to 
+        mitigate misclassification issues encountered with traditional 
+        Euclidean distance metrics.
+    cos_alpha_tol (float): Cosine threshold angle used to determine the 
+        inclusion boundary of neighbors based on the direction of the normal 
+        vector.
 
 Example:
-    We use Bunny point cloud to compute its normals and orient them consistently. The initial reconstruction adheres to Hoppe's algorithm (raw), 
-    whereas the second reconstruction utilises the lambda and cos_alpha_tol parameters.
-    Due to the high density of the Bunny point cloud available in Open3D a larger value of the parameter k is employed to test the algorithm.
-    Usually you do not have at disposal such a refined point clouds, thus you cannot find a proper choice of k: refer to https://eugeniovaretti.github.io/meshreco for these cases.
+    We use Bunny point cloud to compute its normals and orient them consistently.
+    The initial reconstruction adheres to Hoppe's algorithm (raw), whereas the 
+    second reconstruction utilises the lambda and cos_alpha_tol parameters. 
+    Due to the high density of the Bunny point cloud available in Open3D a larger
+    value of the parameter k is employed to test the algorithm.  Usually you do 
+    not have at disposal such a refined point clouds, thus you cannot find a 
+    proper choice of k: refer to 
+    https://eugeniovaretti.github.io/meshreco for these cases.::
 
+        import open3d as o3d
+        import numpy as np
         # Load point cloud
         data = o3d.data.BunnyMesh()
 
@@ -346,8 +362,8 @@ Example:
         poisson_mesh_robust = o3d.geometry.TriangleMesh.create_from_point_cloud_poisson(pcd_robust, depth=8, width=0, scale=1.1, linear_fit=False)[0]
         poisson_mesh_robust.paint_uniform_color(np.array([[0.5],[0.5],[0.5]]))
         poisson_mesh_robust.compute_vertex_normals()
-        o3d.visualization.draw_geometries([poisson_mesh_robust])");
 
+        o3d.visualization.draw_geometries([poisson_mesh_robust]) )");
     pointcloud.def(
             "estimate_color_gradients", &PointCloud::EstimateColorGradients,
             py::call_guard<py::gil_scoped_release>(), py::arg("max_nn") = 30,
@@ -633,11 +649,6 @@ Example:
             m, "PointCloud", "orient_normals_towards_camera_location",
             {{"camera_location",
               "Normals are oriented with towards the camera_location."}});
-    docstring::ClassMethodDocInject(
-            m, "PointCloud", "orient_normals_consistent_tangent_plane",
-            {{"k",
-              "Number of k nearest neighbors used in constructing the "
-              "Riemannian graph used to propagate normal orientation."}});
     docstring::ClassMethodDocInject(
             m, "PointCloud", "crop",
             {{"aabb", "AxisAlignedBoundingBox to crop points."},

--- a/cpp/pybind/t/geometry/pointcloud.cpp
+++ b/cpp/pybind/t/geometry/pointcloud.cpp
@@ -304,7 +304,7 @@ Return:
                    &PointCloud::OrientNormalsConsistentTangentPlane,
                    "Function to orient the normals with respect to consistent "
                    "tangent planes.",
-                   "k"_a);
+                   "k"_a, "lambda"_a = 0.0, "cos_alpha_tol"_a = 1.0);
     pointcloud.def(
             "estimate_color_gradients", &PointCloud::EstimateColorGradients,
             py::call_guard<py::gil_scoped_release>(), py::arg("max_nn") = 30,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [x] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
While exploring existing algorithms for creating meshes from point clouds, we came across Open3D. We noticed that one of the test point clouds we had available failed to reconstruct the mesh using the normal estimation method. We investigated and studied the library regarding the methods we used, and consequently identified some weaknesses in the algorithm.

Our work is documented in [this report](https://eugeniovaretti.github.io/meshreco/Piazza_Valentini_Varetti_MeshReconstructionFromPointCloud_2023.pdf).

Given an input point cloud, the algorithm processes the data primarily based on Euclidean distance, using the K-nearest neighbors (KNN) algorithm as a basis. In the case of specific geometries, this can be problematic when orienting two distinct surfaces of the same volume that should have opposite orientations (e.g., cusps, stenosis, etc.).

Therefore, we provide the user with the ability to manipulate two parameters in the `OrientNormalsConsistentTangentPlane` function (or `orient_normals_consisten_tangent_plane` in Python), namely `lambda` and `cos_alpha_tol`, which respectively allow for a penalty and a threshold on the distance of a point x from the plane defined by a point z and its estimated normal $n_z$ (calculated in the `EstimateNormal` method).

All the work is documented in the report.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [x] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [x] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
Below we show some of the results and improvements that follow from this modification. By using the default values for the (new) parameters, no macroscopic changes will be applied to the original algorithm.
Only a minor modification has been made to the code, specifically the initial point of `traversal_queue`.
All the details and motivations are provided in the report.

## Original Algorithm:
![image](https://github.com/isl-org/Open3D/assets/100780180/0196874d-fa93-442b-b8c2-9a527f653a7f)

## Our changes: 
![image](https://github.com/isl-org/Open3D/assets/100780180/a83a26ba-d10e-40f1-b8b2-7a1e292204b4)

## Differences:
![image](https://github.com/isl-org/Open3D/assets/100780180/666c3608-03c6-4e20-a3c3-eee3f4abe718)

## Unit Tests
All unit tests related to our modifications (PointCloud*) have passed successfully.

![image](https://github.com/isl-org/Open3D/assets/100780180/f767e378-477d-49d2-9ee6-5ef11dd3739d)

## Authors
This pull request is the culmination of exceptional teamwork within an outstanding team, including @SimonePiazza99 and @federicavalentini99.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/6198)
<!-- Reviewable:end -->
