### PR TITLE
Added optional invert parameter in Pointcloud cropping (similar to tensor pointcloud)

### DIFF
--- a/cpp/open3d/geometry/PointCloud.cpp
+++ b/cpp/open3d/geometry/PointCloud.cpp
@@ -541,25 +541,25 @@ std::shared_ptr<PointCloud> PointCloud::FarthestPointDownSample(
     return SelectByIndex(selected_indices);
 }
 
-std::shared_ptr<PointCloud> PointCloud::Crop(
-        const AxisAlignedBoundingBox &bbox,
-        bool invert) const {
+std::shared_ptr<PointCloud> PointCloud::Crop(const AxisAlignedBoundingBox &bbox,
+                                             bool invert) const {
     if (bbox.IsEmpty()) {
         utility::LogError(
                 "AxisAlignedBoundingBox either has zeros size, or has wrong "
                 "bounds.");
     }
-    return SelectByIndex(bbox.GetPointIndicesWithinBoundingBox(points_),invert);
+    return SelectByIndex(bbox.GetPointIndicesWithinBoundingBox(points_),
+                         invert);
 }
-std::shared_ptr<PointCloud> PointCloud::Crop(
-        const OrientedBoundingBox &bbox,
-        bool invert) const {
+std::shared_ptr<PointCloud> PointCloud::Crop(const OrientedBoundingBox &bbox,
+                                             bool invert) const {
     if (bbox.IsEmpty()) {
         utility::LogError(
                 "AxisAlignedBoundingBox either has zeros size, or has wrong "
                 "bounds.");
     }
-    return SelectByIndex(bbox.GetPointIndicesWithinBoundingBox(points_),invert);
+    return SelectByIndex(bbox.GetPointIndicesWithinBoundingBox(points_),
+                         invert);
 }
 
 std::tuple<std::shared_ptr<PointCloud>, std::vector<size_t>>

--- a/cpp/open3d/geometry/PointCloud.cpp
+++ b/cpp/open3d/geometry/PointCloud.cpp
@@ -542,22 +542,24 @@ std::shared_ptr<PointCloud> PointCloud::FarthestPointDownSample(
 }
 
 std::shared_ptr<PointCloud> PointCloud::Crop(
-        const AxisAlignedBoundingBox &bbox) const {
+        const AxisAlignedBoundingBox &bbox,
+        bool invert) const {
     if (bbox.IsEmpty()) {
         utility::LogError(
                 "AxisAlignedBoundingBox either has zeros size, or has wrong "
                 "bounds.");
     }
-    return SelectByIndex(bbox.GetPointIndicesWithinBoundingBox(points_));
+    return SelectByIndex(bbox.GetPointIndicesWithinBoundingBox(points_),invert);
 }
 std::shared_ptr<PointCloud> PointCloud::Crop(
-        const OrientedBoundingBox &bbox) const {
+        const OrientedBoundingBox &bbox,
+        bool invert) const {
     if (bbox.IsEmpty()) {
         utility::LogError(
                 "AxisAlignedBoundingBox either has zeros size, or has wrong "
                 "bounds.");
     }
-    return SelectByIndex(bbox.GetPointIndicesWithinBoundingBox(points_));
+    return SelectByIndex(bbox.GetPointIndicesWithinBoundingBox(points_),invert);
 }
 
 std::tuple<std::shared_ptr<PointCloud>, std::vector<size_t>>

--- a/cpp/open3d/geometry/PointCloud.h
+++ b/cpp/open3d/geometry/PointCloud.h
@@ -186,7 +186,8 @@ public:
     ///
     /// \param bbox AxisAlignedBoundingBox to crop points.
     /// \param invert Optional boolean to invert cropping.
-    std::shared_ptr<PointCloud> Crop(const AxisAlignedBoundingBox &bbox, bool invert=false) const;
+    std::shared_ptr<PointCloud> Crop(const AxisAlignedBoundingBox &bbox,
+                                     bool invert = false) const;
 
     /// \brief Function to crop pointcloud into output pointcloud
     ///
@@ -195,7 +196,8 @@ public:
     ///
     /// \param bbox OrientedBoundingBox to crop points.
     /// \param invert Optional boolean to invert cropping.
-    std::shared_ptr<PointCloud> Crop(const OrientedBoundingBox &bbox, bool invert=false) const;
+    std::shared_ptr<PointCloud> Crop(const OrientedBoundingBox &bbox,
+                                     bool invert = false) const;
 
     /// \brief Function to remove points that have less than \p nb_points in a
     /// sphere of a given radius.

--- a/cpp/open3d/geometry/PointCloud.h
+++ b/cpp/open3d/geometry/PointCloud.h
@@ -185,7 +185,8 @@ public:
     /// clipped.
     ///
     /// \param bbox AxisAlignedBoundingBox to crop points.
-    std::shared_ptr<PointCloud> Crop(const AxisAlignedBoundingBox &bbox) const;
+    /// \param invert Optional boolean to invert cropping.
+    std::shared_ptr<PointCloud> Crop(const AxisAlignedBoundingBox &bbox, bool invert=false) const;
 
     /// \brief Function to crop pointcloud into output pointcloud
     ///
@@ -193,7 +194,8 @@ public:
     /// clipped.
     ///
     /// \param bbox OrientedBoundingBox to crop points.
-    std::shared_ptr<PointCloud> Crop(const OrientedBoundingBox &bbox) const;
+    /// \param invert Optional boolean to invert cropping.
+    std::shared_ptr<PointCloud> Crop(const OrientedBoundingBox &bbox, bool invert=false) const;
 
     /// \brief Function to remove points that have less than \p nb_points in a
     /// sphere of a given radius.

--- a/cpp/pybind/geometry/pointcloud.cpp
+++ b/cpp/pybind/geometry/pointcloud.cpp
@@ -86,16 +86,16 @@ void pybind_pointcloud(py::module &m) {
                  "num_samples"_a)
             .def("crop",
                  (std::shared_ptr<PointCloud>(PointCloud::*)(
-                         const AxisAlignedBoundingBox &) const) &
+                         const AxisAlignedBoundingBox &, bool) const) &
                          PointCloud::Crop,
                  "Function to crop input pointcloud into output pointcloud",
-                 "bounding_box"_a)
+                 "bounding_box"_a, "invert"_a = false)
             .def("crop",
                  (std::shared_ptr<PointCloud>(PointCloud::*)(
-                         const OrientedBoundingBox &) const) &
+                         const OrientedBoundingBox &, bool) const) &
                          PointCloud::Crop,
                  "Function to crop input pointcloud into output pointcloud",
