### PR TITLE
add missing initialization for compute_vertex_normals()

### DIFF
--- a/cpp/open3d/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/geometry/TriangleMesh.cpp
@@ -126,7 +126,9 @@ TriangleMesh &TriangleMesh::ComputeTriangleNormals(
 
 TriangleMesh &TriangleMesh::ComputeVertexNormals(bool normalized /* = true*/) {
     ComputeTriangleNormals(false);
-    vertex_normals_.resize(vertices_.size(), Eigen::Vector3d::Zero());
+    vertex_normals_.resize(vertices_.size());
+    std::fill(vertex_normals_.begin(), vertex_normals_.end(),
+              Eigen::Vector3d::Zero());
     for (size_t i = 0; i < triangles_.size(); i++) {
         auto &triangle = triangles_[i];
         vertex_normals_[triangle(0)] += triangle_normals_[i];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

Fixes #6848 which describes a bug if computing vertex normals that are already initialized.

<!--- Why is this change required? What problem does it solve? -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [ ] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [ ] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->

Before and after applying the bugfix

<img width="576" alt="image" src="https://github.com/user-attachments/assets/4e392091-5882-41ed-845f-92e20f49264a">

<img width="558" alt="image" src="https://github.com/user-attachments/assets/1af2aea8-a272-42ef-9b4c-8982c6124ebc">
