### PR TITLE
Add Mouse Callback to VisualizerWithKeyCallback

### DIFF
--- a/cpp/open3d/visualization/visualizer/VisualizerWithKeyCallback.cpp
+++ b/cpp/open3d/visualization/visualizer/VisualizerWithKeyCallback.cpp
@@ -78,8 +78,9 @@ void VisualizerWithKeyCallback::KeyPressCallback(
     }
 }
 
-void VisualizerWithKeyCallback::MouseMoveCallback(
-        GLFWwindow *window, double x, double y) {
+void VisualizerWithKeyCallback::MouseMoveCallback(GLFWwindow *window,
+                                                  double x,
+                                                  double y) {
     if (mouse_move_callback_) {
         if (mouse_move_callback_(this, x, y)) {
             UpdateGeometry();
@@ -90,8 +91,9 @@ void VisualizerWithKeyCallback::MouseMoveCallback(
     }
 }
 
-void VisualizerWithKeyCallback::MouseScrollCallback(
-        GLFWwindow *window, double x, double y) {
+void VisualizerWithKeyCallback::MouseScrollCallback(GLFWwindow *window,
+                                                    double x,
+                                                    double y) {
     if (mouse_scroll_callback_) {
         if (mouse_scroll_callback_(this, x, y)) {
             UpdateGeometry();
@@ -102,8 +104,10 @@ void VisualizerWithKeyCallback::MouseScrollCallback(
     }
 }
 
-void VisualizerWithKeyCallback::MouseButtonCallback(
-        GLFWwindow *window, int button, int action, int mods) {
+void VisualizerWithKeyCallback::MouseButtonCallback(GLFWwindow *window,
+                                                    int button,
+                                                    int action,
+                                                    int mods) {
     if (mouse_button_callback_) {
         if (mouse_button_callback_(this, button, action, mods)) {
             UpdateGeometry();

--- a/cpp/open3d/visualization/visualizer/VisualizerWithKeyCallback.cpp
+++ b/cpp/open3d/visualization/visualizer/VisualizerWithKeyCallback.cpp
@@ -38,6 +38,21 @@ void VisualizerWithKeyCallback::RegisterKeyActionCallback(
     key_action_to_callback_[key] = callback;
 }
 
+void VisualizerWithKeyCallback::RegisterMouseMoveCallback(
+        std::function<bool(Visualizer *, double, double)> callback) {
+    mouse_move_callback_ = callback;
+}
+
+void VisualizerWithKeyCallback::RegisterMouseScrollCallback(
+        std::function<bool(Visualizer *, double, double)> callback) {
+    mouse_scroll_callback_ = callback;
+}
+
+void VisualizerWithKeyCallback::RegisterMouseButtonCallback(
+        std::function<bool(Visualizer *, int, int, int)> callback) {
+    mouse_button_callback_ = callback;
+}
+
 void VisualizerWithKeyCallback::KeyPressCallback(
         GLFWwindow *window, int key, int scancode, int action, int mods) {
     auto action_callback = key_action_to_callback_.find(key);
@@ -60,6 +75,42 @@ void VisualizerWithKeyCallback::KeyPressCallback(
         UpdateRender();
     } else {
         Visualizer::KeyPressCallback(window, key, scancode, action, mods);
+    }
+}
+
+void VisualizerWithKeyCallback::MouseMoveCallback(
+        GLFWwindow *window, double x, double y) {
+    if (mouse_move_callback_) {
+        if (mouse_move_callback_(this, x, y)) {
+            UpdateGeometry();
+        }
+        UpdateRender();
+    } else {
+        Visualizer::MouseMoveCallback(window, x, y);
+    }
+}
+
+void VisualizerWithKeyCallback::MouseScrollCallback(
+        GLFWwindow *window, double x, double y) {
+    if (mouse_scroll_callback_) {
+        if (mouse_scroll_callback_(this, x, y)) {
+            UpdateGeometry();
+        }
+        UpdateRender();
+    } else {
+        Visualizer::MouseScrollCallback(window, x, y);
+    }
+}
+
+void VisualizerWithKeyCallback::MouseButtonCallback(
+        GLFWwindow *window, int button, int action, int mods) {
+    if (mouse_button_callback_) {
+        if (mouse_button_callback_(this, button, action, mods)) {
+            UpdateGeometry();
+        }
+        UpdateRender();
+    } else {
+        Visualizer::MouseButtonCallback(window, button, action, mods);
     }
 }
 

--- a/cpp/open3d/visualization/visualizer/VisualizerWithKeyCallback.cpp
+++ b/cpp/open3d/visualization/visualizer/VisualizerWithKeyCallback.cpp
@@ -26,6 +26,13 @@ void VisualizerWithKeyCallback::PrintVisualizerHelp() {
     utility::LogInfo(
             "    The default functions of these keys will be overridden.");
     utility::LogInfo("");
+
+    std::string mouse_callbacks = (mouse_move_callback_ ? "MouseMove, " : "");
+    mouse_callbacks += (mouse_scroll_callback_ ? "MouseScroll, " : "");
+    mouse_callbacks += (mouse_button_callback_ ? "MouseButton, " : "");
+    utility::LogInfo("    Custom mouse callbacks registered for: {}",
+                     mouse_callbacks.substr(0, mouse_callbacks.size() - 2));
+    utility::LogInfo("");
 }
 
 void VisualizerWithKeyCallback::RegisterKeyCallback(

--- a/cpp/open3d/visualization/visualizer/VisualizerWithKeyCallback.h
+++ b/cpp/open3d/visualization/visualizer/VisualizerWithKeyCallback.h
@@ -48,12 +48,35 @@ public:
     void RegisterKeyActionCallback(
             int key, std::function<bool(Visualizer *, int, int)> callback);
 
+    /// Register callback function with access to GLFW mouse actions.
+    ///
+    /// \param callback The callback function. The callback function takes
+    /// `Visualizer *`, and the x and y mouse position inside the window. See
+    /// [GLFW mouse
+    /// position](https://www.glfw.org/docs/latest/input_guide.html#input_mouse
+    ///  for more details.
     void RegisterMouseMoveCallback(
             std::function<bool(Visualizer *, double, double)> callback);
 
+    /// Register callback function with access to GLFW mouse actions.
+    ///
+    /// \param callback The callback function. The callback function takes
+    /// `Visualizer *`, and the x and y scroll values. A normal mouse only
+    /// provides a y scroll value. See [GLFW
+    /// scroll](https://www.glfw.org/docs/latest/input_guide.html#scrolling)
+    ///  for more details.
     void RegisterMouseScrollCallback(
             std::function<bool(Visualizer *, double, double)> callback);
 
+    /// Register callback function with access to GLFW mouse actions.
+    ///
+    /// \param callback The callback function. The callback function takes
+    /// `Visualizer *`, `button`, `action` and `mods` as input and returns a
+    /// boolean indicating UpdateGeometry() needs to be run. The `action` can be
+    /// one of GLFW_RELEASE (0), GLFW_PRESS (1) or GLFW_REPEAT (2), see [GLFW
+    /// input interface](https://www.glfw.org/docs/latest/group__input.html).
+    /// The `mods` specifies the modifier key, see [GLFW modifier
+    /// key](https://www.glfw.org/docs/latest/group__mods.html).
     void RegisterMouseButtonCallback(
             std::function<bool(Visualizer *, int, int, int)> callback);
 

--- a/cpp/open3d/visualization/visualizer/VisualizerWithKeyCallback.h
+++ b/cpp/open3d/visualization/visualizer/VisualizerWithKeyCallback.h
@@ -66,9 +66,9 @@ protected:
     void MouseMoveCallback(GLFWwindow *window, double x, double y) override;
     void MouseScrollCallback(GLFWwindow *window, double x, double y) override;
     void MouseButtonCallback(GLFWwindow *window,
-                            int button,
-                            int action,
-                            int mods) override;
+                             int button,
+                             int action,
+                             int mods) override;
     std::string PrintKeyToString(int key);
 
 protected:

--- a/cpp/open3d/visualization/visualizer/VisualizerWithKeyCallback.h
+++ b/cpp/open3d/visualization/visualizer/VisualizerWithKeyCallback.h
@@ -33,6 +33,7 @@ public:
     void PrintVisualizerHelp() override;
     void RegisterKeyCallback(int key,
                              std::function<bool(Visualizer *)> callback);
+
     /// Register callback function with access to GLFW key actions.
     ///
     /// \param key GLFW key value, see [GLFW key
@@ -51,20 +52,22 @@ public:
     /// Register callback function with access to GLFW mouse actions.
     ///
     /// \param callback The callback function. The callback function takes
-    /// `Visualizer *`, and the x and y mouse position inside the window. See
+    /// `Visualizer *`, and the x and y mouse position inside the window and
+    /// returns a boolean indicating if `UpdateGeometry()` needs to be run. See
     /// [GLFW mouse
-    /// position](https://www.glfw.org/docs/latest/input_guide.html#input_mouse
-    ///  for more details.
+    /// position](https://www.glfw.org/docs/latest/input_guide.html#input_mouse)
+    /// for more details.
     void RegisterMouseMoveCallback(
             std::function<bool(Visualizer *, double, double)> callback);
 
     /// Register callback function with access to GLFW mouse actions.
     ///
     /// \param callback The callback function. The callback function takes
-    /// `Visualizer *`, and the x and y scroll values. A normal mouse only
-    /// provides a y scroll value. See [GLFW
-    /// scroll](https://www.glfw.org/docs/latest/input_guide.html#scrolling)
-    ///  for more details.
+    /// `Visualizer *`, and the x and y scroll values and returns a boolean
+    /// indicating if `UpdateGeometry()` needs to be run. A normal mouse only
+    /// provides a y scroll value. See [GLFW mouse
+    /// scrolling](https://www.glfw.org/docs/latest/input_guide.html#scrolling)
+    /// for more details.
     void RegisterMouseScrollCallback(
             std::function<bool(Visualizer *, double, double)> callback);
 

--- a/cpp/open3d/visualization/visualizer/VisualizerWithKeyCallback.h
+++ b/cpp/open3d/visualization/visualizer/VisualizerWithKeyCallback.h
@@ -48,18 +48,36 @@ public:
     void RegisterKeyActionCallback(
             int key, std::function<bool(Visualizer *, int, int)> callback);
 
+    void RegisterMouseMoveCallback(
+            std::function<bool(Visualizer *, double, double)> callback);
+
+    void RegisterMouseScrollCallback(
+            std::function<bool(Visualizer *, double, double)> callback);
+
+    void RegisterMouseButtonCallback(
+            std::function<bool(Visualizer *, int, int, int)> callback);
+
 protected:
     void KeyPressCallback(GLFWwindow *window,
                           int key,
                           int scancode,
                           int action,
                           int mods) override;
+    void MouseMoveCallback(GLFWwindow *window, double x, double y) override;
+    void MouseScrollCallback(GLFWwindow *window, double x, double y) override;
+    void MouseButtonCallback(GLFWwindow *window,
+                            int button,
+                            int action,
+                            int mods) override;
     std::string PrintKeyToString(int key);
 
 protected:
     std::map<int, std::function<bool(Visualizer *)>> key_to_callback_;
     std::map<int, std::function<bool(Visualizer *, int, int)>>
             key_action_to_callback_;
+    std::function<bool(Visualizer *, double, double)> mouse_move_callback_;
+    std::function<bool(Visualizer *, double, double)> mouse_scroll_callback_;
+    std::function<bool(Visualizer *, int, int, int)> mouse_button_callback_;
 };
 
 }  // namespace visualization

--- a/cpp/pybind/visualization/visualizer.cpp
+++ b/cpp/pybind/visualization/visualizer.cpp
@@ -173,7 +173,7 @@ void pybind_visualizer(py::module &m) {
                  "mods as input and returns a boolean indicating if "
                  "UpdateGeometry() needs to be run.",
                  "key"_a, "callback_func"_a)
-                 
+
             .def("register_mouse_move_callback",
                  &VisualizerWithKeyCallback::RegisterMouseMoveCallback,
                  "Function to register a callback function for a mouse move "

--- a/cpp/pybind/visualization/visualizer.cpp
+++ b/cpp/pybind/visualization/visualizer.cpp
@@ -172,7 +172,25 @@ void pybind_visualizer(py::module &m) {
                  "event. The callback function takes Visualizer, action and "
                  "mods as input and returns a boolean indicating if "
                  "UpdateGeometry() needs to be run.",
-                 "key"_a, "callback_func"_a);
+                 "key"_a, "callback_func"_a)
+                 
+            .def("register_mouse_move_callback",
+                 &VisualizerWithKeyCallback::RegisterMouseMoveCallback,
+                 "Function to register a callback function for a mouse move "
+                 "event",
+                 "callback_func"_a)
+
+            .def("register_mouse_scroll_callback",
+                 &VisualizerWithKeyCallback::RegisterMouseScrollCallback,
+                 "Function to register a callback function for a mouse scroll "
+                 "event",
+                 "callback_func"_a)
+
+            .def("register_mouse_button_callback",
+                 &VisualizerWithKeyCallback::RegisterMouseButtonCallback,
+                 "Function to register a callback function for a mouse button "
+                 "event",
+                 "callback_func"_a);
 
     py::class_<VisualizerWithEditing, PyVisualizer<VisualizerWithEditing>,
                std::shared_ptr<VisualizerWithEditing>>

--- a/cpp/pybind/visualization/visualizer.cpp
+++ b/cpp/pybind/visualization/visualizer.cpp
@@ -169,27 +169,47 @@ void pybind_visualizer(py::module &m) {
             .def("register_key_action_callback",
                  &VisualizerWithKeyCallback::RegisterKeyActionCallback,
                  "Function to register a callback function for a key action "
-                 "event. The callback function takes Visualizer, action and "
-                 "mods as input and returns a boolean indicating if "
-                 "UpdateGeometry() needs to be run.",
+                 "event. The callback function takes `Visualizer`, `action` "
+                 "and `mods` as input and returns a boolean indicating if "
+                 "`UpdateGeometry()` needs to be run.  The `action` can be one "
+                 "of `GLFW_RELEASE` (0), `GLFW_PRESS` (1) or `GLFW_REPEAT` "
+                 "(2), see `GLFW input interface "
+                 "<https://www.glfw.org/docs/latest/group__input.html>`__. The "
+                 "`mods` specifies the modifier key, see `GLFW modifier key "
+                 "<https://www.glfw.org/docs/latest/group__mods.html>`__",
                  "key"_a, "callback_func"_a)
 
             .def("register_mouse_move_callback",
                  &VisualizerWithKeyCallback::RegisterMouseMoveCallback,
                  "Function to register a callback function for a mouse move "
-                 "event",
+                 "event. The callback function takes Visualizer, x and y mouse "
+                 "position inside the window as input and returns a boolean "
+                 "indicating if UpdateGeometry() needs to be run. `GLFW mouse "
+                 "position <https://www.glfw.org/docs/latest/"
+                 "input_guide.html#input_mouse>`__ for more details.",
                  "callback_func"_a)
 
             .def("register_mouse_scroll_callback",
                  &VisualizerWithKeyCallback::RegisterMouseScrollCallback,
                  "Function to register a callback function for a mouse scroll "
-                 "event",
+                 "event. The callback function takes Visualizer, x and y mouse "
+                 "scroll offset as input and returns a boolean "
+                 "indicating if UpdateGeometry() needs to be run. `GLFW mouse "
+                 "scrolling <https://www.glfw.org/docs/latest/"
+                 "input_guide.html#scrolling>`__ for more details.",
                  "callback_func"_a)
 
             .def("register_mouse_button_callback",
                  &VisualizerWithKeyCallback::RegisterMouseButtonCallback,
                  "Function to register a callback function for a mouse button "
-                 "event",
+                 "event. The callback function takes `Visualizer`, `button`, "
+                 "`action` and `mods` as input and returns a boolean "
+                 "indicating `UpdateGeometry()` needs to be run. The `action` "
+                 "can be one of GLFW_RELEASE (0), GLFW_PRESS (1) or "
+                 "GLFW_REPEAT (2), see `GLFW input interface "
+                 "<https://www.glfw.org/docs/latest/group__input.html>`__.  "
+                 "The `mods` specifies the modifier key, see `GLFW modifier "
+                 "key <https://www.glfw.org/docs/latest/group__mods.html>`__.",
                  "callback_func"_a);
 
     py::class_<VisualizerWithEditing, PyVisualizer<VisualizerWithEditing>,

--- a/examples/python/visualization/customized_visualization_key_action.py
+++ b/examples/python/visualization/customized_visualization_key_action.py
@@ -41,11 +41,45 @@ def custom_key_action_without_kb_repeat_delay(pcd):
     vis.run()
 
 
+def custom_mouse_action(pcd):
+
+    vis = o3d.visualization.VisualizerWithKeyCallback()
+    buttons = ['left', 'right', 'middle']
+    actions = ['up', 'down']
+    mods_name = ['shift', 'ctrl', 'alt', 'cmd']
+
+    def on_key_action(vis, action, mods):
+        print("on_key_action", action, mods)
+
+    vis.register_key_action_callback(ord("A"), on_key_action)
+
+    def on_mouse_move(vis, x, y):
+        print(f"on_mouse_move({x:.2f}, {y:.2f})")
+
+    def on_mouse_scroll(vis, x, y):
+        print(f"on_mouse_scroll({x:.2f}, {y:.2f})")
+
+    def on_mouse_button(vis, button, action, mods):
+        pressed_mods = " ".join(
+            [mods_name[i] for i in range(4) if mods & (1 << i)])
+        print(f"on_mouse_button: {buttons[button]}, {actions[action]}, " +
+              pressed_mods)
+
+    vis.register_mouse_move_callback(on_mouse_move)
+    vis.register_mouse_scroll_callback(on_mouse_scroll)
+    vis.register_mouse_button_callback(on_mouse_button)
+
+    vis.create_window()
+    vis.add_geometry(pcd)
+    vis.run()
+
+
 if __name__ == "__main__":
     ply_data = o3d.data.PLYPointCloud()
     pcd = o3d.io.read_point_cloud(ply_data.path)
 
-    print(
-        "Customized visualization with smooth key action (without keyboard repeat delay)"
-    )
+    print("Customized visualization with smooth key action "
+          "(without keyboard repeat delay). Press the space-bar.")
     custom_key_action_without_kb_repeat_delay(pcd)
+    print("Customized visualization with mouse action.")
+    custom_mouse_action(pcd)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [x] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

Current Open3D Visualizer provides excellent 3D manipulation capabilities, but there are cases where developers may want to override its behavior. By introducing three additional callback functions for mouse events, developers will be able to handle mouse operations on their side only when necessary. 
The addition of mouse operations has also been discussed in some issues: #2610  #4286 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [x] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

I added three callbacks related to mouse event to VisualizerWithKeyCallback.

* MouseMoveCallback
* MouseScrollCallback
* MouseButtonCallback

Usage: 

```python
import open3d as o3d

bunny = o3d.data.BunnyMesh()
mesh = o3d.io.read_triangle_mesh(bunny.path)
mesh.compute_vertex_normals()

vis = o3d.visualization.VisualizerWithKeyCallback()

def on_key_action(vis, action, mods):
    print("on_key_action", action, mods)

vis.register_key_action_callback(ord("A"), on_key_action)

def on_mouse_move(vis, x, y):
    print("on_mouse_move", x, y)

def on_mouse_scroll(vis, x, y):
    print("on_mouse_scroll", x, y)

def on_mouse_button(vis, button, action, mods):
    print("on_mouse_button", button, action, mods)

vis.register_mouse_move_callback(on_mouse_move)
vis.register_mouse_scroll_callback(on_mouse_scroll)
vis.register_mouse_button_callback(on_mouse_button)

vis.create_window()
vis.add_geometry(mesh)
vis.run()
```

Result:

https://github.com/isl-org/Open3D/assets/31440714/a5f1e06f-3a67-413c-855d-69ed21ff4658