### PR TITLE
Add RemoveDuplicatedTriangles feature using tensor API

### DIFF
--- a/cpp/open3d/t/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/t/geometry/TriangleMesh.cpp
@@ -177,8 +177,8 @@ TriangleMesh &TriangleMesh::Rotate(const core::Tensor &R,
 TriangleMesh &TriangleMesh::RemoveDuplicatedTriangles() {
     core::Tensor triangles = GetTriangleIndices();
     int64_t num_triangles = triangles.GetLength();
-    if (num_triangles < 1) {
-        utility::LogError("Mesh must have at least two triangles.");
+    if (num_triangles < 2) {
+        return *this;
     }
 
     // unordered_map to keep track of existing triangles

--- a/cpp/open3d/t/geometry/TriangleMesh.h
+++ b/cpp/open3d/t/geometry/TriangleMesh.h
@@ -654,6 +654,8 @@ public:
     /// \return Rotated TriangleMesh
     TriangleMesh &Rotate(const core::Tensor &R, const core::Tensor &center);
 
+    TriangleMesh &RemoveDuplicatedTriangles();
+
     /// Normalize both triangle normals and vertex normals to length 1.
     TriangleMesh &NormalizeNormals();
 

--- a/cpp/open3d/t/geometry/TriangleMesh.h
+++ b/cpp/open3d/t/geometry/TriangleMesh.h
@@ -654,6 +654,8 @@ public:
     /// \return Rotated TriangleMesh
     TriangleMesh &Rotate(const core::Tensor &R, const core::Tensor &center);
 
+    /// \brief Remove duplicated triangles from the TriangleMesh
+    /// \return TriangleMesh without duplicated triangles
     TriangleMesh &RemoveDuplicatedTriangles();
 
     /// Normalize both triangle normals and vertex normals to length 1.

--- a/cpp/pybind/t/geometry/trianglemesh.cpp
+++ b/cpp/pybind/t/geometry/trianglemesh.cpp
@@ -176,6 +176,9 @@ The attributes of the triangle mesh have different levels::
                       "Scale points.");
     triangle_mesh.def("rotate", &TriangleMesh::Rotate, "R"_a, "center"_a,
                       "Rotate points and normals (if exist).");
+    triangle_mesh.def("remove_duplicated_triangles",
+                      &TriangleMesh::RemoveDuplicatedTriangles,
+                      "Remove duplicate triangles from a triangle");
 
     triangle_mesh.def(
             "normalize_normals", &TriangleMesh::NormalizeNormals,

--- a/cpp/pybind/t/geometry/trianglemesh.cpp
+++ b/cpp/pybind/t/geometry/trianglemesh.cpp
@@ -178,7 +178,7 @@ The attributes of the triangle mesh have different levels::
                       "Rotate points and normals (if exist).");
     triangle_mesh.def("remove_duplicated_triangles",
                       &TriangleMesh::RemoveDuplicatedTriangles,
-                      "Remove duplicate triangles from a triangle");
+                      "Remove duplicated triangles from a triangle");
 
     triangle_mesh.def(
             "normalize_normals", &TriangleMesh::NormalizeNormals,

--- a/cpp/tests/t/geometry/TriangleMesh.cpp
+++ b/cpp/tests/t/geometry/TriangleMesh.cpp
@@ -327,6 +327,56 @@ TEST_P(TriangleMeshPermuteDevices, Rotate) {
             core::Tensor::Init<float>({{2, 2, 1}, {2, 2, 1}}, device)));
 }
 
+TEST_P(TriangleMeshPermuteDevices, RemoveDuplicatedTriangles) {
+    core::Device device = GetParam();
+
+    t::geometry::TriangleMesh mesh(device);
+
+    mesh.SetVertexPositions(core::Tensor::Init<float>({{0, 0, 0},
+                                                       {1, 0, 0},
+                                                       {0, 0, 1},
+                                                       {1, 0, 1},
+                                                       {0, 1, 0},
+                                                       {1, 1, 0},
+                                                       {0, 1, 1},
+                                                       {1, 1, 1}},
+                                                      device));
+
+    mesh.SetTriangleIndices(core::Tensor::Init<int64_t>({{4, 7, 5},
+                                                         {4, 6, 7},
+                                                         {0, 2, 4},
+                                                         {2, 6, 4},
+                                                         {0, 1, 2},
+                                                         {1, 3, 2},
+                                                         {1, 5, 7},
+                                                         {1, 7, 3},
+                                                         {2, 3, 7},
+                                                         {2, 7, 6},
+                                                         {4, 6, 7},
+                                                         {0, 4, 1},
+                                                         {1, 4, 5}},
+                                                        device));
+
+    mesh.RemoveDuplicatedTriangles();
+
+    EXPECT_EQ(mesh.GetTriangleIndices().GetLength(), 12);
+
+    EXPECT_TRUE(mesh.GetTriangleIndices().AllClose(
+            core::Tensor::Init<int64_t>({{4, 7, 5},
+                                         {4, 6, 7},
+                                         {0, 2, 4},
+                                         {2, 6, 4},
+                                         {0, 1, 2},
+                                         {1, 3, 2},
+                                         {1, 5, 7},
+                                         {1, 7, 3},
+                                         {2, 3, 7},
+                                         {2, 7, 6},
+                                         {0, 4, 1},
+                                         {1, 4, 5}},
+                                        device)));
+}
+
 TEST_P(TriangleMeshPermuteDevices, NormalizeNormals) {
     core::Device device = GetParam();
 

--- a/cpp/tests/t/geometry/TriangleMesh.cpp
+++ b/cpp/tests/t/geometry/TriangleMesh.cpp
@@ -357,9 +357,28 @@ TEST_P(TriangleMeshPermuteDevices, RemoveDuplicatedTriangles) {
                                                          {1, 4, 5}},
                                                         device));
 
