### PR TITLE
add option to retrieve origin data from point cloud generation

### DIFF
--- a/cpp/open3d/geometry/PointCloud.cpp
+++ b/cpp/open3d/geometry/PointCloud.cpp
@@ -29,6 +29,7 @@ PointCloud &PointCloud::Clear() {
     normals_.clear();
     colors_.clear();
     covariances_.clear();
+    origindata_.clear();
     return *this;
 }
 
@@ -111,6 +112,13 @@ PointCloud &PointCloud::operator+=(const PointCloud &cloud) {
             covariances_[old_vert_num + i] = cloud.covariances_[i];
     } else {
         covariances_.clear();
+    }
+    if ((!HasPoints() || HasOriginData()) && cloud.HasOriginData()) {
+        origindata_.resize(new_vert_num);
+        for (size_t i = 0; i < add_vert_num; i++)
+            origindata_[old_vert_num + i] = cloud.origindata_[i];
+    } else {
+        origindata_.clear();
     }
     points_.resize(new_vert_num);
     for (size_t i = 0; i < add_vert_num; i++)

--- a/cpp/open3d/geometry/PointCloud.h
+++ b/cpp/open3d/geometry/PointCloud.h
@@ -84,6 +84,11 @@ public:
         return !points_.empty() && covariances_.size() == points_.size();
     }
 
+    /// Returns 'true' if the point cloud contains per-point origin data.
+    bool HasOriginData() const {
+        return !points_.empty() && origindata_.size() == points_.size();
+    }
+
     /// Normalize point normals to length 1.
     PointCloud &NormalizeNormals() {
         for (size_t i = 0; i < normals_.size(); i++) {
@@ -458,6 +463,20 @@ public:
     static std::shared_ptr<PointCloud> CreateFromVoxelGrid(
             const VoxelGrid &voxel_grid);
 
+    /// \brief Structure corresponding to a single point and describing its
+    /// origin depending on the PointCloud creation type.
+    ///
+    /// Optional information about the origin of the point relative to the data
+    /// used to generate the PointCloud. Currently supports adding geometrical
+    /// information for PointClouds sampled from a triangular mesh. Can be
+    /// expanded as required to include e.g. voxel ID and relative coordinates,
+    /// index of a point in original PointCloud etc.
+    static struct OriginData {
+        size_t tri_id;
+        Eigen::Vector2d tri_uv;
+        // add other data such as voxel ID etc as required
+    };
+
 public:
     /// Points coordinates.
     std::vector<Eigen::Vector3d> points_;
@@ -467,6 +486,8 @@ public:
     std::vector<Eigen::Vector3d> colors_;
     /// Covariance Matrix for each point
     std::vector<Eigen::Matrix3d> covariances_;
+    /// Origin Data for each point
+    std::vector<OriginData> origindata_;
 };
 
 }  // namespace geometry

--- a/cpp/open3d/geometry/TriangleMesh.h
+++ b/cpp/open3d/geometry/TriangleMesh.h
@@ -339,7 +339,8 @@ public:
             size_t number_of_points,
             std::vector<double> &triangle_areas,
             double surface_area,
-            bool use_triangle_normal);
+            bool use_triangle_normal,
+            bool record_origin);
 
     /// Function to sample points uniformly from the mesh.
     ///
@@ -347,8 +348,12 @@ public:
     /// \param use_triangle_normal Set to true to assign the triangle normals to
     /// the returned points instead of the interpolated vertex normals. The
     /// triangle normals will be computed and added to the mesh if necessary.
+    /// \param record_origin Set to true to assign origin triangle ID and
+    /// UV coordinates to the returned points
     std::shared_ptr<PointCloud> SamplePointsUniformly(
-            size_t number_of_points, bool use_triangle_normal = false);
+            size_t number_of_points,
+            bool use_triangle_normal = false,
+            bool record_origin = false);
 
     /// Function to sample points from the mesh with Possion disk, based on the
     /// method presented in Yuksel, "Sample Elimination for Generating Poisson
