### PR TITLE
Modify the ExtractVoxelGrid function to run in Ubuntu

### DIFF
--- a/cpp/open3d/pipelines/integration/UniformTSDFVolume.cpp
+++ b/cpp/open3d/pipelines/integration/UniformTSDFVolume.cpp
@@ -260,10 +260,8 @@ std::shared_ptr<geometry::VoxelGrid> UniformTSDFVolume::ExtractVoxelGrid()
 #ifdef _WIN32
 #pragma omp parallel for schedule(static) \
         num_threads(utility::EstimateMaxThreads())
-#else
-#pragma omp parallel for collapse(2) schedule(static) \
-        num_threads(utility::EstimateMaxThreads())
 #endif
+
     for (int x = 0; x < resolution_; x++) {
         for (int y = 0; y < resolution_; y++) {
             for (int z = 0; z < resolution_; z++) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The open3d.pipelines.integration.UniformTSDFVolume.extract_voxel_grid() function is throwing an error in the released 0.18.0 version of the x86_64 and aarch64 Python packages.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
Remove the conditional compilation parts related to non-WIN32 in UniformTSDFVolume.cpp std::shared_ptrgeometry::VoxelGrid UniformTSDFVolume::ExtractVoxelGrid().
