### PR TITLE
Fix tensor EstimatePointWiseNormalsWithFastEigen3x3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 -   Fix projection of point cloud to Depth/RGBD image if no position attribute is provided (PR #6880)
 -   Support lowercase types when reading PCD files (PR #6930)
 -   Fix visualization/draw ICP example and add warnings (PR #6933)
+-   Fix tensor EstimatePointWiseNormalsWithFastEigen3x3 (PR #6980)
 
 ## 0.13
 

--- a/cpp/open3d/t/geometry/kernel/PointCloudImpl.h
+++ b/cpp/open3d/t/geometry/kernel/PointCloudImpl.h
@@ -956,8 +956,8 @@ OPEN3D_HOST_DEVICE void EstimatePointWiseNormalsWithFastEigen3x3(
             normals_ptr[1] = 0.0;
             normals_ptr[2] = 0.0;
             return;
-        } else if (covariance_ptr[0] < covariance_ptr[4] &&
-                   covariance_ptr[0] < covariance_ptr[8]) {
+        } else if (covariance_ptr[4] < covariance_ptr[0] &&
+                   covariance_ptr[4] < covariance_ptr[8]) {
             normals_ptr[0] = 0.0;
             normals_ptr[1] = 1.0;
             normals_ptr[2] = 0.0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #6967 
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

Very short PR. In the tensor module, [EstimatePointWiseNormalsWithFastEigen3x3](https://github.com/isl-org/Open3D/blob/v0.18.0/cpp/open3d/t/geometry/kernel/PointCloudImpl.h#L839) has a small bug in computing the normal when the covariance norm is 0, setting a normal to `(0,0,1)` instead of the correct `(0,1,0)` value.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

Very short PR. Fix [EstimatePointWiseNormalsWithFastEigen3x3](https://github.com/isl-org/Open3D/blob/v0.18.0/cpp/open3d/t/geometry/kernel/PointCloudImpl.h#L839) to correctly estimate the `(0,1,0)` normal. The *if* clause for the `(0,1,0)` normal case is incorrect, and the normal will be incorrectly estimated to be `(0,0,1)`.

Change the [covariance matrix check of EstimatePointWiseNormalsWithFastEigen3x3](https://github.com/isl-org/Open3D/blob/v0.18.0/cpp/open3d/t/geometry/kernel/PointCloudImpl.h#L959-L960) from
```
else if (covariance_ptr[0] < covariance_ptr[4] &&
                   covariance_ptr[0] < covariance_ptr[8])
```
to 
```
else if (covariance_ptr[4] < covariance_ptr[0] &&
                   covariance_ptr[4] < covariance_ptr[8])
```
similarly to how is done in the [covariance matrix check of FastEigen3x3](https://github.com/isl-org/Open3D/blob/v0.18.0/cpp/open3d/geometry/EstimateNormals.cpp#L199).

