### PR TITLE
Updated delocate-fuse to delocate-merge.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -345,11 +345,8 @@ jobs:
           PYTAG="-cp$(echo ${{ env.python_version }} | tr -d '.')"
           mkdir universal_wheels
           pip install delocate
-          delocate-fuse -v x64_wheels/open3d-*${PYTAG}*.whl arm64_wheels/open3d-*${PYTAG}*.whl
-          # Normalize file name as delocate-fuse doesn't update it
-          OLD_WHL_NAME=$(basename x64_wheels/open3d-*${PYTAG}*.whl)
-          NEW_WHL_NAME=${OLD_WHL_NAME/x86_64/universal2}
-          mv x64_wheels/${OLD_WHL_NAME} universal_wheels/${NEW_WHL_NAME}
+          delocate-merge -v -w universal_wheels x64_wheels/open3d-*${PYTAG}*.whl arm64_wheels/open3d-*${PYTAG}*.whl
+          NEW_WHL_NAME=$(basename universal_wheels/open3d-*${PYTAG}*.whl)
           echo "PIP_PKG_NAME=$NEW_WHL_NAME" >> $GITHUB_ENV
 
       - name: Upload merged wheels


### PR DESCRIPTION
Updated delocate-fuse to delocate-merge (got removed in delocate>=0.12.0).

<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context
The following error occurs in the [Fuse universal2 wheel (3.11, false)](https://github.com/isl-org/Open3D/actions/runs/10644695980/job/29510365691?pr=6896) CI workflow:
```bash
'delocate-fuse' is no longer available.
To fuse two wheels together use 'delocate-merge'.
NOTE: 'delocate-merge' does not overwrite the first wheel.
It creates a new wheel with an automatically determined name.
If the old behavior is needed (not recommended), pin the version to 'delocate==0.11.0'.
```
delocate 0.12.0 released on the 29th of August, so only the latest CI runs show this error.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
The following warning from [delocate](https://pypi.org/project/delocate/) describes what changed with delocate>=0.12.0:
```
:warning: Note: In previous versions (<0.12.0) making dual architecture binaries was performed with the delocate-fuse command.
This commannd would overwrite the first wheel passed in by default.
This led to the user needing to rename the wheel to correctly describe what platforms it supported.
For this and other reasons, wheels created with this were often incorrect.
From version 0.12.0 and on, the delocate-fuse command has been removed and replaced with delocate-merge.
The delocate-merge command will create a new wheel with an automatically generated name based on the wheels that were merged together.
There is no need to perform any further changes to the merged wheel’s name.
If the old behavior is needed (not recommended), pin the version to delocate==0.11.0.
```
I just changed from `delocate-fuse` to `delocate-merge`.