### PR TITLE
Fix segfault (lambda reference capture) of VisualizerWithCustomAnimation::Play

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 -   Fix KDTreeFlann possibly using a dangling pointer instead of internal storage and simplified its members (PR #6734)
 -   Fix RANSAC early stop if no inliers in a specific iteration (PR #6789)
 -   Fix segmentation fault (infinite recursion) of DetectPlanarPatches if multiple points have same coordinates (PR #6794)
+-   Fix segmentation fault (lambda reference capture) of VisualizerWithCustomAnimation::Play (PR #6804)
 
 ## 0.13
 

--- a/cpp/open3d/utility/ProgressBar.h
+++ b/cpp/open3d/utility/ProgressBar.h
@@ -23,6 +23,7 @@ public:
     virtual ProgressBar &operator++();
     void SetCurrentCount(size_t n);
     size_t GetCurrentCount() const;
+    virtual ~ProgressBar() = default;
 
 protected:
     const size_t resolution_ = 40;

--- a/cpp/open3d/visualization/visualizer/VisualizerWithCustomAnimation.cpp
+++ b/cpp/open3d/visualization/visualizer/VisualizerWithCustomAnimation.cpp
@@ -78,8 +78,8 @@ void VisualizerWithCustomAnimation::Play(
     is_redraw_required_ = true;
     UpdateWindowTitle();
     recording_file_index_ = 0;
-    utility::ProgressBar progress_bar(view_control.NumOfFrames(),
-                                      "Play animation: ");
+    auto progress_bar_ptr = std::make_shared<utility::ProgressBar>(
+            view_control.NumOfFrames(), "Play animation: ");
     auto trajectory_ptr = std::make_shared<camera::PinholeCameraTrajectory>();
     bool recording_trajectory = view_control.IsValidPinholeCameraTrajectory();
     if (recording) {
@@ -94,7 +94,7 @@ void VisualizerWithCustomAnimation::Play(
     RegisterAnimationCallback([this, recording, recording_depth,
                                close_window_when_animation_ends,
                                recording_trajectory, trajectory_ptr,
-                               &progress_bar](Visualizer *vis) {
+                               progress_bar_ptr](Visualizer *vis) {
         // The lambda function captures no references to avoid dangling
         // references
         auto &view_control =
@@ -121,7 +121,7 @@ void VisualizerWithCustomAnimation::Play(
             }
         }
         view_control.Step(1.0);
-        ++progress_bar;
+        ++(*progress_bar_ptr);
         if (view_control.IsPlayingEnd(recording_file_index_)) {
             view_control.SetAnimationMode(
                     ViewControlWithCustomAnimation::AnimationMode::FreeMode);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #6589
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fixing segmentation fault when running an animation (clicking CTRL+P) with `draw_geometries_with_custom_animation`.


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [x] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->

The segmentation fault in [VisualizerWithCustomAnimation.cpp](https://github.com/isl-org/Open3D/blob/main/cpp/open3d/visualization/visualizer/VisualizerWithCustomAnimation.cpp#L124) is caused by line 124: `++progress_bar;`, with `progress_bar` being a `utility::ProgressBar` instance captured by reference by a lambda expression. It seems like a dangling reference. Converting `progress_bar` to a shared pointer fixes the segmentation fault.

### Testing
Before the change, this MRE will raise a segmentation fault after clicking CTRL+N and CTRL+P; after the change, it will run correctly:
```python
# Instructions: When the window opens, 
# click CTRL+N to automatically add 360 spin keyframes, 
# then CTRL+P to play the animation

import open3d as o3d

with o3d.utility.VerbosityContextManager(o3d.utility.VerbosityLevel.Debug):
    sample_data = o3d.data.DemoCustomVisualization()
    pcd = o3d.io.read_point_cloud(sample_data.point_cloud_path)

    o3d.visualization.draw_geometries_with_custom_animation([pcd])
```
