### PR TITLE
Add Tensor-based implementation of FarthestPointDownSample

### DIFF
--- a/cpp/open3d/t/geometry/PointCloud.cpp
+++ b/cpp/open3d/t/geometry/PointCloud.cpp
@@ -384,47 +384,37 @@ PointCloud PointCloud::RandomDownSample(double sampling_ratio) const {
 }
 
 PointCloud PointCloud::FarthestPointDownSample(size_t num_samples) const {
-    if (IsCUDA()) {
-        // This version works on CPU as well,
-        // but has worse runtime than the legacy implementation (on CPU)
-        const core::Dtype dtype = GetPointPositions().GetDtype();
-        const int64_t num_points = GetPointPositions().GetLength();
-        if (num_samples == 0) {
-            return PointCloud(GetDevice());
-        } else if (num_samples == size_t(num_points)) {
-            return Clone();
-        } else if (num_samples > size_t(num_points)) {
-            utility::LogError(
-                    "Illegal number of samples: {}, must <= point size: {}",
-                    num_samples, num_points);
-        }
-        core::Tensor selection_mask =
-                core::Tensor::Zeros({num_points}, core::Bool, GetDevice());
-        core::Tensor smallest_distances = core::Tensor::Full(
-                {num_points}, std::numeric_limits<double>::infinity(), dtype,
-                GetDevice());
-
-        int64_t farthest_index = 0;
-
-        for (size_t i = 0; i < num_samples; i++) {
-            selection_mask[farthest_index] = true;
-            core::Tensor selected = GetPointPositions()[farthest_index];
-
-            core::Tensor diff = GetPointPositions() - selected;
-            core::Tensor distances_to_selected = (diff * diff).Sum({1});
-            smallest_distances = open3d::core::Minimum(distances_to_selected,
-                                                       smallest_distances);
-
-            farthest_index = smallest_distances.ArgMax({0}).Item<int64_t>();
-        }
-        return SelectByMask(selection_mask);
-    } else {  // use legacy version for CPU
-        // We want the sampled points has the attributes of the original point
-        // cloud, so full copy is needed.
-        const open3d::geometry::PointCloud lpcd = ToLegacy();
-        return FromLegacy(*lpcd.FarthestPointDownSample(num_samples),
-                          GetPointPositions().GetDtype(), GetDevice());
+    const core::Dtype dtype = GetPointPositions().GetDtype();
+    const int64_t num_points = GetPointPositions().GetLength();
+    if (num_samples == 0) {
+        return PointCloud(GetDevice());
+    } else if (num_samples == size_t(num_points)) {
+        return Clone();
+    } else if (num_samples > size_t(num_points)) {
+        utility::LogError(
+                "Illegal number of samples: {}, must <= point size: {}",
+                num_samples, num_points);
     }
+    core::Tensor selection_mask =
+            core::Tensor::Zeros({num_points}, core::Bool, GetDevice());
+    core::Tensor smallest_distances = core::Tensor::Full(
+            {num_points}, std::numeric_limits<double>::infinity(), dtype,
+            GetDevice());
+
+    int64_t farthest_index = 0;
+
+    for (size_t i = 0; i < num_samples; i++) {
+        selection_mask[farthest_index] = true;
+        core::Tensor selected = GetPointPositions()[farthest_index];
+
+        core::Tensor diff = GetPointPositions() - selected;
+        core::Tensor distances_to_selected = (diff * diff).Sum({1});
+        smallest_distances = open3d::core::Minimum(distances_to_selected,
+                                                   smallest_distances);
+
+        farthest_index = smallest_distances.ArgMax({0}).Item<int64_t>();
+    }
+    return SelectByMask(selection_mask);
 }
 
 std::tuple<PointCloud, core::Tensor> PointCloud::RemoveRadiusOutliers(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR adds a FarthestPointDownSample implementation for tensor-based point clouds. This enables GPU-acceleration for a performance increase of up to 8x. Before, point clouds were copied to the legacy format and then being downsampled on the CPU before being copied back.

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

FarthestPointDownSample is an important downsampling method, however it's performance render this implementation inapplicable for certain scenarios. This PR is trying to increase the performance

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
