### PR TITLE
Implement ComputeTriangleAreas, GetNonManifoldEdges and RemoveNonManifoldEdges in t::geometry::TriangleMesh

### DIFF
--- a/cpp/open3d/t/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/t/geometry/TriangleMesh.cpp
@@ -309,6 +309,9 @@ TriangleMesh &TriangleMesh::ComputeTriangleAreas() {
     }
 
     if (!HasTriangleIndices()) {
+        SetTriangleAttr("areas", core::Tensor::Empty(
+                                         {0}, GetVertexPositions().GetDtype(),
+                                         GetDevice()));
         utility::LogWarning("TriangleMesh has no triangle indices.");
         return *this;
     }

--- a/cpp/open3d/t/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/t/geometry/TriangleMesh.cpp
@@ -1347,6 +1347,163 @@ TriangleMesh TriangleMesh::RemoveUnreferencedVertices() {
     return *this;
 }
 
+template <typename T,
+          typename std::enable_if<std::is_integral<T>::value &&
+                                          !std::is_same<T, bool>::value,
+                                  T>::type * = nullptr>
+using Edge = std::tuple<T, T>;
+
+/// brief Helper function to get an edge with ordered vertex indices.
+template <typename T>
+static inline Edge<T> GetOrderedEdge(T vidx0, T vidx1) {
+    return (vidx0 < vidx1) ? Edge<T>{vidx0, vidx1} : Edge<T>{vidx1, vidx0};
+}
+
+/// brief Helper
+///
+template <typename T>
+static std::unordered_map<Edge<T>,
+                          std::vector<size_t>,
+                          utility::hash_tuple<Edge<T>>>
+GetEdgeToTrianglesMap(const core::Tensor &tris_cpu) {
+    std::unordered_map<Edge<T>, std::vector<size_t>,
+                       utility::hash_tuple<Edge<T>>>
+            tris_per_edge;
+    auto AddEdge = [&](T vidx0, T vidx1, int64_t tidx) {
+        tris_per_edge[GetOrderedEdge(vidx0, vidx1)].push_back(tidx);
+    };
+    const T *tris_ptr = tris_cpu.GetDataPtr<T>();
+    for (int64_t tidx = 0; tidx < tris_cpu.GetLength(); ++tidx) {
+        const T *triangle = &tris_ptr[3 * tidx];
+        AddEdge(triangle[0], triangle[1], tidx);
+        AddEdge(triangle[1], triangle[2], tidx);
+        AddEdge(triangle[2], triangle[0], tidx);
+    }
+    return tris_per_edge;
+}
+
+TriangleMesh TriangleMesh::RemoveNonManifoldEdges() {
+    if (!HasVertexPositions() || GetVertexPositions().GetLength() == 0) {
+        utility::LogWarning(
+                "[RemoveNonManifildEdges] TriangleMesh has no vertices.");
+        return *this;
+    }
+
+    if (!HasTriangleIndices() || GetTriangleIndices().GetLength() == 0) {
+        utility::LogWarning(
+                "[RemoveNonManifoldEdges] TriangleMesh has no triangles.");
+        return *this;
+    }
+
+    GetVertexAttr().AssertSizeSynchronized();
+    GetTriangleAttr().AssertSizeSynchronized();
+
+    core::Tensor tris_cpu =
+            GetTriangleIndices().To(core::Device()).Contiguous();
+
+    ComputeTriangleAreas();
+    core::Tensor tri_areas_cpu =
+            GetTriangleAttr("areas").To(core::Device()).Contiguous();
+
+    DISPATCH_FLOAT_INT_DTYPE_TO_TEMPLATE(
+            GetVertexPositions().GetDtype(), tris_cpu.GetDtype(), [&]() {
+                scalar_t *tri_areas_ptr = tri_areas_cpu.GetDataPtr<scalar_t>();
+                auto edges_to_tris = GetEdgeToTrianglesMap<int_t>(tris_cpu);
+
+                // lambda to compare triangles areas by index
+                auto area_greater_compare = [&tri_areas_ptr](size_t lhs,
+                                                             size_t rhs) {
+                    return tri_areas_ptr[lhs] > tri_areas_ptr[rhs];
+                };
+
+                // go through all edges and for those that have more than 2
+                // triangles attached, remove the triangles with the minimal
+                // area
+                for (auto &kv : edges_to_tris) {
+                    // remove all triangles which are already marked for removal
+                    // (area < 0) note, the erasing of triangles happens
+                    // afterwards
+                    auto tris_end = std::remove_if(
+                            kv.second.begin(), kv.second.end(),
+                            [=](size_t t) { return tri_areas_ptr[t] < 0; });
+                    // count non-removed triangles (with area > 0).
+                    int n_tris = std::distance(kv.second.begin(), tris_end);
+
+                    if (n_tris <= 2) {
+                        // nothing to do here as either:
+                        // - all triangles of the edge are already marked for
+                        // deletion
+                        // - the edge is manifold: it has 1 or 2 triangles with
+                        //   a non-negative area
+                        continue;
+                    }
+
+                    // now erase all triangle indices already marked for removal
+                    kv.second.erase(tris_end, kv.second.end());
+
+                    // find first to triangles with the maximal area
+                    std::nth_element(kv.second.begin(), kv.second.begin() + 1,
+                                     kv.second.end(), area_greater_compare);
+
+                    // mark others for deletion
+                    for (auto it = kv.second.begin() + 2; it < kv.second.end();
+                         ++it) {
+                        tri_areas_ptr[*it] = -1;
+                    }
+                }
+            });
+
+    // mask for triangles with positive area
+    core::Tensor tri_mask = tri_areas_cpu.Gt(0.0).To(GetDevice());
+
+    // pick up positive-area triangles (and their attributes)
+    for (auto item : GetTriangleAttr()) {
+        SetTriangleAttr(item.first, item.second.IndexGet({tri_mask}));
+    }
+
+    return *this;
+}
+
+core::Tensor TriangleMesh::GetNonManifoldEdges(
+        bool allow_boundary_edges /* = true */) const {
+    if (!HasVertexPositions()) {
+        utility::LogWarning(
+                "[GetNonManifoldEdges] TriangleMesh has no vertices.");
+        return {};
+    }
+
+    if (!HasTriangleIndices()) {
+        utility::LogWarning(
+                "[GetNonManifoldEdges] TriangleMesh has no triangles.");
+        return {};
+    }
+
+    core::Tensor result;
+    core::Tensor tris_cpu =
+            GetTriangleIndices().To(core::Device()).Contiguous();
+    core::Dtype tri_dtype = tris_cpu.GetDtype();
+
+    DISPATCH_INT_DTYPE_PREFIX_TO_TEMPLATE(tri_dtype, tris, [&]() {
+        auto edges = GetEdgeToTrianglesMap<scalar_tris_t>(tris_cpu);
+        std::vector<scalar_tris_t> non_manifold_edges;
+
+        for (auto &kv : edges) {
+            if ((allow_boundary_edges &&
+                 (kv.second.size() < 1 || kv.second.size() > 2)) ||
+                (!allow_boundary_edges && kv.second.size() != 2)) {
+                non_manifold_edges.push_back(std::get<0>(kv.first));
+                non_manifold_edges.push_back(std::get<1>(kv.first));
+            }
+        }
+
+        result = core::Tensor(non_manifold_edges,
+                              {(long int)non_manifold_edges.size() / 2, 2},
+                              tri_dtype, GetTriangleIndices().GetDevice());
+    });
+
+    return result;
+}
+
 }  // namespace geometry
 }  // namespace t
 }  // namespace open3d

