### PR TITLE
Support lowercase types (i, u, f) when reading PCD files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 -   Split pybind declarations/definitions to avoid C++ types in Python docs (PR #6869)
 -   Fix minimal oriented bounding box of MeshBase derived classes and add new unit tests (PR #6898)
 -   Fix projection of point cloud to Depth/RGBD image if no position attribute is provided (PR #6880)
+-   Support lowercase types when reading PCD files (PR #6930)
 
 ## 0.13
 

--- a/cpp/open3d/io/file_format/FilePCD.cpp
+++ b/cpp/open3d/io/file_format/FilePCD.cpp
@@ -220,7 +220,8 @@ bool ReadPCDHeader(FILE *file, PCDHeader &header) {
 double UnpackBinaryPCDElement(const char *data_ptr,
                               const char type,
                               const int size) {
-    if (type == 'I') {
+    const char type_uppercase = std::toupper(type, std::locale());
+    if (type_uppercase == 'I') {
         if (size == 1) {
             std::int8_t data;
             memcpy(&data, data_ptr, sizeof(data));
@@ -236,7 +237,7 @@ double UnpackBinaryPCDElement(const char *data_ptr,
         } else {
             return 0.0;
         }
-    } else if (type == 'U') {
+    } else if (type_uppercase == 'U') {
         if (size == 1) {
             std::uint8_t data;
             memcpy(&data, data_ptr, sizeof(data));
@@ -252,7 +253,7 @@ double UnpackBinaryPCDElement(const char *data_ptr,
         } else {
             return 0.0;
         }
-    } else if (type == 'F') {
+    } else if (type_uppercase == 'F') {
         if (size == 4) {
             float data;
             memcpy(&data, data_ptr, sizeof(data));
@@ -281,11 +282,12 @@ double UnpackASCIIPCDElement(const char *data_ptr,
                              const char type,
                              const int size) {
     char *end;
-    if (type == 'I') {
+    const char type_uppercase = std::toupper(type, std::locale());
+    if (type_uppercase == 'I') {
         return (double)std::strtol(data_ptr, &end, 0);
-    } else if (type == 'U') {
+    } else if (type_uppercase == 'U') {
         return (double)std::strtoul(data_ptr, &end, 0);
-    } else if (type == 'F') {
+    } else if (type_uppercase == 'F') {
         return std::strtod(data_ptr, &end);
     }
     return 0.0;
@@ -297,13 +299,14 @@ Eigen::Vector3d UnpackASCIIPCDColor(const char *data_ptr,
     if (size == 4) {
         std::uint8_t data[4] = {0, 0, 0, 0};
         char *end;
-        if (type == 'I') {
+        const char type_uppercase = std::toupper(type, std::locale());
+        if (type_uppercase == 'I') {
             std::int32_t value = std::strtol(data_ptr, &end, 0);
             memcpy(data, &value, 4);
-        } else if (type == 'U') {
+        } else if (type_uppercase == 'U') {
             std::uint32_t value = std::strtoul(data_ptr, &end, 0);
             memcpy(data, &value, 4);
-        } else if (type == 'F') {
+        } else if (type_uppercase == 'F') {
             float value = std::strtof(data_ptr, &end);
             memcpy(data, &value, 4);
         }

--- a/cpp/open3d/t/io/file_format/FilePCD.cpp
+++ b/cpp/open3d/t/io/file_format/FilePCD.cpp
@@ -89,30 +89,34 @@ struct WriteAttributePtr {
 };
 
 static core::Dtype GetDtypeFromPCDHeaderField(char type, int size) {
-    if (type == 'I') {
+    char type_uppercase = std::toupper(type, std::locale());
+    if (type_uppercase == 'I') {
         if (size == 1) return core::Dtype::Int8;
         if (size == 2) return core::Dtype::Int16;
         if (size == 4) return core::Dtype::Int32;
         if (size == 8)
             return core::Dtype::Int64;
         else
-            utility::LogError("Unsupported data type.");
-    } else if (type == 'U') {
+            utility::LogError("Unsupported size {} for data type {}.", size,
+                              type);
+    } else if (type_uppercase == 'U') {
         if (size == 1) return core::Dtype::UInt8;
         if (size == 2) return core::Dtype::UInt16;
         if (size == 4) return core::Dtype::UInt32;
         if (size == 8)
             return core::Dtype::UInt64;
         else
-            utility::LogError("Unsupported data type.");
-    } else if (type == 'F') {
+            utility::LogError("Unsupported size {} for data type {}.", size,
+                              type);
+    } else if (type_uppercase == 'F') {
         if (size == 4) return core::Dtype::Float32;
         if (size == 8)
             return core::Dtype::Float64;
         else
-            utility::LogError("Unsupported data type.");
+            utility::LogError("Unsupported size {} for data type {}.", size,
+                              type);
     } else {
-        utility::LogError("Unsupported data type.");
+        utility::LogError("Unsupported data type {}.", type);
     }
 }
 
@@ -305,13 +309,14 @@ static void ReadASCIIPCDColorsFromField(ReadAttributePtr &attr,
     if (field.size == 4) {
         std::uint8_t data[4] = {0};
         char *end;
-        if (field.type == 'I') {
+        char type_uppercase = std::toupper(field.type, std::locale());
+        if (type_uppercase == 'I') {
             std::int32_t value = std::strtol(data_ptr, &end, 0);
             std::memcpy(data, &value, sizeof(std::int32_t));
-        } else if (field.type == 'U') {
+        } else if (type_uppercase == 'U') {
             std::uint32_t value = std::strtoul(data_ptr, &end, 0);
             std::memcpy(data, &value, sizeof(std::uint32_t));
-        } else if (field.type == 'F') {
+        } else if (type_uppercase == 'F') {
             float value = std::strtof(data_ptr, &end);
             std::memcpy(data, &value, sizeof(float));
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [x] New feature (non-breaking change which adds functionality). Resolves #6925 
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

Other libraries, like PCL, support both lowercase types (`i`, `u`, `f`) and their uppercase "official" counterpart (`I`, `U`, `F`) when loading PCD files. Currently, Open3D raises an error for lowercase types when using `open3d.t.io`, or loads a 0.0 value when using `open3d.io`, without any warning/error.


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [x] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

Add support for lowercase types when reading PCD files by using `std::toupper(type, std::locale())`. 

#### Testing

Trying to load [pc_example.zip](https://github.com/user-attachments/files/16740591/pc_example.zip) (notice `TYPE f f f` instead of `TYPE F F F`):

```
# .PCD v0.7 - Point Cloud Data file format
VERSION 0.7
FIELDS x y z
SIZE 4 4 4
TYPE f f f
COUNT 1 1 1
WIDTH 4
HEIGHT 1
VIEWPOINT 0 0 0 1 0 0 0
POINTS 4
DATA ascii
1.0 2.0 3.0
1.5 2.5 3.5
0.2 4.1 -9.3
7.1 8.3 -4.7
```
with script:
```python
import open3d as o3d
import numpy as np

filename = "pc_example.pcd"

print("open3d.io:")
pcd = o3d.io.read_point_cloud(filename)
print(np.asarray(pcd.points))

print("\nopen3d.t.io:")
pcd = o3d.t.io.read_point_cloud(filename)
print(pcd.point.positions.numpy())
```

##### Before
```bash
open3d.io:
[[0. 0. 0.]
 [0. 0. 0.]
 [0. 0. 0.]
 [0. 0. 0.]]

open3d.t.io:
Traceback (most recent call last):
  File "/home/nicola/Desktop/test/open3d/pcd_types/test-script.py", line 13, in <module>
    pcd = o3d.t.io.read_point_cloud(filename)
RuntimeError: [Open3D Error] (open3d::core::Dtype open3d::t::io::GetDtypeFromPCDHeaderField(char, int)) /home/nicola/Open3D-support-2D/cpp/open3d/t/io/file_format/FilePCD.cpp:115: Unsupported data type.
```
##### After
```bash
open3d.io:
[[ 1.   2.   3. ]
 [ 1.5  2.5  3.5]
 [ 0.2  4.1 -9.3]
 [ 7.1  8.3 -4.7]]

open3d.t.io:
[[ 1.   2.   3. ]
 [ 1.5  2.5  3.5]
 [ 0.2  4.1 -9.3]
 [ 7.1  8.3 -4.7]]
```
