### PR TITLE
List intersections

### DIFF
--- a/cpp/open3d/t/geometry/RaycastingScene.cpp
+++ b/cpp/open3d/t/geometry/RaycastingScene.cpp
@@ -128,7 +128,7 @@ void ListIntersectionsFunc(const RTCFilterFunctionNArguments* args) {
             reinterpret_cast<const ListIntersectionsContext*>(args->context);
     struct RTCRayN* rayN = args->ray;
     struct RTCHitN* hitN = args->hit;
-    const unsigned int N = args->N; 
+    const unsigned int N = args->N;
 
     // Avoid crashing when debug visualizations are used.
     if (context == nullptr) return;
@@ -138,7 +138,7 @@ void ListIntersectionsFunc(const RTCFilterFunctionNArguments* args) {
     unsigned int* ray_ids = context->ray_ids;
     unsigned int* geometry_ids = context->geometry_ids;
     unsigned int* primitive_ids = context->primitive_ids;
-    float* t_hit = context->t_hit;    
+    float* t_hit = context->t_hit;
     Eigen::VectorXi cumsum = context->cumsum;
     unsigned int* track_intersections = context->track_intersections;
 
@@ -162,19 +162,18 @@ void ListIntersectionsFunc(const RTCFilterFunctionNArguments* args) {
         if (std::get<0>(prev_gpIDtfar) != hit.geomID ||
             (std::get<1>(prev_gpIDtfar) != hit.primID &&
              std::get<2>(prev_gpIDtfar) != ray.tfar)) {
-               size_t idx = cumsum[ray_id] + track_intersections[ray_id];
-               ray_ids[idx] = ray_id;
-               geometry_ids[idx]  = hit.geomID;
-               primitive_ids[idx]  = hit.primID;
-               t_hit[idx]  = ray.tfar;
-               previous_geom_prim_ID_tfar->operator[](ray_id) = gpID;
-               ++(track_intersections[ray_id]);
+            size_t idx = cumsum[ray_id] + track_intersections[ray_id];
+            ray_ids[idx] = ray_id;
+            geometry_ids[idx] = hit.geomID;
+            primitive_ids[idx] = hit.primID;
+            t_hit[idx] = ray.tfar;
+            previous_geom_prim_ID_tfar->operator[](ray_id) = gpID;
+            ++(track_intersections[ray_id]);
         }
         // Always ignore hit
         valid[ui] = 0;
     }
 }
-
 
 // Adapted from common/math/closest_point.h
 inline Vec3fa closestPointTriangle(Vec3fa const& p,
@@ -547,18 +546,17 @@ struct RaycastingScene::Impl {
                     LoopFn);
         }
     }
-    
-                                
+
     void ListIntersections(const float* const rays,
-                            const size_t num_rays,
-                            const size_t num_intersections,
-                            Eigen::VectorXi cumsum,
-                            unsigned int* track_intersections,
-                            unsigned int* ray_ids,
-                            unsigned int* geometry_ids,
-                            unsigned int* primitive_ids,
-                            float* t_hit,
-                            const int nthreads) {
+                           const size_t num_rays,
+                           const size_t num_intersections,
+                           Eigen::VectorXi cumsum,
+                           unsigned int* track_intersections,
+                           unsigned int* ray_ids,
+                           unsigned int* geometry_ids,
+                           unsigned int* primitive_ids,
+                           float* t_hit,
+                           const int nthreads) {
         CommitScene();
 
         memset(track_intersections, 0, sizeof(uint32_t) * num_rays);
@@ -621,8 +619,7 @@ struct RaycastingScene::Impl {
                     tbb::blocked_range<size_t>(0, num_rays, BATCH_SIZE),
                     LoopFn);
         }
-    }                            
-                                
+    }
 
     void ComputeClosestPoints(const float* const query_points,
                               const size_t num_query_points,
@@ -833,58 +830,54 @@ core::Tensor RaycastingScene::CountIntersections(const core::Tensor& rays,
     return intersections;
 }
 
-
 std::unordered_map<std::string, core::Tensor>
 RaycastingScene::ListIntersections(const core::Tensor& rays,
-                                                 const int nthreads) {
+                                   const int nthreads) {
     AssertTensorDtypeLastDimDeviceMinNDim<float>(rays, "rays", 6,
                                                  impl_->tensor_device_);
     auto shape = rays.GetShape();
     shape.pop_back();  // Remove last dim, we want to use this shape for the
                        // results.
     size_t num_rays = shape.NumElements();
-    
+
     // determine total number of intersections
     core::Tensor intersections(shape, core::Dtype::FromType<int>());
     core::Tensor track_intersections(shape, core::Dtype::FromType<uint32_t>());
     auto data = rays.Contiguous();
     impl_->CountIntersections(data.GetDataPtr<float>(), num_rays,
-                              intersections.GetDataPtr<int>(), nthreads);    
-    
-    // prepare shape with that number of elements 
+                              intersections.GetDataPtr<int>(), nthreads);
+
+    // prepare shape with that number of elements
     // not sure how to do proper conversion
-    const core::SizeVector dim = {0};    
+    const core::SizeVector dim = {0};
     Eigen::Map<Eigen::VectorXi> intersections_vector(
-      intersections.GetDataPtr<int>(), num_rays);
+            intersections.GetDataPtr<int>(), num_rays);
     Eigen::Map<Eigen::VectorXi> num_intersections(
-      intersections.Sum(dim).GetDataPtr<int>(), 1); 
+            intersections.Sum(dim).GetDataPtr<int>(), 1);
     shape = {num_intersections[0], 1};
-    
+
     // prepare ray allocations (cumsum)
     Eigen::VectorXi cumsum = Eigen::MatrixXi::Zero(num_rays, 1);
-    std::partial_sum(intersections_vector.begin(), intersections_vector.end() - 1, 
-      cumsum.begin() + 1, std::plus<int>());
-    
+    std::partial_sum(intersections_vector.begin(),
+                     intersections_vector.end() - 1, cumsum.begin() + 1,
+                     std::plus<int>());
+
     // generate results structure
     std::unordered_map<std::string, core::Tensor> result;
     result["ray_ids"] = core::Tensor(shape, core::UInt32);
-    result["geometry_ids"] = core::Tensor(shape, core::UInt32);    
+    result["geometry_ids"] = core::Tensor(shape, core::UInt32);
     result["primitive_ids"] = core::Tensor(shape, core::UInt32);
     result["t_hit"] = core::Tensor(shape, core::Float32);
-    
-    impl_->ListIntersections(data.GetDataPtr<float>(), 
-                                num_rays, 
-                                num_intersections[0], 
-                                cumsum,
-                                track_intersections.GetDataPtr<uint32_t>(),
-                                result["ray_ids"].GetDataPtr<uint32_t>(),
-                                result["geometry_ids"].GetDataPtr<uint32_t>(),
-                                result["primitive_ids"].GetDataPtr<uint32_t>(),
-                                result["t_hit"].GetDataPtr<float>(),
-                                nthreads);
+
+    impl_->ListIntersections(data.GetDataPtr<float>(), num_rays,
+                             num_intersections[0], cumsum,
+                             track_intersections.GetDataPtr<uint32_t>(),
+                             result["ray_ids"].GetDataPtr<uint32_t>(),
+                             result["geometry_ids"].GetDataPtr<uint32_t>(),
+                             result["primitive_ids"].GetDataPtr<uint32_t>(),
+                             result["t_hit"].GetDataPtr<float>(), nthreads);
     return result;
 }