--- a/cpp/open3d/t/geometry/TriangleMesh.h
+++ b/cpp/open3d/t/geometry/TriangleMesh.h
@@ -671,6 +671,11 @@ public:
     /// of the individual triangle surfaces.
     double GetSurfaceArea() const;
 
+    /// \brief Function to compute triangle areas and save it as a triangle
+    /// attribute "areas". Prints a warning, if mesh is empty or has no
+    /// triangles.
+    TriangleMesh &ComputeTriangleAreas();
+
     /// \brief Clip mesh with a plane.
     /// This method clips the triangle mesh with the specified plane.
     /// Parts of the mesh on the positive side of the plane will be kept and

--- a/cpp/open3d/t/geometry/TriangleMesh.h
+++ b/cpp/open3d/t/geometry/TriangleMesh.h
@@ -979,6 +979,20 @@ public:
     /// \return The reference to itself.
     TriangleMesh RemoveUnreferencedVertices();
 
+    /// Removes all non-manifold edges, by successively deleting triangles
+    /// with the smallest surface area adjacent to the
+    /// non-manifold edge until the number of adjacent triangles to the edge is
+    /// `<= 2`. If mesh is empty or has no triangles, prints a warning and
+    /// returns immediately. \return The reference to itself.
+    TriangleMesh RemoveNonManifoldEdges();
+
+    /// Returns the non-manifold edges of the triangle mesh.
+    /// If \param allow_boundary_edges is set to false, then also boundary
+    /// edges are returned.
+    /// \return 2d integer tensor with shape {n,2} encoding ordered edges.
+    /// If mesh is empty or has no triangles, returns an empty tensor.
+    core::Tensor GetNonManifoldEdges(bool allow_boundary_edges = true) const;
+
 protected:
     core::Device device_ = core::Device("CPU:0");
     TensorMap vertex_attr_;