-                 "bounding_box"_a)
+                 "bounding_box"_a, "invert"_a = false)
             .def("remove_non_finite_points", &PointCloud::RemoveNonFinitePoints,
                  "Removes all points from the point cloud that have a nan "
                  "entry, or infinite entries. It also removes the "
@@ -289,7 +289,8 @@ camera. Given depth value d at (u, v) image coordinate, the corresponding 3d poi
               "number of points[0-1]"}});
     docstring::ClassMethodDocInject(
             m, "PointCloud", "crop",
-            {{"bounding_box", "AxisAlignedBoundingBox to crop points"}});
+            {{"bounding_box", "AxisAlignedBoundingBox to crop points"},
+            {"invert", "optional boolean to invert cropping"}});
     docstring::ClassMethodDocInject(
             m, "PointCloud", "remove_non_finite_points",
             {{"remove_nan", "Remove NaN values from the PointCloud"},

--- a/cpp/pybind/geometry/pointcloud.cpp
+++ b/cpp/pybind/geometry/pointcloud.cpp
@@ -290,7 +290,7 @@ camera. Given depth value d at (u, v) image coordinate, the corresponding 3d poi
     docstring::ClassMethodDocInject(
             m, "PointCloud", "crop",
             {{"bounding_box", "AxisAlignedBoundingBox to crop points"},
-            {"invert", "optional boolean to invert cropping"}});
+             {"invert", "optional boolean to invert cropping"}});
     docstring::ClassMethodDocInject(
             m, "PointCloud", "remove_non_finite_points",
             {{"remove_nan", "Remove NaN values from the PointCloud"},

--- a/cpp/tests/geometry/PointCloud.cpp
+++ b/cpp/tests/geometry/PointCloud.cpp
@@ -1003,22 +1003,15 @@ TEST(PointCloud, Crop_AxisAlignedBoundingBox_Invert) {
             5.0 * Eigen::Matrix3d::Identity(),
     };
     std::shared_ptr<geometry::PointCloud> pc_crop = pcd.Crop(aabb, true);
-    ExpectEQ(pc_crop->points_, std::vector<Eigen::Vector3d>({
-                                       {3, 1, 1},
-                                       {-1, 1, 1}
-                               }));
-    ExpectEQ(pc_crop->normals_, std::vector<Eigen::Vector3d>({
-                                        {4, 0, 0},
-                                        {5, 0, 0}
-                                }));
-    ExpectEQ(pc_crop->colors_, std::vector<Eigen::Vector3d>({
-                                       {0.4, 0.0, 0.0},
-                                       {0.5, 0.0, 0.0}
-                               }));
-    ExpectEQ(pc_crop->covariances_, std::vector<Eigen::Matrix3d>({
-                                            4.0 * Eigen::Matrix3d::Identity(),
-                                            5.0 * Eigen::Matrix3d::Identity()
-                                    }));
+    ExpectEQ(pc_crop->points_,
+             std::vector<Eigen::Vector3d>({{3, 1, 1}, {-1, 1, 1}}));
+    ExpectEQ(pc_crop->normals_,
+             std::vector<Eigen::Vector3d>({{4, 0, 0}, {5, 0, 0}}));
+    ExpectEQ(pc_crop->colors_,
+             std::vector<Eigen::Vector3d>({{0.4, 0.0, 0.0}, {0.5, 0.0, 0.0}}));
+    ExpectEQ(pc_crop->covariances_,
+             std::vector<Eigen::Matrix3d>({4.0 * Eigen::Matrix3d::Identity(),
+                                           5.0 * Eigen::Matrix3d::Identity()}));
 }
 
 TEST(PointCloud, EstimateNormals) {

--- a/cpp/tests/geometry/PointCloud.cpp
+++ b/cpp/tests/geometry/PointCloud.cpp
@@ -982,6 +982,45 @@ TEST(PointCloud, Crop_OrientedBoundingBox) {
                                     }));
 }
 
