### PR TITLE
Throw error on non-contiguous Python buffer provided to Image ctor.

### DIFF
--- a/cpp/pybind/geometry/image.cpp
+++ b/cpp/pybind/geometry/image.cpp
@@ -86,6 +86,13 @@ void pybind_image(py::module &m) {
              }
              height = (int)info.shape[0];
              width = (int)info.shape[1];
+             if (info.strides[1] != num_of_channels * bytes_per_channel ||
+                 info.strides[0] !=
+                         width * num_of_channels * bytes_per_channel) {
+                 throw std::runtime_error(
+                         "Image can only be initialized from a contiguous "
+                         "buffer.");
+             }
              auto img = new Image();
              img->Prepare(width, height, num_of_channels, bytes_per_channel);
              memcpy(img->data_.data(), info.ptr, img->data_.size());


### PR DESCRIPTION
## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #6403
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

Cropped images (e.g. from OpenCV) provided to Open3D Image ctor are not supported. In tensor API, an error is thrown, while in Eigen API they are silently accepted with errorneous results. This PR raises an error in the Eigen API. See https://github.com/isl-org/Open3D/issues/6403 for a test script and details.

Thanks to @myalos for reporting and debugging. Also thanks to @saurabheights for help

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [ ] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [ ] For fork PRs, I have selected **Allow edits from maintainers**.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/6406)
<!-- Reviewable:end -->
