### PR TITLE
Add env var to disable automatic WebVisualizer use in Jupyter environment

### DIFF
--- a/docs/tutorial/visualization/web_visualizer.rst
+++ b/docs/tutorial/visualization/web_visualizer.rst
@@ -55,6 +55,9 @@ Additional notes on compatibility:
   source for ARM. See the ``3rdparty/webrtc`` folder for more details.
 - Google Colab and Kaggle notebook are not supported. You'll need to run you own
   Jupyter or JupyterLab server.
+- If you prefer using native windows (with blocking calls) instead of embedded
+  graphics in Jupyter cells, you can set the environment variable
+  ``OPEN3D_DISABLE_WEB_VISUALIZER=true`` before importing Open3D.
 
 Standalone mode
 ------------------

--- a/python/open3d/__init__.py
+++ b/python/open3d/__init__.py
@@ -117,7 +117,8 @@ __version__ = "@PROJECT_VERSION@"
 if int(sys.version_info[0]) < 3:
     raise Exception("Open3D only supports Python 3.")
 
-if _build_config["BUILD_JUPYTER_EXTENSION"] and os.environ.get("DISABLE_OPEN3D_WEB_VISUALIZER", "False") != "True":
+if _build_config["BUILD_JUPYTER_EXTENSION"] and os.environ.get(
+        "DISABLE_OPEN3D_WEB_VISUALIZER", "False") != "True":
     import platform
     if not (platform.machine().startswith("arm") or
             platform.machine().startswith("aarch")):

--- a/python/open3d/__init__.py
+++ b/python/open3d/__init__.py
@@ -118,7 +118,7 @@ if int(sys.version_info[0]) < 3:
     raise Exception("Open3D only supports Python 3.")
 
 if _build_config["BUILD_JUPYTER_EXTENSION"] and os.environ.get(
-        "DISABLE_OPEN3D_WEB_VISUALIZER", "False") != "True":
+        "OPEN3D_DISABLE_WEB_VISUALIZER", "False").lower() != "true":
     import platform
     if not (platform.machine().startswith("arm") or
             platform.machine().startswith("aarch")):

--- a/python/open3d/__init__.py
+++ b/python/open3d/__init__.py
@@ -117,7 +117,7 @@ __version__ = "@PROJECT_VERSION@"
 if int(sys.version_info[0]) < 3:
     raise Exception("Open3D only supports Python 3.")
 
-if _build_config["BUILD_JUPYTER_EXTENSION"]:
+if _build_config["BUILD_JUPYTER_EXTENSION"] and os.environ.get("DISABLE_OPEN3D_WEB_VISUALIZER", "False") != "True":
     import platform
     if not (platform.machine().startswith("arm") or
             platform.machine().startswith("aarch")):


### PR DESCRIPTION
Add checking `DISABLE_OPEN3D_WEB_VISUALIZER` environment variable to disable automatically enabling web visualizer when in a Jupyter environment.

## Type

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [x] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

The problem is that when using the Jupyter extension in Visual Studio Code then the web visualizer does not function. This change allows to set an environment variable so that the web visualizer would not automatically be enabled.

## Checklist:

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

When using the `gui.Application` functionality and running it using the Jupyter extension in Visual Studio Code then no visualization appears. When setting the env var `DISABLE_OPEN3D_WEB_VISUALIZER=True` then the WebVisualizer is not enabled and an application window opens.