-
 
 std::unordered_map<std::string, core::Tensor>
 RaycastingScene::ComputeClosestPoints(const core::Tensor& query_points,

--- a/cpp/open3d/t/geometry/RaycastingScene.cpp
+++ b/cpp/open3d/t/geometry/RaycastingScene.cpp
@@ -554,7 +554,7 @@ struct RaycastingScene::Impl {
     void ListIntersections(const float* const rays,
                            const size_t num_rays,
                            const size_t num_intersections,
-                           Eigen::VectorXi cumsum,
+                           const Eigen::VectorXi cumsum,
                            unsigned int* track_intersections,
                            unsigned int* ray_ids,
                            unsigned int* geometry_ids,

--- a/cpp/open3d/t/geometry/RaycastingScene.cpp
+++ b/cpp/open3d/t/geometry/RaycastingScene.cpp
@@ -868,7 +868,8 @@ RaycastingScene::ListIntersections(const core::Tensor& rays,
 
     // generate results structure
     std::unordered_map<std::string, core::Tensor> result;
-    shape[0] = shape[0] + 1;
+    shape.clear();
+    shape.push_back(num_rays + 1);
     result["ray_splits"] = core::Tensor(shape, core::UInt32);
     uint32_t* ptr = result["ray_splits"].GetDataPtr<uint32_t>();
     ptr[0] = 0;

--- a/cpp/open3d/t/geometry/RaycastingScene.cpp
+++ b/cpp/open3d/t/geometry/RaycastingScene.cpp
@@ -872,10 +872,10 @@ RaycastingScene::ListIntersections(const core::Tensor& rays,
     shape.push_back(num_rays + 1);
     result["ray_splits"] = core::Tensor(shape, core::UInt32);
     uint32_t* ptr = result["ray_splits"].GetDataPtr<uint32_t>();
-    ptr[0] = 0;
-    for (int i = 1; i < cumsum.size() + 1; ++i) {
-        ptr[i] = cumsum[i - 1];
+    for (int i = 0; i < cumsum.size(); ++i) {
+        ptr[i] = cumsum[i];
     }
+    ptr[num_rays] = num_intersections;
     shape[0] = intersections_vector.sum();
     result["ray_ids"] = core::Tensor(shape, core::UInt32);
     result["geometry_ids"] = core::Tensor(shape, core::UInt32);

--- a/cpp/open3d/t/geometry/RaycastingScene.cpp
+++ b/cpp/open3d/t/geometry/RaycastingScene.cpp
@@ -868,13 +868,14 @@ RaycastingScene::ListIntersections(const core::Tensor& rays,
 
     // generate results structure
     std::unordered_map<std::string, core::Tensor> result;
-    result["ray_splits"] = core::Tensor({cumsum.size() + 1}, core::UInt32);
+    shape[0] = shape[0] + 1;
+    result["ray_splits"] = core::Tensor(shape, core::UInt32);
     uint32_t* ptr = result["ray_splits"].GetDataPtr<uint32_t>();
     ptr[0] = 0;
     for (int i = 1; i < cumsum.size() + 1; ++i) {
         ptr[i] = cumsum[i - 1];
     }
-    shape = {intersections_vector.sum()};
+    shape[0] = intersections_vector.sum();
     result["ray_ids"] = core::Tensor(shape, core::UInt32);
     result["geometry_ids"] = core::Tensor(shape, core::UInt32);
     result["primitive_ids"] = core::Tensor(shape, core::UInt32);

--- a/cpp/open3d/t/geometry/RaycastingScene.cpp
+++ b/cpp/open3d/t/geometry/RaycastingScene.cpp
@@ -110,6 +110,72 @@ void CountIntersectionsFunc(const RTCFilterFunctionNArguments* args) {
     }
 }
 
+struct ListIntersectionsContext {
+    RTCIntersectContext context;
+    std::vector<std::tuple<uint32_t, uint32_t, float>>*
+            previous_geom_prim_ID_tfar;
+    unsigned int* ray_ids;
+    unsigned int* geometry_ids;
+    unsigned int* primitive_ids;
+    float* t_hit;
+    Eigen::VectorXi cumsum;
+    unsigned int* track_intersections;
+};
+
+void ListIntersectionsFunc(const RTCFilterFunctionNArguments* args) {
+    int* valid = args->valid;
+    const ListIntersectionsContext* context =
+            reinterpret_cast<const ListIntersectionsContext*>(args->context);
+    struct RTCRayN* rayN = args->ray;
+    struct RTCHitN* hitN = args->hit;
+    const unsigned int N = args->N; 
+
+    // Avoid crashing when debug visualizations are used.
+    if (context == nullptr) return;
+
+    std::vector<std::tuple<uint32_t, uint32_t, float>>*
+            previous_geom_prim_ID_tfar = context->previous_geom_prim_ID_tfar;
+    unsigned int* ray_ids = context->ray_ids;
+    unsigned int* geometry_ids = context->geometry_ids;
+    unsigned int* primitive_ids = context->primitive_ids;
+    float* t_hit = context->t_hit;    
+    Eigen::VectorXi cumsum = context->cumsum;
+    unsigned int* track_intersections = context->track_intersections;
+
+    // Iterate over all rays in ray packet.
+    for (unsigned int ui = 0; ui < N; ui += 1) {
+        // Calculate loop and execution mask
+        unsigned int vi = ui + 0;
+        if (vi >= N) continue;
+
+        // Ignore inactive rays.
+        if (valid[vi] != -1) continue;
+
+        // Read ray/hit from ray structure.
+        RTCRay ray = rtcGetRayFromRayN(rayN, N, ui);
+        RTCHit hit = rtcGetHitFromHitN(hitN, N, ui);
+
+        unsigned int ray_id = ray.id;
+        std::tuple<uint32_t, uint32_t, float> gpID(hit.geomID, hit.primID,
+                                                   ray.tfar);
+        auto& prev_gpIDtfar = previous_geom_prim_ID_tfar->operator[](ray_id);
+        if (std::get<0>(prev_gpIDtfar) != hit.geomID ||
+            (std::get<1>(prev_gpIDtfar) != hit.primID &&
+             std::get<2>(prev_gpIDtfar) != ray.tfar)) {
+               size_t idx = cumsum[ray_id] + track_intersections[ray_id];
+               ray_ids[idx] = ray_id;
+               geometry_ids[idx]  = hit.geomID;
+               primitive_ids[idx]  = hit.primID;
+               t_hit[idx]  = ray.tfar;
+               previous_geom_prim_ID_tfar->operator[](ray_id) = gpID;
+               ++(track_intersections[ray_id]);
+        }
+        // Always ignore hit
+        valid[ui] = 0;
+    }
+}
+
+
 // Adapted from common/math/closest_point.h
 inline Vec3fa closestPointTriangle(Vec3fa const& p,
                                    Vec3fa const& a,
@@ -481,6 +547,82 @@ struct RaycastingScene::Impl {
                     LoopFn);
         }
     }
+    
+                                
+    void ListIntersections(const float* const rays,
+                            const size_t num_rays,
+                            const size_t num_intersections,
+                            Eigen::VectorXi cumsum,
+                            unsigned int* track_intersections,
+                            unsigned int* ray_ids,
+                            unsigned int* geometry_ids,
+                            unsigned int* primitive_ids,
+                            float* t_hit,
+                            const int nthreads) {
+        CommitScene();
+
+        memset(track_intersections, 0, sizeof(uint32_t) * num_rays);
+        memset(ray_ids, 0, sizeof(uint32_t) * num_intersections);
+        memset(geometry_ids, 0, sizeof(uint32_t) * num_intersections);
+        memset(primitive_ids, 0, sizeof(uint32_t) * num_intersections);
+        memset(t_hit, 0, sizeof(float) * num_intersections);
+
+        std::vector<std::tuple<uint32_t, uint32_t, float>>
+                previous_geom_prim_ID_tfar(
+                        num_rays,
+                        std::make_tuple(uint32_t(RTC_INVALID_GEOMETRY_ID),
+                                        uint32_t(RTC_INVALID_GEOMETRY_ID),
+                                        0.f));
+
+        ListIntersectionsContext context;
+        rtcInitIntersectContext(&context.context);
+        context.context.filter = ListIntersectionsFunc;
+        context.previous_geom_prim_ID_tfar = &previous_geom_prim_ID_tfar;
+        context.ray_ids = ray_ids;
+        context.geometry_ids = geometry_ids;
+        context.primitive_ids = primitive_ids;
+        context.t_hit = t_hit;
+        context.cumsum = cumsum;
+        context.track_intersections = track_intersections;
+
+        auto LoopFn = [&](const tbb::blocked_range<size_t>& range) {
+            std::vector<RTCRayHit> rayhits(range.size());
+
+            for (size_t i = range.begin(); i < range.end(); ++i) {
+                RTCRayHit* rh = &rayhits[i - range.begin()];
+                const float* r = &rays[i * 6];
+                rh->ray.org_x = r[0];
+                rh->ray.org_y = r[1];
+                rh->ray.org_z = r[2];
+                rh->ray.dir_x = r[3];
+                rh->ray.dir_y = r[4];
+                rh->ray.dir_z = r[5];
+                rh->ray.tnear = 0;
+                rh->ray.tfar = std::numeric_limits<float>::infinity();
+                rh->ray.mask = 0;
+                rh->ray.flags = 0;
+                rh->ray.id = i;
+                rh->hit.geomID = RTC_INVALID_GEOMETRY_ID;
+                rh->hit.instID[0] = RTC_INVALID_GEOMETRY_ID;
+            }
+            rtcIntersect1M(scene_, &context.context, &rayhits[0], range.size(),
+                           sizeof(RTCRayHit));
+        };
+
+        if (nthreads > 0) {
+            tbb::task_arena arena(nthreads);
+            arena.execute([&]() {
+                tbb::parallel_for(
+                        tbb::blocked_range<size_t>(0, num_rays, BATCH_SIZE),
+                        LoopFn);
+            });
+        } else {
+            tbb::parallel_for(
+                    tbb::blocked_range<size_t>(0, num_rays, BATCH_SIZE),
+                    LoopFn);
+        }
+    }                            
+                                
 
     void ComputeClosestPoints(const float* const query_points,
                               const size_t num_query_points,
@@ -690,6 +832,59 @@ core::Tensor RaycastingScene::CountIntersections(const core::Tensor& rays,
                               intersections.GetDataPtr<int>(), nthreads);
     return intersections;
 }
+
+
+std::unordered_map<std::string, core::Tensor>
+RaycastingScene::ListIntersections(const core::Tensor& rays,
+                                                 const int nthreads) {
+    AssertTensorDtypeLastDimDeviceMinNDim<float>(rays, "rays", 6,
+                                                 impl_->tensor_device_);
+    auto shape = rays.GetShape();
+    shape.pop_back();  // Remove last dim, we want to use this shape for the
+                       // results.
+    size_t num_rays = shape.NumElements();
+    
+    // determine total number of intersections
+    core::Tensor intersections(shape, core::Dtype::FromType<int>());
+    core::Tensor track_intersections(shape, core::Dtype::FromType<uint32_t>());
+    auto data = rays.Contiguous();
+    impl_->CountIntersections(data.GetDataPtr<float>(), num_rays,
+                              intersections.GetDataPtr<int>(), nthreads);    
+    
+    // prepare shape with that number of elements 
+    // not sure how to do proper conversion
+    const core::SizeVector dim = {0};    
+    Eigen::Map<Eigen::VectorXi> intersections_vector(
+      intersections.GetDataPtr<int>(), num_rays);
+    Eigen::Map<Eigen::VectorXi> num_intersections(
+      intersections.Sum(dim).GetDataPtr<int>(), 1); 
+    shape = {num_intersections[0], 1};
+    
+    // prepare ray allocations (cumsum)
+    Eigen::VectorXi cumsum = Eigen::MatrixXi::Zero(num_rays, 1);
+    std::partial_sum(intersections_vector.begin(), intersections_vector.end() - 1, 
+      cumsum.begin() + 1, std::plus<int>());
+    
+    // generate results structure
+    std::unordered_map<std::string, core::Tensor> result;
+    result["ray_ids"] = core::Tensor(shape, core::UInt32);
+    result["geometry_ids"] = core::Tensor(shape, core::UInt32);    
+    result["primitive_ids"] = core::Tensor(shape, core::UInt32);
+    result["t_hit"] = core::Tensor(shape, core::Float32);
+    
+    impl_->ListIntersections(data.GetDataPtr<float>(), 
+                                num_rays, 
+                                num_intersections[0], 
+                                cumsum,
+                                track_intersections.GetDataPtr<uint32_t>(),
+                                result["ray_ids"].GetDataPtr<uint32_t>(),
+                                result["geometry_ids"].GetDataPtr<uint32_t>(),
+                                result["primitive_ids"].GetDataPtr<uint32_t>(),
+                                result["t_hit"].GetDataPtr<float>(),
+                                nthreads);
+    return result;
+}
+
 
 std::unordered_map<std::string, core::Tensor>
 RaycastingScene::ComputeClosestPoints(const core::Tensor& query_points,

--- a/cpp/open3d/t/geometry/RaycastingScene.h
+++ b/cpp/open3d/t/geometry/RaycastingScene.h
@@ -104,26 +104,6 @@ public:
     core::Tensor CountIntersections(const core::Tensor &rays,
                                     const int nthreads = 0);
 
-    /// \brief Computes the closest points on the surfaces of the scene.
-    /// \param query_points A tensor with >=2 dims, shape {.., 3} and Dtype
-    /// Float32 describing the query points. {..} can be any number of
-    /// dimensions, e.g., to organize the query_point to create a 3D grid the
-    /// shape can be {depth, height, width, 3}. The last dimension must be 3 and
-    /// has the format [x, y, z].
-    /// \param nthreads The number of threads to use. Set to 0 for automatic.
-    /// \return The returned dictionary contains:
-    ///         - \b points A tensor with the closest surface points. The shape
-    ///           is {..}.
-    ///         - \b geometry_ids A tensor with the geometry IDs. The shape is
-    ///           {..}.
-    ///         - \b primitive_ids A tensor with the primitive IDs, which
-    ///           corresponds to the triangle index. The shape is {..}.
-    ///         - \b primitive_uvs A tensor with the barycentric coordinates of
-    ///           the closest points within the triangles. The shape is {.., 2}.
-    ///         - \b primitive_normals A tensor with the normals of the
-    ///           closest triangle . The shape is {.., 3}.
-    std::unordered_map<std::string, core::Tensor> ListIntersections(
-            const core::Tensor &rays, const int nthreads = 0);
 
     /// \brief Lists the intersections of the rays with the scene
     /// \param rays A tensor with >=2 dims, shape {.., 6}, and Dtype Float32
@@ -149,6 +129,27 @@ public:
     ///         - \b primitive_uvs A tensor with the barycentric coordinates of
     ///           the intersection points within the triangles. The shape is
     ///           {num_intersections, 2}.
+    std::unordered_map<std::string, core::Tensor> ListIntersections(
+            const core::Tensor &rays, const int nthreads = 0);
+
+    /// \brief Computes the closest points on the surfaces of the scene.
+    /// \param query_points A tensor with >=2 dims, shape {.., 3} and Dtype
+    /// Float32 describing the query points. {..} can be any number of
+    /// dimensions, e.g., to organize the query_point to create a 3D grid the
+    /// shape can be {depth, height, width, 3}. The last dimension must be 3 and
+    /// has the format [x, y, z].
+    /// \param nthreads The number of threads to use. Set to 0 for automatic.
+    /// \return The returned dictionary contains:
+    ///         - \b points A tensor with the closest surface points. The shape
+    ///           is {..}.
+    ///         - \b geometry_ids A tensor with the geometry IDs. The shape is
+    ///           {..}.
+    ///         - \b primitive_ids A tensor with the primitive IDs, which
+    ///           corresponds to the triangle index. The shape is {..}.
+    ///         - \b primitive_uvs A tensor with the barycentric coordinates of
+    ///           the closest points within the triangles. The shape is {.., 2}.
+    ///         - \b primitive_normals A tensor with the normals of the
+    ///           closest triangle . The shape is {.., 3}.
     std::unordered_map<std::string, core::Tensor> ComputeClosestPoints(
             const core::Tensor &query_points, const int nthreads = 0);
 

--- a/cpp/open3d/t/geometry/RaycastingScene.h
+++ b/cpp/open3d/t/geometry/RaycastingScene.h
@@ -138,6 +138,8 @@ public:
     ///           {..}.
     ///         - \b primitive_ids A tensor with the primitive IDs, which
     ///           corresponds to the triangle index. The shape is {..}.
+    ///         - \b primitive_uvs A tensor with the barycentric coordinates of
+    ///           the closest points within the triangles. The shape is {.., 2}.
     ///         - \b t_hit A tensor with the distance to the hit. The shape is
     ///         {..}.
     std::unordered_map<std::string, core::Tensor> ComputeClosestPoints(

--- a/cpp/open3d/t/geometry/RaycastingScene.h
+++ b/cpp/open3d/t/geometry/RaycastingScene.h
@@ -134,6 +134,9 @@ public:
     /// \param nthreads The number of threads to use. Set to 0 for automatic.
     /// \return The returned dictionary contains:
     ///         - \b ray_ids A tensor with ray IDs. The shape is {..}.
+    ///         - \b ray_splits A tensor with ray intersection splits. Can be
+    ///         used to iterate over all intersections for each ray. The shape
+    ///         is {..}.
     ///         - \b geometry_ids A tensor with the geometry IDs. The shape is
     ///           {..}.
     ///         - \b primitive_ids A tensor with the primitive IDs, which

--- a/cpp/open3d/t/geometry/RaycastingScene.h
+++ b/cpp/open3d/t/geometry/RaycastingScene.h
@@ -104,7 +104,6 @@ public:
     core::Tensor CountIntersections(const core::Tensor &rays,
                                     const int nthreads = 0);
 
-
     /// \brief Lists the intersections of the rays with the scene
     /// \param rays A tensor with >=2 dims, shape {.., 6}, and Dtype Float32
     /// describing the rays; {..} can be any number of dimensions.

--- a/cpp/open3d/t/geometry/RaycastingScene.h
+++ b/cpp/open3d/t/geometry/RaycastingScene.h
@@ -122,6 +122,23 @@ public:
     ///           the closest points within the triangles. The shape is {.., 2}.
     ///         - \b primitive_normals A tensor with the normals of the
     ///           closest triangle . The shape is {.., 3}.
+    std::unordered_map<std::string, core::Tensor> ListIntersections(
+            const core::Tensor &rays, const int nthreads = 0);
+    
+    /// \brief Lists the intersections of the rays with the scene
+    /// \param query_points A tensor with >=2 dims, shape {.., 3} and Dtype
+    /// Float32 describing the query points. {..} can be any number of
+    /// dimensions, e.g., to organize the query_point to create a 3D grid the
+    /// shape can be {depth, height, width, 3}. The last dimension must be 3 and
+    /// has the format [x, y, z].
+    /// \param nthreads The number of threads to use. Set to 0 for automatic.
+    /// \return The returned dictionary contains:
+    ///         - \b ray_ids A tensor with ray IDs. The shape is {..}.
+    ///         - \b geometry_ids A tensor with the geometry IDs. The shape is
+    ///           {..}.
+    ///         - \b primitive_ids A tensor with the primitive IDs, which
+    ///           corresponds to the triangle index. The shape is {..}.
+    ///         - \b t_hit A tensor with the distance to the hit. The shape is {..}. 
     std::unordered_map<std::string, core::Tensor> ComputeClosestPoints(
             const core::Tensor &query_points, const int nthreads = 0);
 

--- a/cpp/open3d/t/geometry/RaycastingScene.h
+++ b/cpp/open3d/t/geometry/RaycastingScene.h
@@ -124,7 +124,7 @@ public:
     ///           closest triangle . The shape is {.., 3}.
     std::unordered_map<std::string, core::Tensor> ListIntersections(
             const core::Tensor &rays, const int nthreads = 0);
-    
+
     /// \brief Lists the intersections of the rays with the scene
     /// \param query_points A tensor with >=2 dims, shape {.., 3} and Dtype
     /// Float32 describing the query points. {..} can be any number of
@@ -138,7 +138,8 @@ public:
     ///           {..}.
     ///         - \b primitive_ids A tensor with the primitive IDs, which
     ///           corresponds to the triangle index. The shape is {..}.
-    ///         - \b t_hit A tensor with the distance to the hit. The shape is {..}. 
+    ///         - \b t_hit A tensor with the distance to the hit. The shape is
+    ///         {..}.
     std::unordered_map<std::string, core::Tensor> ComputeClosestPoints(
             const core::Tensor &query_points, const int nthreads = 0);
 

--- a/cpp/open3d/t/geometry/RaycastingScene.h
+++ b/cpp/open3d/t/geometry/RaycastingScene.h
@@ -105,11 +105,13 @@ public:
                                     const int nthreads = 0);
 
     /// \brief Computes the closest points on the surfaces of the scene.
-    /// \param query_points A tensor with >=2 dims, shape {.., 3} and Dtype
-    /// Float32 describing the query points. {..} can be any number of
-    /// dimensions, e.g., to organize the query_point to create a 3D grid the
-    /// shape can be {depth, height, width, 3}. The last dimension must be 3 and
-    /// has the format [x, y, z].
+    /// \param rays A tensor with >=2 dims, shape {.., 6}, and Dtype Float32
+    /// describing the rays.
+    /// {..} can be any number of dimensions, e.g., to organize rays for
+    /// creating an image the shape can be {height, width, 6};
+    /// The last dimension must be 6 and has the format [ox, oy, oz, dx, dy, dz]
+    /// with [ox,oy,oz] as the origin and [dx,dy,dz] as the direction. It is not
+    /// necessary to normalize the direction.
     /// \param nthreads The number of threads to use. Set to 0 for automatic.
     /// \return The returned dictionary contains:
     ///         - \b points A tensor with the closest surface points. The shape
@@ -126,26 +128,29 @@ public:
             const core::Tensor &rays, const int nthreads = 0);
 
     /// \brief Lists the intersections of the rays with the scene
-    /// \param query_points A tensor with >=2 dims, shape {.., 3} and Dtype
-    /// Float32 describing the query points. {..} can be any number of
-    /// dimensions, e.g., to organize the query_point to create a 3D grid the
-    /// shape can be {depth, height, width, 3}. The last dimension must be 3 and
-    /// has the format [x, y, z].
+    /// \param rays A tensor with >=2 dims, shape {.., 6}, and Dtype Float32
+    /// describing the rays; {..} can be any number of dimensions.
+    /// The last dimension must be 6 and has the format [ox, oy, oz, dx, dy, dz]
+    /// with [ox,oy,oz] as the origin and [dx,dy,dz] as the direction. It is not
+    /// necessary to normalize the direction although it should be normalised if
+    /// t_hit is to be calculated in coordinate units.
     /// \param nthreads The number of threads to use. Set to 0 for automatic.
-    /// \return The returned dictionary contains:
-    ///         - \b ray_ids A tensor with ray IDs. The shape is {..}.
+    /// \return The returned dictionary contains:    ///
     ///         - \b ray_splits A tensor with ray intersection splits. Can be
     ///         used to iterate over all intersections for each ray. The shape
-    ///         is {..}.
+    ///         is {num_rays + 1}.
+    ///         - \b ray_ids A tensor with ray IDs. The shape is
+    ///         {num_intersections}.
+    ///         - \b t_hit A tensor with the distance to the hit. The shape is
+    ///         {num_intersections}.
     ///         - \b geometry_ids A tensor with the geometry IDs. The shape is
-    ///           {..}.
+    ///           {num_intersections}.
     ///         - \b primitive_ids A tensor with the primitive IDs, which
-    ///           corresponds to the triangle index. The shape is {..}.
+    ///           corresponds to the triangle index. The shape is
+    ///           {num_intersections}.
     ///         - \b primitive_uvs A tensor with the barycentric coordinates of
     ///           the intersection points within the triangles. The shape is
-    ///           {.., 2}.
-    ///         - \b t_hit A tensor with the distance to the hit. The shape is
-    ///         {..}.
+    ///           {num_intersections, 2}.
     std::unordered_map<std::string, core::Tensor> ComputeClosestPoints(
             const core::Tensor &query_points, const int nthreads = 0);
 

--- a/cpp/open3d/t/geometry/RaycastingScene.h
+++ b/cpp/open3d/t/geometry/RaycastingScene.h
@@ -139,7 +139,8 @@ public:
     ///         - \b primitive_ids A tensor with the primitive IDs, which
     ///           corresponds to the triangle index. The shape is {..}.
     ///         - \b primitive_uvs A tensor with the barycentric coordinates of
-    ///           the closest points within the triangles. The shape is {.., 2}.
+    ///           the intersection points within the triangles. The shape is
+    ///           {.., 2}.
     ///         - \b t_hit A tensor with the distance to the hit. The shape is
     ///         {..}.
     std::unordered_map<std::string, core::Tensor> ComputeClosestPoints(

--- a/cpp/open3d/t/geometry/RaycastingScene.h
+++ b/cpp/open3d/t/geometry/RaycastingScene.h
@@ -105,13 +105,11 @@ public:
                                     const int nthreads = 0);
 
     /// \brief Computes the closest points on the surfaces of the scene.
-    /// \param rays A tensor with >=2 dims, shape {.., 6}, and Dtype Float32
-    /// describing the rays.
-    /// {..} can be any number of dimensions, e.g., to organize rays for
-    /// creating an image the shape can be {height, width, 6};
-    /// The last dimension must be 6 and has the format [ox, oy, oz, dx, dy, dz]
-    /// with [ox,oy,oz] as the origin and [dx,dy,dz] as the direction. It is not
-    /// necessary to normalize the direction.
+    /// \param query_points A tensor with >=2 dims, shape {.., 3} and Dtype
+    /// Float32 describing the query points. {..} can be any number of
+    /// dimensions, e.g., to organize the query_point to create a 3D grid the
+    /// shape can be {depth, height, width, 3}. The last dimension must be 3 and
+    /// has the format [x, y, z].
     /// \param nthreads The number of threads to use. Set to 0 for automatic.
     /// \return The returned dictionary contains:
     ///         - \b points A tensor with the closest surface points. The shape

--- a/cpp/pybind/t/geometry/raycasting_scene.cpp
+++ b/cpp/pybind/t/geometry/raycasting_scene.cpp
@@ -246,6 +246,9 @@ Returns:
     ray_ids
         A tensor with ray IDs. The shape is {..}.
         
+    ray_splits
+        A tensor with ray intersection splits. Can be used to iterate over all intersections for each ray. The shape is {..}.        
+        
     geometry_ids
         A tensor with the geometry IDs. The shape is {..}.
 
@@ -259,6 +262,16 @@ Returns:
 
     t_hit
         A tensor with the distance to the hit. The shape is {..}. 
+        
+An example of using ray_splits::
+
+    ray_splits: [0, 2, 3, 6, 6, 8] # note that the length of this is num_rays+1
+    t_hit: [t1, t2, t3, t4, t5, t6, t7, t8]
+
+    for ray_id, (start, end) in enumerate(zip(ray_splits[:-1], ray_splits[1:])):
+        for i,t in enumerate(t_hit[start:end]):
+            print(f'ray {ray_id}, intersection {i} at {t}')
+            
         
 )doc");
 

--- a/cpp/pybind/t/geometry/raycasting_scene.cpp
+++ b/cpp/pybind/t/geometry/raycasting_scene.cpp
@@ -254,7 +254,7 @@ Returns:
         index. The shape is {..}.
         
     primitive_uvs 
-        A tensor with the barycentric coordinates of the closest points within 
+        A tensor with the barycentric coordinates of the intersection points within 
         the triangles. The shape is {.., 2}.
 
     t_hit

--- a/cpp/pybind/t/geometry/raycasting_scene.cpp
+++ b/cpp/pybind/t/geometry/raycasting_scene.cpp
@@ -231,9 +231,7 @@ Lists the intersections of the rays with the scene::
 
 Args:
     rays (open3d.core.Tensor): A tensor with >=2 dims, shape {.., 6}, and Dtype
-        Float32 describing the rays.
-        {..} can be any number of dimensions, e.g., to organize rays for
-        creating an image the shape can be {height, width, 6}.
+        Float32 describing the rays; {..} can be any number of dimensions.
         The last dimension must be 6 and has the format [ox, oy, oz, dx, dy, dz]
         with [ox,oy,oz] as the origin and [dx,dy,dz] as the direction. It is not
         necessary to normalize the direction although it should be normalised if 
@@ -244,25 +242,26 @@ Args:
 Returns:
     The returned dictionary contains
     
-    ray_ids
-        A tensor with ray IDs. The shape is {..}.
-        
     ray_splits
-        A tensor with ray intersection splits. Can be used to iterate over all intersections for each ray. The shape is {..}.        
+        A tensor with ray intersection splits. Can be used to iterate over all intersections for each ray. The shape is {num_rays + 1}.
+    
+    ray_ids
+        A tensor with ray IDs. The shape is {num_intersections}.
+        
+    t_hit
+        A tensor with the distance to the hit. The shape is {num_intersections}. 
         
     geometry_ids
-        A tensor with the geometry IDs. The shape is {..}.
+        A tensor with the geometry IDs. The shape is {num_intersections}.
 
     primitive_ids
         A tensor with the primitive IDs, which corresponds to the triangle
-        index. The shape is {..}.
+        index. The shape is {num_intersections}.
         
     primitive_uvs 
         A tensor with the barycentric coordinates of the intersection points within 
-        the triangles. The shape is {.., 2}.
-
-    t_hit
-        A tensor with the distance to the hit. The shape is {..}. 
+        the triangles. The shape is {num_intersections, 2}.
+    
         
 An example of using ray_splits::
 

--- a/cpp/pybind/t/geometry/raycasting_scene.cpp
+++ b/cpp/pybind/t/geometry/raycasting_scene.cpp
@@ -190,43 +190,44 @@ Lists the intersections of the rays with the scene::
     # Create scene and add the monkey model.
     scene = o3d.t.geometry.RaycastingScene()
     d = o3d.data.MonkeyModel()
-    mesh = o3d.t.io.read_triangle_mesh(d.path)    
+    mesh = o3d.t.io.read_triangle_mesh(d.path)
     mesh_id = scene.add_triangles(mesh)
-    
-    # Create an offset grid of rays.
-    p_min = np.min(mesh.vertex['positions'].numpy() - 1, axis=0)
-    p_max = np.max(mesh.vertex['positions'].numpy() - 1, axis=0)
-    x = np.arange(p_min[0], p_max[0], .1)
-    y = np.arange(p_min[1], p_max[1], .1)
-    xv, yv = np.meshgrid(x, y) 
-    orig = np.vstack([xv.flatten(), yv.flatten(), np.tile(p_min[2], xv.size)]).T
-    dest = np.copy(orig)
-    dest[:, 2] = p_max[2] + 1
-    rays = np.hstack([orig, dest - orig]).astype('float32') 
+
+    # Create a grid of rays covering the bounding box
+    bb_min = mesh.vertex['positions'].min(dim=0).numpy()
+    bb_max = mesh.vertex['positions'].max(dim=0).numpy()
+    x,y = np.linspace(bb_min, bb_max, num=10)[:,:2].T
+    xv, yv = np.meshgrid(x,y)
+    orig = np.stack([xv, yv, np.full_like(xv, bb_min[2]-1)], axis=-1).reshape(-1,3)
+    dest = orig + np.full(orig.shape, (0,0,2+bb_max[2]-bb_min[2]),dtype=np.float32)
+    rays = np.concatenate([orig, dest-orig], axis=-1).astype(np.float32)
 
     # Compute the ray intersections.
     lx = scene.list_intersections(rays)
+    lx = {k:v.numpy() for k,v in lx.items()}
 
-    # Calculate intersection coordinates.
+    # Calculate intersection coordinates using the primitive uvs and the mesh
     v = mesh.vertex['positions'].numpy()
     t = mesh.triangle['indices'].numpy()
-    tidx = lx['primitive_ids'].numpy()
-    uv = lx['primitive_uvs'].numpy()
+    tidx = lx['primitive_ids']
+    uv = lx['primitive_uvs']
     w = 1 - np.sum(uv, axis=1)
     c = \
-      v[t[tidx, 1].flatten(), :] * uv[:, 0][:, None] + \
-      v[t[tidx, 2].flatten(), :] * uv[:, 1][:, None] + \
-      v[t[tidx, 0].flatten(), :] * w[:, None]
-      
-    # Visualize the intersections.
-    entry = o3d.geometry.PointCloud(points = o3d.utility.Vector3dVector(orig))
-    target = o3d.geometry.PointCloud(points = o3d.utility.Vector3dVector(dest))
-    correspondence = [(i, i) for i in range(rays.shape[0])]
-    traj = o3d.geometry.LineSet.create_from_point_cloud_correspondences(entry , target , correspondence)
-    traj.colors = o3d.utility.Vector3dVector(np.tile([1, 0, 0], [rays.shape[0], 1]))
-    x = o3d.geometry.PointCloud(points = o3d.utility.Vector3dVector(c))
-    o3d.visualization.draw([mesh, traj, x])
-    
+    v[t[tidx, 1].flatten(), :] * uv[:, 0][:, None] + \
+    v[t[tidx, 2].flatten(), :] * uv[:, 1][:, None] + \
+    v[t[tidx, 0].flatten(), :] * w[:, None]
+
+    # Calculate intersection coordinates using ray_ids
+    c = rays[lx['ray_ids']][:,:3] + rays[lx['ray_ids']][:,3:]*lx['t_hit'][...,None]
+                                    
+    # Visualize the rays and intersections.
+    lines = o3d.t.geometry.LineSet()
+    lines.point.positions = np.hstack([orig,dest]).reshape(-1,3)
+    lines.line.indices = np.arange(lines.point.positions.shape[0]).reshape(-1,2)
+    lines.line.colors = np.full((lines.line.indices.shape[0],3), (1,0,0))
+    x = o3d.t.geometry.PointCloud(positions=c)
+    o3d.visualization.draw([mesh, lines, x], point_size=8)
+
 
 Args:
     rays (open3d.core.Tensor): A tensor with >=2 dims, shape {.., 6}, and Dtype

--- a/cpp/pybind/t/geometry/raycasting_scene.cpp
+++ b/cpp/pybind/t/geometry/raycasting_scene.cpp
@@ -179,6 +179,41 @@ Returns:
     A tensor with the number of intersections. The shape is {..}.
 )doc");
 
+    raycasting_scene.def("list_intersections",
+                         &RaycastingScene::ListIntersections, "rays"_a,
+                         "nthreads"_a = 0, R"doc(
+Lists the intersections of the rays with the scene.
+
+Args:
+    rays (open3d.core.Tensor): A tensor with >=2 dims, shape {.., 6}, and Dtype
+        Float32 describing the rays.
+        {..} can be any number of dimensions, e.g., to organize rays for
+        creating an image the shape can be {height, width, 6}.
+        The last dimension must be 6 and has the format [ox, oy, oz, dx, dy, dz]
+        with [ox,oy,oz] as the origin and [dx,dy,dz] as the direction. It is not
+        necessary to normalize the direction although it should be normalised if 
+        t_hit is to be calculated in coordinate units.
+
+    nthreads (int): The number of threads to use. Set to 0 for automatic.
+
+Returns:
+    The returned dictionary contains
+    
+    ray_ids
+        A tensor with ray IDs. The shape is {..}.
+        
+    geometry_ids
+        A tensor with the geometry IDs. The shape is {..}.
+
+    primitive_ids
+        A tensor with the primitive IDs, which corresponds to the triangle
+        index. The shape is {..}.
+
+    t_hit
+        A tensor with the distance to the hit. The shape is {..}. 
+        
+)doc");
+
     raycasting_scene.def("compute_closest_points",
                          &RaycastingScene::ComputeClosestPoints,
                          "query_points"_a, "nthreads"_a = 0, R"doc(

--- a/python/test/t/geometry/test_raycasting_scene.py
+++ b/python/test/t/geometry/test_raycasting_scene.py
@@ -150,7 +150,7 @@ def test_list_intersections():
     ans = scene.list_intersections(rays)
 
     np.testing.assert_allclose(ans['t_hit'].numpy(),
-                               np.array([[1.0], [2.0], [0.5]]),
+                               np.array([1.0, 2.0, 0.5]),
                                rtol=1e-6,
                                atol=1e-6)
 

--- a/python/test/t/geometry/test_raycasting_scene.py
+++ b/python/test/t/geometry/test_raycasting_scene.py
@@ -137,6 +137,39 @@ def test_count_lots_of_intersections():
     _ = scene.count_intersections(rays)
 
 
+def test_list_intersections():
+    cube = o3d.t.geometry.TriangleMesh.from_legacy(
+        o3d.geometry.TriangleMesh.create_box())
+
+    scene = o3d.t.geometry.RaycastingScene()
+    scene.add_triangles(cube)
+
+    rays = o3d.core.Tensor([[0.5, 0.5, -1, 0, 0, 1], [0.5, 0.5, 0.5, 0, 0, 1],
+                            [10, 10, 10, 1, 0, 0]],
+                           dtype=o3d.core.float32)
+    ans = scene.list_intersections(rays)
+
+    np.testing.assert_allclose(ans['t_hit'].numpy(),
+                               np.array([[1.0], [2.0], [0.5]]),
+                               rtol=1e-6,
+                               atol=1e-6)
+
+
+# list lots of random ray intersections to test the internal batching
+# we expect no errors for this test
+def test_list_lots_of_intersections():
+    cube = o3d.t.geometry.TriangleMesh.from_legacy(
+        o3d.geometry.TriangleMesh.create_box())
+
+    scene = o3d.t.geometry.RaycastingScene()
+    scene.add_triangles(cube)
+
+    rs = np.random.RandomState(123)
+    rays = o3d.core.Tensor.from_numpy(rs.rand(123456, 6).astype(np.float32))
+
+    _ = scene.list_intersections(rays)
+
+
 def test_compute_closest_points():
     vertices = o3d.core.Tensor([[0, 0, 0], [1, 0, 0], [1, 1, 0]],
                                dtype=o3d.core.float32)
@@ -248,7 +281,9 @@ def test_output_shapes(shape):
         'primitive_ids': [],
         'primitive_uvs': [2],
         'primitive_normals': [3],
-        'points': [3]
+        'points': [3],
+        'ray_ids': [],
+        'ray_splits': []
     }
 
     ans = scene.cast_rays(rays)
@@ -262,6 +297,21 @@ def test_output_shapes(shape):
     ans = scene.compute_closest_points(query_points)
     for k, v in ans.items():
         expected_shape = shape + last_dim[k]
+        assert list(
+            v.shape
+        ) == expected_shape, 'shape mismatch: expected {} but got {} for {}'.format(
+            expected_shape, list(v.shape), k)
+
+    ans = scene.list_intersections(rays)
+    nx = np.sum(scene.count_intersections(rays).numpy()).tolist()
+    for k, v in ans.items():
+        alt_shape = np.copy(shape)
+        if k == 'ray_splits':
+            alt_shape[0] = shape[0] + 1
+        else:
+            alt_shape[0] = nx
+        #use np.append otherwise issues if alt_shape = [0] and last_dim[k] = []
+        expected_shape = np.append(alt_shape, last_dim[k]).tolist()
         assert list(
             v.shape
         ) == expected_shape, 'shape mismatch: expected {} but got {} for {}'.format(

--- a/python/test/t/geometry/test_raycasting_scene.py
+++ b/python/test/t/geometry/test_raycasting_scene.py
@@ -305,11 +305,10 @@ def test_output_shapes(shape):
     ans = scene.list_intersections(rays)
     nx = np.sum(scene.count_intersections(rays).numpy()).tolist()
     for k, v in ans.items():
-        alt_shape = np.copy(shape)
         if k == 'ray_splits':
-            alt_shape[0] = shape[0] + 1
+            alt_shape = [np.prod(rays.shape[:-1]) + 1]
         else:
-            alt_shape[0] = nx
+            alt_shape = [nx]
         #use np.append otherwise issues if alt_shape = [0] and last_dim[k] = []
         expected_shape = np.append(alt_shape, last_dim[k]).tolist()
         assert list(

--- a/util/check_style.py
+++ b/util/check_style.py
@@ -78,7 +78,7 @@ class CppFormatter:
         """
         Returns (true, true) if (style, header) is valid.
         """
-        with open(file_path, 'r', encoding='utf-8') as f:
+        with open(file_path, 'r') as f:
             is_valid_header = f.read().startswith(CppFormatter.standard_header)
 
         cmd = [
@@ -156,7 +156,7 @@ class PythonFormatter:
         Returns (true, true) if (style, header) is valid.
         """
 
-        with open(file_path, 'r', encoding='utf-8') as f:
+        with open(file_path, 'r') as f:
             content = f.read()
             is_valid_header = (len(content) == 0 or content.startswith(
                 PythonFormatter.standard_header))
@@ -218,7 +218,7 @@ class JupyterFormatter:
         are merged into one.
         """
         # Ref: https://gist.github.com/oskopek/496c0d96c79fb6a13692657b39d7c709
-        with open(file_path, "r", encoding='utf-8') as f:
+        with open(file_path, "r") as f:
             notebook = nbformat.read(f, as_version=nbformat.NO_CONVERT)
         nbformat.validate(notebook)
 
@@ -241,7 +241,7 @@ class JupyterFormatter:
                 changed = True
 
         if apply:
-            with open(file_path, "w", encoding='utf-8') as f:
+            with open(file_path, "w") as f:
                 nbformat.write(notebook, f, version=nbformat.NO_CONVERT)
 
         return not changed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add "ListIntersections" (C++) / "list_intersections" (python) function that returns a dictionary for all ray intersections present in a raycasting scene.

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [x] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Flexibility in ray inclusion / exclusion.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [x] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [x] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
Accepts a rays tensor. The returned dictionary contains:

    ray_ids
        A tensor with ray IDs. The shape is {..}.
        
    geometry_ids
        A tensor with the geometry IDs. The shape is {..}.

    primitive_ids
        A tensor with the primitive IDs, which corresponds to the triangle
        index. The shape is {..}.

    primitive_uvs 
        A tensor with the barycentric coordinates of
        the closest points within the triangles. The shape is {.., 2}.

    t_hit
        A tensor with the distance to the hit. The shape is {..}. 

Runs `count_intersections` first to pre-allocate results arrays then executes the actual function.

Can be tested with the following code:

```
import open3d as o3d
import numpy as np

d = o3d.data.MonkeyModel()
mesh = o3d.t.io.read_triangle_mesh(d.path)
p_min = np.min(mesh.vertex['positions'].numpy() - 1, axis=0)
p_max = np.max(mesh.vertex['positions'].numpy() - 1, axis=0)
x = np.arange(p_min[0], p_max[0], .1)
y = np.arange(p_min[1], p_max[1], .1)
xv, yv = np.meshgrid(x, y) 
orig = np.vstack([xv.flatten(), yv.flatten(), np.tile(p_min[2], xv.size)]).T
dest = np.copy(orig)
dest[:, 2] = p_max[2] + 1
rays = np.hstack([orig, dest - orig]).astype('float32') 

scene = o3d.t.geometry.RaycastingScene()
mesh_id = scene.add_triangles(mesh)
lx = scene.list_intersections(rays)
```
Output:
```
>>> rays.shape
(540, 6)

>>> lx['ray_ids'].numpy().T
array([[318, 318, 319, 319, 320, 320, 321, 321, 322, 322, 323, 323, 345,
        345, 346, 346, 347, 347, 348, 348, 349, 349, 350, 350, 372, 372,
        373, 373, 374, 374, 375, 375, 376, 376, 377, 377, 399, 399, 400,
        400, 401, 401, 402, 402, 403, 403, 404, 404, 426, 426, 427, 427,
        428, 428, 429, 429, 430, 430, 431, 431, 453, 453, 454, 454, 455,
        455, 456, 456, 457, 457, 480, 480, 481, 481, 482, 482, 483, 483,
        484, 484, 485, 485, 505, 505, 506, 506, 507, 507, 508, 508, 509,
        509, 510, 510, 511, 511, 512, 512, 526, 526, 527, 527, 528, 528,
        529, 529, 530, 530, 531, 531, 532, 532, 533, 533, 534, 534, 535,
        535, 536, 536, 537, 537, 538, 538, 539, 539]], dtype=uint32)

>>> lx['geometry_ids'].numpy().T
array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=uint32)

>>> lx['primitive_ids'].numpy().T
array([[12297,  1938,  4245,  1912, 12109,  2832, 12088,  2787,  4417,
         9773, 12287,  8901,  4433,  2006,  4235,  1946,  4211, 10834,
        12093,  2959, 12295,  1922, 12283,  8938,  4400,  1983, 12085,
         2015, 12077,  2109, 12068,  9961, 12253,  1998, 12225,  1097,
        12279,  8977,  4203,  1969, 12051,  9948,  4194,  9920,  4385,
         9836,  4359,  1096, 12333,  1111, 12042,  1973,  4175,  2065,
        12029,  9927, 12321,  9825, 12356,  1089,  4787, 10512, 12588,
        10488,  4721,  2036,  4696,  9890,  4704,  2606, 12555, 12406,
        12564, 10452,  4694,  2301,  4677,  2277, 12544,  2574,  4675,
         5650,  5823,  5575,  5813, 13514,  4685,  2715,  4690, 10428,
         4691, 10193,  4667, 10312,  4670,  2692, 12543, 13548, 15393,
         6035,  7524, 13900, 15387,  6283, 15728,  6292, 15733, 13451,
        13648, 13476,  5809,  9054, 13710,  9010,  4648,  1718,  4660,
         1759,  4662, 10392,  4645, 10376, 12512,  1703,  4642,  9006]],
      dtype=uint32)

>>>lx['primitive_uvs'].numpy().T
array([[8.50260928e-02, 6.51837885e-01, 1.03081293e-01, 3.91855270e-01,
        8.05648923e-01, 5.80210924e-01, 1.40363634e-01, 4.72955555e-01,
        3.64858925e-01, 2.04821900e-01, 6.26785994e-01, 7.60398880e-02,
        1.04184061e-01, 2.94283777e-01, 2.93564528e-01, 6.82043910e-01,
        1.17763458e-02, 1.93700671e-01, 3.53171467e-03, 3.03192195e-02,
        5.40782988e-01, 1.92260608e-01, 4.34213966e-01, 6.12139523e-01,
        5.72637856e-01, 6.21795833e-01, 1.55210704e-01, 1.16427779e-01,
        9.15720105e-01, 3.63248348e-01, 8.89678299e-01, 5.30207932e-01,
        6.57920063e-01, 8.82471576e-02, 1.01874083e-01, 1.09900184e-01,
        7.86101043e-01, 1.81164563e-01, 5.11571527e-01, 1.69970412e-02,
        1.00328386e-01, 2.37347394e-01, 2.26802994e-02, 1.81675166e-01,
        5.41030526e-01, 7.16622248e-02, 4.13606241e-02, 2.97267050e-01,
        4.64487553e-01, 1.66320521e-02, 5.10603547e-01, 4.46072996e-01,
        6.01617873e-01, 3.57365131e-01, 5.13987005e-01, 2.44175628e-01,
        1.64774716e-01, 2.06305742e-01, 6.90514445e-01, 1.78633600e-01,
        1.05318859e-01, 2.54442692e-01, 4.06445339e-02, 3.29573601e-01,
        5.06643891e-01, 2.37140119e-01, 1.31217435e-01, 2.17609853e-01,
        3.27986866e-01, 4.65133274e-03, 8.08010638e-01, 3.72975886e-01,
        6.18177712e-01, 5.14547825e-01, 4.61467683e-01, 1.66717678e-01,
        6.89924583e-02, 4.14696962e-01, 2.27413654e-01, 7.33788610e-01,
        4.05685335e-01, 7.58898035e-02, 1.38070121e-01, 5.24565458e-01,
        2.51125902e-01, 7.64557898e-01, 4.52516317e-01, 7.91438341e-01,
        2.20954821e-01, 6.51578248e-01, 5.62553287e-01, 4.47666347e-01,
        7.86239356e-02, 1.15206286e-01, 6.36142194e-01, 3.99974853e-01,
        4.65191007e-01, 2.71531105e-01, 1.17488220e-01, 8.56871128e-01,
        1.96953505e-01, 6.84856653e-01, 4.82201636e-01, 2.80162394e-01,
        1.94526419e-01, 5.61448792e-03, 6.73465431e-02, 4.94458348e-01,
        7.45218247e-02, 9.88216773e-02, 1.32805824e-01, 6.08568132e-01,
        7.81525373e-02, 1.48485616e-01, 3.72431427e-01, 1.60334751e-01,
        7.44871572e-02, 4.66253549e-01, 3.14146519e-01, 4.40233052e-02,
        1.48861185e-01, 3.42773944e-01, 3.97519767e-02, 4.67371553e-01,
        4.99460287e-02, 8.69180620e-01],
       [3.92546691e-02, 1.67678565e-01, 3.65194201e-01, 4.47089612e-01,
        1.26379047e-04, 3.68818521e-01, 1.90832779e-01, 1.35176867e-01,
        3.05290520e-01, 5.80557048e-01, 2.97499180e-01, 5.30879274e-02,
        2.21387267e-01, 6.46204174e-01, 3.79589945e-01, 1.86955437e-01,
        8.65287006e-01, 6.06772840e-01, 4.78246175e-02, 6.14985645e-01,
        3.59579146e-01, 2.66485035e-01, 2.73514956e-01, 3.65829051e-01,
        1.82528138e-01, 3.16096485e-01, 4.36164469e-01, 4.94528979e-01,
        2.34494451e-02, 1.03755906e-01, 6.05465584e-02, 4.63592499e-01,
        6.02329001e-02, 2.00819299e-01, 5.75036347e-01, 8.54499578e-01,
        1.67031765e-01, 2.93776039e-02, 6.69649169e-02, 1.01286829e-01,
        8.44411194e-01, 2.02314824e-01, 2.68521532e-02, 7.42257297e-01,
        3.14291596e-01, 1.53447643e-01, 6.90125883e-01, 6.37456998e-02,
        4.60704058e-01, 7.82134652e-01, 4.86005783e-01, 3.26901466e-01,
        2.96064347e-01, 4.09353852e-01, 3.34959358e-01, 6.70883581e-02,
        4.87725213e-02, 6.34807169e-01, 1.99106425e-01, 5.09882152e-01,
        6.14799976e-01, 1.92902938e-01, 2.93571591e-01, 7.06736818e-02,
        4.36887369e-02, 2.95727044e-01, 8.39247465e-01, 9.20358598e-02,
        5.14076471e-01, 1.55397788e-01, 1.48478355e-02, 9.43628401e-02,
        3.18643987e-01, 3.43717992e-01, 1.53597191e-01, 3.62733036e-01,
        1.27671719e-01, 3.86326134e-01, 5.63073039e-01, 7.00732917e-02,
        5.23127794e-01, 7.82335460e-01, 6.78201020e-01, 2.89844066e-01,
        2.95127273e-01, 3.91148739e-02, 4.72639620e-01, 1.01692388e-02,
        1.92888826e-01, 1.89839691e-01, 7.12942183e-02, 6.05209507e-02,
        8.27150643e-01, 3.16473961e-01, 7.92979747e-02, 5.56479931e-01,
        2.22815737e-01, 1.68949321e-01, 3.75169277e-01, 7.28604645e-02,
        7.43002892e-01, 1.27236247e-01, 1.60706714e-01, 6.42337501e-01,
        4.55084860e-01, 5.32845736e-01, 7.88478732e-01, 3.08783919e-01,
        2.64580131e-01, 7.74997652e-01, 6.83005676e-02, 1.53609201e-01,
        4.40520406e-01, 3.76733273e-01, 4.96786356e-01, 7.34959781e-01,
        3.65802705e-01, 5.00856578e-01, 3.25992048e-01, 1.70454092e-03,
        1.85889587e-01, 2.30168775e-01, 4.06972110e-01, 2.14318082e-01,
        5.39930463e-01, 1.18742652e-01]], dtype=float32)

>>> lx['t_hit'].numpy().T
array([[0.8435714 , 0.93022877, 0.84232   , 0.94535124, 0.83926505,
        0.9475919 , 0.8404622 , 0.949586  , 0.8430659 , 0.9405413 ,
        0.8463084 , 0.921236  , 0.83460045, 0.9428818 , 0.829282  ,
        0.958152  , 0.8238311 , 0.94325334, 0.82550997, 0.94131124,
        0.83107746, 0.95320255, 0.839386  , 0.93259716, 0.8331073 ,
        0.9460807 , 0.8237588 , 0.96223986, 0.81628525, 0.9666485 ,
        0.81862414, 0.9659599 , 0.826654  , 0.95780087, 0.8420907 ,
        0.93435174, 0.8350253 , 0.94551253, 0.8188721 , 0.9639249 ,
        0.80940276, 0.9687127 , 0.8120805 , 0.967958  , 0.8238137 ,
        0.9589816 , 0.8503339 , 0.9307414 , 0.8364902 , 0.9418003 ,
        0.8019855 , 0.9645548 , 0.7877976 , 0.97038263, 0.79091233,
        0.9694287 , 0.81348133, 0.9587221 , 0.8602229 , 0.9216753 ,
        0.83709997, 0.9308639 , 0.6462993 , 0.9639895 , 0.6154006 ,
        0.97064835, 0.6210553 , 0.96957433, 0.68068993, 0.95639205,
        0.55123186, 0.8929472 , 0.5219662 , 0.96521115, 0.50918746,
        0.9916076 , 0.51180327, 0.98705995, 0.5309491 , 0.95183134,
        0.5730049 , 0.80399156, 0.59807265, 0.73571694, 0.516519  ,
        0.84292406, 0.48224548, 0.9099531 , 0.4638537 , 0.97253287,
        0.45487374, 0.99615115, 0.4568556 , 0.9969643 , 0.46949258,
        0.9533076 , 0.49270236, 0.8698291 , 0.5398988 , 0.5576007 ,
        0.5450186 , 0.5949125 , 0.56059927, 0.6183859 , 0.56956923,
        0.6249971 , 0.5710189 , 0.70505244, 0.55278033, 0.8113385 ,
        0.50697887, 0.9186829 , 0.4648054 , 0.9423307 , 0.44438577,
        0.964288  , 0.43005514, 0.97802615, 0.42262608, 0.9722668 ,
        0.42434618, 0.9756199 , 0.43452722, 0.9747778 , 0.45160547,
        0.9560417 ]], dtype=float32)
```

Visualisation:

```
entry = o3d.geometry.PointCloud(points = o3d.utility.Vector3dVector(orig))
target = o3d.geometry.PointCloud(points = o3d.utility.Vector3dVector(dest))
correspondence = [(i, i) for i in range(rays.shape[0])]
traj = o3d.geometry.LineSet.create_from_point_cloud_correspondences(entry , target , correspondence)
traj.colors = o3d.utility.Vector3dVector(np.tile([1, 0, 0], [rays.shape[0], 1]))
o3d.visualization.draw([mesh, traj])

# intersection points
v = mesh.vertex['positions'].numpy()
t = mesh.triangle['indices'].numpy()
tidx = lx['primitive_ids'].numpy()
uv = lx['primitive_uvs'].numpy()
w = 1 - np.sum(uv, axis=1)
c = \
  v[t[tidx, 1].flatten(), :] * uv[:, 0][:, None] + \
  v[t[tidx, 2].flatten(), :] * uv[:, 1][:, None] + \
  v[t[tidx, 0].flatten(), :] * w[:, None] 
x = o3d.geometry.PointCloud(points = o3d.utility.Vector3dVector(c))

# visualise
o3d.visualization.draw([mesh, traj, x])
```
![image](https://github.com/isl-org/Open3D/assets/54913410/d82941d7-9f79-4a85-b5d5-b0c3b9f0acbc)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/6442)
<!-- Reviewable:end -->
