### PR TITLE
Add missing keyword arg names to visualization bindings

### DIFF
--- a/cpp/pybind/visualization/o3dvisualizer.cpp
+++ b/cpp/pybind/visualization/o3dvisualizer.cpp
@@ -158,16 +158,17 @@ void pybind_o3dvisualizer(py::module& m) {
                  "close",
                  "callback"_a)
             .def("show_menu", &O3DVisualizer::ShowMenu,
-                 "show_menu(show): shows or hides the menu in the window, "
-                 "except on macOS since the menubar is not in the window "
-                 "and all applications must have a menubar.")
+                 "Shows or hides the menu in the window, except on macOS since "
+                 "the menubar is not in the window and all applications must "
+                 "have a menubar.",
+                 "show"_a)
             // from O3DVisualizer
             .def("add_action", &O3DVisualizer::AddAction,
-                 "Adds a button to the custom actions section of the UI "
-                 "and a corresponding menu item in the \"Actions\" menu. "
-                 "add_action(name, callback). The callback will be given "
-                 "one parameter, the O3DVisualizer instance, and does not "
-                 "return any value.")
+                 "Adds a button to the custom actions section of the UI and a "
+                 "corresponding menu item in the \"Actions\" menu. The "
+                 "callback will be given one parameter, the O3DVisualizer "
+                 "instance, and does not return any value.",
+                 "name"_a, "callback"_a)
             .def("add_geometry",
                  py::overload_cast<const std::string&,
                                    std::shared_ptr<geometry::Geometry3D>,
@@ -176,8 +177,7 @@ void pybind_o3dvisualizer(py::module& m) {
                          &O3DVisualizer::AddGeometry),
                  "name"_a, "geometry"_a, "material"_a = nullptr, "group"_a = "",
                  "time"_a = 0.0, "is_visible"_a = true,
-                 "Adds a geometry: add_geometry(name, geometry, material=None, "
-                 "group='', time=0.0, is_visible=True). 'name' must be unique.")
+                 "Adds a geometry. 'name' must be unique.")
             .def("add_geometry",
                  py::overload_cast<const std::string&,
                                    std::shared_ptr<t::geometry::Geometry>,
@@ -186,9 +186,7 @@ void pybind_o3dvisualizer(py::module& m) {
                          &O3DVisualizer::AddGeometry),
                  "name"_a, "geometry"_a, "material"_a = nullptr, "group"_a = "",
                  "time"_a = 0.0, "is_visible"_a = true,
-                 "Adds a Tensor-based add_geometry: geometry(name, geometry, "
-                 "material=None, "
-                 "group='', time=0.0, is_visible=True). 'name' must be unique.")
+                 "Adds a Tensor-based geometry. 'name' must be unique.")
             .def("add_geometry",
                  py::overload_cast<
                          const std::string&,
@@ -197,10 +195,8 @@ void pybind_o3dvisualizer(py::module& m) {
                          double, bool>(&O3DVisualizer::AddGeometry),
                  "name"_a, "model"_a, "material"_a = nullptr, "group"_a = "",
                  "time"_a = 0.0, "is_visible"_a = true,
-                 "Adds a TriangleMeshModel: add_geometry(name, model, "
-                 "material=None, "
-                 "group='', time=0.0, is_visible=True). 'name' must be unique. "
-                 "'material' is ignored.")
+                 "Adds a TriangleMeshModel. 'name' must be unique. 'material' "
+                 "is ignored.")
             .def(
                     "add_geometry",
                     [](py::object dv, const py::dict& d) {
@@ -239,37 +235,39 @@ void pybind_o3dvisualizer(py::module& m) {
                     "(optional)\n"
                     "group: a string declaring the group it is a member of "
                     "(optional)\n"
-                    "time: a time value\n")
+                    "time: a time value\n",
+                    "d"_a)
             .def("remove_geometry", &O3DVisualizer::RemoveGeometry,
-                 "remove_geometry(name): removes the geometry with the "
-                 "name.")
+                 "Removes the geometry with the name.", "name"_a)
             .def("update_geometry", &O3DVisualizer::UpdateGeometry,
-                 "update_geometry(name, tpoint_cloud, update_flags): updates "
-                 "the attributes of the named geometry specified by "
+                 "Updates the attributes of the named geometry specified by "
                  "update_flags with tpoint_cloud. Note: Currently this "
-                 "function only works with T Geometry Point Clouds.")
+                 "function only works with T Geometry Point Clouds.",
+                 "name"_a, "tpoint_cloud"_a, "update_flags"_a)
             .def("show_geometry", &O3DVisualizer::ShowGeometry,
                  "Checks or unchecks the named geometry in the list. Note that "
                  "even if show_geometry(name, True) is called, the object may "
                  "not actually be visible if its group is unchecked, or if an "
-                 "animation is in progress.")
+                 "animation is in progress.",
+                 "name"_a, "show"_a)
             .def("get_geometry", &O3DVisualizer::GetGeometry,
-                 "get_geometry(name): Returns the DrawObject corresponding to "
-                 "the name. This should be treated as read-only. Modify "
-                 "visibility with show_geometry(), and other values by "
-                 "removing the object and re-adding it with the new values")
+                 "Returns the DrawObject corresponding to the name. This "
+                 "should be treated as read-only. Modify visibility with "
+                 "show_geometry(), and other values by removing the object and "
+                 "re-adding it with the new values",
+                 "name"_a)
             .def("get_geometry_material", &O3DVisualizer::GetGeometryMaterial,
-                 "get_geometry_material(name): Returns the MaterialRecord "
-                 "corresponding to the name. The returned material is a copy, "
-                 "therefore modifying it directly will not change the "
-                 "visualization.")
+                 "Returns the MaterialRecord corresponding to the name. The "
+                 "returned material is a copy, therefore modifying it directly "
+                 "will not change the visualization.",
+                 "name"_a)
             .def("modify_geometry_material",
                  &O3DVisualizer::ModifyGeometryMaterial,
-                 "modify_geometry_material(name,material): Updates the named "
-                 "geometry to use the new provided material.")
+                 "Updates the named geometry to use the new provided material.",
+                 "name"_a, "material"_a)
             .def("add_3d_label", &O3DVisualizer::Add3DLabel,
-                 "add_3d_label([x,y,z], text): displays text anchored at the "
-                 "3D coordinate specified")
+                 "Displays text anchored at the 3D coordinate specified",
+                 "pos"_a, "text"_a)
             .def("clear_3d_labels", &O3DVisualizer::Clear3DLabels,
                  "Clears all 3D text")
             .def("setup_camera",
@@ -277,22 +275,22 @@ void pybind_o3dvisualizer(py::module& m) {
                                    const Eigen::Vector3f&,
                                    const Eigen::Vector3f&>(
                          &O3DVisualizer::SetupCamera),
-                 "setup_camera(field_of_view, center, eye, up): sets the "
-                 "camera view so that the camera is located at 'eye', pointing "
-                 "towards 'center', and oriented so that the up vector is 'up'")
+                 "Sets the camera view so that the camera is located at 'eye', "
+                 "pointing towards 'center', and oriented so that the up "
+                 "vector is 'up'",
+                 "field_of_view"_a, "center"_a, "eye"_a, "up"_a)
             .def("setup_camera",
                  py::overload_cast<const camera::PinholeCameraIntrinsic&,
                                    const Eigen::Matrix4d&>(
                          &O3DVisualizer::SetupCamera),
-                 "setup_camera(intrinsic, extrinsic_matrix): sets the camera "
-                 "view")
+                 "Sets the camera view", "intrinsic"_a, "extrinsic_matrix"_a)
             .def("setup_camera",
                  py::overload_cast<const Eigen::Matrix3d&,
                                    const Eigen::Matrix4d&, int, int>(
                          &O3DVisualizer::SetupCamera),
-                 "setup_camera(intrinsic_matrix, extrinsic_matrix, "
-                 "intrinsic_width_px, intrinsic_height_px): sets the camera "
-                 "view")
+                 "Sets the camera view", "intrinsic_matrix"_a,
+                 "extrinsic_matrix"_a, "intrinsic_width_px"_a,
+                 "intrinsic_height_px"_a)
             .def("reset_camera_to_default",
                  &O3DVisualizer::ResetCameraToDefault,
                  "Sets camera to default position")
