### PR TITLE
Fix compile error on Mac OS with latest Clang

### DIFF
--- a/cpp/open3d/utility/FileSystem.cpp
+++ b/cpp/open3d/utility/FileSystem.cpp
@@ -32,11 +32,12 @@
 #define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
 #endif
 #ifdef __APPLE__
-// CMAKE_OSX_DEPLOYMENT_TARGET "10.15" or newer
-#define _LIBCPP_NO_EXPERIMENTAL_DEPRECATION_WARNING_FILESYSTEM
-#endif
+#include <filesystem>
+namespace fs = std::__fs::filesystem;
+#else
 #include <experimental/filesystem>
 namespace fs = std::experimental::filesystem;
+#endif
 
 #include "open3d/utility/Logging.h"
 


### PR DESCRIPTION
## Description

Fixes compilation error on Mac OS with clang 14.0+.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/6320)
<!-- Reviewable:end -->