--- a/cpp/pybind/t/geometry/trianglemesh.cpp
+++ b/cpp/pybind/t/geometry/trianglemesh.cpp
@@ -1006,6 +1006,21 @@ Example:
         surface_area = box.compute_triangle_areas().triangle.areas.sum()
 )");
 
+    triangle_mesh.def("remove_non_manifold_edges",
+                      &TriangleMesh::RemoveNonManifoldEdges,
+                      R"(Function that removes all non-manifold edges, by
+successively deleting  triangles with the smallest surface
+area adjacent to the non-manifold edge until the number of
+adjacent triangles to the edge is `<= 2`.
+
+Returns:
+    The mesh.
+)");
+
+    triangle_mesh.def("get_non_manifold_edges",
+                      &TriangleMesh::GetNonManifoldEdges,
+                      "allow_boundary_edges"_a = true,
+                      R"(Returns the list consisting of non-manifold edges.)");
 }
 
 }  // namespace geometry

--- a/cpp/pybind/t/geometry/trianglemesh.cpp
+++ b/cpp/pybind/t/geometry/trianglemesh.cpp
@@ -985,9 +985,27 @@ Example:
         top_face = box.select_by_index([2, 3, 6, 7])
 )");
 
-    triangle_mesh.def("remove_unreferenced_vertices",
-                      &TriangleMesh::RemoveUnreferencedVertices,
-                      "Removes unreferenced vertices from the mesh in-place.");
+    triangle_mesh.def(
+            "remove_unreferenced_vertices",
+            &TriangleMesh::RemoveUnreferencedVertices,
+            R"(Removes unreferenced vertices from the mesh in-place.)");
+
+    triangle_mesh.def(
+            "compute_triangle_areas", &TriangleMesh::ComputeTriangleAreas,
+            R"(Compute triangle areas and save it as \"areas\" triangle attribute.
+
+Returns:
+    The mesh.
+
+Example:
+
+    This code computes the overall surface area of a box:
+
+        import open3d as o3d
+        box = o3d.t.geometry.TriangleMesh.create_box()
+        surface_area = box.compute_triangle_areas().triangle.areas.sum()
+)");
+
 }
 
 }  // namespace geometry

--- a/cpp/tests/t/geometry/TriangleMesh.cpp
+++ b/cpp/tests/t/geometry/TriangleMesh.cpp
@@ -1343,5 +1343,20 @@ TEST_P(TriangleMeshPermuteDevices, RemoveUnreferencedVertices) {
     EXPECT_TRUE(torus.GetTriangleNormals().AllClose(expected_tri_normals));
 }
 
+TEST_P(TriangleMeshPermuteDevices, ComputeTriangleAreas) {
+    core::Device device = GetParam();
+    t::geometry::TriangleMesh mesh_empty;
+    EXPECT_NO_THROW(mesh_empty.ComputeTriangleAreas());
+
+    std::shared_ptr<open3d::geometry::TriangleMesh> mesh =
+            open3d::geometry::TriangleMesh::CreateSphere(1.0, 3);
+    t::geometry::TriangleMesh t_mesh = t::geometry::TriangleMesh::FromLegacy(
+            *mesh, core::Float64, core::Int64, device);
+    std::vector<double> areas;
+    mesh->GetSurfaceArea(areas);
+    t_mesh.ComputeTriangleAreas();
+    EXPECT_TRUE(t_mesh.GetTriangleAttr("areas").AllClose(
+            core::Tensor(areas, {(int)areas.size()}, core::Float64)));
+}
 }  // namespace tests
 }  // namespace open3d