@@ -300,23 +298,26 @@ void pybind_o3dvisualizer(py::module& m) {
                  "Returns the selection sets, as [{'obj_name', "
                  "[SelectedIndex]}]")
             .def("set_on_animation_frame", &O3DVisualizer::SetOnAnimationFrame,
-                 "set_on_animation(callback): Sets a callback that will be "
-                 "called every frame of the animation. The callback will be "
-                 "called as callback(o3dvis, current_time).")
+                 "Sets a callback that will be called every frame of the "
+                 "animation. The callback will be called as callback(o3dvis, "
+                 "current_time).",
+                 "callback"_a)
             .def("set_on_animation_tick", &O3DVisualizer::SetOnAnimationTick,
-                 "set_on_animation(callback): Sets a callback that will be "
-                 "called every frame of the animation. The callback will be "
-                 "called as callback(o3dvis, time_since_last_tick, "
-                 "total_elapsed_since_animation_started). Note that this "
-                 "is a low-level callback. If you need to change the current "
+                 "Sets a callback that will be called every frame of the "
+                 "animation. The callback will be called as callback(o3dvis, "
+                 "time_since_last_tick, "
+                 "total_elapsed_since_animation_started). Note that this is a "
+                 "low-level callback. If you need to change the current "
                  "timestamp being shown you will need to update the "
                  "o3dvis.current_time property in the callback. The callback "
                  "must return either O3DVisualizer.TickResult.IGNORE if no "
-                 "redraw is required or O3DVisualizer.TickResult.REDRAW "
-                 "if a redraw is required.")
+                 "redraw is required or O3DVisualizer.TickResult.REDRAW if a "
+                 "redraw is required.",
+                 "callback"_a)
             .def("export_current_image", &O3DVisualizer::ExportCurrentImage,
-                 "export_image(path). Exports a PNG image of what is "
-                 "currently displayed to the given path.")
+                 "Exports a PNG image of what is currently displayed to the "
+                 "given path.",
+                 "path"_a)
             .def("start_rpc_interface", &O3DVisualizer::StartRPCInterface,
                  "address"_a, "timeout"_a,
                  "Starts the RPC interface.\n"
@@ -325,20 +326,22 @@ void pybind_o3dvisualizer(py::module& m) {
             .def("stop_rpc_interface", &O3DVisualizer::StopRPCInterface,
                  "Stops the RPC interface.")
             .def("set_background", &O3DVisualizer::SetBackground,
-                 "set_background(color, image=None): Sets the background color "
-                 "and, optionally, the background image. Passing None for the "
-                 "background image will clear any image already there.")
+                 "Sets the background color and, optionally, the background "
+                 "image. Passing None for the background image will clear any "
+                 "image already there.",
+                 "bg_color"_a, "bg_image"_a)
             .def("set_ibl", &O3DVisualizer::SetIBL,
-                 "set_ibl(ibl_name): Sets the IBL and its matching skybox. If "
-                 "ibl_name_ibl.ktx is found in the default resource directory "
-                 "then it is used. Otherwise, ibl_name is assumed to be a path "
-                 "to the ibl KTX file.")
+                 "Sets the IBL and its matching skybox. If ibl_name_ibl.ktx is "
+                 "found in the default resource directory then it is used. "
+                 "Otherwise, ibl_name is assumed to be a path to the ibl KTX "
+                 "file.",
+                 "ibl_name"_a)
             .def("set_ibl_intensity", &O3DVisualizer::SetIBLIntensity,
-                 "set_ibl_intensity(intensity): Sets the intensity of the "
-                 "current IBL")
+                 "Sets the intensity of the current IBL", "intensity"_a)
             .def("enable_raw_mode", &O3DVisualizer::EnableBasicMode,
-                 "enable_raw_mode(enable): Enables/disables raw mode for "
-                 "simplified lighting environment.")
+                 "Enables/disables raw mode for simplified lighting "
+                 "environment.",
+                 "enable"_a)
             .def("show_skybox", &O3DVisualizer::ShowSkybox,
                  "Show/Hide the skybox", "show"_a)
             .def_property(

--- a/cpp/pybind/visualization/o3dvisualizer.cpp
+++ b/cpp/pybind/visualization/o3dvisualizer.cpp
@@ -134,7 +134,8 @@ void pybind_o3dvisualizer(py::module& m) {
                     "Returns 'window_undefined' otherwise.")
             .def("post_redraw", &O3DVisualizer::PostRedraw,
                  "Tells the window to redraw")
-            .def("show", &O3DVisualizer::Show, "Shows or hides the window")
+            .def("show", &O3DVisualizer::Show, "Shows or hides the window",
+                 "vis"_a)
             .def("close", &O3DVisualizer::Close,
                  "Closes the window and destroys it, unless an on_close "
                  "callback cancels the close.")
@@ -143,17 +144,19 @@ void pybind_o3dvisualizer(py::module& m) {
                     [](O3DVisualizer& w, UnownedPointer<gui::Dialog> dlg) {
                         w.ShowDialog(TakeOwnership<gui::Dialog>(dlg));
                     },
-                    "Displays the dialog")
+                    "Displays the dialog", "dlg"_a)
             .def("close_dialog", &O3DVisualizer::CloseDialog,
                  "Closes the current dialog")
             .def("show_message_box", &O3DVisualizer::ShowMessageBox,
                  "Displays a simple dialog with a title and message and okay "
-                 "button")
+                 "button",
+                 "title"_a, "message"_a)
             .def("set_on_close", &O3DVisualizer::SetOnClose,
                  "Sets a callback that will be called when the window is "
                  "closed. The callback is given no arguments and should return "
                  "True to continue closing the window or False to cancel the "
-                 "close")
+                 "close",
+                 "callback"_a)
             .def("show_menu", &O3DVisualizer::ShowMenu,
                  "show_menu(show): shows or hides the menu in the window, "
                  "except on macOS since the menubar is not in the window "
@@ -337,7 +340,7 @@ void pybind_o3dvisualizer(py::module& m) {
                  "enable_raw_mode(enable): Enables/disables raw mode for "
                  "simplified lighting environment.")
             .def("show_skybox", &O3DVisualizer::ShowSkybox,
-                 "Show/Hide the skybox")
+                 "Show/Hide the skybox", "show"_a)
             .def_property(
                     "show_settings",
                     [](const O3DVisualizer& dv) {

--- a/cpp/pybind/visualization/rendering/material.cpp
+++ b/cpp/pybind/visualization/rendering/material.cpp
@@ -39,8 +39,8 @@ void pybind_material(py::module& m) {
             "such as TriangleMesh, LineSets, and PointClouds");
 
     mat.def(py::init<>())
-            .def(py::init<Material>())
-            .def(py::init<const std::string&>())
+            .def(py::init<Material>(), "", "mat"_a)
+            .def(py::init<const std::string&>(), "", "material_name"_a)
             .def("set_default_properties", &Material::SetDefaultProperties,
                  "Fills material with defaults for common PBR material "
                  "properties used by Open3D")

--- a/cpp/pybind/visualization/visualizer.cpp
+++ b/cpp/pybind/visualization/visualizer.cpp
@@ -68,7 +68,7 @@ void pybind_visualizer(py::module &m) {
             .def("close", &Visualizer::Close,
                  "Function to notify the window to be closed")
             .def("reset_view_point", &Visualizer::ResetViewPoint,
-                 "Function to reset view point")
+                 "Function to reset view point", "reset_bounding_box"_a = false)
             .def("update_geometry", &Visualizer::UpdateGeometry,
                  "Function to update geometry. This function must be called "
                  "when geometry has been changed. Otherwise the behavior of "
@@ -77,7 +77,8 @@ void pybind_visualizer(py::module &m) {
             .def("update_renderer", &Visualizer::UpdateRender,
                  "Function to inform render needed to be updated")
             .def("set_full_screen", &Visualizer::SetFullScreen,
-                 "Function to change between fullscreen and windowed")
+                 "Function to change between fullscreen and windowed",
+                 "fullscreen"_a)
             .def("toggle_full_screen", &Visualizer::ToggleFullScreen,
                  "Function to toggle between fullscreen and windowed")
             .def("is_full_screen", &Visualizer::IsFullScreen,
@@ -160,7 +161,9 @@ void pybind_visualizer(py::module &m) {
                             "Visualizer with editing capabilities.");
     py::detail::bind_default_constructor<VisualizerWithEditing>(
             visualizer_edit);
-    visualizer_edit.def(py::init<double, bool, const std::string &>())
+    visualizer_edit
+            .def(py::init<double, bool, const std::string &>(), "voxel_size"_a,
+                 "use_dialog"_a, "directory"_a)
             .def("__repr__",
                  [](const VisualizerWithEditing &vis) {
                      return std::string("VisualizerWithEditing with name ") +
@@ -189,7 +192,7 @@ void pybind_visualizer(py::module &m) {
                             vis.GetWindowName();
                  })
             .def("pick_points", &VisualizerWithVertexSelection::PickPoints,
-                 "Function to pick points")
+                 "Function to pick points", "x"_a, "y"_a, "w"_a, "h"_a)
             .def("get_picked_points",
                  &VisualizerWithVertexSelection::GetPickedPoints,
                  "Function to get picked points")
@@ -198,23 +201,26 @@ void pybind_visualizer(py::module &m) {
                  "Function to clear picked points")
             .def("add_picked_points",
                  &VisualizerWithVertexSelection::AddPickedPoints,
-                 "Function to add picked points")
+                 "Function to add picked points", "indices"_a)
             .def("remove_picked_points",
                  &VisualizerWithVertexSelection::RemovePickedPoints,
-                 "Function to remove picked points")
+                 "Function to remove picked points", "indices"_a)
             .def("register_selection_changed_callback",
                  &VisualizerWithVertexSelection::
                          RegisterSelectionChangedCallback,
-                 "Registers a function to be called when selection changes")
+                 "Registers a function to be called when selection changes",
+                 "f"_a)
             .def("register_selection_moving_callback",
                  &VisualizerWithVertexSelection::
                          RegisterSelectionMovingCallback,
                  "Registers a function to be called while selection moves. "
                  "Geometry's vertex values can be changed, but do not change"
-                 "the number of vertices.")
+                 "the number of vertices.",
+                 "f"_a)
             .def("register_selection_moved_callback",
                  &VisualizerWithVertexSelection::RegisterSelectionMovedCallback,
-                 "Registers a function to be called after selection moves");
+                 "Registers a function to be called after selection moves",
+                 "f"_a);
 
     py::class_<VisualizerWithVertexSelection::PickedPoint>
             visualizer_vselect_pickedpoint(m, "PickedPoint");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

