### PR TITLE
Removed the rudementary operations of taking the arc cosine from the function of comparing pairs

### DIFF
--- a/cpp/open3d/pipelines/registration/Feature.cpp
+++ b/cpp/open3d/pipelines/registration/Feature.cpp
@@ -32,7 +32,7 @@ static Eigen::Vector4d ComputePairFeatures(const Eigen::Vector3d &p1,
     auto n2_copy = n2;
     double angle1 = n1_copy.dot(dp2p1) / result(3);
     double angle2 = n2_copy.dot(dp2p1) / result(3);
-    if (acos(fabs(angle1)) > acos(fabs(angle2))) {
+    if (fabs(angle1) < fabs(angle2)) {
         n1_copy = n2;
         n2_copy = n1;
         dp2p1 *= -1.0;


### PR DESCRIPTION
…

Since the arccosine function is always decreasing on its domain, the expression acos(x) > acos(y) is equivalent to the expression x < y.

<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/6312)
<!-- Reviewable:end -->