+TEST(PointCloud, Crop_AxisAlignedBoundingBox_Invert) {
+    geometry::AxisAlignedBoundingBox aabb({0, 0, 0}, {2, 2, 2});
+    geometry::PointCloud pcd({{0, 0, 0},
+                              {2, 2, 2},
+                              {1, 1, 1},
+                              {1, 1, 2},
+                              {3, 1, 1},
+                              {-1, 1, 1}});
+    pcd.normals_ = {{0, 0, 0}, {1, 0, 0}, {2, 0, 0},
+                    {3, 0, 0}, {4, 0, 0}, {5, 0, 0}};
+    pcd.colors_ = {{0.0, 0.0, 0.0}, {0.1, 0.0, 0.0}, {0.2, 0.0, 0.0},
+                   {0.3, 0.0, 0.0}, {0.4, 0.0, 0.0}, {0.5, 0.0, 0.0}};
+    pcd.covariances_ = {
+            0.0 * Eigen::Matrix3d::Identity(),
+            1.0 * Eigen::Matrix3d::Identity(),
+            2.0 * Eigen::Matrix3d::Identity(),
+            3.0 * Eigen::Matrix3d::Identity(),
+            4.0 * Eigen::Matrix3d::Identity(),
+            5.0 * Eigen::Matrix3d::Identity(),
+    };
+    std::shared_ptr<geometry::PointCloud> pc_crop = pcd.Crop(aabb, true);
+    ExpectEQ(pc_crop->points_, std::vector<Eigen::Vector3d>({
+                                       {3, 1, 1},
+                                       {-1, 1, 1}
+                               }));
+    ExpectEQ(pc_crop->normals_, std::vector<Eigen::Vector3d>({
+                                        {4, 0, 0},
+                                        {5, 0, 0}
+                                }));
+    ExpectEQ(pc_crop->colors_, std::vector<Eigen::Vector3d>({
+                                       {0.4, 0.0, 0.0},
+                                       {0.5, 0.0, 0.0}
+                               }));
+    ExpectEQ(pc_crop->covariances_, std::vector<Eigen::Matrix3d>({
+                                            4.0 * Eigen::Matrix3d::Identity(),
+                                            5.0 * Eigen::Matrix3d::Identity()
+                                    }));
+}
+
 TEST(PointCloud, EstimateNormals) {
     geometry::PointCloud pcd({
             {0, 0, 0},


### PR DESCRIPTION
## Type

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [x] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

Tensor Pointcloud have the invert option in cropping but not the basic Pointcloud. Even though SelectbyIndex allows it.Needed it for a project and thought it was missing. The boolean is optional so this is minimal change.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [ ] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [x] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [x] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

Added optional invert bool in crop function for geometry::Pointcloud. For the unit test i reused the previous cropping tests but inverted the results.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/6377)
<!-- Reviewable:end -->
