### PR TITLE
Expose minimal oriented bounding box to python api

### DIFF
--- a/cpp/pybind/geometry/boundingvolume.cpp
+++ b/cpp/pybind/geometry/boundingvolume.cpp
@@ -84,7 +84,7 @@ Returns:
      bounding box is oriented such that the axes are ordered with respect to
      the principal components.
 )doc")
-            .def_static("create_minimal_from_points",
+            .def_static("create_from_points_minimal",
                         &OrientedBoundingBox::CreateFromPointsMinimal,
                         "points"_a, "robust"_a = false,
                         R"doc(

--- a/cpp/pybind/geometry/boundingvolume.cpp
+++ b/cpp/pybind/geometry/boundingvolume.cpp
@@ -84,6 +84,27 @@ Returns:
      bounding box is oriented such that the axes are ordered with respect to
      the principal components.
 )doc")
+            .def_static("create_from_points_minimal",
+                        &OrientedBoundingBox::CreateFromPointsMinimal, "points"_a,
+                        "robust"_a = false,
+                        R"doc(
+Creates the oriented bounding box with the smallest volume.
+
+The algorithm makes use of the fact that at least one edge of
+the convex hull must be collinear with an edge of the minimum
+bounding box: for each triangle in the convex hull, calculate
+the minimal axis aligned box in the frame of that triangle.
+at the end, return the box with the smallest volume
+
+Args:
+     points (open3d.utility.Vector3dVector): Input points.
+     robust (bool): If set to true uses a more robust method which works in
+          degenerate cases but introduces noise to the points coordinates.
+
+Returns:
+     open3d.geometry.OrientedBoundingBox: The oriented bounding box. The
+     bounding box is oriented such that its volume is minimized.
+)doc")
             .def("volume", &OrientedBoundingBox::Volume,
                  "Returns the volume of the bounding box.")
             .def("get_box_points", &OrientedBoundingBox::GetBoxPoints,

--- a/cpp/pybind/geometry/boundingvolume.cpp
+++ b/cpp/pybind/geometry/boundingvolume.cpp
@@ -85,8 +85,8 @@ Returns:
      the principal components.
 )doc")
             .def_static("create_minimal_from_points",
-                        &OrientedBoundingBox::CreateFromPointsMinimal, "points"_a,
-                        "robust"_a = false,
+                        &OrientedBoundingBox::CreateFromPointsMinimal,
+                        "points"_a, "robust"_a = false,
                         R"doc(
 Creates the oriented bounding box with the smallest volume.
 

--- a/cpp/pybind/geometry/boundingvolume.cpp
+++ b/cpp/pybind/geometry/boundingvolume.cpp
@@ -84,7 +84,7 @@ Returns:
      bounding box is oriented such that the axes are ordered with respect to
      the principal components.
 )doc")
-            .def_static("create_from_points_minimal",
+            .def_static("create_minimal_from_points",
                         &OrientedBoundingBox::CreateFromPointsMinimal, "points"_a,
                         "robust"_a = false,
                         R"doc(

--- a/cpp/pybind/t/geometry/boundingvolume.cpp
+++ b/cpp/pybind/t/geometry/boundingvolume.cpp
@@ -355,15 +355,17 @@ that could be computed for example with O'Rourke's algorithm
 (cf. http://cs.smith.edu/~jorourke/Papers/MinVolBox.pdf, https://www.geometrictools.com/Documentation/MinimumVolumeBox.pdf)
 This is a wrapper for a CPU implementation.)",
                    "points"_a, "robust"_a = false);
-    obb.def_static("create_minimal_from_points", &OrientedBoundingBox::CreateFromPointsMinimal,
-                   R"(Creates the oriented bounding box with the smallest volume.
+    obb.def_static(
+            "create_minimal_from_points",
+            &OrientedBoundingBox::CreateFromPointsMinimal,
+            R"(Creates the oriented bounding box with the smallest volume.
 The algorithm makes use of the fact that at least one edge of
 the convex hull must be collinear with an edge of the minimum
 bounding box: for each triangle in the convex hull, calculate
 the minimal axis aligned box in the frame of that triangle.
 at the end, return the box with the smallest volume.
 This is a wrapper for a CPU implementation.)",
-                   "points"_a, "robust"_a = false);
+            "points"_a, "robust"_a = false);
 
     docstring::ClassMethodDocInject(
             m, "OrientedBoundingBox", "set_center",

--- a/cpp/pybind/t/geometry/boundingvolume.cpp
+++ b/cpp/pybind/t/geometry/boundingvolume.cpp
@@ -421,14 +421,14 @@ This is a wrapper for a CPU implementation.)",
               "degenerate cases but introduces noise to the points "
               "coordinates."}});
     docstring::ClassMethodDocInject(
-        m, "OrientedBoundingBox", "create_minimal_from_points",
-        {{"points",
-          "A list of points with data type of float32 or float64 (N x 3 "
-          "tensor, where N must be larger than 3)."},
-         {"robust",
-          "If set to true uses a more robust method which works in "
-          "degenerate cases but introduces noise to the points "
-          "coordinates."}});
+            m, "OrientedBoundingBox", "create_minimal_from_points",
+            {{"points",
+              "A list of points with data type of float32 or float64 (N x 3 "
+              "tensor, where N must be larger than 3)."},
+             {"robust",
+              "If set to true uses a more robust method which works in "
+              "degenerate cases but introduces noise to the points "
+              "coordinates."}});
 }
 
 }  // namespace geometry

