### PR TITLE
fix build with fmt-v11

### DIFF
--- a/cpp/open3d/t/geometry/RaycastingScene.cpp
+++ b/cpp/open3d/t/geometry/RaycastingScene.cpp
@@ -1179,7 +1179,7 @@ namespace fmt {
 template <>
 struct formatter<RTCError> {
     template <typename FormatContext>
-    auto format(const RTCError& c, FormatContext& ctx) {
+    auto format(const RTCError& c, FormatContext& ctx) const {
         const char* name = rtcGetErrorString(c);
         return format_to(ctx.out(), name);
     }

--- a/cpp/open3d/utility/IJsonConvertible.h
+++ b/cpp/open3d/utility/IJsonConvertible.h
@@ -86,8 +86,7 @@ namespace fmt {
 template <>
 struct formatter<Json::Value> {
     template <typename FormatContext>
-    auto format(const Json::Value &value, FormatContext &ctx)
-            -> decltype(ctx.out()) {
+    auto format(const Json::Value &value, FormatContext &ctx) const -> decltype(ctx.out())  {
         return format_to(ctx.out(), "{}", open3d::utility::JsonToString(value));
     }
 

--- a/cpp/open3d/utility/IJsonConvertible.h
+++ b/cpp/open3d/utility/IJsonConvertible.h
@@ -86,7 +86,8 @@ namespace fmt {
 template <>
 struct formatter<Json::Value> {
     template <typename FormatContext>
-    auto format(const Json::Value &value, FormatContext &ctx) const -> decltype(ctx.out())  {
+    auto format(const Json::Value &value, FormatContext &ctx) const
+            -> decltype(ctx.out()) {
         return format_to(ctx.out(), "{}", open3d::utility::JsonToString(value));
     }
 

--- a/cpp/open3d/visualization/rendering/RendererHandle.h
+++ b/cpp/open3d/visualization/rendering/RendererHandle.h
@@ -164,7 +164,7 @@ struct formatter<
                          char>> {
     template <typename FormatContext>
     auto format(const open3d::visualization::rendering::REHandle_abstract& uid,
-                FormatContext& ctx) -> decltype(ctx.out()) {
+                FormatContext& ctx) const -> decltype(ctx.out()) {
         return format_to(ctx.out(), "[{}, {}, hash: {}]",
                          open3d::visualization::rendering::REHandle_abstract::
                                  TypeToString(uid.type),


### PR DESCRIPTION
`fmt v11` requires that `format` function of user-defined formatter should be `const`.