### PR TITLE
Add path to v0.18.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ docs/Doxyfile
 docs/getting_started.rst
 docs/docker.rst
 docs/tensorboard.md
+
+# Docker files
+.Open3D_bash_history

--- a/cpp/open3d/Open3D.h.in
+++ b/cpp/open3d/Open3D.h.in
@@ -32,7 +32,7 @@
 #include "open3d/geometry/Geometry.h"
 #include "open3d/geometry/HalfEdgeTriangleMesh.h"
 #include "open3d/geometry/Image.h"
-#include "open3d/geometry/KDTreeFlann.h"
+// #include "open3d/geometry/KDTreeFlann.h"
 #include "open3d/geometry/Keypoint.h"
 #include "open3d/geometry/Line3D.h"
 #include "open3d/geometry/LineSet.h"


### PR DESCRIPTION
KDTreeFlann conflicts with the dependent library used in CoreMap. This patch comments out `KDTreeFlann.h` so it won't be exported causing the conflict. 