--- a/cpp/pybind/t/geometry/boundingvolume.cpp
+++ b/cpp/pybind/t/geometry/boundingvolume.cpp
@@ -355,17 +355,6 @@ that could be computed for example with O'Rourke's algorithm
 (cf. http://cs.smith.edu/~jorourke/Papers/MinVolBox.pdf, https://www.geometrictools.com/Documentation/MinimumVolumeBox.pdf)
 This is a wrapper for a CPU implementation.)",
                    "points"_a, "robust"_a = false);
-    obb.def_static(
-            "create_minimal_from_points",
-            &OrientedBoundingBox::CreateFromPointsMinimal,
-            R"(Creates the oriented bounding box with the smallest volume.
-The algorithm makes use of the fact that at least one edge of
-the convex hull must be collinear with an edge of the minimum
-bounding box: for each triangle in the convex hull, calculate
-the minimal axis aligned box in the frame of that triangle.
-at the end, return the box with the smallest volume.
-This is a wrapper for a CPU implementation.)",
-            "points"_a, "robust"_a = false);
 
     docstring::ClassMethodDocInject(
             m, "OrientedBoundingBox", "set_center",
@@ -415,15 +404,6 @@ This is a wrapper for a CPU implementation.)",
               "created."}});
     docstring::ClassMethodDocInject(
             m, "OrientedBoundingBox", "create_from_points",
-            {{"points",
-              "A list of points with data type of float32 or float64 (N x 3 "
-              "tensor, where N must be larger than 3)."},
-             {"robust",
-              "If set to true uses a more robust method which works in "
-              "degenerate cases but introduces noise to the points "
-              "coordinates."}});
-    docstring::ClassMethodDocInject(
-            m, "OrientedBoundingBox", "create_minimal_from_points",
             {{"points",
               "A list of points with data type of float32 or float64 (N x 3 "
               "tensor, where N must be larger than 3)."},

--- a/cpp/pybind/t/geometry/boundingvolume.cpp
+++ b/cpp/pybind/t/geometry/boundingvolume.cpp
@@ -355,7 +355,7 @@ that could be computed for example with O'Rourke's algorithm
 (cf. http://cs.smith.edu/~jorourke/Papers/MinVolBox.pdf, https://www.geometrictools.com/Documentation/MinimumVolumeBox.pdf)
 This is a wrapper for a CPU implementation.)",
                    "points"_a, "robust"_a = false);
-    obb.def_static("create_from_points_minimal", &OrientedBoundingBox::CreateFromPointsMinimal,
+    obb.def_static("create_minimal_from_points", &OrientedBoundingBox::CreateFromPointsMinimal,
                    R"(Creates the oriented bounding box with the smallest volume.
 The algorithm makes use of the fact that at least one edge of
 the convex hull must be collinear with an edge of the minimum
@@ -421,7 +421,7 @@ This is a wrapper for a CPU implementation.)",
               "degenerate cases but introduces noise to the points "
               "coordinates."}});
     docstring::ClassMethodDocInject(
-        m, "OrientedBoundingBox", "create_from_points_minimal",
+        m, "OrientedBoundingBox", "create_minimal_from_points",
         {{"points",
           "A list of points with data type of float32 or float64 (N x 3 "
           "tensor, where N must be larger than 3)."},

--- a/cpp/pybind/t/geometry/boundingvolume.cpp
+++ b/cpp/pybind/t/geometry/boundingvolume.cpp
@@ -355,6 +355,15 @@ that could be computed for example with O'Rourke's algorithm
 (cf. http://cs.smith.edu/~jorourke/Papers/MinVolBox.pdf, https://www.geometrictools.com/Documentation/MinimumVolumeBox.pdf)
 This is a wrapper for a CPU implementation.)",
                    "points"_a, "robust"_a = false);
+    obb.def_static("create_from_points_minimal", &OrientedBoundingBox::CreateFromPointsMinimal,
+                   R"(Creates the oriented bounding box with the smallest volume.
+The algorithm makes use of the fact that at least one edge of
+the convex hull must be collinear with an edge of the minimum
+bounding box: for each triangle in the convex hull, calculate
+the minimal axis aligned box in the frame of that triangle.
+at the end, return the box with the smallest volume.
+This is a wrapper for a CPU implementation.)",
+                   "points"_a, "robust"_a = false);
 
     docstring::ClassMethodDocInject(
             m, "OrientedBoundingBox", "set_center",
@@ -411,6 +420,15 @@ This is a wrapper for a CPU implementation.)",
               "If set to true uses a more robust method which works in "
               "degenerate cases but introduces noise to the points "
               "coordinates."}});
+    docstring::ClassMethodDocInject(
+        m, "OrientedBoundingBox", "create_from_points_minimal",
+        {{"points",
+          "A list of points with data type of float32 or float64 (N x 3 "
+          "tensor, where N must be larger than 3)."},
+         {"robust",
+          "If set to true uses a more robust method which works in "
+          "degenerate cases but introduces noise to the points "
+          "coordinates."}});
 }
 
 }  // namespace geometry


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR exposes the minimal volume bounding box function to the python API.

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [X] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

Only the static function `create_from_points` is currently exposed to the Python API.
However, in the CPP API, another option exists which is to create a bounding box with a minimal volume that is not exposed.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [X] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [X] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [X] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [X] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