@@ -362,11 +367,14 @@ public:
     /// \param use_triangle_normal If True assigns the triangle normals instead
     /// of the interpolated vertex normals to the returned points. The triangle
     /// normals will be computed and added to the mesh if necessary.
+    /// \param record_origin Set to true to assign origin triangle ID and
+    /// UV coordinates to the returned points
     std::shared_ptr<PointCloud> SamplePointsPoissonDisk(
             size_t number_of_points,
             double init_factor = 5,
             const std::shared_ptr<PointCloud> pcl_init = nullptr,
-            bool use_triangle_normal = false);
+            bool use_triangle_normal = false,
+            bool record_origin = false);
 
     /// Function to subdivide triangle mesh using the simple midpoint algorithm.
     /// Each triangle is subdivided into four triangles per iteration and the

--- a/cpp/pybind/geometry/pointcloud.cpp
+++ b/cpp/pybind/geometry/pointcloud.cpp
@@ -46,6 +46,8 @@ void pybind_pointcloud(py::module &m) {
                  "Returns ``True`` if the point cloud contains point colors.")
             .def("has_covariances", &PointCloud::HasCovariances,
                  "Returns ``True`` if the point cloud contains covariances.")
+            .def("has_origin_data", &PointCloud::HasOriginData,
+                 "Returns ``True`` if the point cloud contains origin data.")
             .def("normalize_normals", &PointCloud::NormalizeNormals,
                  "Normalize point normals to length 1.")
             .def("paint_uniform_color", &PointCloud::PaintUniformColor,
@@ -256,10 +258,27 @@ camera. Given depth value d at (u, v) image coordinate, the corresponding 3d poi
             .def_readwrite("covariances", &PointCloud::covariances_,
                            "``float64`` array of shape ``(num_points, 3, 3)``, "
                            "use ``numpy.asarray()`` to access data: Points "
-                           "covariances.");
+                           "covariances.")
+            .def(
+                    "origin_data",
+                    [](const std::shared_ptr<PointCloud> pcl) {
+                        std::vector<size_t> tri_id;
+                        std::vector<Eigen::Vector2d> tri_uv;
+                        for (auto i = 0; i < pcl->origindata_.size(); ++i) {
+                            tri_id.push_back(pcl->origindata_[i].tri_id);
+                            tri_uv.push_back(pcl->origindata_[i].tri_uv);
+                        };
+                        return py::dict("tri_id"_a = tri_id,
+                                        "tri_uv"_a = tri_uv);
+                    },
+                    "dict with entries of shape ``(num_points, ...)``, "
+                    "each corresponding to different origin data information. "
+                    "Use ``numpy.asarray()`` to access matrix data (e.g., "
+                    "tri_uv).");
     docstring::ClassMethodDocInject(m, "PointCloud", "has_colors");
     docstring::ClassMethodDocInject(m, "PointCloud", "has_normals");
     docstring::ClassMethodDocInject(m, "PointCloud", "has_points");
