### PR TITLE
Voxel Downsample for Tensor interface

### DIFF
--- a/cpp/benchmarks/t/geometry/PointCloud.cpp
+++ b/cpp/benchmarks/t/geometry/PointCloud.cpp
@@ -69,7 +69,7 @@ void LegacyVoxelDownSample(benchmark::State& state, float voxel_size) {
 void VoxelDownSample(benchmark::State& state,
                      const core::Device& device,
                      float voxel_size,
-                     const core::HashBackendType& backend) {
+                     const std::string& reduction) {
     t::geometry::PointCloud pcd;
     // t::io::CreatePointCloudFromFile lacks support of remove_inf_points and
     // remove_nan_points
@@ -77,10 +77,10 @@ void VoxelDownSample(benchmark::State& state,
     pcd = pcd.To(device);
 
     // Warm up.
-    pcd.VoxelDownSample(voxel_size, backend);
+    pcd.VoxelDownSample(voxel_size, reduction);
 
     for (auto _ : state) {
-        pcd.VoxelDownSample(voxel_size, backend);
+        pcd.VoxelDownSample(voxel_size, reduction);
         core::cuda::Synchronize(device);
     }
 }
@@ -387,28 +387,34 @@ BENCHMARK_CAPTURE(ToLegacyPointCloud, CUDA, core::Device("CUDA:0"))
         ->Unit(benchmark::kMillisecond);
 #endif
 
-#define ENUM_VOXELSIZE(DEVICE, BACKEND)                                       \
-    BENCHMARK_CAPTURE(VoxelDownSample, BACKEND##_0_01, DEVICE, 0.01, BACKEND) \
-            ->Unit(benchmark::kMillisecond);                                  \
-    BENCHMARK_CAPTURE(VoxelDownSample, BACKEND##_0_02, DEVICE, 0.08, BACKEND) \
-            ->Unit(benchmark::kMillisecond);                                  \
-    BENCHMARK_CAPTURE(VoxelDownSample, BACKEND##_0_04, DEVICE, 0.04, BACKEND) \
-            ->Unit(benchmark::kMillisecond);                                  \
-    BENCHMARK_CAPTURE(VoxelDownSample, BACKEND##_0_08, DEVICE, 0.08, BACKEND) \
-            ->Unit(benchmark::kMillisecond);                                  \
-    BENCHMARK_CAPTURE(VoxelDownSample, BACKEND##_0_16, DEVICE, 0.16, BACKEND) \
-            ->Unit(benchmark::kMillisecond);                                  \
-    BENCHMARK_CAPTURE(VoxelDownSample, BACKEND##_0_32, DEVICE, 0.32, BACKEND) \
+#define ENUM_VOXELSIZE(DEVICE, REDUCTION)                              \
+    BENCHMARK_CAPTURE(VoxelDownSample, REDUCTION##_0_01, DEVICE, 0.01, \
+                      REDUCTION)                                       \
+            ->Unit(benchmark::kMillisecond);                           \
+    BENCHMARK_CAPTURE(VoxelDownSample, REDUCTION##_0_02, DEVICE, 0.08, \
+                      REDUCTION)                                       \
+            ->Unit(benchmark::kMillisecond);                           \
+    BENCHMARK_CAPTURE(VoxelDownSample, REDUCTION##_0_04, DEVICE, 0.04, \
+                      REDUCTION)                                       \
+            ->Unit(benchmark::kMillisecond);                           \
+    BENCHMARK_CAPTURE(VoxelDownSample, REDUCTION##_0_08, DEVICE, 0.08, \
+                      REDUCTION)                                       \
+            ->Unit(benchmark::kMillisecond);                           \
+    BENCHMARK_CAPTURE(VoxelDownSample, REDUCTION##_0_16, DEVICE, 0.16, \
+                      REDUCTION)                                       \
+            ->Unit(benchmark::kMillisecond);                           \
+    BENCHMARK_CAPTURE(VoxelDownSample, REDUCTION##_0_32, DEVICE, 0.32, \
+                      REDUCTION)                                       \
             ->Unit(benchmark::kMillisecond);
 
+const std::string kReductionMean = "mean";
 #ifdef BUILD_CUDA_MODULE
-#define ENUM_VOXELDOWNSAMPLE_BACKEND()                                  \
-    ENUM_VOXELSIZE(core::Device("CPU:0"), core::HashBackendType::TBB)   \
-    ENUM_VOXELSIZE(core::Device("CUDA:0"), core::HashBackendType::Slab) \
-    ENUM_VOXELSIZE(core::Device("CUDA:0"), core::HashBackendType::StdGPU)
+#define ENUM_VOXELDOWNSAMPLE_REDUCTION()                  \
+    ENUM_VOXELSIZE(core::Device("CPU:0"), kReductionMean) \
+    ENUM_VOXELSIZE(core::Device("CUDA:0"), kReductionMean)
 #else
-#define ENUM_VOXELDOWNSAMPLE_BACKEND() \
-    ENUM_VOXELSIZE(core::Device("CPU:0"), core::HashBackendType::TBB)
+#define ENUM_VOXELDOWNSAMPLE_REDUCTION() \
+    ENUM_VOXELSIZE(core::Device("CPU:0"), kReductionMean)
 #endif
 
 BENCHMARK_CAPTURE(LegacyVoxelDownSample, Legacy_0_01, 0.01)
@@ -423,7 +429,7 @@ BENCHMARK_CAPTURE(LegacyVoxelDownSample, Legacy_0_16, 0.16)
         ->Unit(benchmark::kMillisecond);
 BENCHMARK_CAPTURE(LegacyVoxelDownSample, Legacy_0_32, 0.32)
         ->Unit(benchmark::kMillisecond);
-ENUM_VOXELDOWNSAMPLE_BACKEND()
+ENUM_VOXELDOWNSAMPLE_REDUCTION()
 
 BENCHMARK_CAPTURE(LegacyUniformDownSample, Legacy_2, 2)
         ->Unit(benchmark::kMillisecond);

--- a/cpp/open3d/core/CMakeLists.txt
+++ b/cpp/open3d/core/CMakeLists.txt
@@ -47,6 +47,8 @@ target_sources(core PRIVATE
     kernel/BinaryEWCPU.cpp
     kernel/IndexGetSet.cpp
     kernel/IndexGetSetCPU.cpp
+    kernel/IndexReduction.cpp
+    kernel/IndexReductionCPU.cpp
     kernel/Kernel.cpp
     kernel/NonZero.cpp
     kernel/NonZeroCPU.cpp
@@ -90,6 +92,7 @@ if (BUILD_CUDA_MODULE)
         kernel/ArangeCUDA.cu
         kernel/BinaryEWCUDA.cu
         kernel/IndexGetSetCUDA.cu
+        kernel/IndexReductionCUDA.cu
         kernel/NonZeroCUDA.cu
         kernel/ReductionCUDA.cu
         kernel/UnaryEWCUDA.cu

--- a/cpp/open3d/core/Tensor.cpp
+++ b/cpp/open3d/core/Tensor.cpp
@@ -958,16 +958,16 @@ void Tensor::IndexSet(const std::vector<Tensor>& index_tensors,
 
 void Tensor::IndexAdd_(const Tensor& index, const Tensor& src) {}
 
-void Tensor::IndexMean_(const Tensor& index, const Tensor& src) {
+void Tensor::IndexSum_(const Tensor& index, const Tensor& src) {
     if (NumDims() != 1 || index.NumDims() != 1 || src.NumDims() != 1) {
-        utility::LogError("IndexMean_ only supports 1D tensors.");
+        utility::LogError("IndexSum_ only supports 1D tensors.");
     }
 
     AssertTensorDtype(index, core::Int64);
     AssertTensorShape(index, src.GetShape());
     AssertTensorDtype(*this, src.GetDtype());
 
-    kernel::IndexMean_(index, src, *this);
+    kernel::IndexSum_(index, src, *this);
 }
 
 void Tensor::IndexMin_(const Tensor& index, const Tensor& src) {}

--- a/cpp/open3d/core/Tensor.cpp
+++ b/cpp/open3d/core/Tensor.cpp
@@ -961,7 +961,7 @@ void Tensor::IndexAdd_(int64_t dim, const Tensor& index, const Tensor& src) {
         utility::LogError("IndexAdd_ only supports 1D index tensors.");
     }
 
-    // dim check
+    // Dim check.
     if (dim < 0) {
         utility::LogError("IndexAdd_ only supports sum at non-negative dim.");
     }
@@ -975,9 +975,6 @@ void Tensor::IndexAdd_(int64_t dim, const Tensor& index, const Tensor& src) {
                 "IndexAdd_ only supports src tensor with same dimension as "
                 "this tensor.");
     }
-
-    utility::LogInfo("src shape = {}, dst_shape = {}", src.GetShape(),
-                     GetShape());
     for (int64_t d = 0; d < NumDims(); ++d) {
         if (d != dim && src.GetShape(d) != GetShape(d)) {
             utility::LogError(
@@ -988,12 +985,11 @@ void Tensor::IndexAdd_(int64_t dim, const Tensor& index, const Tensor& src) {
         }
     }
 
-    // type check
+    // Type check.
     AssertTensorDtype(index, core::Int64);
     AssertTensorDtype(*this, src.GetDtype());
 
-    // Call
-    // Permute dim to the 1st dim for reduction
+    // Apply kernel.
     kernel::IndexAdd_(dim, index, src, *this);
 }
 

--- a/cpp/open3d/core/Tensor.cpp
+++ b/cpp/open3d/core/Tensor.cpp
@@ -22,6 +22,7 @@
 #include "open3d/core/TensorFunction.h"
 #include "open3d/core/TensorKey.h"
 #include "open3d/core/kernel/Arange.h"
+#include "open3d/core/kernel/IndexReduction.h"
 #include "open3d/core/kernel/Kernel.h"
 #include "open3d/core/linalg/Det.h"
 #include "open3d/core/linalg/Inverse.h"
@@ -954,6 +955,24 @@ void Tensor::IndexSet(const std::vector<Tensor>& index_tensors,
     kernel::IndexSet(src_tensor, pre_processed_dst, aip.GetIndexTensors(),
                      aip.GetIndexedShape(), aip.GetIndexedStrides());
 }
+
+void Tensor::IndexAdd_(const Tensor& index, const Tensor& src) {}
+
+void Tensor::IndexMean_(const Tensor& index, const Tensor& src) {
+    if (NumDims() != 1 || index.NumDims() != 1 || src.NumDims() != 1) {
+        utility::LogError("IndexMean_ only supports 1D tensors.");
+    }
+
+    AssertTensorDtype(index, core::Int64);
+    AssertTensorShape(index, src.GetShape());
+    AssertTensorDtype(*this, src.GetDtype());
+
+    kernel::IndexMean_(index, src, *this);
+}
+
+void Tensor::IndexMin_(const Tensor& index, const Tensor& src) {}
+
+void Tensor::IndexMax_(const Tensor& index, const Tensor& src) {}
 
 Tensor Tensor::Permute(const SizeVector& dims) const {
     // Check dimension size

--- a/cpp/open3d/core/Tensor.h
+++ b/cpp/open3d/core/Tensor.h
@@ -584,7 +584,7 @@ public:
     ///
     /// Note: Only support 1D index and src tensors now.
     void IndexAdd_(const Tensor& index, const Tensor& src);
-    void IndexMean_(const Tensor& index, const Tensor& src);
+    void IndexSum_(const Tensor& index, const Tensor& src);
     void IndexMax_(const Tensor& index, const Tensor& src);
     void IndexMin_(const Tensor& index, const Tensor& src);
 

--- a/cpp/open3d/core/Tensor.h
+++ b/cpp/open3d/core/Tensor.h
@@ -575,12 +575,12 @@ public:
     void IndexSet(const std::vector<Tensor>& index_tensors,
                   const Tensor& src_tensor);
 
-    /// \brief In-place advanced reduction by index.
+    /// \brief Advanced in-place reduction by index.
     ///
     /// See
     /// https://pytorch.org/docs/stable/generated/torch.Tensor.index_add_.html
     ///
-    /// self[index[i]] = operator(self[index[i]], src[i])
+    /// self[index[i]] = operator(self[index[i]], src[i]).
     ///
     /// Note: Only support 1D index and src tensors now.
     void IndexAdd_(int64_t dim, const Tensor& index, const Tensor& src);

--- a/cpp/open3d/core/Tensor.h
+++ b/cpp/open3d/core/Tensor.h
@@ -575,6 +575,19 @@ public:
     void IndexSet(const std::vector<Tensor>& index_tensors,
                   const Tensor& src_tensor);
 
+    /// \brief In-place advanced reduction by index.
+    ///
+    /// See
+    /// https://pytorch.org/docs/stable/generated/torch.Tensor.index_add_.html
+    ///
+    /// self[index[i]] = operator(self[index[i]], src[i])
+    ///
+    /// Note: Only support 1D index and src tensors now.
+    void IndexAdd_(const Tensor& index, const Tensor& src);
+    void IndexMean_(const Tensor& index, const Tensor& src);
+    void IndexMax_(const Tensor& index, const Tensor& src);
+    void IndexMin_(const Tensor& index, const Tensor& src);
+
     /// \brief Permute (dimension shuffle) the Tensor, returns a view.
     ///
     /// \param dims The desired ordering of dimensions.

--- a/cpp/open3d/core/Tensor.h
+++ b/cpp/open3d/core/Tensor.h
@@ -583,10 +583,7 @@ public:
     /// self[index[i]] = operator(self[index[i]], src[i])
     ///
     /// Note: Only support 1D index and src tensors now.
-    void IndexAdd_(const Tensor& index, const Tensor& src);
-    void IndexSum_(const Tensor& index, const Tensor& src);
-    void IndexMax_(const Tensor& index, const Tensor& src);
-    void IndexMin_(const Tensor& index, const Tensor& src);
+    void IndexAdd_(int64_t dim, const Tensor& index, const Tensor& src);
 
     /// \brief Permute (dimension shuffle) the Tensor, returns a view.
     ///

--- a/cpp/open3d/core/kernel/IndexReduction.cpp
+++ b/cpp/open3d/core/kernel/IndexReduction.cpp
@@ -13,15 +13,15 @@ namespace open3d {
 namespace core {
 namespace kernel {
 
-void IndexMean_(const Tensor& index, const Tensor& src, Tensor& dst) {
+void IndexSum_(const Tensor& index, const Tensor& src, Tensor& dst) {
     if (dst.IsCPU()) {
-        IndexMeanCPU_(index, src, dst);
+        IndexSumCPU_(index, src, dst);
     } else if (src.IsCUDA()) {
 #ifdef BUILD_CUDA_MODULE
-        IndexMeanCUDA_(index, src, dst);
+        IndexSumCUDA_(index, src, dst);
 #endif
     } else {
-        utility::LogError("IndexMean_: Unimplemented device");
+        utility::LogError("IndexSum_: Unimplemented device");
     }
 }
 

--- a/cpp/open3d/core/kernel/IndexReduction.cpp
+++ b/cpp/open3d/core/kernel/IndexReduction.cpp
@@ -17,23 +17,17 @@ void IndexAdd_(int64_t dim,
                const Tensor& index,
                const Tensor& src,
                Tensor& dst) {
+    // Permute the reduction dimension to the first.
     SizeVector permute = {};
-    SizeVector reverse_permute = {};
     for (int64_t d = 0; d <= dim; ++d) {
         if (d == 0) {
             permute.push_back(dim);
         } else {
             permute.push_back(d - 1);
         }
-        if (d == dim) {
-            reverse_permute.push_back(0);
-        } else {
-            reverse_permute.push_back(d + 1);
-        }
     }
     for (int64_t d = dim + 1; d < src.NumDims(); ++d) {
         permute.push_back(d);
-        reverse_permute.push_back(d);
     }
 
     auto src_permute = src.Permute(permute);
@@ -48,9 +42,6 @@ void IndexAdd_(int64_t dim,
     } else {
         utility::LogError("IndexAdd_: Unimplemented device");
     }
-
-    // Not sure if it is necessary
-    dst = dst_permute.Permute(reverse_permute);
 }
 
 }  // namespace kernel

--- a/cpp/open3d/core/kernel/IndexReduction.cpp
+++ b/cpp/open3d/core/kernel/IndexReduction.cpp
@@ -1,0 +1,30 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// Copyright (c) 2018-2023 www.open3d.org
+// SPDX-License-Identifier: MIT
+// ----------------------------------------------------------------------------
+
+#include "open3d/core/kernel/IndexReduction.h"
+
+#include "open3d/utility/Logging.h"
+
+namespace open3d {
+namespace core {
+namespace kernel {
+
+void IndexMean_(const Tensor& index, const Tensor& src, Tensor& dst) {
+    if (dst.IsCPU()) {
+        IndexMeanCPU_(index, src, dst);
+    } else if (src.IsCUDA()) {
+#ifdef BUILD_CUDA_MODULE
+        IndexMeanCUDA_(index, src, dst);
+#endif
+    } else {
+        utility::LogError("IndexMean_: Unimplemented device");
+    }
+}
+
+}  // namespace kernel
+}  // namespace core
+}  // namespace open3d

--- a/cpp/open3d/core/kernel/IndexReduction.h
+++ b/cpp/open3d/core/kernel/IndexReduction.h
@@ -14,12 +14,21 @@ namespace open3d {
 namespace core {
 namespace kernel {
 
-void IndexSum_(const Tensor& index, const Tensor& src, Tensor& dst);
+void IndexAdd_(int64_t dim,
+               const Tensor& index,
+               const Tensor& src,
+               Tensor& dst);
 
-void IndexSumCPU_(const Tensor& index, const Tensor& src, Tensor& dst);
+void IndexAddCPU_(int64_t dim,
+                  const Tensor& index,
+                  const Tensor& src,
+                  Tensor& dst);
 
 #ifdef BUILD_CUDA_MODULE
-void IndexSumCUDA_(const Tensor& index, const Tensor& src, Tensor& dst);
+void IndexAddCUDA_(int64_t dim,
+                   const Tensor& index,
+                   const Tensor& src,
+                   Tensor& dst);
 #endif
 
 }  // namespace kernel

--- a/cpp/open3d/core/kernel/IndexReduction.h
+++ b/cpp/open3d/core/kernel/IndexReduction.h
@@ -1,0 +1,27 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// Copyright (c) 2018-2023 www.open3d.org
+// SPDX-License-Identifier: MIT
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include "open3d/core/Tensor.h"
+#include "open3d/utility/Logging.h"
+
+namespace open3d {
+namespace core {
+namespace kernel {
+
+void IndexMean_(const Tensor& index, const Tensor& src, Tensor& dst);
+
+void IndexMeanCPU_(const Tensor& index, const Tensor& src, Tensor& dst);
+
+#ifdef BUILD_CUDA_MODULE
+void IndexMeanCUDA_(const Tensor& index, const Tensor& src, Tensor& dst);
+#endif
+
+}  // namespace kernel
+}  // namespace core
+}  // namespace open3d

--- a/cpp/open3d/core/kernel/IndexReduction.h
+++ b/cpp/open3d/core/kernel/IndexReduction.h
@@ -14,12 +14,12 @@ namespace open3d {
 namespace core {
 namespace kernel {
 
-void IndexMean_(const Tensor& index, const Tensor& src, Tensor& dst);
+void IndexSum_(const Tensor& index, const Tensor& src, Tensor& dst);
 
-void IndexMeanCPU_(const Tensor& index, const Tensor& src, Tensor& dst);
+void IndexSumCPU_(const Tensor& index, const Tensor& src, Tensor& dst);
 
 #ifdef BUILD_CUDA_MODULE
-void IndexMeanCUDA_(const Tensor& index, const Tensor& src, Tensor& dst);
+void IndexSumCUDA_(const Tensor& index, const Tensor& src, Tensor& dst);
 #endif
 
 }  // namespace kernel

--- a/cpp/open3d/core/kernel/IndexReductionCPU.cpp
+++ b/cpp/open3d/core/kernel/IndexReductionCPU.cpp
@@ -14,7 +14,10 @@ namespace open3d {
 namespace core {
 namespace kernel {
 
-void IndexSumCPU_(const Tensor& index, const Tensor& src, Tensor& dst) {}
+void IndexAddCPU_(int64_t dim,
+                  const Tensor& index,
+                  const Tensor& src,
+                  Tensor& dst) {}
 
 }  // namespace kernel
 }  // namespace core

--- a/cpp/open3d/core/kernel/IndexReductionCPU.cpp
+++ b/cpp/open3d/core/kernel/IndexReductionCPU.cpp
@@ -14,7 +14,7 @@ namespace open3d {
 namespace core {
 namespace kernel {
 
-void IndexMeanCPU_(const Tensor& index, const Tensor& src, Tensor& dst) {}
+void IndexSumCPU_(const Tensor& index, const Tensor& src, Tensor& dst) {}
 
 }  // namespace kernel
 }  // namespace core

--- a/cpp/open3d/core/kernel/IndexReductionCPU.cpp
+++ b/cpp/open3d/core/kernel/IndexReductionCPU.cpp
@@ -6,7 +6,7 @@
 // ----------------------------------------------------------------------------
 
 #include "open3d/core/Dispatch.h"
-#include "open3d/core/ParallelFor.h"
+#include "open3d/core/Indexer.h"
 #include "open3d/core/Tensor.h"
 #include "open3d/utility/Logging.h"
 
@@ -14,10 +14,65 @@ namespace open3d {
 namespace core {
 namespace kernel {
 
+template <typename func_t>
+void LaunchIndexReductionKernel(int64_t dim,
+                                const Device& device,
+                                const Tensor& index,
+                                const Tensor& src,
+                                Tensor& dst,
+                                const func_t& element_kernel) {
+    // index: [N,], src: [N, D], dst: [M, D]
+    // In Indexer, output shape defines the actual master strides.
+    // However, in IndexAdd_, input dominates the iterations.
+    // So put dst (output) at indexer's input, and src (input) at output.
+    Indexer indexer({dst}, src, DtypePolicy::NONE);
+
+    // Index is simply a 1D contiguous tensor, with a different stride
+    // behavior to src. So use raw pointer for simplicity.
+    auto index_ptr = index.GetDataPtr<int64_t>();
+
+    int64_t broadcasting_elems = 1;
+    for (int64_t d = 1; d < src.NumDims(); ++d) {
+        broadcasting_elems *= src.GetShape(d);
+    }
+    auto element_func = [=](int64_t workload_idx) {
+        int reduction_idx = workload_idx / broadcasting_elems;
+        int broadcasting_idx = workload_idx % broadcasting_elems;
+
+        const int64_t idx = index_ptr[reduction_idx];
+        int64_t dst_idx = idx * broadcasting_elems + broadcasting_idx;
+
+        void* src_ptr = indexer.GetOutputPtr(0, workload_idx);
+        void* dst_ptr = indexer.GetInputPtr(0, dst_idx);
+        // Note input and output is switched here to adapt to the indexer
+        element_kernel(src_ptr, dst_ptr);
+    };
+
+    // TODO: check in detail
+    // No OpenMP could be faster, otherwise there would be thousands of atomics.
+    for (int64_t d = 0; d < indexer.NumWorkloads(); ++d) {
+        element_func(d);
+    }
+}
+
+template <typename scalar_t>
+static OPEN3D_HOST_DEVICE void CPUSumKernel(const void* src, void* dst) {
+    scalar_t* dst_s_ptr = static_cast<scalar_t*>(dst);
+    const scalar_t* src_s_ptr = static_cast<const scalar_t*>(src);
+    *dst_s_ptr += *src_s_ptr;
+}
+
 void IndexAddCPU_(int64_t dim,
                   const Tensor& index,
                   const Tensor& src,
-                  Tensor& dst) {}
+                  Tensor& dst) {
+    DISPATCH_FLOAT_DTYPE_TO_TEMPLATE(src.GetDtype(), [&]() {
+        LaunchIndexReductionKernel(dim, src.GetDevice(), index, src, dst,
+                                   [](const void* src, void* dst) {
+                                       CPUSumKernel<scalar_t>(src, dst);
+                                   });
+    });
+}
 
 }  // namespace kernel
 }  // namespace core

--- a/cpp/open3d/core/kernel/IndexReductionCPU.cpp
+++ b/cpp/open3d/core/kernel/IndexReductionCPU.cpp
@@ -1,0 +1,21 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// Copyright (c) 2018-2023 www.open3d.org
+// SPDX-License-Identifier: MIT
+// ----------------------------------------------------------------------------
+
+#include "open3d/core/Dispatch.h"
+#include "open3d/core/ParallelFor.h"
+#include "open3d/core/Tensor.h"
+#include "open3d/utility/Logging.h"
+
+namespace open3d {
+namespace core {
+namespace kernel {
+
+void IndexMeanCPU_(const Tensor& index, const Tensor& src, Tensor& dst) {}
+
+}  // namespace kernel
+}  // namespace core
+}  // namespace open3d

--- a/cpp/open3d/core/kernel/IndexReductionCUDA.cu
+++ b/cpp/open3d/core/kernel/IndexReductionCUDA.cu
@@ -18,25 +18,87 @@ namespace core {
 namespace kernel {
 
 template <typename func_t>
-void LaunchIndexReductionKernel(const Device& device,
+void LaunchIndexReductionKernel(int64_t dim,
+                                const Device& device,
                                 const Tensor& index,
                                 const Tensor& src,
                                 Tensor& dst,
                                 const func_t& element_kernel) {
     OPEN3D_ASSERT_HOST_DEVICE_LAMBDA(func_t);
-    Indexer indexer({index, src}, dst, DtypePolicy::NONE);
-    auto element_func = [=] OPEN3D_HOST_DEVICE(int64_t i) {
-        const int64_t idx = *(indexer.GetInputPtr<int64_t>(0, i));
-        element_kernel(indexer.GetInputPtr(1, i), indexer.GetOutputPtr(idx));
-    };
-    utility::LogInfo(
-            "LaunchIndexReductionKernel: NumWorkloads = {}, index shape: {}, "
-            "src shape: {}, dst shape: {}",
-            index.GetLength(), index.GetShape(), src.GetShape(),
-            dst.GetShape());
 
-    ParallelFor(device, index.GetLength(), element_func);
+    // index: [N,], src: [N, D], dst: [M, D]
+    core::Tensor reshaped_index = index;
+    if (src.NumDims() > 1) {
+        reshaped_index = reshaped_index.View({-1, 1});
+    }
+    Indexer indexer({reshaped_index.View({-1}), src.View({-1})}, dst.View({-1}),
+                    DtypePolicy::NONE);
+    utility::LogInfo("dst ptr = {}", dst.GetDataPtr());
+
+    int64_t broadcasting_elems = 1;
+    for (int64_t d = 1; d < src.NumDims(); ++d) {
+        broadcasting_elems *= src.GetShape(d);
+    }
+
+    std::cout << "Master shape: \n";
+    for (int i = 0; i < indexer.NumDims(); ++i) {
+        std::cout << indexer.GetMasterShape()[i] << " ";
+    }
+    std::cout << "\n";
+
+    std::cout << "Master stride: \n";
+    for (int i = 0; i < indexer.NumDims(); ++i) {
+        std::cout << indexer.GetMasterStrides()[i] << " ";
+    }
+    std::cout << "\n";
+
+    // TensorRef index_tr = indexer.GetInput(0);
+    // std::cout << "index_tr shape: \n";
+    // for (int i = 0; i < index_tr.ndims_; ++i) {
+    //     std::cout << index_tr.shape_[i] << " ";
+    // }
+    // std::cout << "\n";
+
+    // TensorRef src_tr = indexer.GetInput(1);
+    // std::cout << "src_tr shape: \n";
+    // for (int i = 0; i < src_tr.ndims_; ++i) {
+    //     std::cout << src_tr.shape_[i] << " ";
+    // }
+    // std::cout << "\n";
+
+    // TensorRef dst_tr = indexer.GetOutput(0);
+    // std::cout << "dst_tr shape: \n";
+    // for (int i = 0; i < dst_tr.ndims_; ++i) {
+    //     std::cout << dst_tr.shape_[i] << " ";
+    // }
+    // std::cout << "\n";
+
+    utility::LogInfo("broadcasting_elems: {}, index length: {}",
+                     broadcasting_elems, reshaped_index.GetLength());
+
+    auto element_func = [=] OPEN3D_HOST_DEVICE(int64_t workload_idx) {
+        int reduction_idx = workload_idx / broadcasting_elems;
+        int broadcasting_idx = workload_idx % broadcasting_elems;
+
+        const int64_t idx = *(indexer.GetInputPtr<int64_t>(0, reduction_idx));
+        int64_t output_idx = idx * broadcasting_elems + broadcasting_idx;
+        // printf("output_idx: %ld, output_ptr %p\n", output_idx,
+        //        indexer.GetOutputPtr(output_idx));
+        // printf("workload idx: %ld reduction idx: %d broadcasting idx: %d idx:
+        // "
+        //        "%ld output_idx: %ld\n",
+        //        workload_idx, reduction_idx, broadcasting_idx, idx,
+        //        output_idx);
+
+        element_kernel(indexer.GetInputPtr(1, workload_idx),
+                       indexer.GetOutputPtr(output_idx));
+    };
+
+    ParallelFor(device, reshaped_index.GetLength() * broadcasting_elems,
+                element_func);
     OPEN3D_GET_LAST_CUDA_ERROR("LaunchIndexReductionKernel failed.");
+    utility::LogInfo("LaunchIndexReductionKernel done, dst = {}",
+                     dst.ToString());
 }
 
 template <typename scalar_t>
@@ -46,10 +108,13 @@ static OPEN3D_HOST_DEVICE void CUDASumKernel(const void* src, void* dst) {
     atomicAdd(dst_s_ptr, *src_s_ptr);
 }
 
-void IndexSumCUDA_(const Tensor& index, const Tensor& src, Tensor& dst) {
+void IndexAddCUDA_(int64_t dim,
+                   const Tensor& index,
+                   const Tensor& src,
+                   Tensor& dst) {
     DISPATCH_FLOAT_DTYPE_TO_TEMPLATE(src.GetDtype(), [&]() {
         LaunchIndexReductionKernel(
-                src.GetDevice(), index, src, dst,
+                dim, src.GetDevice(), index, src, dst,
                 [] OPEN3D_HOST_DEVICE(const void* src, void* dst) {
                     CUDASumKernel<scalar_t>(src, dst);
                 });

--- a/cpp/open3d/core/kernel/IndexReductionCUDA.cu
+++ b/cpp/open3d/core/kernel/IndexReductionCUDA.cu
@@ -4,18 +4,51 @@
 // Copyright (c) 2018-2023 www.open3d.org
 // SPDX-License-Identifier: MIT
 // ----------------------------------------------------------------------------
+#include <type_traits>
 
 #include "open3d/core/CUDAUtils.h"
 #include "open3d/core/Dispatch.h"
 #include "open3d/core/Indexer.h"
 #include "open3d/core/ParallelFor.h"
 #include "open3d/core/Tensor.h"
+#include "open3d/t/geometry/kernel/GeometryMacros.h"
 
 namespace open3d {
 namespace core {
 namespace kernel {
 
-void IndexMeanCUDA_(const Tensor& index, const Tensor& src, Tensor& dst) {}
+template <typename func_t>
+void LaunchIndexReductionKernel(const Device& device,
+                                const Tensor& index,
+                                const Tensor& src,
+                                Tensor& dst,
+                                const func_t& element_kernel) {
+    OPEN3D_ASSERT_HOST_DEVICE_LAMBDA(func_t);
+    Indexer indexer({index, src}, dst, DtypePolicy::NONE);
+    auto element_func = [=] OPEN3D_HOST_DEVICE(int64_t i) {
+        const int64_t idx = *(indexer.GetInputPtr<int64_t>(0, i));
+        element_kernel(indexer.GetInputPtr(1, i), indexer.GetOutputPtr(idx));
+    };
+    ParallelFor(device, indexer.NumWorkloads(), element_func);
+    OPEN3D_GET_LAST_CUDA_ERROR("LaunchIndexReductionKernel failed.");
+}
+
+template <typename scalar_t>
+static OPEN3D_HOST_DEVICE void CUDASumKernel(const void* src, void* dst) {
+    scalar_t* dst_s_ptr = static_cast<scalar_t*>(dst);
+    const scalar_t* src_s_ptr = static_cast<const scalar_t*>(src);
+    atomicAdd(dst_s_ptr, *src_s_ptr);
+}
+
+void IndexSumCUDA_(const Tensor& index, const Tensor& src, Tensor& dst) {
+    DISPATCH_FLOAT_DTYPE_TO_TEMPLATE(src.GetDtype(), [&]() {
+        LaunchIndexReductionKernel(
+                src.GetDevice(), index, src, dst,
+                [] OPEN3D_HOST_DEVICE(const void* src, void* dst) {
+                    CUDASumKernel<scalar_t>(src, dst);
+                });
+    });
+}
 
 }  // namespace kernel
 }  // namespace core

--- a/cpp/open3d/core/kernel/IndexReductionCUDA.cu
+++ b/cpp/open3d/core/kernel/IndexReductionCUDA.cu
@@ -1,0 +1,22 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// Copyright (c) 2018-2023 www.open3d.org
+// SPDX-License-Identifier: MIT
+// ----------------------------------------------------------------------------
+
+#include "open3d/core/CUDAUtils.h"
+#include "open3d/core/Dispatch.h"
+#include "open3d/core/Indexer.h"
+#include "open3d/core/ParallelFor.h"
+#include "open3d/core/Tensor.h"
+
+namespace open3d {
+namespace core {
+namespace kernel {
+
+void IndexMeanCUDA_(const Tensor& index, const Tensor& src, Tensor& dst) {}
+
+}  // namespace kernel
+}  // namespace core
+}  // namespace open3d

--- a/cpp/open3d/core/kernel/IndexReductionCUDA.cu
+++ b/cpp/open3d/core/kernel/IndexReductionCUDA.cu
@@ -29,7 +29,13 @@ void LaunchIndexReductionKernel(const Device& device,
         const int64_t idx = *(indexer.GetInputPtr<int64_t>(0, i));
         element_kernel(indexer.GetInputPtr(1, i), indexer.GetOutputPtr(idx));
     };
-    ParallelFor(device, indexer.NumWorkloads(), element_func);
+    utility::LogInfo(
+            "LaunchIndexReductionKernel: NumWorkloads = {}, index shape: {}, "
+            "src shape: {}, dst shape: {}",
+            index.GetLength(), index.GetShape(), src.GetShape(),
+            dst.GetShape());
+
+    ParallelFor(device, index.GetLength(), element_func);
     OPEN3D_GET_LAST_CUDA_ERROR("LaunchIndexReductionKernel failed.");
 }
 

--- a/cpp/open3d/core/kernel/IndexReductionCUDA.cu
+++ b/cpp/open3d/core/kernel/IndexReductionCUDA.cu
@@ -49,14 +49,12 @@ void LaunchIndexReductionKernel(int64_t dim,
 
         void* src_ptr = indexer.GetOutputPtr(0, workload_idx);
         void* dst_ptr = indexer.GetInputPtr(0, dst_idx);
-        // Note input and output is switched here to adapt to the indexer
+        // Note input and output is switched here to adapt to the indexer.
         element_kernel(src_ptr, dst_ptr);
     };
 
     ParallelFor(device, indexer.NumWorkloads(), element_func);
     OPEN3D_GET_LAST_CUDA_ERROR("LaunchIndexReductionKernel failed.");
-    utility::LogInfo("LaunchIndexReductionKernel done, dst = {}",
-                     dst.ToString());
 }
 
 template <typename scalar_t>

--- a/cpp/open3d/t/geometry/PointCloud.cpp
+++ b/cpp/open3d/t/geometry/PointCloud.cpp
@@ -322,8 +322,10 @@ PointCloud PointCloud::VoxelDownSample(double voxel_size,
         auto attr_dtype = point_attr.GetDtype();
 
         // Use float to avoid unsupported tensor types.
-        auto voxel_attr = core::Tensor::Zeros(
-                {num_voxels, point_attr.GetShape(1)}, core::Float32, device_);
+        core::SizeVector attr_shape = point_attr.GetShape();
+        attr_shape[0] = num_voxels;
+        auto voxel_attr =
+                core::Tensor::Zeros(attr_shape, core::Float32, device_);
         if (reduction == "mean") {
             voxel_attr.IndexAdd_(0, index_map_point2voxel,
                                  point_attr.To(core::Float32));

--- a/cpp/open3d/t/geometry/PointCloud.cpp
+++ b/cpp/open3d/t/geometry/PointCloud.cpp
@@ -293,6 +293,9 @@ PointCloud PointCloud::VoxelDownSample(double voxel_size,
     // Maps voxel to indices ranging from 0 to set.size()
     core::Tensor origin2down_indices, masks;
     points_voxeli_hashset.Insert(points_voxeli, origin2down_indices, masks);
+
+    // Find and insert are two different passes
+    points_voxeli_hashset.Find(points_voxeli, origin2down_indices, masks);
     origin2down_indices = origin2down_indices.To(core::Int64);
 
     int64_t num_points = points_voxeli.GetLength();
@@ -305,6 +308,8 @@ PointCloud PointCloud::VoxelDownSample(double voxel_size,
     index_count.IndexSum_(
             origin2down_indices,
             core::Tensor::Ones({num_points}, core::Float32, device_));
+    // utility::LogInfo("indices = {}", origin2down_indices.ToString());
+    utility::LogInfo("index_count = {}", index_count.ToString());
 
     for (auto &kv : point_attr_) {
         auto down_attr = core::Tensor::Zeros({num_points_down, 3},

--- a/cpp/open3d/t/geometry/PointCloud.h
+++ b/cpp/open3d/t/geometry/PointCloud.h
@@ -330,8 +330,7 @@ public:
     ///
     /// \param voxel_size Voxel size. A positive number.
     PointCloud VoxelDownSample(double voxel_size,
-                               const core::HashBackendType &backend =
-                                       core::HashBackendType::Default) const;
+                               const std::string &reduction = "mean") const;
 
     /// \brief Downsamples a point cloud by selecting every kth index point and
     /// its attributes.

--- a/cpp/open3d/t/geometry/PointCloud.h
+++ b/cpp/open3d/t/geometry/PointCloud.h
@@ -329,6 +329,7 @@ public:
     /// \brief Downsamples a point cloud with a specified voxel size.
     ///
     /// \param voxel_size Voxel size. A positive number.
+    /// \param reduction Reduction type. Currently only support "mean".
     PointCloud VoxelDownSample(double voxel_size,
                                const std::string &reduction = "mean") const;
 

--- a/cpp/pybind/t/geometry/pointcloud.cpp
+++ b/cpp/pybind/t/geometry/pointcloud.cpp
@@ -72,8 +72,8 @@ The attributes of the point cloud have different levels::
     # The shape must be (N, 3). The device of "positions" determines the device
     # of the point cloud.
     pcd.point.positions = o3d.core.Tensor([[0, 0, 0],
-                                              [1, 1, 1],
-                                              [2, 2, 2]], dtype, device)
+                                           [1, 1, 1],
+                                           [2, 2, 2]], dtype, device)
 
     # Common attributes: "normals", "colors".
     # Common attributes are used in built-in point cloud operations. The
@@ -82,11 +82,11 @@ The attributes of the point cloud have different levels::
     # "normals" and "colors" must have shape (N, 3) and must be on the same
     # device as the point cloud.
     pcd.point.normals = o3d.core.Tensor([[0, 0, 1],
-                                            [0, 1, 0],
-                                            [1, 0, 0]], dtype, device)
+                                         [0, 1, 0],
+                                         [1, 0, 0]], dtype, device)
     pcd.point.colors = o3d.core.Tensor([[0.0, 0.0, 0.0],
-                                            [0.1, 0.1, 0.1],
-                                            [0.2, 0.2, 0.2]], dtype, device)
+                                        [0.1, 0.1, 0.1],
+                                        [0.2, 0.2, 0.2]], dtype, device)
 
     # User-defined attributes.
     # You can also attach custom attributes. The value tensor must be on the
@@ -217,7 +217,26 @@ The attributes of the point cloud have different levels::
             },
             "Downsamples a point cloud with a specified voxel size and a "
             "reduction type.",
-            "voxel_size"_a, "reduction"_a = "mean");
+            "voxel_size"_a, "reduction"_a = "mean",
+            R"doc(Downsamples a point cloud with a specified voxel size.
+
+Args:
+    voxel_size (float): The size of the voxel used to downsample the point cloud.
+
+    reduction (str): The approach to pool point properties in a voxel. Can only be "mean" at current.
+
+Return:
+    A downsampled point cloud with point properties reduced in each voxel.
+
+Example:
+
+    We will load the Eagle dataset, downsample it, and show the result::
+
+        eagle = o3d.data.EaglePointCloud()
+        pcd = o3d.t.io.read_point_cloud(eagle.path)
+        pcd_down = pcd.voxel_down_sample(voxel_size=0.05)
+        o3d.visualization.draw([{'name': 'pcd', 'geometry': pcd}, {'name': 'pcd_down', 'geometry': pcd_down}])
+    )doc");
     pointcloud.def("uniform_down_sample", &PointCloud::UniformDownSample,
                    "Downsamples a point cloud by selecting every kth index "
                    "point and its attributes.",
@@ -240,8 +259,8 @@ The attributes of the point cloud have different levels::
 sphere of a given search radius. 
 
 Args:
-    nb_points. Number of neighbor points required within the radius.
-    search_radius. Radius of the sphere.
+    nb_points: Number of neighbor points required within the radius.
+    search_radius: Radius of the sphere.
 
 Return:
     Tuple of filtered point cloud and boolean mask tensor for selected values
@@ -254,8 +273,8 @@ Return:
 neighbors in average. This function is not recommended to use on GPU. 
 
 Args:
-    nb_neighbors. Number of neighbors around the target point.
-    std_ratio. Standard deviation ratio.
+    nb_neighbors: Number of neighbors around the target point.
+    std_ratio: Standard deviation ratio.
 
 Return:
     Tuple of filtered point cloud and boolean mask tensor for selected values
@@ -270,8 +289,8 @@ Return:
 infinite value. It also removes the corresponding attributes. 
     
 Args:
-    remove_nan. Remove NaN values from the PointCloud.
-    remove_infinite. Remove infinite values from the PointCloud.
+    remove_nan: Remove NaN values from the PointCloud.
+    remove_infinite: Remove infinite values from the PointCloud.
 
 Return:
     Tuple of filtered point cloud and boolean mask tensor for selected values
@@ -326,7 +345,7 @@ Return:
             "with_normals"_a = false,
             "Factory function to create a pointcloud (with only 'points') from "
             "a depth image and a camera model.\n\n Given depth value d at (u, "
-            "v) image coordinate, the corresponding 3d point is:\n z = d / "
+            "v) image coordinate, the corresponding 3d point is:\n\n z = d / "
             "depth_scale\n\n x = (u - cx) * z / fx\n\n y = (v - cy) * z / fy");
     pointcloud.def_static(
             "create_from_rgbd_image", &PointCloud::CreateFromRGBDImage,
@@ -371,14 +390,16 @@ This is a wrapper for a CPU implementation and a copy of the point cloud data
 and resulting visible triangle mesh and indiecs will be made.
 
 Args:
-    camera_location. All points not visible from that location will be removed.
-    radius. The radius of the spherical projection.
+    camera_location: All points not visible from that location will be removed.
+
+    radius: The radius of the spherical projection.
 
 Return:
     Tuple of visible triangle mesh and indices of visible points on the same
     device as the point cloud.
 
 Example:
+
     We use armadillo mesh to compute the visible points from given camera::
 
         # Convert mesh to a point cloud and estimate dimensions.
@@ -407,15 +428,18 @@ with Noise', 1996. This is a wrapper for a CPU implementation and a copy of the
 point cloud data and resulting labels will be made.
 
 Args:
-    eps. Density parameter that is used to find neighbouring points.
-    min_points. Minimum number of points to form a cluster.
-    print_progress (default False). If 'True' the progress is visualized in the console.
+    eps: Density parameter that is used to find neighbouring points.
+
+    min_points: Minimum number of points to form a cluster.
+
+print_progress (default False): If 'True' the progress is visualized in the console.
 
 Return:
     A Tensor list of point labels on the same device as the point cloud, -1
     indicates noise according to the algorithm.
 
 Example:
+
     We use Redwood dataset for demonstration::
 
         import matplotlib.pyplot as plt
@@ -434,23 +458,25 @@ Example:
     pointcloud.def(
             "segment_plane", &PointCloud::SegmentPlane,
             "distance_threshold"_a = 0.01, "ransac_n"_a = 3,
-            "num_iterations"_a = 100, "probability"_a = 0.99999999,
+            "num_iterations"_a = 100, "probability"_a = 0.999,
             R"(Segments a plane in the point cloud using the RANSAC algorithm.
 This is a wrapper for a CPU implementation and a copy of the point cloud data and
 resulting plane model and inlier indiecs will be made.
 
 Args:
-    distance_threshold (default 0.01). Max distance a point can be from the plane
-    model, and still be considered an inlier.
-    ransac_n (default 3). Number of initial points to be considered inliers in each iteration.
-    num_iterations (default 100). Maximum number of iterations.
-    probability (default 0.99999999). Expected probability of finding the optimal plane.
+    distance_threshold (default 0.01): Max distance a point can be from the plane model, and still be considered an inlier.
+
+    ransac_n (default 3): Number of initial points to be considered inliers in each iteration.
+    num_iterations (default 100): Maximum number of iterations.
+
+    probability (default 0.999): Expected probability of finding the optimal plane.
 
 Return:
-    Tuple of the plane model ax + by + cz + d = 0 and the indices of
+    Tuple of the plane model `ax + by + cz + d = 0` and the indices of
     the plane inliers on the same device as the point cloud.
 
 Example:
+
     We use Redwood dataset to compute its plane model and inliers::
 
         sample_pcd_data = o3d.data.PCDPointCloud()
@@ -468,16 +494,11 @@ Example:
             R"doc(Compute the convex hull of a triangle mesh using qhull. This runs on the CPU.
 
 Args:
-    joggle_inputs (default False). Handle precision problems by
-    randomly perturbing the input data. Set to True if perturbing the input
-    iis acceptable but you need convex simplicial output. If False,
-    neighboring facets may be merged in case of precision problems. See
-    `QHull docs <http://www.qhull.org/html/qh-impre.htm#joggle>`__ for more
-    details.
+    joggle_inputs (default False): Handle precision problems by randomly perturbing the input data. Set to True if perturbing the input is acceptable but you need convex simplicial output. If False, neighboring facets may be merged in case of precision problems. See `QHull docs <http://www.qhull.org/html/qh-impre.htm#joggle>`__ for more details.
 
 Return:
     TriangleMesh representing the convexh hull. This contains an
-    extra vertex property "point_indices" that contains the index of the
+    extra vertex property `point_indices` that contains the index of the
     corresponding vertex in the original mesh.
 
 Example:
@@ -496,9 +517,9 @@ The implementation is inspired by the PCL implementation. Reference:
 https://pointclouds.org/documentation/classpcl_1_1_boundary_estimation.html
 
 Args:
-    radius. Neighbor search radius parameter.
-    max_nn (default 30). Maximum number of neighbors to search.
-    angle_threshold (default 90.0). Angle threshold to decide if a point is on the boundary.
+    radius: Neighbor search radius parameter.
+    max_nn (default 30): Maximum number of neighbors to search.
+    angle_threshold (default 90.0): Angle threshold to decide if a point is on the boundary.
 
 Return:
     Tensor of boundary points and its boolean mask tensor.

--- a/cpp/pybind/t/geometry/pointcloud.cpp
+++ b/cpp/pybind/t/geometry/pointcloud.cpp
@@ -211,12 +211,13 @@ The attributes of the point cloud have different levels::
                    "output point cloud.");
     pointcloud.def(
             "voxel_down_sample",
-            [](const PointCloud& pointcloud, const double voxel_size) {
-                return pointcloud.VoxelDownSample(
-                        voxel_size, core::HashBackendType::Default);
+            [](const PointCloud& pointcloud, const double voxel_size,
+               const std::string& reduction) {
+                return pointcloud.VoxelDownSample(voxel_size, reduction);
             },
-            "Downsamples a point cloud with a specified voxel size.",
-            "voxel_size"_a);
+            "Downsamples a point cloud with a specified voxel size and a "
+            "reduction type.",
+            "voxel_size"_a, "reduction"_a = "mean");
     pointcloud.def("uniform_down_sample", &PointCloud::UniformDownSample,
                    "Downsamples a point cloud by selecting every kth index "
                    "point and its attributes.",

--- a/cpp/tests/t/geometry/PointCloud.cpp
+++ b/cpp/tests/t/geometry/PointCloud.cpp
@@ -901,7 +901,7 @@ TEST_P(PointCloudPermuteDevices, VoxelDownSample) {
                                       device));
     auto pcd_small_down = pcd_small.VoxelDownSample(1);
     EXPECT_TRUE(pcd_small_down.GetPointPositions().AllClose(
-            core::Tensor::Init<float>({{0, 0, 0}}, device)));
+            core::Tensor::Init<float>({{0.375, 0.375, 0.575}}, device)));
 }
 
 TEST_P(PointCloudPermuteDevices, UniformDownSample) {

--- a/python/test/t/geometry/test_pointcloud.py
+++ b/python/test/t/geometry/test_pointcloud.py
@@ -161,7 +161,7 @@ def test_member_functions(device):
 
     pcd_small_down = pcd.voxel_down_sample(1)
     assert pcd_small_down.point.positions.allclose(
-        o3c.Tensor([[0, 0, 0]], dtype, device))
+        o3c.Tensor([[0.375, 0.375, 0.575]], dtype, device))
 
 
 def test_extrude_rotation():


### PR DESCRIPTION
This PR addresses #6172 #5519 and allows averaging properties in voxel downsample. Previously, points are simply put at grid corners.

To achieve this, the operation `IndexAdd_` (similar for [pytorch](https://pytorch.org/docs/stable/generated/torch.Tensor.index_add_.html)) for tensors is introduced.

An alternative would be reusing Benjamin's Voxel Pooling. We may revisit this later.

Now the behavior is the same as legacy, but there is a slight voxel coordinate offset due to implementation discrepancies. The legacy version computes a bound that slightly shifts the voxels.
<table>
  <tr>
  <td><img src="https://github.com/isl-org/Open3D/assets/6127282/deb7c895-477d-4b0e-9270-b294ad70c416" width="480"/></td>
  <td><img src="https://github.com/isl-org/Open3D/assets/6127282/6a07ea2f-04b5-48b9-92f3-8705ecd10c31" width="480"/></td>
  </tr>
</table>

Next TODOs
- [ ] Further enhance backward compatibility via fixing discrepancies to legacy voxel downsample 
- [x] More tests for IndexAdd_
- [x] Some screenshots



<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/6249)
<!-- Reviewable:end -->
