### PR TITLE
Reduce Google cloud CI costs, update Open3D project email

### DIFF
--- a/.github/workflows/ubuntu-cuda.yml
+++ b/.github/workflows/ubuntu-cuda.yml
@@ -11,7 +11,8 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, reopened, synchronize]
+    # Reduce CI frequency for paid CI.
+    types: [review_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/ubuntu-openblas.yml
+++ b/.github/workflows/ubuntu-openblas.yml
@@ -6,7 +6,8 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, reopened, synchronize]
+    # Reduce CI frequency for paid CI.
+    types: [review_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,7 +256,7 @@ string(CONCAT OPEN3D_VERSION
 )
 set(OPEN3D_VERSION_FULL "${OPEN3D_VERSION}${OPEN3D_VERSION_DEVHASH}")
 # Set additional info
-set(PROJECT_EMAIL       "info@open3d.org")
+set(PROJECT_EMAIL       "open3d@intel.com")
 set(PROJECT_DOCS        "https://www.open3d.org/docs")
 set(PROJECT_CODE        "https://github.com/isl-org/Open3D")
 set(PROJECT_ISSUES      "https://github.com/isl-org/Open3D/issues")


### PR DESCRIPTION
- Run paid CI on GCP for main, when review is requested and manually only to reduce Google Cloud CI costs.
- Change Open3D project email to open3d@intel.com

