### PR TITLE
Windows CI out of disk space workaround

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -420,7 +420,9 @@ jobs:
     # no need to run on Windows
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/master' }}
-    needs: [build-wheel, windows]
+    # temp workaround for Windows CUDA Debug CI out of space. Still update docs.
+    # needs: [build-wheel, windows]
+    needs: [build-wheel]
     steps:
       - name: GCloud CLI auth
         uses: google-github-actions/auth@v1

--- a/cpp/open3d/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/geometry/TriangleMesh.cpp
@@ -1634,7 +1634,8 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SelectByIndex(
             output->triangles_.push_back(
                     Eigen::Vector3i(nvidx0, nvidx1, nvidx2));
             if (has_triangle_material_ids) {
-                output->triangle_material_ids_.push_back(triangle_material_ids_[tidx]);
+                output->triangle_material_ids_.push_back(
+                        triangle_material_ids_[tidx]);
             }
             if (has_triangle_normals) {
                 output->triangle_normals_.push_back(triangle_normals_[tidx]);

--- a/docs/tutorial/visualization/cpu_rendering.rst
+++ b/docs/tutorial/visualization/cpu_rendering.rst
@@ -91,7 +91,24 @@ The method for enabling interactive CPU rendering depends on your system:
    them installed is not sufficient. You can check the drivers in use with the
    ``glxinfo`` command.
 
-2.  **You use Nvidia or AMD drivers or old Mesa drivers (< v20.2).**  We provide
+2.  **You use Nvidia or AMD drivers, but your OS comes with recent Mesa drivers (>= v20.2).** 
+    Install Mesa drivers if they are not installed in your system (e.g. `sudo apt install libglx0-mesa`
+    in Ubuntu). Preload the Mesa driver library before running any Open3D application requiring CPU rendering.
+    For example:
+
+    .. code:: bash
+
+        export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libGLX_mesa.so.0
+        Open3D
+
+    Or with Python code:
+
+    .. code:: bash
+
+        export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libGLX_mesa.so.0
+        python examples/python/visualization/draw.py
+
+3.  **Your OS has old Mesa drivers (< v20.2).**  We provide
     the Mesa software rendering library binary for download `here
     <https://github.com/isl-org/open3d_downloads/releases/download/mesa-libgl/mesa_libGL_22.0.tar.xz>`__.
     This is automatically downloaded to
@@ -115,5 +132,4 @@ The method for enabling interactive CPU rendering depends on your system:
 
     .. code:: bash
 
-        LD_PRELOAD=$HOME/.local/lib/libGL.so.1.5.0 python
-        examples/python/visualization/draw.py
+        LD_PRELOAD=$HOME/.local/lib/libGL.so.1.5.0 python examples/python/visualization/draw.py


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Description

Windows CI (CUDA, Debug) is failing due to "out of disk space". This bypasses this check and updates the docs, allowing devel Python wheels and C++ binaries to be available.

**Misc:**
- Style fix.
- CPU rendering tutorial (for Nvidia/ AMD drivers)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [ ] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [ ] For fork PRs, I have selected **Allow edits from maintainers**.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/6281)
<!-- Reviewable:end -->
