### PR TITLE
Implement open3d::t::geometry::TriangleMesh::SelectByIndex

### DIFF
--- a/cpp/open3d/core/Dispatch.h
+++ b/cpp/open3d/core/Dispatch.h
@@ -113,3 +113,34 @@
             open3d::utility::LogError("Unsupported data type.");  \
         }                                                         \
     }()
+
+#define DISPATCH_INT_DTYPE_PREFIX_TO_TEMPLATE(DTYPE, PREFIX, ...) \
+    [&] {                                                         \
+        if (DTYPE == open3d::core::Int8) {                        \
+            using scalar_##PREFIX##_t = int8_t;                   \
+            return __VA_ARGS__();                                 \
+        } else if (DTYPE == open3d::core::Int16) {                \
+            using scalar_##PREFIX##_t = int16_t;                  \
+            return __VA_ARGS__();                                 \
+        } else if (DTYPE == open3d::core::Int32) {                \
+            using scalar_##PREFIX##_t = int32_t;                  \
+            return __VA_ARGS__();                                 \
+        } else if (DTYPE == open3d::core::Int64) {                \
+            using scalar_##PREFIX##_t = int64_t;                  \
+            return __VA_ARGS__();                                 \
+        } else if (DTYPE == open3d::core::UInt8) {                \
+            using scalar_##PREFIX##_t = uint8_t;                  \
+            return __VA_ARGS__();                                 \
+        } else if (DTYPE == open3d::core::UInt16) {               \
+            using scalar_##PREFIX##_t = uint16_t;                 \
+            return __VA_ARGS__();                                 \
+        } else if (DTYPE == open3d::core::UInt32) {               \
+            using scalar_##PREFIX##_t = uint32_t;                 \
+            return __VA_ARGS__();                                 \
+        } else if (DTYPE == open3d::core::UInt64) {               \
+            using scalar_##PREFIX##_t = uint64_t;                 \
+            return __VA_ARGS__();                                 \
+        } else {                                                  \
+            open3d::utility::LogError("Unsupported data type.");  \
+        }                                                         \
+    }()

--- a/cpp/open3d/t/geometry/TriangleMesh.h
+++ b/cpp/open3d/t/geometry/TriangleMesh.h
@@ -930,6 +930,16 @@ public:
     /// \return A new mesh with the selected faces.
     TriangleMesh SelectFacesByMask(const core::Tensor &mask) const;
 
+    /// Returns a new mesh with the vertices selected by a vector of indices.
+    /// If an item from the indices list exceeds the max vertex number of
+    /// the mesh or has a negative value, it is ignored.
+    /// \param indices An integer list of indices. Duplicates are
+    /// allowed, but ignored. Signed and unsigned integral types are allowed.
+    /// \return A new mesh with the selected vertices and faces built
+    /// from the selected vertices. If the original mesh is empty, return
+    /// an empty mesh.
+    TriangleMesh SelectByIndex(const core::Tensor &indices) const;
+
 protected:
     core::Device device_ = core::Device("CPU:0");
     TensorMap vertex_attr_;

--- a/cpp/open3d/t/geometry/TriangleMesh.h
+++ b/cpp/open3d/t/geometry/TriangleMesh.h
@@ -927,7 +927,8 @@ public:
     /// Returns a new mesh with the faces selected by a boolean mask.
     /// \param mask A boolean mask with the shape (N) with N as the number of
     /// faces in the mesh.
-    /// \return A new mesh with the selected faces.
+    /// \return A new mesh with the selected faces. If the original mesh is
+    /// empty, return an empty mesh.
     TriangleMesh SelectFacesByMask(const core::Tensor &mask) const;
 
     /// Returns a new mesh with the vertices selected by a vector of indices.

--- a/cpp/pybind/t/geometry/trianglemesh.cpp
+++ b/cpp/pybind/t/geometry/trianglemesh.cpp
@@ -901,7 +901,7 @@ Args:
         number of faces in the mesh.
     
 Returns:
-    A new mesh with the selected faces.
+    A new mesh with the selected faces. If the original mesh is empty, return an empty mesh.
 
 Example:
 

--- a/cpp/pybind/t/geometry/trianglemesh.cpp
+++ b/cpp/pybind/t/geometry/trianglemesh.cpp
@@ -924,6 +924,30 @@ Example:
         o3d.visualization.draw(parts)
 
 )");
