### PR TITLE
Always pre-transform vertices while reading with Assimp.

### DIFF
--- a/cpp/open3d/io/TriangleMeshIO.h
+++ b/cpp/open3d/io/TriangleMeshIO.h
@@ -31,6 +31,7 @@ struct ReadTriangleMeshOptions {
     /// `aiProcessPreset_TargetRealtime_Fast,
     /// aiProcess_RemoveRedundantMaterials, aiProcess_OptimizeMeshes,
     /// aiProcess_PreTransformVertices`.
+    /// https://github.com/assimp/assimp/blob/master/include/assimp/postprocess.h
     ///
     /// Note that identical vertices will always be joined regardless of whether
     /// post-processing is enabled or not, which changes the number of vertices

--- a/cpp/open3d/io/file_format/FileASSIMP.cpp
+++ b/cpp/open3d/io/file_format/FileASSIMP.cpp
@@ -97,7 +97,8 @@ void LoadTextures(const std::string& filename,
                     }
                 } else {
                     utility::LogWarning(
-                            "Unsupported texture format for texture {} for file {}: Only jpg and "
+                            "Unsupported texture format for texture {} for "
+                            "file {}: Only jpg and "
                             "png textures are supported.",
                             path.C_Str(), filename);
                 }

--- a/cpp/open3d/t/io/file_format/FileASSIMP.cpp
+++ b/cpp/open3d/t/io/file_format/FileASSIMP.cpp
@@ -35,14 +35,16 @@ namespace t {
 namespace io {
 
 // Split all polygons with more than 3 edges into triangles.
+// Ref:
+// https://github.com/assimp/assimp/blob/master/include/assimp/postprocess.h
 const unsigned int kPostProcessFlags_compulsory =
         aiProcess_JoinIdenticalVertices | aiProcess_Triangulate |
-        aiProcess_SortByPType;
+        aiProcess_SortByPType | aiProcess_PreTransformVertices;
 
 const unsigned int kPostProcessFlags_fast =
-        aiProcessPreset_TargetRealtime_Fast |
-        aiProcess_RemoveRedundantMaterials | aiProcess_OptimizeMeshes |
-        aiProcess_PreTransformVertices;
+        kPostProcessFlags_compulsory | aiProcess_GenNormals |
+        aiProcess_GenUVCoords | aiProcess_RemoveRedundantMaterials |
+        aiProcess_OptimizeMeshes;
 
 bool ReadTriangleMeshUsingASSIMP(
         const std::string& filename,
@@ -58,7 +60,8 @@ bool ReadTriangleMeshUsingASSIMP(
 
     const auto* scene = importer.ReadFile(filename.c_str(), post_process_flags);
     if (!scene) {
-        utility::LogWarning("Unable to load file {} with ASSIMP", filename);
+        utility::LogWarning("Unable to load file {} with ASSIMP: {}", filename,
+                            importer.GetErrorString());
         return false;
     }
 
@@ -219,7 +222,7 @@ bool WriteTriangleMeshUsingASSIMP(const std::string& filename,
     // Sanity checks...
     if (write_ascii) {
         utility::LogWarning(
-                "TriangleMesh can't be saved in ASCII fromat as .glb");
+                "TriangleMesh can't be saved in ASCII format as .glb");
         return false;
     }
     if (compressed) {
@@ -470,7 +473,9 @@ bool WriteTriangleMeshUsingASSIMP(const std::string& filename,
     // Export
     if (exporter.Export(ai_scene.get(), "glb2", filename.c_str()) ==
         AI_FAILURE) {
-        utility::LogWarning("Got error: {}", exporter.GetErrorString());
+        utility::LogWarning(
+                "Got error: ({}) while writing TriangleMesh to file {}.",
+                exporter.GetErrorString(), filename);
         return false;
     }
 


### PR DESCRIPTION

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

While reading glb files with bone transforms (especially scaling) and a single mesh, the transform is ignored if post_process is not enabled. This can cause reading a mesh with incorrect scale factor. 

e.g.: 03d693e178e54766af2905e90cbc1f03.glb file from Objaverse

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [ ] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

This PR adds the PreTransformVertices option to the Assimp backend call by default, so that all transforms are always applied.

Also improves error messages when reading / writing fails.

