### PR TITLE
Update supported Python versions (PyPI) in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For more, please visit the [Open3D documentation](http://www.open3d.org/docs).
 ## Python quick start
 
 Pre-built pip packages support Ubuntu 18.04+, macOS 10.15+ and Windows 10+
-(64-bit) with Python 3.8-3.11.
+(64-bit) with Python 3.7-3.10.
 
 ```bash
 # Install


### PR DESCRIPTION
Just a small update of the readme, I just tried to install from pip on Python 3.11 but wasn't able to. According to the readme this should be possible.

I looked at the list of wheels (https://pypi.org/project/open3d/#files) and found that they are only provided for Python 3.7-3.10 so I updated the readme with this information.

I also had to install `libomp` in my M1 macbook air (macos) but didn't find it mentioned on the readme, not sure if this was supposed to be packaged with the wheel (I installed the 3.10 one).

Thanks for your work!