+
+    triangle_mesh.def(
+            "select_by_index", &TriangleMesh::SelectByIndex, "indices"_a,
+            R"(Returns a new mesh with the vertices selected according to the indices list.
+If an item from the indices list exceeds the max vertex number of the mesh
+or has a negative value, it is ignored.
+
+Args:
+    indices (open3d.core.Tensor): An integer list of indices. Duplicates are
+    allowed, but ignored. Signed and unsigned integral types are accepted.
+
+Returns:
+    A new mesh with the selected vertices and faces built from these vertices.
+    If the original mesh is empty, return an empty mesh.
+
+Example:
+
+    This code selects the top face of a box, which has indices [2, 3, 6, 7]::
+
+        import open3d as o3d
+        import numpy as np
+        box = o3d.t.geometry.TriangleMesh.create_box()
+        top_face = box.select_by_index([2, 3, 6, 7])
+)");
 }
 
 }  // namespace geometry

--- a/cpp/tests/t/geometry/TriangleMesh.cpp
+++ b/cpp/tests/t/geometry/TriangleMesh.cpp
@@ -941,6 +941,113 @@ TEST_P(TriangleMeshPermuteDevices, CreateMobius) {
             triangle_indices_custom));
 }
 
+TEST_P(TriangleMeshPermuteDevices, SelectFacesByMask) {
+    // check that an exception is thrown if the mesh is empty
+    t::geometry::TriangleMesh mesh_empty;
+    core::Tensor mask_empty =
+            core::Tensor::Zeros({12}, core::Bool, mesh_empty.GetDevice());
+    core::Tensor mask_full =
+            core::Tensor::Ones({12}, core::Bool, mesh_empty.GetDevice());
+
+    // check completely empty mesh
+    EXPECT_TRUE(mesh_empty.SelectFacesByMask(mask_empty).IsEmpty());
+    EXPECT_TRUE(mesh_empty.SelectFacesByMask(mask_full).IsEmpty());
+
+    // check mesh w/o triangles
+    core::Tensor cpu_vertices =
+            core::Tensor::Ones({2, 3}, core::Float32, mesh_empty.GetDevice());
+    mesh_empty.SetVertexPositions(cpu_vertices);
+    EXPECT_TRUE(mesh_empty.SelectFacesByMask(mask_empty).IsEmpty());
+    EXPECT_TRUE(mesh_empty.SelectFacesByMask(mask_full).IsEmpty());
+
+    // create box with normals, colors and labels defined.
+    t::geometry::TriangleMesh box = t::geometry::TriangleMesh::CreateBox();
+    core::Tensor vertex_colors = core::Tensor::Init<float>({{0.0, 0.0, 0.0},
+                                                            {1.0, 1.0, 1.0},
+                                                            {2.0, 2.0, 2.0},
+                                                            {3.0, 3.0, 3.0},
+                                                            {4.0, 4.0, 4.0},
+                                                            {5.0, 5.0, 5.0},
+                                                            {6.0, 6.0, 6.0},
+                                                            {7.0, 7.0, 7.0}});
+    ;
+    core::Tensor vertex_labels = core::Tensor::Init<float>({{0.0, 0.0, 0.0},
+                                                            {1.0, 1.0, 1.0},
+                                                            {2.0, 2.0, 2.0},
+                                                            {3.0, 3.0, 3.0},
+                                                            {4.0, 4.0, 4.0},
+                                                            {5.0, 5.0, 5.0},
+                                                            {6.0, 6.0, 6.0},
+                                                            {7.0, 7.0, 7.0}}) *
+                                 10;
+    ;
+    core::Tensor triangle_labels =
+            core::Tensor::Init<float>({{0.0, 0.0, 0.0},
+                                       {1.0, 1.0, 1.0},
+                                       {2.0, 2.0, 2.0},
+                                       {3.0, 3.0, 3.0},
+                                       {4.0, 4.0, 4.0},
+                                       {5.0, 5.0, 5.0},
+                                       {6.0, 6.0, 6.0},
+                                       {7.0, 7.0, 7.0},
+                                       {8.0, 8.0, 8.0},
+                                       {9.0, 9.0, 9.0},
+                                       {10.0, 10.0, 10.0},
+                                       {11.0, 11.0, 11.0}}) *
+            100;
+    box.SetVertexColors(vertex_colors);
+    box.SetVertexAttr("labels", vertex_labels);
+    box.ComputeTriangleNormals();
+    box.SetTriangleAttr("labels", triangle_labels);
+
+    // empty index list
+    EXPECT_TRUE(box.SelectFacesByMask(mask_empty).IsEmpty());
+
+    // set the expected value
+    core::Tensor expected_verts = core::Tensor::Init<float>({{0.0, 0.0, 1.0},
+                                                             {1.0, 0.0, 1.0},
+                                                             {0.0, 1.0, 1.0},
+                                                             {1.0, 1.0, 1.0}});
+    core::Tensor expected_vert_colors =
+            core::Tensor::Init<float>({{2.0, 2.0, 2.0},
+                                       {3.0, 3.0, 3.0},
+                                       {6.0, 6.0, 6.0},
+                                       {7.0, 7.0, 7.0}});
+    core::Tensor expected_vert_labels =
+            core::Tensor::Init<float>({{20.0, 20.0, 20.0},
+                                       {30.0, 30.0, 30.0},
+                                       {60.0, 60.0, 60.0},
+                                       {70.0, 70.0, 70.0}});
+    core::Tensor expected_tris =
+            core::Tensor::Init<int64_t>({{0, 1, 3}, {0, 3, 2}});
+    core::Tensor tris_mask =
+            core::Tensor::Init<bool>({0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0});
+    core::Tensor expected_tri_normals =
+            box.GetTriangleNormals().IndexGet({tris_mask});
+    core::Tensor expected_tri_labels = core::Tensor::Init<float>(
+            {{800.0, 800.0, 800.0}, {900.0, 900.0, 900.0}});
+
+    // check basic case
+    t::geometry::TriangleMesh selected = box.SelectFacesByMask(tris_mask);
+
+    EXPECT_TRUE(selected.GetVertexPositions().AllClose(expected_verts));
+    EXPECT_TRUE(selected.GetVertexColors().AllClose(expected_vert_colors));
+    EXPECT_TRUE(
+            selected.GetVertexAttr("labels").AllClose(expected_vert_labels));
+    EXPECT_TRUE(selected.GetTriangleIndices().AllClose(expected_tris));
+    EXPECT_TRUE(selected.GetTriangleNormals().AllClose(expected_tri_normals));
+    EXPECT_TRUE(
+            selected.GetTriangleAttr("labels").AllClose(expected_tri_labels));
+
+    // Check that initial mesh is unchanged.
+    t::geometry::TriangleMesh box_untouched =
+            t::geometry::TriangleMesh::CreateBox();
+    EXPECT_TRUE(box.GetVertexPositions().AllClose(
+            box_untouched.GetVertexPositions()));
+    EXPECT_TRUE(box.GetTriangleIndices().AllClose(
+            box_untouched.GetTriangleIndices()));
+}
+
 TEST_P(TriangleMeshPermuteDevices, SelectByIndex) {
     // check that an exception is thrown if the mesh is empty
     t::geometry::TriangleMesh mesh_empty;

--- a/cpp/tests/t/geometry/TriangleMesh.cpp
+++ b/cpp/tests/t/geometry/TriangleMesh.cpp
@@ -941,5 +941,154 @@ TEST_P(TriangleMeshPermuteDevices, CreateMobius) {
             triangle_indices_custom));
 }
 
