### PR TITLE
Make plane segmentation from point cloud deterministic

### DIFF
--- a/cpp/open3d/geometry/PointCloudSegmentation.cpp
+++ b/cpp/open3d/geometry/PointCloudSegmentation.cpp
@@ -165,7 +165,7 @@ std::tuple<Eigen::Vector4d, std::vector<size_t>> PointCloud::SegmentPlane(
     RandomSampler<size_t> sampler(num_points);
     // Pre-generate all random samples before entering the parallel region
     std::vector<std::vector<size_t>> all_sampled_indices;
-    all_sampled_indices.reserve(num_iterations);    
+    all_sampled_indices.reserve(num_iterations);
     for (int i = 0; i < num_iterations; i++) {
         all_sampled_indices.push_back(sampler(ransac_n));
     }

--- a/cpp/open3d/geometry/PointCloudSegmentation.cpp
+++ b/cpp/open3d/geometry/PointCloudSegmentation.cpp
@@ -167,8 +167,7 @@ std::tuple<Eigen::Vector4d, std::vector<size_t>> PointCloud::SegmentPlane(
     std::vector<std::vector<size_t>> all_sampled_indices;
     all_sampled_indices.reserve(num_iterations);    
     for (int i = 0; i < num_iterations; i++) {
-        std::vector<size_t> sampled_indices = sampler(ransac_n);
-        all_sampled_indices.push_back(std::move(sampled_indices));
+        all_sampled_indices.push_back(sampler(ransac_n));
     }
 
     // Return if ransac_n is less than the required plane model parameters.


### PR DESCRIPTION
This change makes the results deterministic when a random seed is set.

<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [ ] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [ ] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