+    mesh.SetTriangleNormals(core::Tensor::Init<float>({{4, 7, 5},
+                                                       {4, 6, 7},
+                                                       {0, 2, 4},
+                                                       {2, 6, 4},
+                                                       {0, 1, 2},
+                                                       {1, 3, 2},
+                                                       {1, 5, 7},
+                                                       {1, 7, 3},
+                                                       {2, 3, 7},
+                                                       {2, 7, 6},
+                                                       {4, 6, 7},
+                                                       {0, 4, 1},
+                                                       {1, 4, 5}},
+                                                      device));
+
+    mesh.SetTriangleColors(core::Tensor::Ones({13, 3}, core::Float32, device));
+
     mesh.RemoveDuplicatedTriangles();
 
     EXPECT_EQ(mesh.GetTriangleIndices().GetLength(), 12);
+    EXPECT_EQ(mesh.GetTriangleNormals().GetLength(), 12);
+    EXPECT_EQ(mesh.GetTriangleColors().GetLength(), 12);
 
     EXPECT_TRUE(mesh.GetTriangleIndices().AllClose(
             core::Tensor::Init<int64_t>({{4, 7, 5},
@@ -375,6 +394,21 @@ TEST_P(TriangleMeshPermuteDevices, RemoveDuplicatedTriangles) {
                                          {0, 4, 1},
                                          {1, 4, 5}},
                                         device)));
+
+    EXPECT_TRUE(mesh.GetTriangleNormals().AllClose(
+            core::Tensor::Init<float>({{4, 7, 5},
+                                       {4, 6, 7},
+                                       {0, 2, 4},
+                                       {2, 6, 4},
+                                       {0, 1, 2},
+                                       {1, 3, 2},
+                                       {1, 5, 7},
+                                       {1, 7, 3},
+                                       {2, 3, 7},
+                                       {2, 7, 6},
+                                       {0, 4, 1},
+                                       {1, 4, 5}},
+                                      device)));
 }
 
 TEST_P(TriangleMeshPermuteDevices, NormalizeNormals) {

--- a/python/test/t/geometry/test_trianglemesh.py
+++ b/python/test/t/geometry/test_trianglemesh.py
@@ -417,3 +417,29 @@ def test_pickle(device):
                                 mesh.vertex.positions.cpu().numpy())
         np.testing.assert_equal(mesh_load.triangle.indices.cpu().numpy(),
                                 mesh.triangle.indices.cpu().numpy())
+
+
+@pytest.mark.parametrize("device", list_devices())
+def test_remove_duplicated_triangles(device):
+
+    mesh = o3d.t.geometry.TriangleMesh()
+    vertex_positions = o3c.Tensor(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, 1.0],
+         [0.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 1.0], [1.0, 1.0, 1.0]],
+        o3c.float32, device)
+    triangle_indices = o3c.Tensor(
+        [[4, 7, 5], [4, 6, 7], [0, 2, 4], [2, 6, 4], [0, 1, 2], [1, 3, 2],
+         [1, 5, 7], [1, 7, 3], [2, 3, 7], [2, 7, 6], [4, 6, 7], [0, 4, 1],
+         [1, 4, 5]], o3c.int64, device)
+    mesh.vertex.positions = vertex_positions
+    mesh.triangle.indices = triangle_indices
+
+    mesh.remove_duplicated_triangles()
+
+    assert mesh.triangle.indices.shape == (12, 3)
+    np.testing.assert_allclose(
+        mesh.triangle.indices.cpu().numpy(),
+        o3c.Tensor(
+            [[4, 7, 5], [4, 6, 7], [0, 2, 4], [2, 6, 4], [0, 1, 2], [1, 3, 2],
+             [1, 5, 7], [1, 7, 3], [2, 3, 7], [2, 7, 6], [0, 4, 1], [1, 4, 5]],
+            o3c.int64, device).cpu().numpy())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ x] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This PR is an implementation of the RemoveDuplicatedTriangles but using the tensor API to be able to run it either on CPU or GPU (only CPU for now in this PR).
This was also an opportunity to get familiar with the Open3D code.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x ] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x ] This PR changes Open3D behavior or adds new functionality.
    -   [x ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [x ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x ] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x ] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

Here is the note of my PR for the RemoveDuplicatedTriangles feture using Tensor API.

The first problem of this feature is how to identify duplicated triangles.
I keep the same solution than the Eigen based API RemoveDuplicatedTriangles that is to use a unordered_map that has a complexity of search in O(1) due to the use of a hash function.

This unordered_map is implemented with a tuple as key instead of a tensor directly is because the hash function using a tensor is not implemented.
So we have to "convert" a vertice tensor of 3 points to a tuple to be able to keep track of the triangle.

The second problem is how to remove the duplicated triangles.
I choose to iterate on the index of the unique triangles and to copy them in a new tensor

I did this like that because we don't know the size of the new tensor of triangles until we have looped on all triangles.

I have tried to use :
	tensor.reshape(), but it reshapes the tensor in a tensor with the same number of elements.
	tensor.append(), but we need it doesn't increase the size of the vector where we append elements.

In the worst case where we have only one duplicated triangles we will need to iterate one time on the number of triangles and an other time on number of triangles - 1,
so the complexity is in O(n*(n-1)) and in the best case O(n) due to the test if before the second loop.

I have also treated the case if there are some normales triangles. I suppose that the number of triangles and normales triangles are the same and they are at a corresponding index.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/6409)
<!-- Reviewable:end -->