+TEST_P(TriangleMeshPermuteDevices, SelectByIndex) {
+    // check that an exception is thrown if the mesh is empty
+    t::geometry::TriangleMesh mesh_empty;
+    core::Tensor indices_empty = core::Tensor::Init<int64_t>({});
+
+    // check completely empty mesh
+    EXPECT_TRUE(mesh_empty.SelectByIndex(indices_empty).IsEmpty());
+    EXPECT_TRUE(mesh_empty.SelectByIndex(core::Tensor::Init<int64_t>({0}))
+                        .IsEmpty());
+
+    // check mesh w/o triangles
+    core::Tensor vertices_no_tris_orig =
+            core::Tensor::Ones({2, 3}, core::Float32, mesh_empty.GetDevice());
+    core::Tensor expected_vertices_no_tris_orig =
+            core::Tensor::Ones({1, 3}, core::Float32, mesh_empty.GetDevice());
+    mesh_empty.SetVertexPositions(vertices_no_tris_orig);
+    t::geometry::TriangleMesh selected_no_tris_orig =
+            mesh_empty.SelectByIndex(core::Tensor::Init<int64_t>({0}));
+    EXPECT_TRUE(selected_no_tris_orig.GetVertexPositions().AllClose(
+            expected_vertices_no_tris_orig));
+
+    // create box with normals, colors and labels defined.
+    t::geometry::TriangleMesh box = t::geometry::TriangleMesh::CreateBox();
+    core::Tensor vertex_colors = core::Tensor::Init<float>({{0.0, 0.0, 0.0},
+                                                            {1.0, 1.0, 1.0},
+                                                            {2.0, 2.0, 2.0},
+                                                            {3.0, 3.0, 3.0},
+                                                            {4.0, 4.0, 4.0},
+                                                            {5.0, 5.0, 5.0},
+                                                            {6.0, 6.0, 6.0},
+                                                            {7.0, 7.0, 7.0}});
+    ;
+    core::Tensor vertex_labels = core::Tensor::Init<float>({{0.0, 0.0, 0.0},
+                                                            {1.0, 1.0, 1.0},
+                                                            {2.0, 2.0, 2.0},
+                                                            {3.0, 3.0, 3.0},
+                                                            {4.0, 4.0, 4.0},
+                                                            {5.0, 5.0, 5.0},
+                                                            {6.0, 6.0, 6.0},
+                                                            {7.0, 7.0, 7.0}}) *
+                                 10;
+    ;
+    core::Tensor triangle_labels =
+            core::Tensor::Init<float>({{0.0, 0.0, 0.0},
+                                       {1.0, 1.0, 1.0},
+                                       {2.0, 2.0, 2.0},
+                                       {3.0, 3.0, 3.0},
+                                       {4.0, 4.0, 4.0},
+                                       {5.0, 5.0, 5.0},
+                                       {6.0, 6.0, 6.0},
+                                       {7.0, 7.0, 7.0},
+                                       {8.0, 8.0, 8.0},
+                                       {9.0, 9.0, 9.0},
+                                       {10.0, 10.0, 10.0},
+                                       {11.0, 11.0, 11.0}}) *
+            100;
+    box.SetVertexColors(vertex_colors);
+    box.SetVertexAttr("labels", vertex_labels);
+    box.ComputeTriangleNormals();
+    box.SetTriangleAttr("labels", triangle_labels);
+
+    // empty index list
+    EXPECT_TRUE(box.SelectByIndex(indices_empty).IsEmpty());
+
+    // set the expected value
+    core::Tensor expected_verts = core::Tensor::Init<float>({{0.0, 0.0, 1.0},
+                                                             {1.0, 0.0, 1.0},
+                                                             {0.0, 1.0, 1.0},
+                                                             {1.0, 1.0, 1.0}});
+    core::Tensor expected_vert_colors =
+            core::Tensor::Init<float>({{2.0, 2.0, 2.0},
+                                       {3.0, 3.0, 3.0},
+                                       {6.0, 6.0, 6.0},
+                                       {7.0, 7.0, 7.0}});
+    core::Tensor expected_vert_labels =
+            core::Tensor::Init<float>({{20.0, 20.0, 20.0},
+                                       {30.0, 30.0, 30.0},
+                                       {60.0, 60.0, 60.0},
+                                       {70.0, 70.0, 70.0}});
+    core::Tensor expected_tris =
+            core::Tensor::Init<int64_t>({{0, 1, 3}, {0, 3, 2}});
+    core::Tensor tris_mask =
+            core::Tensor::Init<bool>({0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0});
+    core::Tensor expected_tri_normals =
+            box.GetTriangleNormals().IndexGet({tris_mask});
+    core::Tensor expected_tri_labels = core::Tensor::Init<float>(
+            {{800.0, 800.0, 800.0}, {900.0, 900.0, 900.0}});
+
+    // check basic case
+    core::Tensor indices = core::Tensor::Init<int64_t>({2, 3, 6, 7});
+    t::geometry::TriangleMesh selected = box.SelectByIndex(indices);
+
+    EXPECT_TRUE(selected.GetVertexPositions().AllClose(expected_verts));
+    EXPECT_TRUE(selected.GetVertexColors().AllClose(expected_vert_colors));
+    EXPECT_TRUE(
+            selected.GetVertexAttr("labels").AllClose(expected_vert_labels));
+    EXPECT_TRUE(selected.GetTriangleIndices().AllClose(expected_tris));
+    EXPECT_TRUE(selected.GetTriangleNormals().AllClose(expected_tri_normals));
+    EXPECT_TRUE(
+            selected.GetTriangleAttr("labels").AllClose(expected_tri_labels));
+
+    // check duplicated indices case
+    core::Tensor indices_duplicate =
+            core::Tensor::Init<int16_t>({2, 2, 3, 3, 6, 7, 7});
+    t::geometry::TriangleMesh selected_duplicate =
+            box.SelectByIndex(indices_duplicate);
+    EXPECT_TRUE(
+            selected_duplicate.GetVertexPositions().AllClose(expected_verts));
+    EXPECT_TRUE(selected_duplicate.GetVertexColors().AllClose(
+            expected_vert_colors));
+    EXPECT_TRUE(selected_duplicate.GetVertexAttr("labels").AllClose(
+            expected_vert_labels));
+    EXPECT_TRUE(
+            selected_duplicate.GetTriangleIndices().AllClose(expected_tris));
+    EXPECT_TRUE(selected_duplicate.GetTriangleNormals().AllClose(
+            expected_tri_normals));
+    EXPECT_TRUE(selected_duplicate.GetTriangleAttr("labels").AllClose(
+            expected_tri_labels));
+
+    // select with empty triangles as result
+    // set the expected value
+    core::Tensor expected_verts_no_tris = core::Tensor::Init<float>(
+            {{0.0, 0.0, 0.0}, {1.0, 0.0, 1.0}, {0.0, 1.0, 0.0}});
+    core::Tensor expected_vert_colors_no_tris = core::Tensor::Init<float>(
+            {{0.0, 0.0, 0.0}, {3.0, 3.0, 3.0}, {4.0, 4.0, 4.0}});
+    core::Tensor expected_vert_labels_no_tris = core::Tensor::Init<float>(
+            {{0.0, 0.0, 0.0}, {30.0, 30.0, 30.0}, {40.0, 40.0, 40.0}});
+
+    core::Tensor indices_no_tris = core::Tensor::Init<int64_t>({0, 3, 4});
+    t::geometry::TriangleMesh selected_no_tris =
+            box.SelectByIndex(indices_no_tris);
+
+    EXPECT_TRUE(selected_no_tris.GetVertexPositions().AllClose(
+            expected_verts_no_tris));
+    EXPECT_TRUE(selected_no_tris.GetVertexColors().AllClose(
+            expected_vert_colors_no_tris));
+    EXPECT_TRUE(selected_no_tris.GetVertexAttr("labels").AllClose(
+            expected_vert_labels_no_tris));
+    EXPECT_FALSE(selected_no_tris.HasTriangleIndices());
+
+    // check that initial mesh is unchanged
+    t::geometry::TriangleMesh box_untouched =
+            t::geometry::TriangleMesh::CreateBox();
+    EXPECT_TRUE(box.GetVertexPositions().AllClose(
+            box_untouched.GetVertexPositions()));
+    EXPECT_TRUE(box.GetTriangleIndices().AllClose(
+            box_untouched.GetTriangleIndices()));
+}
+
 }  // namespace tests
 }  // namespace open3d

