### PR TITLE
Fix incomplete VoxelGrid creation from triangles intersecting multiple voxels

### DIFF
--- a/cpp/open3d/geometry/VoxelGridFactory.cpp
+++ b/cpp/open3d/geometry/VoxelGridFactory.cpp
@@ -143,8 +143,8 @@ std::shared_ptr<VoxelGrid> VoxelGrid::CreateFromTriangleMeshWithinBounds(
                                 box_center, box_half_size, v0, v1, v2)) {
                         Eigen::Vector3i grid_index(widx, hidx, didx);
                         output->AddVoxel(geometry::Voxel(grid_index));
-                        // Don't `break` here, since a triangle can span 
-                        // across multiple voxels. 
+                        // Don't `break` here, since a triangle can span
+                        // across multiple voxels.
                     }
                 }
             }

--- a/cpp/open3d/geometry/VoxelGridFactory.cpp
+++ b/cpp/open3d/geometry/VoxelGridFactory.cpp
@@ -143,7 +143,6 @@ std::shared_ptr<VoxelGrid> VoxelGrid::CreateFromTriangleMeshWithinBounds(
                                 box_center, box_half_size, v0, v1, v2)) {
                         Eigen::Vector3i grid_index(widx, hidx, didx);
                         output->AddVoxel(geometry::Voxel(grid_index));
-                        break;
                     }
                 }
             }

--- a/cpp/open3d/geometry/VoxelGridFactory.cpp
+++ b/cpp/open3d/geometry/VoxelGridFactory.cpp
@@ -143,6 +143,8 @@ std::shared_ptr<VoxelGrid> VoxelGrid::CreateFromTriangleMeshWithinBounds(
                                 box_center, box_half_size, v0, v1, v2)) {
                         Eigen::Vector3i grid_index(widx, hidx, didx);
                         output->AddVoxel(geometry::Voxel(grid_index));
+                        // Don't `break` here, since a triangle can span 
+                        // across multiple voxels. 
                     }
                 }
             }


### PR DESCRIPTION
Set all the relevant voxels, since a triangle can span across multiple ones
Currently, we break after the first voxel in the depth axis for some reason, but a single triangle can be relevant to multiple voxels.

Is there any option to release a version including this PR, since I really want to integrate this into a solution I'm building.

<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #6324
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context
The current voxel grid generated is wrong and contains only the first voxel in the depth axis.

<!--- Why is this change required? What problem does it solve? -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [ ] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

Mesh itself I've tested:
![image](https://github.com/isl-org/Open3D/assets/13475031/f8cb2d02-6c0f-4e52-b2dc-92c7dc67a8a6)

VoxelGrid before the fix:
![image](https://github.com/isl-org/Open3D/assets/13475031/7a4c336f-f690-4c04-aaab-cc4af10a5b82)

VoxelGrid after the fix:
![image](https://github.com/isl-org/Open3D/assets/13475031/efa90a22-74a6-4809-9bc2-97fd4eee1b82)


<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/6325)
<!-- Reviewable:end -->
