### PR TITLE
Fix ransac update of the iteration number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 -   Fix log error message for `probability` argument validation in `PointCloud::SegmentPlane` (PR #6622)
 -   Fix macOS arm64 builds, add CI runner for macOS arm64 (PR #6695)
 -   Fix KDTreeFlann possibly using a dangling pointer instead of internal storage and simplified its members (PR #6734)
+-   Fix RANSAC early stop if no inliers in a specific iteration (PR #6789)
 
 ## 0.13
 

--- a/cpp/open3d/pipelines/registration/Registration.cpp
+++ b/cpp/open3d/pipelines/registration/Registration.cpp
@@ -235,13 +235,15 @@ RegistrationResult RegistrationRANSACBasedOnCorrespondence(
                                     max_correspondence_distance,
                                     transformation);
 
-                    // Update exit condition if necessary.
-                    // If confidence is 1.0, then it is safely inf, we always
-                    // consume all the iterations.
+                    // Update exit condition if necessary
                     double est_k_local_d =
                             std::log(1.0 - criteria.confidence_) /
                             std::log(1.0 -
                                      std::pow(corres_inlier_ratio, ransac_n));
+                    // This prevents having a negative number of iterations:
+                    // est_k_local_d = -inf if corres_inlier_ratio = 0.0
+                    est_k_local_d =
+                            est_k_local_d < 0 ? est_k_local : est_k_local_d;
                     est_k_local =
                             est_k_local_d < est_k_global
                                     ? static_cast<int>(std::ceil(est_k_local_d))


### PR DESCRIPTION
The update of the iteration number is forced to be non-negative (was negative if corres_inlier_ratio = 0.0)

<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #6709 
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Issue [6709](https://github.com/isl-org/Open3D/issues/6709): RANSAC incorrectly exits early if `corres_inlier_ratio` is 0.0 during a RANSAC iteration.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
The `corres_inlier_ratio` of a specific RANSAC iteration is employed to update `est_k_local_d` (the maximum number of iterations to be performed) using the formula $` est\_k\_local\_d={\text{log} (1-criteria.confidence\_ ) \over \text{log} ( 1-corres\_inlier\_ratio^{ransac\_n})} `$. 

However, if `corres_inlier_ratio = 0.0` then `est_k_local_d = -inf`. Hence, the maximum number of iterations is negative and RANSAC exits early. 

Instead, we want RANSAC to continue to test new transformations. This PR adds a check to ensure that `est_k_local_d` is non-negative.