--- a/python/test/t/geometry/test_trianglemesh.py
+++ b/python/test/t/geometry/test_trianglemesh.py
@@ -417,3 +417,135 @@ def test_pickle(device):
                                 mesh.vertex.positions.cpu().numpy())
         np.testing.assert_equal(mesh_load.triangle.indices.cpu().numpy(),
                                 mesh.triangle.indices.cpu().numpy())
+
+
+@pytest.mark.parametrize("device", list_devices())
+def test_select_by_index_32(device):
+    sphere_custom = o3d.t.geometry.TriangleMesh.create_sphere(
+        1, 3, o3c.float64, o3c.int32, device)
+
+    expected_verts = o3c.Tensor(
+        [[0.0, 0.0, 1.0], [0.866025, 0, 0.5], [0.433013, 0.75, 0.5],
+         [-0.866025, 0.0, 0.5], [-0.433013, -0.75, 0.5], [0.433013, -0.75, 0.5]
+        ], o3c.float64, device)
+
+    expected_tris = o3c.Tensor([[0, 1, 2], [0, 3, 4], [0, 4, 5], [0, 5, 1]],
+                               o3c.int32, device)
+
+    # check indices shape mismatch
+    indices_2d = o3c.Tensor([[0, 2], [3, 5], [6, 7]], o3c.int32, device)
+    with pytest.raises(RuntimeError):
+        selected = sphere_custom.select_by_index(indices_2d)
+
+    # check indices type mismatch
+    indices_float = o3c.Tensor([2.0, 4.0], o3c.float32, device)
+    with pytest.raises(RuntimeError):
+        selected = sphere_custom.select_by_index(indices_float)
+
+    # check the expected mesh with int8 input
+    indices_8 = o3c.Tensor([0, 2, 3, 5, 6, 7], o3c.int8, device)
+    selected = sphere_custom.select_by_index(indices_8)
+    assert selected.vertex.positions.allclose(expected_verts)
+    assert selected.triangle.indices.allclose(expected_tris)
+
+    # check the expected mesh with int16 input
+    indices_16 = o3c.Tensor([2, 0, 5, 3, 7, 6], o3c.int16, device)
+    selected = sphere_custom.select_by_index(indices_16)
+    assert selected.vertex.positions.allclose(expected_verts)
+    assert selected.triangle.indices.allclose(expected_tris)
+
+    # check the expected mesh with uint32 input
+    indices_u32 = o3c.Tensor([7, 6, 5, 3, 2, 0], o3c.uint32, device)
+    selected = sphere_custom.select_by_index(indices_u32)
+    assert selected.vertex.positions.allclose(expected_verts)
+    assert selected.triangle.indices.allclose(expected_tris)
+
+    # check the expected mesh with uint64 input and unsorted indices
+    indices_u64 = o3c.Tensor([7, 6, 3, 5, 0, 2], o3c.uint64, device)
+    selected = sphere_custom.select_by_index(indices_u64)
+    assert selected.vertex.positions.allclose(expected_verts)
+    assert selected.triangle.indices.allclose(expected_tris)
+
+    # check that an index exceeding the max vertex index of the mesh is ignored
+    selected = sphere_custom.select_by_index([0, 2, 3, 5, 6, 99, 7])
+    assert selected.vertex.positions.allclose(expected_verts)
+    assert selected.triangle.indices.allclose(expected_tris)
+
+    # check that a negative index is ignored
+    selected = sphere_custom.select_by_index([0, 2, 3, 5, -10, 6, 7])
+    assert selected.vertex.positions.allclose(expected_verts)
+    assert selected.triangle.indices.allclose(expected_tris)
+
+    # check that the original mesh is unmodified
+    untouched_sphere = o3d.t.geometry.TriangleMesh.create_sphere(
+        1, 3, o3c.float64, o3c.int32, device)
+    assert sphere_custom.vertex.positions.allclose(
+        untouched_sphere.vertex.positions)
+    assert sphere_custom.triangle.indices.allclose(
+        untouched_sphere.triangle.indices)
+
+
+@pytest.mark.parametrize("device", list_devices())
+def test_select_by_index_64(device):
+    sphere_custom = o3d.t.geometry.TriangleMesh.create_sphere(
+        1, 3, o3c.float64, o3c.int64, device)
+
+    # check indices shape mismatch
+    with pytest.raises(RuntimeError):
+        indices_2d = o3c.Tensor([[0, 2], [3, 5], [6, 7]], o3c.int64, device)
+        selected = sphere_custom.select_by_index(indices_2d)
+
+    # check indices type mismatch
+    with pytest.raises(RuntimeError):
+        indices_float = o3c.Tensor([2.0, 4.0], o3c.float64, device)
+        selected = sphere_custom.select_by_index(indices_float)
+
+    expected_verts = o3c.Tensor(
+        [[0.0, 0.0, 1.0], [0.866025, 0, 0.5], [0.433013, 0.75, 0.5],
+         [-0.866025, 0.0, 0.5], [-0.433013, -0.75, 0.5], [0.433013, -0.75, 0.5]
+        ], o3c.float64, device)
+
+    expected_tris = o3c.Tensor([[0, 1, 2], [0, 3, 4], [0, 4, 5], [0, 5, 1]],
+                               o3c.int64, device)
+
+    # check the expected mesh with int8 input
+    indices_u8 = o3c.Tensor([0, 2, 3, 5, 6, 7], o3c.uint8, device)
+    selected = sphere_custom.select_by_index(indices_u8)
+    assert selected.vertex.positions.allclose(expected_verts)
+    assert selected.triangle.indices.allclose(expected_tris)
+
+    # check the expected mesh with int16 input
+    indices_u16 = o3c.Tensor([2, 0, 5, 3, 7, 6], o3c.uint16, device)
+    selected = sphere_custom.select_by_index(indices_u16)
+    assert selected.vertex.positions.allclose(expected_verts)
+    assert selected.triangle.indices.allclose(expected_tris)
+
+    # check the expected mesh with int32 input
+    indices_32 = o3c.Tensor([7, 6, 5, 3, 2, 0], o3c.int32, device)
+    selected = sphere_custom.select_by_index(indices_32)
+    assert selected.vertex.positions.allclose(expected_verts)
+    assert selected.triangle.indices.allclose(expected_tris)
+
+    # check the expected mesh with int64 input and unsorted indices
+    indices_64 = o3c.Tensor([7, 6, 3, 5, 0, 2], o3c.int64, device)
+    selected = sphere_custom.select_by_index(indices_64)
+    assert selected.vertex.positions.allclose(expected_verts)
+    assert selected.triangle.indices.allclose(expected_tris)
+
+    # check that an index exceeding the max vertex index of the mesh is ignored
+    selected = sphere_custom.select_by_index([0, 2, 3, 5, 6, 99, 7])
+    assert selected.vertex.positions.allclose(expected_verts)
+    assert selected.triangle.indices.allclose(expected_tris)
+
+    # check that a negative index is ignored
+    selected = sphere_custom.select_by_index([0, 2, 3, 5, -10, 6, 7])
+    assert selected.vertex.positions.allclose(expected_verts)
+    assert selected.triangle.indices.allclose(expected_tris)
+
+    # check that the original mesh is unmodified
+    untouched_sphere = o3d.t.geometry.TriangleMesh.create_sphere(
+        1, 3, o3c.float64, o3c.int64, device)
+    assert sphere_custom.vertex.positions.allclose(
+        untouched_sphere.vertex.positions)
+    assert sphere_custom.triangle.indices.allclose(
+        untouched_sphere.triangle.indices)

