### PR TITLE
Add O3DVisualizer API to enable collapse control of verts in the side panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 -   Fix segmentation fault (infinite recursion) of DetectPlanarPatches if multiple points have same coordinates (PR #6794)
 -   Fix build with fmt v10.2.0 (#6783)
 -   Fix segmentation fault (lambda reference capture) of VisualizerWithCustomAnimation::Play (PR #6804)
+-   Add O3DVisualizer API to enable collapse control of verts in the side panel (PR #6865)
 
 ## 0.13
 

--- a/cpp/open3d/visualization/gui/Layout.cpp
+++ b/cpp/open3d/visualization/gui/Layout.cpp
@@ -386,10 +386,7 @@ CollapsableVert::CollapsableVert(const char* text,
                                  int spacing,
                                  const Margins& margins /*= Margins()*/)
     : Vert(spacing, margins), impl_(new CollapsableVert::Impl()) {
-    static int g_next_id = 1;
-
-    impl_->text_ = text;
-    impl_->id_ = impl_->text_ + "##collapsing_" + std::to_string(g_next_id++);
+    SetText(text);
 }
 
 CollapsableVert::~CollapsableVert() {}
@@ -397,6 +394,15 @@ CollapsableVert::~CollapsableVert() {}
 void CollapsableVert::SetIsOpen(bool is_open) { impl_->is_open_ = is_open; }
 
 bool CollapsableVert::GetIsOpen() { return impl_->is_open_; }
+
+void CollapsableVert::SetText(const char* text) {
+    static int g_next_id = 1;
+
+    impl_->text_ = text;
+    impl_->id_ = impl_->text_ + "##collapsing_" + std::to_string(g_next_id++);
+}
+
+std::string CollapsableVert::GetText() const { return impl_->text_; };
 
 FontId CollapsableVert::GetFontId() const { return impl_->font_id_; }
 

--- a/cpp/open3d/visualization/gui/Layout.h
+++ b/cpp/open3d/visualization/gui/Layout.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "open3d/visualization/gui/Widget.h"
 
 namespace open3d {

--- a/cpp/open3d/visualization/gui/Layout.h
+++ b/cpp/open3d/visualization/gui/Layout.h
@@ -148,6 +148,9 @@ public:
     /// Returns true if open and false if collapsed.
     bool GetIsOpen();
 
+    void SetText(const char* text);
+    std::string GetText() const;
+
     FontId GetFontId() const;
     void SetFontId(FontId font_id);
 

--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
@@ -1706,7 +1706,7 @@ Ctrl-alt-click to polygon select)";
         }
     }
 
-    void SetCollapsableVertOpen(const std::string &name, bool open) {
+    void SetPanelOpen(const std::string &name, bool open) {
         if (name == settings.mouse_panel->GetText()) {
             settings.mouse_panel->SetIsOpen(open);
         } else if (name == settings.scene_panel->GetText()) {
@@ -2458,8 +2458,8 @@ void O3DVisualizer::SetMouseMode(SceneWidget::Controls mode) {
     impl_->SetMouseMode(mode);
 }
 
-void O3DVisualizer::SetCollapsableVertOpen(const std::string &name, bool open) {
-    impl_->SetCollapsableVertOpen(name, open);
+void O3DVisualizer::SetPanelOpen(const std::string &name, bool open) {
+    impl_->SetPanelOpen(name, open);
 }
 
 void O3DVisualizer::EnableGroup(const std::string &group, bool enable) {

--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
@@ -291,6 +291,7 @@ struct O3DVisualizer::Impl {
     std::function<bool()> on_animation_tick_;
     std::shared_ptr<io::rpc::ZMQReceiver> receiver_;
     std::shared_ptr<MessageProcessor> message_processor_;
+    std::map<std::string, CollapsableVert *> side_panel_verts_;
 
     UIState ui_state_;
     bool can_auto_show_settings_ = true;
@@ -420,6 +421,7 @@ struct O3DVisualizer::Impl {
         settings.mouse_panel =
                 new CollapsableVert("Mouse Controls", v_spacing, margins);
         settings.panel->AddChild(GiveOwnership(settings.mouse_panel));
+        side_panel_verts_.emplace("Mouse Controls", settings.mouse_panel);
 
         settings.mouse_tab = new TabControl();
         settings.mouse_panel->AddChild(GiveOwnership(settings.mouse_tab));
@@ -541,6 +543,7 @@ Ctrl-alt-click to polygon select)";
         // Scene controls
         settings.scene_panel = new CollapsableVert("Scene", v_spacing, margins);
         settings.panel->AddChild(GiveOwnership(settings.scene_panel));
+        side_panel_verts_.emplace("Scene", settings.scene_panel);
 
         settings.show_skybox = new Checkbox("Show Skybox");
         settings.show_skybox->SetOnChecked(
@@ -649,6 +652,7 @@ Ctrl-alt-click to polygon select)";
         settings.light_panel = new CollapsableVert("Lighting", 0, margins);
         settings.light_panel->SetIsOpen(false);
         settings.panel->AddChild(GiveOwnership(settings.light_panel));
+        side_panel_verts_.emplace("Lighting", settings.light_panel);
 
         h = new Horiz(v_spacing);
         settings.use_ibl = new Checkbox("HDR map");
@@ -769,6 +773,7 @@ Ctrl-alt-click to polygon select)";
         settings.geometries_panel =
                 new CollapsableVert("Geometries", v_spacing, margins);
         settings.panel->AddChild(GiveOwnership(settings.geometries_panel));
+        side_panel_verts_.emplace("Geometries", settings.geometries_panel);
 
         settings.geometries = new TreeView();
         settings.geometries_panel->AddChild(GiveOwnership(settings.geometries));
@@ -1706,6 +1711,14 @@ Ctrl-alt-click to polygon select)";
         }
     }
 
+    void SetCollapsableVertOpen(const std::string &name, bool open) {
+        auto it = side_panel_verts_.find(name);
+        if (it != side_panel_verts_.end() && it->second) {
+            it->second->SetIsOpen(open);
+            window_->SetNeedsLayout();
+        }
+    }
+
     void SetPicking() {
         if (selections_->GetNumberOfSets() == 0) {
             NewSelectionSet();
@@ -2444,6 +2457,10 @@ void O3DVisualizer::SetLineWidth(int line_width) {
 
 void O3DVisualizer::SetMouseMode(SceneWidget::Controls mode) {
     impl_->SetMouseMode(mode);
+}
+
+void O3DVisualizer::SetCollapsableVertOpen(const std::string &name, bool open) {
+    impl_->SetCollapsableVertOpen(name, open);
 }
 
 void O3DVisualizer::EnableGroup(const std::string &group, bool enable) {

--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
@@ -291,7 +291,6 @@ struct O3DVisualizer::Impl {
     std::function<bool()> on_animation_tick_;
     std::shared_ptr<io::rpc::ZMQReceiver> receiver_;
     std::shared_ptr<MessageProcessor> message_processor_;
-    std::map<std::string, CollapsableVert *> side_panel_verts_;
 
     UIState ui_state_;
     bool can_auto_show_settings_ = true;
@@ -421,7 +420,6 @@ struct O3DVisualizer::Impl {
         settings.mouse_panel =
                 new CollapsableVert("Mouse Controls", v_spacing, margins);
         settings.panel->AddChild(GiveOwnership(settings.mouse_panel));
-        side_panel_verts_.emplace("Mouse Controls", settings.mouse_panel);
 
         settings.mouse_tab = new TabControl();
         settings.mouse_panel->AddChild(GiveOwnership(settings.mouse_tab));
@@ -543,7 +541,6 @@ Ctrl-alt-click to polygon select)";
         // Scene controls
         settings.scene_panel = new CollapsableVert("Scene", v_spacing, margins);
         settings.panel->AddChild(GiveOwnership(settings.scene_panel));
-        side_panel_verts_.emplace("Scene", settings.scene_panel);
 
         settings.show_skybox = new Checkbox("Show Skybox");
         settings.show_skybox->SetOnChecked(
@@ -652,7 +649,6 @@ Ctrl-alt-click to polygon select)";
         settings.light_panel = new CollapsableVert("Lighting", 0, margins);
         settings.light_panel->SetIsOpen(false);
         settings.panel->AddChild(GiveOwnership(settings.light_panel));
-        side_panel_verts_.emplace("Lighting", settings.light_panel);
 
         h = new Horiz(v_spacing);
         settings.use_ibl = new Checkbox("HDR map");
@@ -773,7 +769,6 @@ Ctrl-alt-click to polygon select)";
         settings.geometries_panel =
                 new CollapsableVert("Geometries", v_spacing, margins);
         settings.panel->AddChild(GiveOwnership(settings.geometries_panel));
-        side_panel_verts_.emplace("Geometries", settings.geometries_panel);
 
         settings.geometries = new TreeView();
         settings.geometries_panel->AddChild(GiveOwnership(settings.geometries));
@@ -1712,10 +1707,14 @@ Ctrl-alt-click to polygon select)";
     }
 
     void SetCollapsableVertOpen(const std::string &name, bool open) {
-        auto it = side_panel_verts_.find(name);
-        if (it != side_panel_verts_.end() && it->second) {
-            it->second->SetIsOpen(open);
-            window_->SetNeedsLayout();
+        if (name == settings.mouse_panel->GetText()) {
+            settings.mouse_panel->SetIsOpen(open);
+        } else if (name == settings.scene_panel->GetText()) {
+            settings.scene_panel->SetIsOpen(open);
+        } else if (name == settings.light_panel->GetText()) {
+            settings.light_panel->SetIsOpen(open);
+        } else if (name == settings.geometries_panel->GetText()) {
+            settings.geometries_panel->SetIsOpen(open);
         }
     }
 

--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.h
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.h
@@ -175,7 +175,7 @@ public:
     void SetLineWidth(int line_width);
     void EnableGroup(const std::string& group, bool enable);
     void SetMouseMode(gui::SceneWidget::Controls mode);
-    void SetCollapsableVertOpen(const std::string& name, bool open);
+    void SetPanelOpen(const std::string& name, bool open);
 
     std::vector<O3DVisualizerSelections::SelectionSet> GetSelectionSets() const;
 

--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.h
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.h
@@ -175,6 +175,7 @@ public:
     void SetLineWidth(int line_width);
     void EnableGroup(const std::string& group, bool enable);
     void SetMouseMode(gui::SceneWidget::Controls mode);
+    void SetCollapsableVertOpen(const std::string& name, bool open);
 
     std::vector<O3DVisualizerSelections::SelectionSet> GetSelectionSets() const;
 

--- a/cpp/pybind/visualization/gui/gui.cpp
+++ b/cpp/pybind/visualization/gui/gui.cpp
@@ -1772,6 +1772,10 @@ void pybind_gui_classes(py::module &m) {
                  "window is visible")
             .def("get_is_open", &CollapsableVert::GetIsOpen,
                  "Check if widget is open.")
+            .def("set_text", &CollapsableVert::SetText, "text"_a,
+                 "Sets the text for the CollapsableVert")
+            .def("get_text", &CollapsableVert::GetText,
+                 "Gets the text for the CollapsableVert")
             .def_property("font_id", &CollapsableVert::GetFontId,
                           &CollapsableVert::SetFontId,
                           "Set the font using the FontId returned from "

--- a/cpp/pybind/visualization/o3dvisualizer.cpp
+++ b/cpp/pybind/visualization/o3dvisualizer.cpp
@@ -344,10 +344,9 @@ void pybind_o3dvisualizer(py::module& m) {
                  "enable"_a)
             .def("show_skybox", &O3DVisualizer::ShowSkybox,
                  "Show/Hide the skybox", "show"_a)
-            .def("set_collapsable_vert_open",
-                 &O3DVisualizer::SetCollapsableVertOpen,
-                 "Expand/Collapse verts in side panels", "vert_name"_a,
-                 "open"_a)
+            .def("set_panel_open", &O3DVisualizer::SetPanelOpen,
+                 "Expand/Collapse verts(panels) within the settings panel",
+                 "name"_a, "open"_a)
             .def_property(
                     "show_settings",
                     [](const O3DVisualizer& dv) {

--- a/cpp/pybind/visualization/o3dvisualizer.cpp
+++ b/cpp/pybind/visualization/o3dvisualizer.cpp
@@ -344,6 +344,10 @@ void pybind_o3dvisualizer(py::module& m) {
                  "enable"_a)
             .def("show_skybox", &O3DVisualizer::ShowSkybox,
                  "Show/Hide the skybox", "show"_a)
+            .def("set_collapsable_vert_open",
+                 &O3DVisualizer::SetCollapsableVertOpen,
+                 "Expand/Collapse verts in side panels", "vert_name"_a,
+                 "open"_a)
             .def_property(
                     "show_settings",
                     [](const O3DVisualizer& dv) {


### PR DESCRIPTION
Add API SetCollapsableVertOpen to control the toggling of the verts in the side panel

<!--- Provide a general summary of your changes in the Title above -->

## Type
-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [x] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context
When we have start the viewer with side panel ("show settings"), the default toggle vert (pane) in the side panel defaults to ON for the "Mouse Controls" and "Scene", but no "Lighting". These default on panels took a lot of space and I find myself always collapsing the settings since I mostly want to control the visibility of objects in "Geometries". This becomes quite annoying very soon.

## Checklist:

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [x] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
**Before**: Side vert "Mouse Controls" and "Scene" always defaults to ON

![Screenshot from 2024-07-10 11-44-12](https://github.com/isl-org/Open3D/assets/8307900/1ce813b5-471e-498d-8535-868778207ec9)

**After** The displayed result after calling the new API
```c++
O3DVisualizer::SetCollapsableVertOpen("Mouse Controls", false);
```
![Screenshot from 2024-07-11 09-59-02](https://github.com/isl-org/Open3D/assets/8307900/f97774d2-ea8e-4b12-806d-828a53de7cdf)
