### PR TITLE
Expose Near Clip and Far Clip parameters to the Python Bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Check for support of CUDA Memory Pools at runtime (#4679)
 * Fix `toString`, `CreateFromPoints` methods and improve docs in `AxisAlignedBoundingBox`. 🐛📝
 * Migrate Open3d documentation to furo theme ✨ (#6470)
+* Expose Near Clip + Far Clip parameters to setup_camera in OffscreenRenderer (#6520)
 
 ## 0.13
 

--- a/cpp/pybind/visualization/rendering/rendering.cpp
+++ b/cpp/pybind/visualization/rendering/rendering.cpp
@@ -81,15 +81,19 @@ public:
     void SetupCamera(float verticalFoV,
                      const Eigen::Vector3f &center,
                      const Eigen::Vector3f &eye,
-                     const Eigen::Vector3f &up) {
+                     const Eigen::Vector3f &up,
+                     float nearClip = -1.0f,
+                     float farClip  = -1.0f) {
         float aspect = 1.0f;
         if (height_ > 0) {
             aspect = float(width_) / float(height_);
         }
         auto *camera = scene_->GetCamera();
         auto far_plane =
+                farClip > 0.0 ? farClip :
                 Camera::CalcFarPlane(*camera, scene_->GetBoundingBox());
-        camera->SetProjection(verticalFoV, aspect, Camera::CalcNearPlane(),
+        camera->SetProjection(verticalFoV, aspect,
+                              nearClip > 0.0 ? nearClip : Camera::CalcNearPlane(),
                               far_plane, rendering::Camera::FovType::Vertical);
         camera->LookAt(center, eye, up);
     }
@@ -164,10 +168,14 @@ void pybind_rendering_classes(py::module &m) {
             .def("setup_camera",
                  py::overload_cast<float, const Eigen::Vector3f &,
                                    const Eigen::Vector3f &,
-                                   const Eigen::Vector3f &>(
+                                   const Eigen::Vector3f &,
+                                   float, float>(
                          &PyOffscreenRenderer::SetupCamera),
-                 "setup_camera(vertical_field_of_view, center, eye, up): "
-                 "sets camera view using bounding box of current geometry")
+                 "setup_camera(vertical_field_of_view, center, eye, up, "
+                 "near_clip, far_clip): "
+                 "sets camera view using bounding box of current geometry "
+                 "if the near_clip and far_clip parameters are unset",
+                 py::arg("nearClip") = -1.0f, py::arg("farClip") = -1.0f)
             .def("setup_camera",
                  py::overload_cast<const camera::PinholeCameraIntrinsic &,
                                    const Eigen::Matrix4d &>(

--- a/cpp/pybind/visualization/rendering/rendering.cpp
+++ b/cpp/pybind/visualization/rendering/rendering.cpp
@@ -176,6 +176,8 @@ void pybind_rendering_classes(py::module &m) {
                  "near_clip, far_clip): "
                  "sets camera view using bounding box of current geometry "
                  "if the near_clip and far_clip parameters are unset",
+                 py::arg("verticalFoV"), py::arg("center"),
+                 py::arg("eye"), py::arg("up"),
                  py::arg("nearClip") = -1.0f, py::arg("farClip") = -1.0f)
             .def("setup_camera",
                  py::overload_cast<const camera::PinholeCameraIntrinsic &,

--- a/cpp/pybind/visualization/rendering/rendering.cpp
+++ b/cpp/pybind/visualization/rendering/rendering.cpp
@@ -83,18 +83,20 @@ public:
                      const Eigen::Vector3f &eye,
                      const Eigen::Vector3f &up,
                      float nearClip = -1.0f,
-                     float farClip  = -1.0f) {
+                     float farClip = -1.0f) {
         float aspect = 1.0f;
         if (height_ > 0) {
             aspect = float(width_) / float(height_);
         }
         auto *camera = scene_->GetCamera();
-        auto far_plane =
-                farClip > 0.0 ? farClip :
-                Camera::CalcFarPlane(*camera, scene_->GetBoundingBox());
-        camera->SetProjection(verticalFoV, aspect,
-                              nearClip > 0.0 ? nearClip : Camera::CalcNearPlane(),
-                              far_plane, rendering::Camera::FovType::Vertical);
+        auto far_plane = farClip > 0.0
+                                 ? farClip
+                                 : Camera::CalcFarPlane(
+                                           *camera, scene_->GetBoundingBox());
+        camera->SetProjection(
+                verticalFoV, aspect,
+                nearClip > 0.0 ? nearClip : Camera::CalcNearPlane(), far_plane,
+                rendering::Camera::FovType::Vertical);
         camera->LookAt(center, eye, up);
     }
 
@@ -168,8 +170,7 @@ void pybind_rendering_classes(py::module &m) {
             .def("setup_camera",
                  py::overload_cast<float, const Eigen::Vector3f &,
                                    const Eigen::Vector3f &,
-                                   const Eigen::Vector3f &,
-                                   float, float>(
+                                   const Eigen::Vector3f &, float, float>(
                          &PyOffscreenRenderer::SetupCamera),
                  "setup_camera(vertical_field_of_view, center, eye, up, "
                  "near_clip, far_clip): "

--- a/cpp/pybind/visualization/rendering/rendering.cpp
+++ b/cpp/pybind/visualization/rendering/rendering.cpp
@@ -175,7 +175,7 @@ void pybind_rendering_classes(py::module &m) {
                  "setup_camera(vertical_field_of_view, center, eye, up, "
                  "near_clip, far_clip): "
                  "sets camera view using bounding box of current geometry "
-                 "if the near_clip and far_clip parameters are unset",
+                 "if the near_clip and far_clip parameters are not set",
                  py::arg("verticalFoV"), py::arg("center"), py::arg("eye"),
                  py::arg("up"), py::arg("nearClip") = -1.0f,
                  py::arg("farClip") = -1.0f)

--- a/cpp/pybind/visualization/rendering/rendering.cpp
+++ b/cpp/pybind/visualization/rendering/rendering.cpp
@@ -176,9 +176,9 @@ void pybind_rendering_classes(py::module &m) {
                  "near_clip, far_clip): "
                  "sets camera view using bounding box of current geometry "
                  "if the near_clip and far_clip parameters are unset",
-                 py::arg("verticalFoV"), py::arg("center"),
-                 py::arg("eye"), py::arg("up"),
-                 py::arg("nearClip") = -1.0f, py::arg("farClip") = -1.0f)
+                 py::arg("verticalFoV"), py::arg("center"), py::arg("eye"),
+                 py::arg("up"), py::arg("nearClip") = -1.0f,
+                 py::arg("farClip") = -1.0f)
             .def("setup_camera",
                  py::overload_cast<const camera::PinholeCameraIntrinsic &,
                                    const Eigen::Matrix4d &>(

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -21,7 +21,7 @@ if errorlevel 9009 (
     exit /b 1
 )
 
-python make.py %1
+python make_docs.py %1
 goto end
 
 :end


### PR DESCRIPTION
Add optional args to set the NearClip and FarClip of the camera in the Offscreen Renderer.

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [x] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation, Context, and Description

Open3D Python doesn't currently expose a method for the `OffscreenRenderer` to convert depth units to absolute units, since all camera setting methods automatically normalize to the scene bounding box (without exposing those normalized values anywhere).  This simple PR optionally exposes those options to enable depth to be output in absolute units.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.