--- a/cpp/tests/t/geometry/TriangleMesh.cpp
+++ b/cpp/tests/t/geometry/TriangleMesh.cpp
@@ -1402,11 +1402,15 @@ TEST_P(TriangleMeshPermuteDevices, RemoveNonManifoldEdges) {
     expected_edges = core::eigen_converter::EigenVector2iVectorToTensor(
             legacy_mesh.GetNonManifoldEdges(true), core::Int64, device);
     EXPECT_TRUE(mesh.GetNonManifoldEdges(true).AllClose(expected_edges));
-    expected_edges = core::eigen_converter::EigenVector2iVectorToTensor(
-            legacy_mesh.GetNonManifoldEdges(false), core::Int64, device);
-    std::cout << mesh.GetNonManifoldEdges(false).ToString() << std::endl;
-    std::cout << expected_edges.ToString() << std::endl;
-
+#ifdef _MSC_VER
+    expected_edges = core::Tensor::Init<int64_t>(
+            {{0 8}, {1 8}, {0 1}, {6 7}, {0 2}, {0 4}, {2, 8}, {6 6}, {4 8}},
+            device);
+#else
+    expected_edges = core::Tensor::Init<int64_t>(
+            {{0 8}, {1 8}, {0 1}, {6 7}, {0 2}, {0 4}, {6 6}, {4 8}, {2 8}},
+            device);
+#endif
     EXPECT_TRUE(mesh.GetNonManifoldEdges(false).AllClose(expected_edges));
 
     mesh.RemoveNonManifoldEdges();

--- a/cpp/tests/t/geometry/TriangleMesh.cpp
+++ b/cpp/tests/t/geometry/TriangleMesh.cpp
@@ -1360,6 +1360,7 @@ TEST_P(TriangleMeshPermuteDevices, ComputeTriangleAreas) {
 }
 
 TEST_P(TriangleMeshPermuteDevices, RemoveNonManifoldEdges) {
+    using ::testing::UnorderedElementsAreArray;
     core::Device device = GetParam();
     t::geometry::TriangleMesh mesh_empty;
     EXPECT_TRUE(mesh_empty.RemoveNonManifoldEdges().IsEmpty());
@@ -1402,16 +1403,18 @@ TEST_P(TriangleMeshPermuteDevices, RemoveNonManifoldEdges) {
     expected_edges = core::eigen_converter::EigenVector2iVectorToTensor(
             legacy_mesh.GetNonManifoldEdges(true), core::Int64, device);
     EXPECT_TRUE(mesh.GetNonManifoldEdges(true).AllClose(expected_edges));
-#ifdef _MSC_VER
-    expected_edges = core::Tensor::Init<int64_t>(
-            {{0 8}, {1 8}, {0 1}, {6 7}, {0 2}, {0 4}, {2, 8}, {6 6}, {4 8}},
-            device);
-#else
-    expected_edges = core::Tensor::Init<int64_t>(
-            {{0 8}, {1 8}, {0 1}, {6 7}, {0 2}, {0 4}, {6 6}, {4 8}, {2 8}},
-            device);
-#endif
-    EXPECT_TRUE(mesh.GetNonManifoldEdges(false).AllClose(expected_edges));
+    EXPECT_THAT(
+            core::eigen_converter::TensorToEigenVector2iVector(
+                    mesh.GetNonManifoldEdges(false)),
+            UnorderedElementsAreArray(std::vector<Eigen::Vector2i>{{0, 8},
+                                                                   {1, 8},
+                                                                   {0, 1},
+                                                                   {6, 7},
+                                                                   {0, 2},
+                                                                   {0, 4},
+                                                                   {6, 6},
+                                                                   {4, 8},
+                                                                   {2, 8}}));
 
     mesh.RemoveNonManifoldEdges();
 

--- a/cpp/tests/t/geometry/TriangleMesh.cpp
+++ b/cpp/tests/t/geometry/TriangleMesh.cpp
@@ -1404,6 +1404,9 @@ TEST_P(TriangleMeshPermuteDevices, RemoveNonManifoldEdges) {
     EXPECT_TRUE(mesh.GetNonManifoldEdges(true).AllClose(expected_edges));
     expected_edges = core::eigen_converter::EigenVector2iVectorToTensor(
             legacy_mesh.GetNonManifoldEdges(false), core::Int64, device);
+    std::cout << mesh.GetNonManifoldEdges(false).ToString() << std::endl;
+    std::cout << expected_edges.ToString() << std::endl;
+
     EXPECT_TRUE(mesh.GetNonManifoldEdges(false).AllClose(expected_edges));
 
     mesh.RemoveNonManifoldEdges();

--- a/python/test/t/geometry/test_trianglemesh.py
+++ b/python/test/t/geometry/test_trianglemesh.py
@@ -755,13 +755,24 @@ def test_remove_non_manifold_edges(device, int_t, float_t):
     test_box_legacy = test_box.to_legacy()
 
     # allow boundary edges
-    edges = test_box_legacy.get_non_manifold_edges()
+    expected_edges = test_box_legacy.get_non_manifold_edges()
     np.testing.assert_allclose(test_box.get_non_manifold_edges().numpy(),
-                               np.asarray(edges))
+                               np.asarray(expected_edges))
     # disallow boundary edges
-    edges = test_box_legacy.get_non_manifold_edges(False)
-    np.testing.assert_allclose(
-        test_box.get_non_manifold_edges(False).numpy(), np.asarray(edges))
+    # MSVC produces edges in a different order, so compare sorted legacy results
+    expected_edges = np.array([
+        [0, 1],
+        [0, 2],
+        [0, 4],
+        [0, 6],
+        [1, 7],
+        [2, 8],
+        [4, 8],
+        [6, 8],
+        [6, 8],
+    ])
+    edges = np.sort(test_box.get_non_manifold_edges(False).numpy(), axis=0)
+    np.testing.assert_allclose(edges, expected_edges)
 
     test_box.remove_non_manifold_edges()
 

--- a/python/test/t/geometry/test_trianglemesh.py
+++ b/python/test/t/geometry/test_trianglemesh.py
@@ -709,3 +709,28 @@ def check_remove_unreferenced_vertices(device, int_t, float_t):
 def test_remove_unreferenced_vertices(device, int_t, float_t):
     check_no_unreferenced_vertices(device, int_t, float_t)
     check_remove_unreferenced_vertices(device, int_t, float_t)
+
+
+@pytest.mark.parametrize("device", list_devices())
+@pytest.mark.parametrize("int_t", (o3c.int32, o3c.int64))
+@pytest.mark.parametrize("float_t", (o3c.float32, o3c.float64))
+def test_compute_triangle_areas(device, int_t, float_t):
+    torus = o3d.t.geometry.TriangleMesh.create_torus(2, 1, 6, 3, float_t, int_t,
+                                                     device)
+
+    expected_areas = o3c.Tensor([
+        2.341874249399399, 1.1709371246996996, 1.299038105676658,
+        1.2990381056766576, 1.1709371246996996, 2.3418742493993996,
+        2.341874249399399, 1.1709371246996996, 1.299038105676658,
+        1.2990381056766573, 1.1709371246996996, 2.341874249399399,
+        2.341874249399399, 1.1709371246996998, 1.2990381056766582,
+        1.2990381056766576, 1.1709371246996993, 2.3418742493993996,
+        2.3418742493993987, 1.1709371246996996, 1.2990381056766578,
+        1.299038105676657, 1.1709371246996991, 2.3418742493993987,
+        2.3418742493993987, 1.1709371246996996, 1.299038105676658,
+        1.2990381056766573, 1.170937124699699, 2.341874249399399,
+        2.3418742493994, 1.1709371246997002, 1.299038105676659,
+        1.2990381056766582, 1.1709371246997, 2.3418742493994005
+    ], float_t, device)
+    assert torus.compute_triangle_areas().triangle.areas.allclose(
+        expected_areas)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Implement a few methods which are available with the geometry::TriangleMesh API.

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [x] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [x] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [x] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

In this PR three methods for t::geometry::TriangleMesh are implemented.

**t::geometry::TriangleMesh::ComputeTriangleAreas**
Split the logic from ComputeSurfaceArea into a helper static function
and introduce a new method which computes triangle areas and writes the
resulting tensor into attributes of the mesh.
IIUC, in geometry::TriangleMesh the corresponding function is GetSurfaceArea(std::vector &areas), where the areas are filled with the triangle areas.

**t::geometry::TriangleMesh::GetNonManifoldEdges** mimics the logic of the legacy method.

**t::geometry::TriangleMesh::RemoveNonManifoldEdges** follows the logic of
the legacy method but there are a few differences:
* the main difference is that the outer while-loop is removed. I don't
  see how after the first iteration any edge can have more than 2
  adjucent triangles, which makes the further iterations unnecessary.
* I count triangles with non-negative areas immediately and do not rely
  on the total number of adjacent triangles (which would also include
  triangles marked for removal).
* To choose a triangle with the minimal area out of the existing
  adjacent triangles I use a heap structure.