### PR TITLE
Switched QHull ImGUI and GoogleTest to use FetchContent

### DIFF
--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -96,8 +96,6 @@ function(open3d_build_3rdparty_library name)
     if(arg_SOURCES)
         foreach(src IN LISTS arg_SOURCES)
             get_filename_component(abs_src "${src}" ABSOLUTE BASE_DIR "${arg_DIRECTORY}")
-            # Mark as generated to skip CMake's file existence checks
-#            set_source_files_properties(${abs_src} PROPERTIES GENERATED TRUE)
             target_sources(${name} PRIVATE ${abs_src})
         endforeach()
         foreach(incl IN LISTS include_dirs)
@@ -1030,6 +1028,8 @@ if(NOT USE_SYSTEM_QHULLCPP)
             src/libqhull_r/rboxlib_r.c
         INCLUDE_DIRS
             src/
+        DEPENDS
+            ext_qhull
     )
     open3d_build_3rdparty_library(3rdparty_qhullcpp DIRECTORY ${QHULL_SOURCE_DIR}
         SOURCES
@@ -1055,6 +1055,8 @@ if(NOT USE_SYSTEM_QHULLCPP)
             src/libqhullcpp/RoadLogEvent.cpp
         INCLUDE_DIRS
             src/
+        DEPENDS
+            ext_qhull
     )
     target_link_libraries(3rdparty_qhullcpp PRIVATE 3rdparty_qhull_r)
     list(APPEND Open3D_3RDPARTY_PRIVATE_TARGETS_FROM_CUSTOM Open3D::3rdparty_qhullcpp)
@@ -1154,6 +1156,8 @@ if (BUILD_UNIT_TESTS)
                 googletest/
                 googlemock/include/
                 googlemock/
+            DEPENDS
+                ext_googletest
         )
     endif()
 endif()

--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -1182,8 +1182,6 @@ if(BUILD_GUI)
                 imgui_tables.cpp
                 imgui_widgets.cpp
                 imgui.cpp
-            DEPENDS
-                ext_imgui
         )
         list(APPEND Open3D_3RDPARTY_PRIVATE_TARGETS_FROM_CUSTOM Open3D::3rdparty_imgui)
     else()

--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -97,7 +97,7 @@ function(open3d_build_3rdparty_library name)
         foreach(src IN LISTS arg_SOURCES)
             get_filename_component(abs_src "${src}" ABSOLUTE BASE_DIR "${arg_DIRECTORY}")
             # Mark as generated to skip CMake's file existence checks
-            set_source_files_properties(${abs_src} PROPERTIES GENERATED TRUE)
+#            set_source_files_properties(${abs_src} PROPERTIES GENERATED TRUE)
             target_sources(${name} PRIVATE ${abs_src})
         endforeach()
         foreach(incl IN LISTS include_dirs)
@@ -1030,8 +1030,6 @@ if(NOT USE_SYSTEM_QHULLCPP)
             src/libqhull_r/rboxlib_r.c
         INCLUDE_DIRS
             src/
-        DEPENDS
-            ext_qhull
     )
     open3d_build_3rdparty_library(3rdparty_qhullcpp DIRECTORY ${QHULL_SOURCE_DIR}
         SOURCES
@@ -1057,8 +1055,6 @@ if(NOT USE_SYSTEM_QHULLCPP)
             src/libqhullcpp/RoadLogEvent.cpp
         INCLUDE_DIRS
             src/
-        DEPENDS
-            ext_qhull
     )
     target_link_libraries(3rdparty_qhullcpp PRIVATE 3rdparty_qhull_r)
     list(APPEND Open3D_3RDPARTY_PRIVATE_TARGETS_FROM_CUSTOM Open3D::3rdparty_qhullcpp)
@@ -1158,8 +1154,6 @@ if (BUILD_UNIT_TESTS)
                 googletest/
                 googlemock/include/
                 googlemock/
-            DEPENDS
-                ext_googletest
         )
     endif()
 endif()

