### PR TITLE
fix visualization/draw ICP example and add warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 -   Split pybind declarations/definitions to avoid C++ types in Python docs (PR #6869)
 -   Fix minimal oriented bounding box of MeshBase derived classes and add new unit tests (PR #6898)
 -   Fix projection of point cloud to Depth/RGBD image if no position attribute is provided (PR #6880)
+-   Fix visualization/draw ICP example and add warnings (PR #6933)
 
 ## 0.13
 

--- a/examples/python/visualization/draw.py
+++ b/examples/python/visualization/draw.py
@@ -153,17 +153,33 @@ def selections():
                 RuntimeWarning)
             return [], []
         if source_name not in sets[0]:
-            warnings.warn("First set should contain Source (yellow) points.",
-                          RuntimeWarning)
+            warnings.warn(
+                "First selection set should contain Source (yellow) points.",
+                RuntimeWarning)
             return [], []
 
         source_set = sets[0][source_name]
         if two_set:
+            if not len(sets) == 2:
+                warnings.warn(
+                    "Two set registration requires exactly two selection sets of corresponding points.",
+                    RuntimeWarning)
+                return [], []
             target_set = sets[1][target_name]
         else:
+            if target_name not in sets[0]:
+                warnings.warn(
+                    "Selection set should contain Target (blue) points.",
+                    RuntimeWarning)
+                return [], []
             target_set = sets[0][target_name]
         source_picked = sorted(list(source_set), key=lambda x: x.order)
         target_picked = sorted(list(target_set), key=lambda x: x.order)
+        if len(source_picked) != len(target_picked):
+            warnings.warn(
+                f"Registration requires equal number of corresponding points (current selection: {len(source_picked)} source, {len(target_picked)} target).",
+                RuntimeWarning)
+            return [], []
         return source_picked, target_picked
 
     def _do_icp(o3dvis, source_picked, target_picked):

--- a/examples/python/visualization/draw.py
+++ b/examples/python/visualization/draw.py
@@ -11,6 +11,7 @@ import open3d as o3d
 import open3d.visualization as vis
 import os
 import random
+import warnings
 
 pyexample_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 test_data_path = os.path.join(os.path.dirname(pyexample_path), 'test_data')
@@ -142,30 +143,30 @@ def selections():
     source_name = "Source (yellow)"
     target_name = "Target (blue)"
 
-    def do_icp_one_set(o3dvis):
+    def _prep_correspondences(o3dvis, two_set=False):
         # sets: [name: [{ "index": int, "order": int, "point": (x, y, z)}, ...],
         #        ...]
         sets = o3dvis.get_selection_sets()
-        source_picked = sorted(list(sets[0][source_name]),
-                               key=lambda x: x.order)
-        target_picked = sorted(list(sets[0][target_name]),
-                               key=lambda x: x.order)
-        source_indices = [idx.index for idx in source_picked]
-        target_indices = [idx.index for idx in target_picked]
+        if not sets:
+            warnings.warn(
+                "Empty selection sets. Select point correspondences for initial rough transform.",
+                RuntimeWarning)
+            return [], []
+        if source_name not in sets[0]:
+            warnings.warn("First set should contain Source (yellow) points.",
+                          RuntimeWarning)
+            return [], []
 
-        t = get_icp_transform(source, target, source_indices, target_indices)
-        source.transform(t)
-
-        # Update the source geometry
-        o3dvis.remove_geometry(source_name)
-        o3dvis.add_geometry({"name": source_name, "geometry": source})
-
-    def do_icp_two_sets(o3dvis):
-        sets = o3dvis.get_selection_sets()
         source_set = sets[0][source_name]
-        target_set = sets[1][target_name]
+        if two_set:
+            target_set = sets[1][target_name]
+        else:
+            target_set = sets[0][target_name]
         source_picked = sorted(list(source_set), key=lambda x: x.order)
         target_picked = sorted(list(target_set), key=lambda x: x.order)
+        return source_picked, target_picked
+
+    def _do_icp(o3dvis, source_picked, target_picked):
         source_indices = [idx.index for idx in source_picked]
         target_indices = [idx.index for idx in target_picked]
 
@@ -175,6 +176,12 @@ def selections():
         # Update the source geometry
         o3dvis.remove_geometry(source_name)
         o3dvis.add_geometry({"name": source_name, "geometry": source})
+
+    def do_icp_one_set(o3dvis):
+        _do_icp(o3dvis, *_prep_correspondences(o3dvis))
+
+    def do_icp_two_sets(o3dvis):
+        _do_icp(o3dvis, *_prep_correspondences(o3dvis, two_set=True))
 
     vis.draw([{
         "name": source_name,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #6887 
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

A minor issue, but the ICP example in `examples/python/visualization/draw.py` requires the user to select point correspondences for a preliminary rough transformation before ICP registration, but users may not be aware of this. Currently, if no point correspondences are selected, the application crashes with an IndexError.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description
Here are the changes I've made:
* prevented the IndexError when running the ICP example without point correspondences and added a RuntimeWarning for the user to hightlight the need to select point correspondences.
* additionally prevented a KeyError when the "Source (yellow)" cloud is not contained in the first selection set and added a RuntimeWarning for this.
* refactored the existing `do_ICP_one_set` and `do_ICP_two_set` with new functions `_prep_correspondences` and `_do_ICP` to reduce duplicate code.