### PR TITLE
:sparkles: Create the function ComputeClosestPoint to speedup the que…

### DIFF
--- a/cpp/open3d/t/geometry/RaycastingScene.h
+++ b/cpp/open3d/t/geometry/RaycastingScene.h
@@ -152,6 +152,23 @@ public:
     std::unordered_map<std::string, core::Tensor> ComputeClosestPoints(
             const core::Tensor &query_points, const int nthreads = 0);
 
+    /// \brief Computes the closest point on the surface of the scene to a single query point.
+    /// 
+    /// This function calculates the closest point on any surface within the scene to the provided query point.
+    /// It's optimized for single-point queries, making it suitable for applications that require precise,
+    /// real-time calculations of nearest surface points, such as collision detection or interactive simulations.
+    ///
+    /// \param query_point An Eigen::Vector3d object representing the coordinates of the query point in the format [x, y, z].
+    ///
+    /// \return An Eigen::Vector3d object representing the closest point on the surface to the query point.
+    ///         The return format is also [x, y, z], indicating the coordinates of the closest surface point.
+    ///
+    /// \note The scene must be committed (prepared for querying) before calling this function. If the scene has not been
+    ///       previously committed, the function will commit it automatically. However, for efficiency, it's recommended
+    ///       to manually commit the scene once all geometries have been added, before performing any queries.
+    Eigen::Vector3d ComputeClosestPoint(
+            const Eigen::Vector3d& query_point);
+
     /// \brief Computes the distance to the surface of the scene.
     /// \param query_points A tensor with >=2 dims, shape {.., 3} and Dtype
     /// Float32 describing the query points. {..} can be any number of


### PR DESCRIPTION
Computes the closest point on the surface of the scene to a single query point.

This function calculates the closest point on any surface within the scene to the provided query point.
It's optimized for single-point queries, making it suitable for applications that require precise, real-time calculations of nearest surface points, such as collision detection or interactive simulations.

## Type
-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [x] New feature (non-breaking change which adds functionality). Resolves #6718 
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context
- It speeds up the query when you just have a point cloud and you want to do registration for instance.

## Checklist:
-   [ ] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.