--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -1028,8 +1028,6 @@ if(NOT USE_SYSTEM_QHULLCPP)
             src/libqhull_r/rboxlib_r.c
         INCLUDE_DIRS
             src/
-        DEPENDS
-            ext_qhull
     )
     open3d_build_3rdparty_library(3rdparty_qhullcpp DIRECTORY ${QHULL_SOURCE_DIR}
         SOURCES
@@ -1055,8 +1053,6 @@ if(NOT USE_SYSTEM_QHULLCPP)
             src/libqhullcpp/RoadLogEvent.cpp
         INCLUDE_DIRS
             src/
-        DEPENDS
-            ext_qhull
     )
     target_link_libraries(3rdparty_qhullcpp PRIVATE 3rdparty_qhull_r)
     list(APPEND Open3D_3RDPARTY_PRIVATE_TARGETS_FROM_CUSTOM Open3D::3rdparty_qhullcpp)
@@ -1156,8 +1152,6 @@ if (BUILD_UNIT_TESTS)
                 googletest/
                 googlemock/include/
                 googlemock/
-            DEPENDS
-                ext_googletest
         )
     endif()
 endif()

--- a/3rdparty/googletest/googletest.cmake
+++ b/3rdparty/googletest/googletest.cmake
@@ -1,6 +1,6 @@
-include(ExternalProject)
+include(FetchContent)
 
-ExternalProject_Add(
+FetchContent_Declare(
     ext_googletest
     PREFIX googletest
     URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.tar.gz
@@ -12,5 +12,5 @@ ExternalProject_Add(
     INSTALL_COMMAND ""
 )
 
-ExternalProject_Get_Property(ext_googletest SOURCE_DIR)
-set(GOOGLETEST_SOURCE_DIR ${SOURCE_DIR})
+FetchContent_Populate(ext_googletest)
+FetchContent_GetProperties(ext_googletest SOURCE_DIR GOOGLETEST_SOURCE_DIR)

--- a/3rdparty/imgui/imgui.cmake
+++ b/3rdparty/imgui/imgui.cmake
@@ -1,6 +1,6 @@
-include(ExternalProject)
+include(FetchContent)
 
-ExternalProject_Add(
+FetchContent_Declare(
     ext_imgui
     PREFIX imgui
     URL https://github.com/ocornut/imgui/archive/refs/tags/v1.88.tar.gz
@@ -12,5 +12,5 @@ ExternalProject_Add(
     INSTALL_COMMAND ""
 )
 
-ExternalProject_Get_Property(ext_imgui SOURCE_DIR)
-set(IMGUI_SOURCE_DIR ${SOURCE_DIR})
+FetchContent_Populate(ext_imgui)
+FetchContent_GetProperties(ext_imgui SOURCE_DIR IMGUI_SOURCE_DIR)

--- a/3rdparty/qhull/qhull.cmake
+++ b/3rdparty/qhull/qhull.cmake
@@ -1,6 +1,6 @@
-include(ExternalProject)
+include(FetchContent)
 
-ExternalProject_Add(
+FetchContent_Declare(
     ext_qhull
     PREFIX qhull
     # v8.0.0+ causes seg fault
@@ -14,5 +14,5 @@ ExternalProject_Add(
     INSTALL_COMMAND ""
 )
 
-ExternalProject_Get_Property(ext_qhull SOURCE_DIR)
-set(QHULL_SOURCE_DIR ${SOURCE_DIR})
+FetchContent_Populate(ext_qhull)
+FetchContent_GetProperties(ext_qhull SOURCE_DIR QHULL_SOURCE_DIR)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Changed the CMake scripts for 3rdparty dependencies to not mark files in the Open3D git repo as generated. This is because the `clean` target would delete them and break the build.

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #6644
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context
When running the clean target on some generators, source files not fetched by `ExternalProject` would be deleted. This would prevent rebuilding without using git to reset those files. See issue #6644 for details. 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-  [ ] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

Switched GoogleTest and QHull dependencies to use `FetchContent` instead of `ExternalProject`. Removed `GENERATED` property from source files passed to `open3d_build_3rdparty_library`.
