### PR TITLE
Increase Ubuntu wheel CI build space.

### DIFF
--- a/util/ci_utils.sh
+++ b/util/ci_utils.sh
@@ -244,8 +244,8 @@ build_pip_package() {
 
     echo "Packaging Open3D full pip package..."
     make VERBOSE=1 -j"$NPROC" pip-package
-    mv open3d*.whl lib/python_package/pip_package/   # restore CPU wheel
-    popd # PWD=Open3D
+    mv open3d*.whl lib/python_package/pip_package/ # restore CPU wheel
+    popd                                           # PWD=Open3D
 }
 
 # Test wheel in blank virtual environment
@@ -464,10 +464,13 @@ build_docs() {
 }
 
 maximize_ubuntu_github_actions_build_space() {
-    df -h
-    $SUDO rm -rf /usr/share/dotnet
-    $SUDO rm -rf /usr/local/lib/android
-    $SUDO rm -rf /opt/ghc
+    # https://github.com/easimon/maximize-build-space/blob/master/action.yml
+    df -h .                                  # => 26GB
+    $SUDO rm -rf /usr/share/dotnet           # ~17GB
+    $SUDO rm -rf /usr/local/lib/android      # ~11GB
+    $SUDO rm -rf /opt/ghc                    # ~2.7GB
+    $SUDO rm -rf /opt/hostedtoolcache/CodeQL # ~5.4GB
+    $SUDO docker image prune --all --force   # ~4.5GB
     $SUDO rm -rf "$AGENT_TOOLSDIRECTORY"
-    df -h
+    df -h . # => 53GB
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

Ubuntu wheel CI is failing due to lack of disk space.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [ ] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [ ] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [ ] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

Delete unnecessary software from Github runners. Free space increased from 48 GB to 53 GB.

Successful run: https://github.com/isl-org/Open3D/actions/runs/5482597521

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/6255)
<!-- Reviewable:end -->
