### PR TITLE
Update check_style.py

### DIFF
--- a/util/check_style.py
+++ b/util/check_style.py
@@ -78,7 +78,7 @@ class CppFormatter:
         """
         Returns (true, true) if (style, header) is valid.
         """
-        with open(file_path, 'r') as f:
+        with open(file_path, 'r', encoding='utf-8') as f:
             is_valid_header = f.read().startswith(CppFormatter.standard_header)
 
         cmd = [
@@ -156,7 +156,7 @@ class PythonFormatter:
         Returns (true, true) if (style, header) is valid.
         """
 
-        with open(file_path, 'r') as f:
+        with open(file_path, 'r', encoding='utf-8') as f:
             content = f.read()
             is_valid_header = (len(content) == 0 or content.startswith(
                 PythonFormatter.standard_header))
@@ -218,7 +218,7 @@ class JupyterFormatter:
         are merged into one.
         """
         # Ref: https://gist.github.com/oskopek/496c0d96c79fb6a13692657b39d7c709
-        with open(file_path, "r") as f:
+        with open(file_path, "r", encoding='utf-8') as f:
             notebook = nbformat.read(f, as_version=nbformat.NO_CONVERT)
         nbformat.validate(notebook)
 
@@ -241,7 +241,7 @@ class JupyterFormatter:
                 changed = True
 
         if apply:
-            with open(file_path, "w") as f:
+            with open(file_path, "w", encoding='utf-8') as f:
                 nbformat.write(notebook, f, version=nbformat.NO_CONVERT)
 
         return not changed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes the encoding error (on Windows). Complimentary to #1935 

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #1933
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Upon running `python .\util\check_style.py --apply` on Windows get error:

```
Applying C++/CUDA style (8 processes)
multiprocessing.pool.RemoteTraceback:
"""
Traceback (most recent call last):
  File "C:\anaconda3\lib\multiprocessing\pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "C:\anaconda3\lib\multiprocessing\pool.py", line 48, in mapstar
    return list(map(*args))
  File "C:\Open3d\util\check_style.py", line 82, in _check_style
    is_valid_header = f.read().startswith(CppFormatter.standard_header)
  File "C:\anaconda3\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 9393: character maps to <undefined>

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "C:\Open3d\util\check_style.py", line 447, in <module>
    main()
  File "C:\Open3d\util\check_style.py", line 409, in main
    changed_files_cpp, wrong_header_files_cpp = cpp_formatter.run(
  File "C:\Open3d\util\check_style.py", line 118, in run
    is_valid_files = pool.map(
  File "C:\anaconda3\lib\multiprocessing\pool.py", line 364, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
  File "C:\anaconda3\lib\multiprocessing\pool.py", line 771, in get
    raise self._value
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 9393: character maps to <undefined>
```

Which is fixed by adding `encoding='utf-8'` to `open()` in `check_style` as per [stackoverflow](https://stackoverflow.com/questions/49562499/how-to-fix-unicodedecodeerror-charmap-codec-cant-decode-byte-0x9d-in-posit)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/6443)
<!-- Reviewable:end -->
