### PR TITLE
Fix for C4146 Error in CPUNegElementKernel with Unsigned Types

### DIFF
--- a/cpp/open3d/core/kernel/UnaryEWCPU.cpp
+++ b/cpp/open3d/core/kernel/UnaryEWCPU.cpp
@@ -96,8 +96,9 @@ static void CPUCosElementKernel(const void* src, void* dst) {
 
 template <typename scalar_t>
 static void CPUNegElementKernel(const void* src, void* dst) {
-    *static_cast<scalar_t*>(dst) =
-            static_cast<scalar_t>(-*static_cast<const scalar_t*>(src));
+    using signed_scalar_t = std::make_signed_t<scalar_t>;
+    *static_cast<scalar_t*>(dst) = static_cast<scalar_t>(
+            -static_cast<signed_scalar_t>(*static_cast<const scalar_t*>(src)));
 }
 
 template <typename scalar_t>

--- a/cpp/open3d/core/kernel/UnaryEWCPU.cpp
+++ b/cpp/open3d/core/kernel/UnaryEWCPU.cpp
@@ -94,11 +94,20 @@ static void CPUCosElementKernel(const void* src, void* dst) {
             static_cast<scalar_t>(std::cos(*static_cast<const scalar_t*>(src)));
 }
 
-template <typename scalar_t>
+template <typename scalar_t,
+          typename std::enable_if<std::is_integral<scalar_t>::value,
+                                  int>::type = 0>
 static void CPUNegElementKernel(const void* src, void* dst) {
     using signed_scalar_t = std::make_signed_t<scalar_t>;
     *static_cast<scalar_t*>(dst) = static_cast<scalar_t>(
             -static_cast<signed_scalar_t>(*static_cast<const scalar_t*>(src)));
+}
+
+template <typename scalar_t,
+          typename std::enable_if<!std::is_integral<scalar_t>::value,
+                                  int>::type = 0>
+static void CPUNegElementKernel(const void* src, void* dst) {
+    *static_cast<scalar_t*>(dst) = -*static_cast<const scalar_t*>(src);
 }
 
 template <typename scalar_t>


### PR DESCRIPTION
Fix the compile error.
UnaryEWCPU.cpp(100): error C4146: unary minus operator applied to unsigned type, result still unsigned

<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->

The CPUNegElementKernel function in UnaryEWCPU.cpp triggers a compilation error (C4146) when instantiated with an unsigned scalar_t type.
This error is caused by applying the unary minus operator to an unsigned type, where the result remains unsigned, leading to undefined behavior.

I am tyring to write port for vpckg.
I got C4146 error during the compilations.

manual build option( other options are default)
```
        -DBUILD_SHARED_LIBS=OFF
        -DWITH_OPENMP=OFF
        -DBUILD_EXAMPLES=OFF
        -DBUILD_UNIT_TESTS=OFF
        -DBUILD_BENCHMARKS=OFF
        -DBUILD_GUI=OFF
        -DBUILD_ISPC_MODULE=OFF
        -DUSE_SYSTEM_EIGEN3=ON
        -DUSE_SYSTEM_CURL=ON
        -DUSE_SYSTEM_GLEW=ON
        -DUSE_SYSTEM_GLFW=ON
        -DUSE_SYSTEM_JPEG=ON
        -DUSE_SYSTEM_LIBLZF=OFF
        -DUSE_SYSTEM_PNG=OFF
        -DUSE_SYSTEM_TINYGLTF=ON
        -DUSE_SYSTEM_TINYOBJLOADER=ON
        -DUSE_SYSTEM_FMT=ON
        -DUSE_SYSTEM_PYBIND11=ON
        -DUSE_SYSTEM_GOOGLETEST=ON
        -DUSE_SYSTEM_IMGUI=ON
        -DBUILD_PYTHON_MODULE=OFF
        -DBUILD_LIBREALSENSE=OFF
        -DBUILD_AZURE_KINECT=OFF
        -DBUILD_FILAMENT_FROM_SOURCE=OFF
        -DSTATIC_WINDOWS_RUNTIME=${STATIC_WINDOWS_RUNTIME}
        -DBUILD_CUDA_MODULE=OFF
        -DBUILD_TENSORFLOW_OPS=OFF
        -DGLIBCXX_USE_CXX11_ABI=ON
        -DDEVELOPER_BUILD=OFF
```

OS: windows 11
Compiler:MSVC (visuals studio 2022 17.8)