--- a/python/test/t/geometry/test_trianglemesh.py
+++ b/python/test/t/geometry/test_trianglemesh.py
@@ -420,6 +420,96 @@ def test_pickle(device):
 
 
 @pytest.mark.parametrize("device", list_devices())
+def test_select_faces_by_mask_32(device):
+    sphere_custom = o3d.t.geometry.TriangleMesh.create_sphere(
+        1, 3, o3c.float64, o3c.int32, device)
+
+    expected_verts = o3c.Tensor(
+        [[0.0, 0.0, 1.0], [0.866025, 0, 0.5], [0.433013, 0.75, 0.5],
+         [-0.866025, 0.0, 0.5], [-0.433013, -0.75, 0.5], [0.433013, -0.75, 0.5]
+        ], o3c.float64, device)
+
+    expected_tris = o3c.Tensor([[0, 1, 2], [0, 3, 4], [0, 4, 5], [0, 5, 1]],
+                               o3c.int32, device)
+
+    # check indices shape mismatch
+    mask_2d = o3c.Tensor([[False, False], [False, False], [False, False]],
+                         o3c.bool, device)
+    with pytest.raises(RuntimeError):
+        selected = sphere_custom.select_faces_by_mask(mask_2d)
+
+    # check indices type mismatch
+    mask_float = o3c.Tensor([
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    ], o3c.float32, device)
+    with pytest.raises(RuntimeError):
+        selected = sphere_custom.select_faces_by_mask(mask_float)
+
+    # check the basic case
+    mask = o3c.Tensor([
+        True, False, False, False, False, False, True, False, True, False, True,
+        False, False, False, False, False, False, False, False, False, False,
+        False, False, False
+    ], o3c.bool, device)
+    selected = sphere_custom.select_faces_by_mask(mask)
+    assert selected.vertex.positions.allclose(expected_verts)
+    assert selected.triangle.indices.allclose(expected_tris)
+
+    # check that the original mesh is unmodified
+    untouched_sphere = o3d.t.geometry.TriangleMesh.create_sphere(
+        1, 3, o3c.float64, o3c.int32, device)
+    assert sphere_custom.vertex.positions.allclose(
+        untouched_sphere.vertex.positions)
+    assert sphere_custom.triangle.indices.allclose(
+        untouched_sphere.triangle.indices)
+
+
+@pytest.mark.parametrize("device", list_devices())
+def test_select_faces_by_mask_64(device):
+    sphere_custom = o3d.t.geometry.TriangleMesh.create_sphere(
+        1, 3, o3c.float64, o3c.int64, device)
+
+    # check indices shape mismatch
+    mask_2d = o3c.Tensor([[False, False], [False, False], [False, False]],
+                         o3c.bool, device)
+    with pytest.raises(RuntimeError):
+        selected = sphere_custom.select_faces_by_mask(mask_2d)
+
+    # check indices type mismatch
+    mask_float = o3c.Tensor([
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    ], o3c.float32, device)
+    with pytest.raises(RuntimeError):
+        selected = sphere_custom.select_faces_by_mask(mask_float)
+
+    expected_verts = o3c.Tensor(
+        [[0.0, 0.0, 1.0], [0.866025, 0, 0.5], [0.433013, 0.75, 0.5],
+         [-0.866025, 0.0, 0.5], [-0.433013, -0.75, 0.5], [0.433013, -0.75, 0.5]
+        ], o3c.float64, device)
+
+    expected_tris = o3c.Tensor([[0, 1, 2], [0, 3, 4], [0, 4, 5], [0, 5, 1]],
+                               o3c.int64, device)
+    # check the basic case
+    mask = o3c.Tensor([
+        True, False, False, False, False, False, True, False, True, False, True,
+        False, False, False, False, False, False, False, False, False, False,
+        False, False, False
+    ], o3c.bool, device)
+
+    selected = sphere_custom.select_faces_by_mask(mask)
+    assert selected.vertex.positions.allclose(expected_verts)
+    assert selected.triangle.indices.allclose(expected_tris)
+
+    # check that the original mesh is unmodified
+    untouched_sphere = o3d.t.geometry.TriangleMesh.create_sphere(
+        1, 3, o3c.float64, o3c.int64, device)
+    assert sphere_custom.vertex.positions.allclose(
+        untouched_sphere.vertex.positions)
+    assert sphere_custom.triangle.indices.allclose(
+        untouched_sphere.triangle.indices)
+
+
+@pytest.mark.parametrize("device", list_devices())
 def test_select_by_index_32(device):
     sphere_custom = o3d.t.geometry.TriangleMesh.create_sphere(
         1, 3, o3c.float64, o3c.int32, device)


### PR DESCRIPTION
The method uses tensor API. It takes a list of indices and returns a new mesh built with the selected vertices and triangles formed by these vertices.

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [x] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

The method is available with the `open3d::geometry::TriangleMesh` but not in `open3d::t::geometry::TriangleMesh`.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [?] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.   <---- here I am not sure about the Python doc, as I could not generate it locally.
    -   [x] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

The implementation is inspired by
  open3d::geometry::TriangleMesh::SelectByIndex.
and by
  open3d::t::geometry::TriangleMesh::SelectFacesByMask.

We first compute a mask of vertices to be selected.  If the input index exceeds the maximum number of vertices, we throw an exception. Based on the vertex mask we build a mapping index vector using inclusive prefix sum algorithm. We then update the selected vertex indices in the triangles CPU copy and build the triangles mask. I put that to a templated helper static function to avoid the code duplication for Int32 and Int64 vertex indices types.

With the computed masks we can select the vertices and triangles back on the mesh's device and copy the attributes.

FYI @ssheorey

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/6415)
<!-- Reviewable:end -->