I was using the python visualization API, and I noticed that some of the keyword arguments in the python bindings show up as "arg0" "arg1" etc. This made it confusing, because I had to keep switching between the python API and the source code to see what the arguments really meant. This adds the missing argument names.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [x] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->

Before, if I ran something like `help(open3d.visualization.Visualizer.reset_view_point)`, I would get a message that looks like this (notice the `arg0`):

```
Help on instancemethod in module open3d.cpu.pybind.visualization:

reset_view_point(...)
    reset_view_point(self, arg0)
    Function to reset view point
    
    Args:
        arg0 (bool)
    
    Returns:
        None
```

Now it looks like this:

```
Help on instancemethod in module open3d.cpu.pybind.visualization:

reset_view_point(...)
    reset_view_point(self, reset_bounding_box=False)
    Function to reset view point
    
    Args:
        reset_bounding_box (bool, optional, default=False): Set to ``False`` to keep current viewpoint
    
    Returns:
        None
```

I have added similar fixes for other functions in `open3d.visualization`. I believe this is the only module where the keyword arguments were missing in the python docs.  In `O3DVisualizer`, some of the documentation style was inconsistent, so I cleaned that up, too.

I checked the generated html docs and verified that the results look okay. Let me know if you'd like any other changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/6407)
<!-- Reviewable:end -->
