### PR TITLE
Add color for sampling from mesh 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Main
-
+-   Fix TriangleMesh::SamplePointsUniformly and TriangleMesh::SamplePointsPoissonDisk now sampling colors from mesh if available (PR #6842)
 -   Fix TriangleMesh::SamplePointsUniformly not sampling triangle meshes uniformly (PR #6653)
 -   Fix tensor based TSDF integration example.
 -   Use GLIBCXX_USE_CXX11_ABI=ON by default

--- a/cpp/open3d/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/geometry/TriangleMesh.cpp
@@ -637,6 +637,8 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsPoissonDisk(
     // update pcl
     bool has_vert_normal = pcl->HasNormals();
     bool has_vert_color = pcl->HasColors();
+    bool has_textures_ = HasTextures();
+    bool has_triangle_uvs_ = HasTriangleUvs();
     int next_free = 0;
     for (size_t idx = 0; idx < pcl->points_.size(); ++idx) {
         if (!deleted[idx]) {
@@ -644,7 +646,7 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsPoissonDisk(
             if (has_vert_normal) {
                 pcl->normals_[next_free] = pcl->normals_[idx];
             }
-            if (has_vert_color) {
+            if (has_vert_color || (has_textures_ && has_triangle_uvs_)) {
                 pcl->colors_[next_free] = pcl->colors_[idx];
             }
             next_free++;

--- a/cpp/open3d/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/geometry/TriangleMesh.cpp
@@ -11,7 +11,6 @@
 #include <numeric>
 #include <queue>
 #include <tuple>
-#include <iostream>
 
 #include "open3d/geometry/BoundingVolume.h"
 #include "open3d/geometry/IntersectionTest.h"
@@ -482,15 +481,21 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformlyImpl(
                                       c * vertex_colors_[triangle(2)];
         }
         if (has_textures_ && has_triangle_uvs_) {
-            Eigen::Vector2d uv = a * triangle_uvs_[3*tidx] + 
-                    b * triangle_uvs_[3*tidx+1] + 
-                    c * triangle_uvs_[3*tidx+2];
+            Eigen::Vector2d uv = a * triangle_uvs_[3 * tidx] +
+                                 b * triangle_uvs_[3 * tidx + 1] +
+                                 c * triangle_uvs_[3 * tidx + 2];
             int w = textures_[0].width_;
             int h = textures_[0].height_;
-            pcd->colors_[point_idx] = Eigen::Vector3d(
-                        (double) *(textures_[0].PointerAt<uint8_t>(uv(0) * w, uv(1)*h, 0)) / 255 , 
-                        (double) *(textures_[0].PointerAt<uint8_t>(uv(0) * w, uv(1)*h, 1)) / 255 , 
-                        (double) *(textures_[0].PointerAt<uint8_t>(uv(0) * w, uv(1)*h, 2)) / 255);
+            pcd->colors_[point_idx] =
+                    Eigen::Vector3d((double)*(textures_[0].PointerAt<uint8_t>(
+                                            uv(0) * w, uv(1) * h, 0)) /
+                                            255,
+                                    (double)*(textures_[0].PointerAt<uint8_t>(
+                                            uv(0) * w, uv(1) * h, 1)) /
+                                            255,
+                                    (double)*(textures_[0].PointerAt<uint8_t>(
+                                            uv(0) * w, uv(1) * h, 2)) /
+                                            255);
         }
     }
     return pcd;

--- a/cpp/open3d/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/geometry/TriangleMesh.cpp
@@ -431,7 +431,6 @@ std::shared_ptr<TriangleMesh> TriangleMesh::FilterSmoothTaubin(
     return mesh;
 }
 
-
 std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformlyImpl(
         size_t number_of_points,
         const std::vector<double> &triangle_areas,
@@ -484,17 +483,16 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformlyImpl(
                                       c * vertex_colors_[triangle(2)];
         }
         // if there is a texture, sample from texture instead
-        if (has_textures_ && has_triangle_uvs_ && has_triangle_material_ids_){
-          
+        if (has_textures_ && has_triangle_uvs_ && has_triangle_material_ids_) {
             Eigen::Vector2d uv = a * triangle_uvs_[3 * tidx] +
-                        b * triangle_uvs_[3 * tidx + 1] +
-                        c * triangle_uvs_[3 * tidx + 2];
+                                 b * triangle_uvs_[3 * tidx + 1] +
+                                 c * triangle_uvs_[3 * tidx + 2];
             int material_id = triangle_material_ids_[tidx];
             int w = textures_[material_id].width_;
             int h = textures_[material_id].height_;
 
-            pcd->colors_[point_idx] =
-                Eigen::Vector3d((double)*(textures_[material_id].PointerAt<uint8_t>(
+            pcd->colors_[point_idx] = Eigen::Vector3d(
+                    (double)*(textures_[material_id].PointerAt<uint8_t>(
                             uv(0) * w, uv(1) * h, 0)) /
                             255,
                     (double)*(textures_[material_id].PointerAt<uint8_t>(

--- a/cpp/open3d/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/geometry/TriangleMesh.cpp
@@ -11,6 +11,7 @@
 #include <numeric>
 #include <queue>
 #include <tuple>
+#include <iostream>
 
 #include "open3d/geometry/BoundingVolume.h"
 #include "open3d/geometry/IntersectionTest.h"
@@ -440,7 +441,7 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformlyImpl(
 
     // sample point cloud
     bool has_vert_normal = HasVertexNormals();
-    bool has_vert_color = HasVertexColors();
+    // bool has_vert_color = HasVertexColors();
     utility::random::UniformRealGenerator<double> uniform_generator(0.0, 1.0);
     auto pcd = std::make_shared<PointCloud>();
     pcd->points_.resize(number_of_points);
@@ -450,9 +451,9 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformlyImpl(
     if (use_triangle_normal && !HasTriangleNormals()) {
         ComputeTriangleNormals(true);
     }
-    if (has_vert_color) {
+    // if (has_vert_color) {
         pcd->colors_.resize(number_of_points);
-    }
+    // }
 
     for (size_t point_idx = 0; point_idx < number_of_points; ++point_idx) {
         double r1 = uniform_generator();
@@ -478,6 +479,18 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformlyImpl(
                                       b * vertex_colors_[triangle(1)] +
                                       c * vertex_colors_[triangle(2)];
         }
+        // if (has_triangle_uvs && has_textures) {
+            Eigen::Vector2d uv = a * triangle_uvs_[triangle(0)] + 
+                    b * triangle_uvs_[triangle(1)] + 
+                    c * triangle_uvs_[triangle(2)];
+
+            int w = textures_[0].width_;
+            int h = textures_[0].height_;
+            pcd->colors_[point_idx] = Eigen::Vector3d(
+                        (double) *textures_[0].PointerAt<uint8_t>(uv(0) * w, uv(1) * h, 0) / 255 , 
+                        (double) *textures_[0].PointerAt<uint8_t>(uv(0) * w, uv(1) * h, 1) / 255 , 
+                        (double) *textures_[0].PointerAt<uint8_t>(uv(0) * w, uv(1) * h, 2) / 255);
+        // }
     }
 
     return pcd;


### PR DESCRIPTION
Adds color to point cloud sampled from mesh
(https://github.com/isl-org/Open3D/issues/2483)

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [x ] New feature (non-breaking change which adds functionality). Resolves #2483
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [x] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [x] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
