### PR TITLE
upgrade embree to v4.3.3 and fix fmt formatter for RTCError

### DIFF
--- a/3rdparty/embree/embree.cmake
+++ b/3rdparty/embree/embree.cmake
@@ -67,8 +67,8 @@ endif()
 ExternalProject_Add(
     ext_embree
     PREFIX embree
-    URL https://github.com/embree/embree/archive/refs/tags/v4.3.1.tar.gz
-    URL_HASH SHA256=824edcbb7a8cd393c5bdb7a16738487b21ecc4e1d004ac9f761e934f97bb02a4
+    URL https://github.com/embree/embree/archive/refs/tags/v4.3.3.tar.gz
+    URL_HASH SHA256=8a3bc3c3e21aa209d9861a28f8ba93b2f82ed0dc93341dddac09f1f03c36ef2d
     DOWNLOAD_DIR "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/embree"
     UPDATE_COMMAND ""
     CMAKE_ARGS

--- a/cpp/open3d/t/geometry/RaycastingScene.cpp
+++ b/cpp/open3d/t/geometry/RaycastingScene.cpp
@@ -1180,33 +1180,7 @@ template <>
 struct formatter<RTCError> {
     template <typename FormatContext>
     auto format(const RTCError& c, FormatContext& ctx) {
-        const char* name = nullptr;
-        switch (c) {
-            case RTC_ERROR_NONE:
-                name = "RTC_ERROR_NONE";
-                break;
-            case RTC_ERROR_UNKNOWN:
-                name = "RTC_ERROR_UNKNOWN";
-                break;
-            case RTC_ERROR_INVALID_ARGUMENT:
-                name = "RTC_ERROR_INVALID_ARGUMENT";
-                break;
-            case RTC_ERROR_INVALID_OPERATION:
-                name = "RTC_ERROR_INVALID_OPERATION";
-                break;
-            case RTC_ERROR_OUT_OF_MEMORY:
-                name = "RTC_ERROR_OUT_OF_MEMORY";
-                break;
-            case RTC_ERROR_UNSUPPORTED_CPU:
-                name = "RTC_ERROR_UNSUPPORTED_CPU";
-                break;
-            case RTC_ERROR_CANCELLED:
-                name = "RTC_ERROR_CANCELLED";
-                break;
-            case RTC_ERROR_LEVEL_ZERO_RAYTRACING_SUPPORT_MISSING:
-                name = "RTC_ERROR_LEVEL_ZERO_RAYTRACING_SUPPORT_MISSING";
-                break;
-        }
+        const char* name = rtcGetErrorString(c);
         return format_to(ctx.out(), name);
     }
 

--- a/cpp/open3d/t/geometry/RaycastingScene.cpp
+++ b/cpp/open3d/t/geometry/RaycastingScene.cpp
@@ -1203,8 +1203,10 @@ struct formatter<RTCError> {
             case RTC_ERROR_CANCELLED:
                 name = "RTC_ERROR_CANCELLED";
                 break;
+            case RTC_ERROR_LEVEL_ZERO_RAYTRACING_SUPPORT_MISSING:
+                name = "RTC_ERROR_LEVEL_ZERO_RAYTRACING_SUPPORT_MISSING";
+                break;
         }
-        // return formatter<string_view>::format(name, ctx);
         return format_to(ctx.out(), name);
     }
 


### PR DESCRIPTION
This pull request fixes the following build error:

```
Open3D/cpp/open3d/t/geometry/RaycastingScene.cpp:1184:9: error: enumeration value ‘RTC_ERROR_LEVEL_ZERO_RAYTRACING_SUPPORT_MISSING’ not handled in switch [-Werror=switch]
 1184 |         switch (c) {
      |         ^~~~~~
cc1plus: all warnings being treated as errors
```