### PR TITLE
[Mesh] TriangleMesh's "+=" operator applies regardless of the presenc…

### DIFF
--- a/cpp/open3d/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/geometry/TriangleMesh.cpp
@@ -52,9 +52,6 @@ TriangleMesh &TriangleMesh::Rotate(const Eigen::Matrix3d &R,
 
 TriangleMesh &TriangleMesh::operator+=(const TriangleMesh &mesh) {
     if (mesh.IsEmpty()) return (*this);
-    bool add_textures = HasTriangleUvs() && HasTextures() &&
-                        HasTriangleMaterialIds() && mesh.HasTriangleUvs() &&
-                        mesh.HasTextures() && mesh.HasTriangleMaterialIds();
     size_t old_vert_num = vertices_.size();
     MeshBase::operator+=(mesh);
     size_t old_tri_num = triangles_.size();
@@ -77,19 +74,22 @@ TriangleMesh &TriangleMesh::operator+=(const TriangleMesh &mesh) {
     if (HasAdjacencyList()) {
         ComputeAdjacencyList();
     }
-    if (add_textures) {
+    if (mesh.HasTriangleUvs()) {
         size_t old_tri_uv_num = triangle_uvs_.size();
         triangle_uvs_.resize(old_tri_uv_num + mesh.triangle_uvs_.size());
         for (size_t i = 0; i < mesh.triangle_uvs_.size(); i++) {
             triangle_uvs_[old_tri_uv_num + i] = mesh.triangle_uvs_[i];
         }
-
+    }
+    if (mesh.HasTextures()) {
         size_t old_tex_num = textures_.size();
         textures_.resize(old_tex_num + mesh.textures_.size());
         for (size_t i = 0; i < mesh.textures_.size(); i++) {
             textures_[old_tex_num + i] = mesh.textures_[i];
         }
-
+    }
+    if (mesh.HasTriangleMaterialIds()) {
+        size_t old_tex_num = textures_.size();
         size_t old_mat_id_num = triangle_material_ids_.size();
         triangle_material_ids_.resize(old_mat_id_num +
                                       mesh.triangle_material_ids_.size());
@@ -97,10 +97,6 @@ TriangleMesh &TriangleMesh::operator+=(const TriangleMesh &mesh) {
             triangle_material_ids_[old_mat_id_num + i] =
                     mesh.triangle_material_ids_[i] + (int)old_tex_num;
         }
-    } else {
-        triangle_uvs_.clear();
-        textures_.clear();
-        triangle_material_ids_.clear();
     }
     return (*this);
 }


### PR DESCRIPTION
…e of existing features.

Allows appending of UV coordinates, textures and material IDs with `+=` operator overload in `TriangleMesh` class irrespective of the presence of these attributes in the existing mesh (mesh on LHS to += operator)

## Type

-   [x ] Bug fix (non-breaking change which fixes an issue): Fixes # #4794
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

The `+=` operator overload of `TriangleMesh` class does not append UV coordinates, textures and material IDs when the existing mesh (mesh on LHS to += operator) already contains any of these attributes. There is no reason to limit `+=` for UVs to `TriangleMesh` with the attributes already assigned as it currently happens [here](https://github.com/isl-org/Open3D/blob/fbf549b23c079ae255d1b8a20db33fd35f942585/cpp/open3d/geometry/TriangleMesh.cpp#L74-L76).  

## Checklist:

-   [ ] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [ ] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [ ] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

The current change doesn't check if the presence of UV coordinates, textures and material IDs in the existing mesh and appends only based on their availability in the incoming mesh. 

I am attaching a screenshot that shows the addition of UV coordinates based on `+=` operator. The code is as follows
```
    auto box = geometry::TriangleMesh::CreateBox(1.0, 1.0, 1.0, true, true);    
    auto sphere = geometry::TriangleMesh::CreateSphere(1.0, 6, true);   
    rendering::MaterialRecord material;
    material.albedo_img = texture_image;
    material.name = "material";
            
    auto scene = std::make_shared<geometry::TriangleMesh>();
        
    // Append new meshes using +=
    *scene += *box;
    *scene += *sphere;
            
    gui::Application::GetInstance().Initialize(argc, argv);
    auto vis1 = std::make_shared<visualizer::O3DVisualizer>("Textures", 1024, 768);
    vis1->AddGeometry("scene", scene, &material);
    vis1->ResetCameraToDefault();
    gui::Application::GetInstance().AddWindow(vis1);
    gui::Application::GetInstance().Run();
```
The following is the resulting mesh with its texture UVs.
![Screenshot from 2024-03-27 15-41-48](https://github.com/isl-org/Open3D/assets/28064971/33d37347-0e3b-4e89-bda8-3c17d2c1e117)
  

 