+    docstring::ClassMethodDocInject(m, "PointCloud", "has_origin_data");
     docstring::ClassMethodDocInject(m, "PointCloud", "normalize_normals");
     docstring::ClassMethodDocInject(
             m, "PointCloud", "paint_uniform_color",

--- a/cpp/pybind/geometry/trianglemesh.cpp
+++ b/cpp/pybind/geometry/trianglemesh.cpp
@@ -221,7 +221,8 @@ void pybind_trianglemesh(py::module &m) {
             .def("sample_points_uniformly",
                  &TriangleMesh::SamplePointsUniformly,
                  "Function to uniformly sample points from the mesh.",
-                 "number_of_points"_a = 100, "use_triangle_normal"_a = false)
+                 "number_of_points"_a = 100, "use_triangle_normal"_a = false,
+                 "record_origin"_a = false)
             .def("sample_points_poisson_disk",
                  &TriangleMesh::SamplePointsPoissonDisk,
                  "Function to sample points from the mesh, where each point "
@@ -231,7 +232,7 @@ void pybind_trianglemesh(py::module &m) {
                  "noise). Method is based on Yuksel, \"Sample Elimination for "
                  "Generating Poisson Disk Sample Sets\", EUROGRAPHICS, 2015.",
                  "number_of_points"_a, "init_factor"_a = 5, "pcl"_a = nullptr,
-                 "use_triangle_normal"_a = false)
+                 "use_triangle_normal"_a = false, "record_origin"_a = false)
             .def("subdivide_midpoint", &TriangleMesh::SubdivideMidpoint,
                  "Function subdivide mesh using midpoint algorithm.",
                  "number_of_iterations"_a = 1)
@@ -554,7 +555,10 @@ void pybind_trianglemesh(py::module &m) {
               "If True assigns the triangle normals instead of the "
               "interpolated vertex normals to the returned points. The "
               "triangle normals will be computed and added to the mesh if "
-              "necessary."}});
+              "necessary."},
+             {"record_origin",
+              "If True assigns origin triangle ID and UV coordinates to the "
+              "returned points."}});
     docstring::ClassMethodDocInject(
             m, "TriangleMesh", "sample_points_poisson_disk",
             {{"number_of_points", "Number of points that should be sampled."},
@@ -568,7 +572,10 @@ void pybind_trianglemesh(py::module &m) {
               "If True assigns the triangle normals instead of the "
               "interpolated vertex normals to the returned points. The "
               "triangle normals will be computed and added to the mesh if "
-              "necessary."}});
+              "necessary."},
+             {"record_origin",
+              "If True assigns origin triangle ID and UV coordinates to the "
+              "returned points."}});
     docstring::ClassMethodDocInject(
             m, "TriangleMesh", "subdivide_midpoint",
             {{"number_of_iterations",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [x] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

Record the origin of points in the data used for generating those points. In my context, this is is a triangular mesh where I wish to record triangle ID and UV coordinates per point, to then relate a number functions on the same surface to the sampled point cloud. 

Tried to code such that this pull request is: (1) non-breaking / does not slow existing functionality, (2) easily scalable so other origin data types (e.g., voxel ID / relative coordinates) can be added. 

However, I am not fluent in C++ and not sure if the proposed implementation is reasonable. Further, I wasn't sure this suggested functionality will be considered useful / accepted. As such, I only added the option to record origin data data in 
- `PointCloud::operator+=`
- `TriangleMesh::SamplePointsUniformlyImpl`
- `TriangleMesh::SamplePointsUniformly`
- `TriangleMesh::SamplePointsPoissonDisk`

<!--- Why is this change required? What problem does it solve? -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [x] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [x] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->

```
import open3d as o3d
import numpy as np
cube = o3d.geometry.TriangleMesh.create_box()                                                
pts = cube.sample_points_uniformly(4000)     
pts.origin_data()
{'tri_id': [], 'tri_uv': std::vector<Eigen::Vector2d> with 0 elements.
Use numpy.asarray() to access data.}

pts.has_origin_data()                                                                                            
False
                                                                                                                
pts = cube.sample_points_uniformly(4000, record_origin=True)
pts.has_origin_data()
True

pts.origin_data().keys()
dict_keys(['tri_id', 'tri_uv'])

np.asarray(pts.origin_data()['tri_uv'])                                                                          
array([[0.65370755, 0.25589466],                                                                                            
       [0.81755558, 0.14071095],                                                                                            
       [0.5513747 , 0.32234846],                                                                                            
       ...,                                                                                                                 
       [0.96641095, 0.02235785],                                                                                            
       [0.29790422, 0.39937283],                                                                                            
       [0.70699849, 0.17731053]])

v = np.asarray(cube.vertices) 
t = np.asarray(cube.triangles)
tidx = np.array(pts.origin_data()['tri_id']) # simple list
uv = np.asarray(pts.origin_data()['tri_uv'])
w = 1 - np.sum(uv, axis = 1)
c = v[t[tidx, 0], :] * uv[:, 0][:, None] + v[t[tidx, 1], :] * uv[:, 1][:, None] + v[t[tidx, 2], :] * w[:, None] # point coordinates from barycentric coordinates
np.allclose(c, np.asarray(pts.points))
True
```