### PR TITLE
Fix unused variable error when OpenMP is disabled

### DIFF
--- a/cpp/open3d/pipelines/registration/Feature.cpp
+++ b/cpp/open3d/pipelines/registration/Feature.cpp
@@ -157,6 +157,8 @@ CorrespondenceSet CorrespondencesFromFeatures(const Feature &source_features,
 
     const int kOuterThreads = std::min(kMaxThreads, num_searches);
     const int kInnerThreads = std::max(kMaxThreads / num_searches, 1);
+    (void)kOuterThreads;
+    (void)kInnerThreads;
 #pragma omp parallel for num_threads(kOuterThreads)
     for (int k = 0; k < num_searches; ++k) {
         geometry::KDTreeFlann kdtree(features[1 - k]);

--- a/cpp/open3d/pipelines/registration/Feature.cpp
+++ b/cpp/open3d/pipelines/registration/Feature.cpp
@@ -154,10 +154,9 @@ CorrespondenceSet CorrespondencesFromFeatures(const Feature &source_features,
     std::vector<CorrespondenceSet> corres(num_searches);
 
     const int kMaxThreads = utility::EstimateMaxThreads();
-
     const int kOuterThreads = std::min(kMaxThreads, num_searches);
     const int kInnerThreads = std::max(kMaxThreads / num_searches, 1);
-    (void)kOuterThreads;
+    (void)kOuterThreads;  // Avoids compiler warning if OpenMP is disabled
     (void)kInnerThreads;
 #pragma omp parallel for num_threads(kOuterThreads)
     for (int k = 0; k < num_searches; ++k) {

--- a/cpp/open3d/t/pipelines/registration/Feature.cpp
+++ b/cpp/open3d/t/pipelines/registration/Feature.cpp
@@ -102,6 +102,7 @@ core::Tensor CorrespondencesFromFeatures(const core::Tensor &source_features,
 
     const int kMaxThreads = utility::EstimateMaxThreads();
     const int kOuterThreads = std::min(kMaxThreads, num_searches);
+    (void)kOuterThreads;
 
     // corres[0]: corres_ij, corres[1]: corres_ji
 #pragma omp parallel for num_threads(kOuterThreads)

--- a/cpp/open3d/t/pipelines/registration/Feature.cpp
+++ b/cpp/open3d/t/pipelines/registration/Feature.cpp
@@ -102,7 +102,7 @@ core::Tensor CorrespondencesFromFeatures(const core::Tensor &source_features,
 
     const int kMaxThreads = utility::EstimateMaxThreads();
     const int kOuterThreads = std::min(kMaxThreads, num_searches);
-    (void)kOuterThreads;
+    (void)kOuterThreads;  // Avoids compiler warning if OpenMP is disabled
 
     // corres[0]: corres_ij, corres[1]: corres_ji
 #pragma omp parallel for num_threads(kOuterThreads)


### PR DESCRIPTION
## Type

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #6514
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

```
error: unused variable 'kInnerThreads' [-Werror,-Wunused-variable]
```
type of errors occur when building without OpenMP on macOS Sonoma.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

Adds ``(void)kOuterThreads;`` style fixes to suppress the warnings.
