### PR TITLE
Fix IntegrateRGBD example compilation

### DIFF
--- a/examples/cpp/IntegrateRGBD.cpp
+++ b/examples/cpp/IntegrateRGBD.cpp
@@ -68,7 +68,6 @@ int main(int argc, char *argv[]) {
     FILE *file = utility::filesystem::FOpen(match_filename, "r");
     if (file == NULL) {
         utility::LogWarning("Unable to open file {}", match_filename);
-        fclose(file);
         return 0;
     }
     char buffer[DEFAULT_IO_BUFFER_SIZE];


### PR DESCRIPTION
Compilation of Open3D failed for gcc-12 with:
```
examples/cpp/IntegrateRGBD.cpp:71:15: error: argument 1 null where non-null expected [-Werror=nonnull]
   71 |         fclose(file);
```

Since `file` is already `NULL`, we shouldn't try to `fclose()` it.

## Type

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [ ] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D/6453)
<!-- Reviewable:end -->
