### PR TITLE
add numpy version warning to documentation

### DIFF
--- a/docs/getting_started.in.rst
+++ b/docs/getting_started.in.rst
@@ -52,6 +52,15 @@ Pip (PyPI)
 
 .. warning::
 
+   Versions of ``numpy>=2.0.0`` are not fully supported by ``Open3D<=0.18.0`` and may lead to errors.
+   Consider downgrading ``numpy``, e.g. with
+
+   .. code-block:: bash
+
+        pip install "numpy<2.0.0"
+
+.. warning::
+
    Please upgrade your ``pip`` to a version >=20.3 to install Open3D in Linux,
    e.g. with
 

--- a/docs/getting_started.in.rst
+++ b/docs/getting_started.in.rst
@@ -52,8 +52,9 @@ Pip (PyPI)
 
 .. warning::
 
-   Versions of ``numpy>=2.0.0`` are not fully supported by ``Open3D<=0.18.0`` and may lead to errors.
-   Consider downgrading ``numpy``, e.g. with
+   Versions of ``numpy>=2.0.0`` require the latest development version of Open3D or
+   ``Open3D>0.18.0``. If you are using an older version of Open3D, downgrade ``numpy`` 
+   with
 
    .. code-block:: bash
 


### PR DESCRIPTION
## Motivation and Context
Release of `numpy==2.0.0` causes many Open3D features to segfault, which I saw will be fixed with the `pybind` update in #6874 .
Due to only requiring `numpy>=1.18.0` in the `Open3D<=0.18.0` releases, new Open3D installs will also install `numpy==2.0.0`, and thus break a large part of the functionality.
I think it's important to communicate this to users, although I'm unsure if this is the right place and way to do so, especially since this documentation will also only update for the next release of Open3D.
I hope this feedback is helpful, thank you!

## Description

Add warning about `numpy` versions  to the "Getting Started" documentation. 

