### PR TITLE
Allow setting view status from json string

### DIFF
--- a/cpp/open3d/visualization/visualizer/Visualizer.h
+++ b/cpp/open3d/visualization/visualizer/Visualizer.h
@@ -209,10 +209,17 @@ public:
                                 bool do_render = true,
                                 bool convert_to_world_coordinate = false);
     void CaptureRenderOption(const std::string &filename = "");
+
     /// Function to reset view point.
     void ResetViewPoint(bool reset_bounding_box = false);
 
     const std::string &GetWindowName() const { return window_name_; }
+
+    /// Get the current view status as a json string of ViewTrajectory.
+    std::string GetViewStatus();
+
+    /// Set the current view status from a json string of ViewTrajectory.
+    void SetViewStatus(const std::string &view_status_str);
 
 protected:
     /// Function to initialize OpenGL
@@ -229,11 +236,13 @@ protected:
     /// meshes individually).
     virtual void Render(bool render_screen = false);
 
+    /// Copy the current view status to clipboard.
     void CopyViewStatusToClipboard();
 
+    /// Apply the view point from clipboard.
     void CopyViewStatusFromClipboard();
 
-    // callback functions
+    /// Callback functions
     virtual void WindowRefreshCallback(GLFWwindow *window);
     virtual void WindowResizeCallback(GLFWwindow *window, int w, int h);
     virtual void MouseMoveCallback(GLFWwindow *window, double x, double y);

--- a/cpp/pybind/visualization/visualizer.cpp
+++ b/cpp/pybind/visualization/visualizer.cpp
@@ -117,7 +117,14 @@ void pybind_visualizer(py::module &m) {
                  &Visualizer::CaptureDepthPointCloud,
                  "Function to capture and save local point cloud", "filename"_a,
                  "do_render"_a = false, "convert_to_world_coordinate"_a = false)
-            .def("get_window_name", &Visualizer::GetWindowName);
+            .def("get_window_name", &Visualizer::GetWindowName)
+            .def("get_view_status", &Visualizer::GetViewStatus,
+                 "Get the current view status as a json string of "
+                 "ViewTrajectory.")
+            .def("set_view_status", &Visualizer::SetViewStatus,
+                 "Set the current view status from a json string of "
+                 "ViewTrajectory.",
+                 "view_status_str"_a);
 
     py::class_<VisualizerWithKeyCallback,
                PyVisualizer<VisualizerWithKeyCallback>,


### PR DESCRIPTION
This PR allows setting view status from a json string. This allows setting the visualizer to the exact same view points.

Example usage:
1. Launch the Open3D visualizer (legacy)
2. Press ctrl+c to copy the view status as a json string
3. As an example, in a new visualizer, you can use the following code to set the view status
    ```python
    vis = o3d.visualization.Visualizer()
    vis.create_window()
    vis.add_geometry(mesh)
    vis.update_geometry(mesh)
    vis.set_view_status(view_status_str)  # view_status_str is the json string
    vis.poll_events()
    vis.update_renderer()
    buffer = vis.capture_screen_float_buffer()
    vis.destroy_window()
    ```

Changes:
- `Visualizer::CopyViewStatusToClipboard()`: unchanged
- `Visualizer::CopyViewStatusFromClipboard()`: unchanged
- `Visualizer::GetViewStatus()`: added
- `SetViewStatus(const std::string &view_status_str)`: added

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [x] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   (N/A) Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   (N/A) I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/6241)
<!-- Reviewable:end -->
