### PR TITLE
Fix seg fault in t::geometry::TriangleMesh::SelectByIndex for negative index

### DIFF
--- a/cpp/open3d/t/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/t/geometry/TriangleMesh.cpp
@@ -1171,6 +1171,7 @@ TriangleMesh TriangleMesh::SelectByIndex(const core::Tensor &indices) const {
                                     "out of range. "
                                     "It is ignored.",
                                     indices_ptr[i]);
+                            continue;
                         }
                         vertex_mask_ptr[indices_ptr[i]] = 1;
                     }

--- a/cpp/tests/t/geometry/TriangleMesh.cpp
+++ b/cpp/tests/t/geometry/TriangleMesh.cpp
@@ -1143,16 +1143,18 @@ TEST_P(TriangleMeshPermuteDevices, SelectByIndex) {
 
     // check basic case
     core::Tensor indices = core::Tensor::Init<int64_t>({2, 3, 6, 7});
-    t::geometry::TriangleMesh selected = box.SelectByIndex(indices);
+    t::geometry::TriangleMesh selected_basic = box.SelectByIndex(indices);
 
-    EXPECT_TRUE(selected.GetVertexPositions().AllClose(expected_verts));
-    EXPECT_TRUE(selected.GetVertexColors().AllClose(expected_vert_colors));
+    EXPECT_TRUE(selected_basic.GetVertexPositions().AllClose(expected_verts));
     EXPECT_TRUE(
-            selected.GetVertexAttr("labels").AllClose(expected_vert_labels));
-    EXPECT_TRUE(selected.GetTriangleIndices().AllClose(expected_tris));
-    EXPECT_TRUE(selected.GetTriangleNormals().AllClose(expected_tri_normals));
+            selected_basic.GetVertexColors().AllClose(expected_vert_colors));
+    EXPECT_TRUE(selected_basic.GetVertexAttr("labels").AllClose(
+            expected_vert_labels));
+    EXPECT_TRUE(selected_basic.GetTriangleIndices().AllClose(expected_tris));
     EXPECT_TRUE(
-            selected.GetTriangleAttr("labels").AllClose(expected_tri_labels));
+            selected_basic.GetTriangleNormals().AllClose(expected_tri_normals));
+    EXPECT_TRUE(selected_basic.GetTriangleAttr("labels").AllClose(
+            expected_tri_labels));
 
     // check duplicated indices case
     core::Tensor indices_duplicate =
@@ -1171,6 +1173,14 @@ TEST_P(TriangleMeshPermuteDevices, SelectByIndex) {
             expected_tri_normals));
     EXPECT_TRUE(selected_duplicate.GetTriangleAttr("labels").AllClose(
             expected_tri_labels));
+
+    core::Tensor indices_negative =
+            core::Tensor::Init<int64_t>({2, -4, 3, 6, 7});
+    t::geometry::TriangleMesh selected_negative =
+            box.SelectByIndex(indices_negative);
+    EXPECT_TRUE(
+            selected_negative.GetVertexPositions().AllClose(expected_verts));
+    EXPECT_TRUE(selected_negative.GetTriangleIndices().AllClose(expected_tris));
 
     // select with empty triangles as result
     // set the expected value


### PR DESCRIPTION
Sorry about the issue. It was introduced by https://github.com/isl-org/Open3D/pull/6415. When I moved from forbidding the invalid indices to ignoring them, I forgot to actually ignore them, which led to a possible invalid data access by a negative index.
That went unnoticed, as the test was only in python and was flaky.

## Type

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #

## Motivation and Context

A data access by negative index.

## Checklist:

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [x] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.
FYI @ssheorey 