### PR TITLE
Fix minimal oriented bounding box of MeshBase derived classes and add new unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 -   Fix build with fmt v10.2.0 (#6783)
 -   Fix segmentation fault (lambda reference capture) of VisualizerWithCustomAnimation::Play (PR #6804)
 -   Add O3DVisualizer API to enable collapse control of verts in the side panel (PR #6865)
+-   Fix minimal oriented bounding box of MeshBase derived classes and add new unit tests (PR #6897)
 
 ## 0.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 -   Fix build with fmt v10.2.0 (#6783)
 -   Fix segmentation fault (lambda reference capture) of VisualizerWithCustomAnimation::Play (PR #6804)
 -   Add O3DVisualizer API to enable collapse control of verts in the side panel (PR #6865)
--   Fix minimal oriented bounding box of MeshBase derived classes and add new unit tests (PR #6897)
+-   Fix minimal oriented bounding box of MeshBase derived classes and add new unit tests (PR #6898)
 
 ## 0.13
 

--- a/cpp/open3d/geometry/MeshBase.cpp
+++ b/cpp/open3d/geometry/MeshBase.cpp
@@ -51,7 +51,7 @@ OrientedBoundingBox MeshBase::GetOrientedBoundingBox(bool robust) const {
 }
 
 OrientedBoundingBox MeshBase::GetMinimalOrientedBoundingBox(bool robust) const {
-    return OrientedBoundingBox::CreateFromPoints(vertices_, robust);
+    return OrientedBoundingBox::CreateFromPointsMinimal(vertices_, robust);
 }
 
 MeshBase &MeshBase::Transform(const Eigen::Matrix4d &transformation) {

--- a/cpp/tests/geometry/TetraMesh.cpp
+++ b/cpp/tests/geometry/TetraMesh.cpp
@@ -9,6 +9,7 @@
 
 #include <Eigen/Geometry>
 
+#include "open3d/geometry/BoundingVolume.h"
 #include "open3d/geometry/PointCloud.h"
 #include "open3d/geometry/TriangleMesh.h"
 #include "tests/Tests.h"
@@ -117,6 +118,229 @@ TEST(TetraMesh, GetMaxBound) {
 
     ExpectEQ(Eigen::Vector3d(996.078431, 996.078431, 996.078431),
              tm.GetMaxBound());
+}
+
+TEST(TetraMesh, GetCenter) {
+    int size = 100;
+
+    Eigen::Vector3d dmin(0.0, 0.0, 0.0);
+    Eigen::Vector3d dmax(1000.0, 1000.0, 1000.0);
+
+    geometry::TetraMesh tm;
+
+    tm.vertices_.resize(size);
+    Rand(tm.vertices_, dmin, dmax, 0);
+
+    ExpectEQ(tm.GetCenter(),
+             Eigen::Vector3d(531.137254, 535.176470, 501.882352));
+
+    geometry::TetraMesh tm_empty;
+    ExpectEQ(tm_empty.GetCenter(), Eigen::Vector3d(0, 0, 0));
+}
+
+TEST(TetraMesh, GetAxisAlignedBoundingBox) {
+    geometry::TetraMesh tm;
+    geometry::AxisAlignedBoundingBox aabb;
+
+    tm = geometry::TetraMesh();
+    aabb = tm.GetAxisAlignedBoundingBox();
+    EXPECT_EQ(aabb.min_bound_, Eigen::Vector3d(0, 0, 0));
+    EXPECT_EQ(aabb.max_bound_, Eigen::Vector3d(0, 0, 0));
+    EXPECT_EQ(aabb.color_, Eigen::Vector3d(1, 1, 1));
+
+    tm = geometry::TetraMesh({{0, 0, 0}}, {{0, 0, 0, 0}});
+    aabb = tm.GetAxisAlignedBoundingBox();
+    EXPECT_EQ(aabb.min_bound_, Eigen::Vector3d(0, 0, 0));
+    EXPECT_EQ(aabb.max_bound_, Eigen::Vector3d(0, 0, 0));
+    EXPECT_EQ(aabb.color_, Eigen::Vector3d(1, 1, 1));
+
+    tm = geometry::TetraMesh({{0, 2, 0},
+                              {1, 1, 2},
+                              {1, 0, 3},
+                              {0, 1, 4},
+                              {1, 2, 5},
+                              {1, 3, 6},
+                              {0, 0, 7},
+                              {0, 3, 8},
+                              {1, 0, 9},
+                              {0, 2, 10}},
+                             {{0, 1, 2, 3},
+                              {4, 0, 1, 2},
+                              {4, 5, 2, 3},
+                              {4, 0, 2, 3},
+                              {4, 0, 5, 3},
+                              {6, 0, 5, 3},
+                              {6, 7, 8, 5},
+                              {9, 4, 7, 1},
+                              {9, 4, 0, 1},
+                              {9, 0, 1, 3},
+                              {9, 6, 7, 8},
+                              {9, 4, 7, 5},
+                              {9, 6, 7, 5},
+                              {9, 4, 0, 5},
+                              {9, 6, 0, 5}});
+    aabb = tm.GetAxisAlignedBoundingBox();
+    EXPECT_EQ(aabb.min_bound_, Eigen::Vector3d(0, 0, 0));
+    EXPECT_EQ(aabb.max_bound_, Eigen::Vector3d(1, 3, 10));
+    EXPECT_EQ(aabb.color_, Eigen::Vector3d(1, 1, 1));
+}
+
+TEST(TetraMesh, GetOrientedBoundingBox) {
+    geometry::TetraMesh tm;
+    geometry::OrientedBoundingBox obb;
+
+    // Empty (GetOrientedBoundingBox requires >=4 points)
+    tm = geometry::TetraMesh();
+    EXPECT_ANY_THROW(tm.GetOrientedBoundingBox());
+
+    // Point
+    tm = geometry::TetraMesh({{0, 0, 0}}, {{0, 0, 0, 0}});
+    EXPECT_ANY_THROW(tm.GetOrientedBoundingBox());
+    tm = geometry::TetraMesh({{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}},
+                             {{0, 1, 2, 3}});
+    EXPECT_ANY_THROW(tm.GetOrientedBoundingBox());
+    EXPECT_NO_THROW(tm.GetOrientedBoundingBox(true));
+
+    // Plane
+    tm = geometry::TetraMesh({{0, 0, 0}, {0, 0, 1}, {0, 1, 0}, {0, 1, 1}},
+                             {{0, 1, 2, 3}});
+    EXPECT_ANY_THROW(tm.GetOrientedBoundingBox());
+    EXPECT_NO_THROW(tm.GetOrientedBoundingBox(true));
+
+    // Valid 4 points
+    tm = geometry::TetraMesh({{0, 0, 0}, {0, 0, 1}, {0, 1, 0}, {1, 1, 1}},
+                             {{0, 1, 2, 3}});
+    tm.GetOrientedBoundingBox();
+
+    // 8 points with known ground truth
+    tm = geometry::TetraMesh({{0, 0, 0},
+                              {0, 0, 1},
+                              {0, 2, 0},
+                              {0, 2, 1},
+                              {3, 0, 0},
+                              {3, 0, 1},
+                              {3, 2, 0},
+                              {3, 2, 1}},
+                             {{0, 1, 2, 3},
+                              {4, 5, 6, 7},
+                              {0, 1, 4, 5},
+                              {2, 3, 6, 7},
+                              {0, 2, 4, 6},
+                              {1, 3, 5, 7}});
+    obb = tm.GetOrientedBoundingBox();
+    EXPECT_EQ(obb.center_, Eigen::Vector3d(1.5, 1, 0.5));
+    EXPECT_EQ(obb.extent_, Eigen::Vector3d(3, 2, 1));
+    EXPECT_EQ(obb.color_, Eigen::Vector3d(1, 1, 1));
+    EXPECT_EQ(obb.R_, Eigen::Matrix3d::Identity());
+    ExpectEQ(Sort(obb.GetBoxPoints()),
+             Sort(std::vector<Eigen::Vector3d>({{0, 0, 0},
+                                                {0, 0, 1},
+                                                {0, 2, 0},
+                                                {0, 2, 1},
+                                                {3, 0, 0},
+                                                {3, 0, 1},
+                                                {3, 2, 0},
+                                                {3, 2, 1}})));
+
+    // Check for a bug where the OBB rotation contained a reflection for this
+    // example.
+    tm = geometry::TetraMesh({{0, 2, 4}, {7, 9, 1}, {5, 2, 0}, {3, 8, 7}},
+                             {{0, 1, 2, 3}});
+    obb = tm.GetOrientedBoundingBox();
+    EXPECT_GT(obb.R_.determinant(), 0.999);
+}
+
+TEST(TetraMesh, GetMinimalOrientedBoundingBox) {
+    geometry::TetraMesh tm;
+    geometry::OrientedBoundingBox obb;
+
+    // Empty (GetOrientedBoundingBox requires >=4 points)
+    tm = geometry::TetraMesh();
+    EXPECT_ANY_THROW(tm.GetMinimalOrientedBoundingBox());
+
+    // Point
+    tm = geometry::TetraMesh({{0, 0, 0}}, {{0, 0, 0, 0}});
+    EXPECT_ANY_THROW(tm.GetMinimalOrientedBoundingBox());
+    tm = geometry::TetraMesh({{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}},
+                             {{0, 1, 2, 3}});
+    EXPECT_ANY_THROW(tm.GetMinimalOrientedBoundingBox());
+    EXPECT_NO_THROW(tm.GetMinimalOrientedBoundingBox(true));
+
+    // Plane
+    tm = geometry::TetraMesh({{0, 0, 0}, {0, 0, 1}, {0, 1, 0}, {0, 1, 1}},
+                             {{0, 1, 2, 3}});
+    EXPECT_ANY_THROW(tm.GetMinimalOrientedBoundingBox());
+    EXPECT_NO_THROW(tm.GetMinimalOrientedBoundingBox(true));
+
+    // Valid 4 points
+    tm = geometry::TetraMesh({{0, 0, 0}, {0, 0, 1}, {0, 1, 0}, {1, 1, 1}},
+                             {{0, 1, 2, 3}});
+    tm.GetMinimalOrientedBoundingBox();
+
+    // 8 points with known ground truth
+    tm = geometry::TetraMesh({{0, 0, 0},
+                              {0, 0, 1},
+                              {0, 2, 0},
+                              {0, 2, 1},
+                              {3, 0, 0},
+                              {3, 0, 1},
+                              {3, 2, 0},
+                              {3, 2, 1}},
+                             {{0, 1, 2, 3},
+                              {4, 5, 6, 7},
+                              {0, 1, 4, 5},
+                              {2, 3, 6, 7},
+                              {0, 2, 4, 6},
+                              {1, 3, 5, 7}});
+    obb = tm.GetMinimalOrientedBoundingBox();
+    EXPECT_EQ(obb.center_, Eigen::Vector3d(1.5, 1, 0.5));
+    EXPECT_EQ(obb.extent_, Eigen::Vector3d(3, 2, 1));
+    EXPECT_EQ(obb.color_, Eigen::Vector3d(1, 1, 1));
+    ExpectEQ(Sort(obb.GetBoxPoints()),
+             Sort(std::vector<Eigen::Vector3d>({{0, 0, 0},
+                                                {0, 0, 1},
+                                                {0, 2, 0},
+                                                {0, 2, 1},
+                                                {3, 0, 0},
+                                                {3, 0, 1},
+                                                {3, 2, 0},
+                                                {3, 2, 1}})));
+
+    // Check for a bug where the OBB rotation contained a reflection for this
+    // example.
+    tm = geometry::TetraMesh({{0, 2, 4}, {7, 9, 1}, {5, 2, 0}, {3, 8, 7}},
+                             {{0, 1, 2, 3}});
+    obb = tm.GetMinimalOrientedBoundingBox();
+    EXPECT_GT(obb.R_.determinant(), 0.999);
+
+    // should always be equal/smaller than axis aligned- & oriented bounding box
+    tm = geometry::TetraMesh({{0.866, 0.474, 0.659},
+                              {0.943, 0.025, 0.789},
+                              {0.386, 0.264, 0.691},
+                              {0.938, 0.588, 0.496},
+                              {0.221, 0.116, 0.257},
+                              {0.744, 0.182, 0.052},
+                              {0.019, 0.525, 0.699},
+                              {0.722, 0.134, 0.668}},
+                             {{0, 1, 2, 3},
+                              {4, 0, 2, 3},
+                              {4, 0, 1, 2},
+                              {5, 4, 6, 3},
+                              {5, 4, 2, 3},
+                              {5, 4, 1, 2},
+                              {7, 1, 2, 6},
+                              {7, 5, 2, 6},
+                              {7, 5, 1, 2},
+                              {7, 5, 4, 6},
+                              {7, 5, 4, 1},
+                              {7, 0, 1, 6},
+                              {7, 4, 0, 6},
+                              {7, 4, 0, 1}});
+    geometry::OrientedBoundingBox mobb = tm.GetMinimalOrientedBoundingBox();
+    obb = tm.GetOrientedBoundingBox();
+    geometry::AxisAlignedBoundingBox aabb = tm.GetAxisAlignedBoundingBox();
+    EXPECT_GT(obb.Volume(), mobb.Volume());
+    EXPECT_GT(aabb.Volume(), mobb.Volume());
 }
 
 TEST(TetraMesh, Transform) {


### PR DESCRIPTION
## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #6866
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

Fixing the [`MeshBase::GetMinimalOrientedBoundingBox`](https://github.com/isl-org/Open3D/blob/v0.18.0/cpp/open3d/geometry/MeshBase.cpp#L53-L55) method, which did not return the minimal oriented bounding box. Also adding new unit tests for the derived classes `TriangleMesh` and `TetraMesh` for the different bounding box generation algorithms, since they were not covered.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [x] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

The [`MeshBase::GetMinimalOrientedBoundingBox`](https://github.com/isl-org/Open3D/blob/v0.18.0/cpp/open3d/geometry/MeshBase.cpp#L53-L55) method was calling `OrientedBoundingBox::CreateFromPoints` (so same functionality as [MeshBase::GetOrientedBoundingBox](https://github.com/isl-org/Open3D/blob/v0.18.0/cpp/open3d/geometry/MeshBase.cpp#L49-L51)) instead of `OrientedBoundingBox::CreateFromPointsMinimal` (as done in [PointCloud::GetMinimalOrientedBoundingBox](https://github.com/isl-org/Open3D/blob/v0.18.0/cpp/open3d/geometry/PointCloud.cpp#L55-L58)). I have also added new unit tests for the _minimal oriented bounding box_, _oriented bounding box_, _axis-aligned bounding box_, and _get center_ for both `TriangleMesh` and `TetraMesh` objects.

#### Testing

Testing code (in the visualization the bounding boxes of the meshes are slightly enlarged for better visibility)

```python
import numpy as np
import open3d as o3d

# Create a point cloud
points = np.array(
    [[0.866, 0.474, 0.659],
     [0.943, 0.025, 0.789],
     [0.386, 0.264, 0.691],
     [0.938, 0.588, 0.496],
     [0.221, 0.116, 0.257],
     [0.744, 0.182, 0.052],
     [0.019, 0.525, 0.699],
     [0.722, 0.134, 0.668]]
)

box_pcl = o3d.geometry.PointCloud()
box_pcl.points = o3d.utility.Vector3dVector(points)
box_pcl.colors = o3d.utility.Vector3dVector(np.random.rand(8, 3))

# Create a triangle mesh from the point cloud
box_triangle_mesh = o3d.geometry.TriangleMesh.create_from_point_cloud_alpha_shape(
    pcd=box_pcl, alpha=1.0
)

# Create a tetra mesh from the point cloud
box_tetra_mesh, size = o3d.geometry.TetraMesh.create_from_point_cloud(box_pcl)

# Get the minimal oriented bounding box of the point cloud
obbox_pcd = box_pcl.get_minimal_oriented_bounding_box(robust=True)
obbox_pcd.color = [0.2, 0.9, 0.2] # green
print(f"Minimal OBB pcd volume (green): {obbox_pcd.volume():.4f}")

# Get the minimal oriented bounding box of the triangle mesh
obbox_triangle_mesh = box_triangle_mesh.get_minimal_oriented_bounding_box(robust=True)
obbox_triangle_mesh.color = [1.0, 0.2, 0.2] # red
print(f"Minimal OBB triangle_mesh volume (red): {obbox_triangle_mesh.volume():.4f}")
obbox_triangle_mesh.scale(1.01, center=obbox_triangle_mesh.get_center())

# Get the minimal oriented bounding box of the tetra mesh
obbox_tetra_mesh = box_tetra_mesh.get_minimal_oriented_bounding_box(robust=True)
obbox_tetra_mesh.color = [0.2, 0.2, 1.0] # blue
print(f"Minimal OBB tetra_mesh volume (blue): {obbox_tetra_mesh.volume():.4f}")
obbox_tetra_mesh.scale(1.02, center=obbox_tetra_mesh.get_center())

# Visualization
o3d.visualization.draw_geometries(
    [box_pcl, obbox_pcd, obbox_triangle_mesh, obbox_tetra_mesh],
    window_name="minimal_obboxes",
    lookat=[0, 0.2, 0.5],
    up=[0, 0, 1],
    front=[1, 0, 0],
    zoom=1,
    point_show_normal=False,
    mesh_show_wireframe=False,
    mesh_show_back_face=False,
)
```

##### Before the fix
![Before Minimal OBB fix](https://github.com/user-attachments/assets/2b02305d-42cc-48db-96b4-03eea3b06d92)

```
Minimal OBB pcd volume (green): 0.3591
Minimal OBB triangle_mesh volume (red): 0.4390
Minimal OBB tetra_mesh volume (blue): 0.4390
```

##### After the fix
![After Minimal OBB fix](https://github.com/user-attachments/assets/66f358a7-82f1-4231-954c-c14ce6eec7e3)

```
Minimal OBB pcd volume (green): 0.3591
Minimal OBB triangle_mesh volume (red): 0.3591
Minimal OBB tetra_mesh volume (blue): 0.3591
```