### PR TITLE
fix alpha shape reconstruction if alpha too small for point scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 -   Fix projection of point cloud to Depth/RGBD image if no position attribute is provided (PR #6880)
 -   Support lowercase types when reading PCD files (PR #6930)
 -   Fix visualization/draw ICP example and add warnings (PR #6933)
+-   Fix alpha shape reconstruction if alpha too small for point scale (PR #6998)
 
 ## 0.13
 

--- a/cpp/open3d/geometry/SurfaceReconstructionAlphaShape.cpp
+++ b/cpp/open3d/geometry/SurfaceReconstructionAlphaShape.cpp
@@ -158,28 +158,37 @@ std::shared_ptr<TriangleMesh> TriangleMesh::CreateFromPointCloudAlphaShape(
             "[CreateFromPointCloudAlphaShape] done remove duplicate triangles "
             "and unreferenced vertices");
 
-    auto tmesh = t::geometry::TriangleMesh::FromLegacy(*mesh);
+    if (mesh->vertices_.size() > 0) {
+        auto tmesh = t::geometry::TriangleMesh::FromLegacy(*mesh);
 
-    // use new object tmesh2 here even if some arrays share memory with tmesh.
-    // We don't want to replace the blobs in tmesh.
-    auto tmesh2 = t::geometry::vtkutils::ComputeNormals(
-            tmesh, /*vertex_normals=*/true, /*face_normals=*/false,
-            /*consistency=*/true, /*auto_orient_normals=*/true,
-            /*splitting=*/false);
+        // use new object tmesh2 here even if some arrays share memory with
+        // tmesh. We don't want to replace the blobs in tmesh.
+        auto tmesh2 = t::geometry::vtkutils::ComputeNormals(
+                tmesh, /*vertex_normals=*/true, /*face_normals=*/false,
+                /*consistency=*/true, /*auto_orient_normals=*/true,
+                /*splitting=*/false);
 
-    mesh->vertices_ = core::eigen_converter::TensorToEigenVector3dVector(
-            tmesh2.GetVertexPositions());
-    mesh->triangles_ = core::eigen_converter::TensorToEigenVector3iVector(
-            tmesh2.GetTriangleIndices());
-    if (mesh->HasVertexColors()) {
-        mesh->vertex_colors_ =
-                core::eigen_converter::TensorToEigenVector3dVector(
-                        tmesh2.GetVertexColors());
-    }
-    if (mesh->HasVertexNormals()) {
-        mesh->vertex_normals_ =
-                core::eigen_converter::TensorToEigenVector3dVector(
-                        tmesh2.GetVertexNormals());
+        mesh->vertices_ = core::eigen_converter::TensorToEigenVector3dVector(
+                tmesh2.GetVertexPositions());
+        mesh->triangles_ = core::eigen_converter::TensorToEigenVector3iVector(
+                tmesh2.GetTriangleIndices());
+        if (mesh->HasVertexColors()) {
+            mesh->vertex_colors_ =
+                    core::eigen_converter::TensorToEigenVector3dVector(
+                            tmesh2.GetVertexColors());
+        }
+        if (mesh->HasVertexNormals()) {
+            mesh->vertex_normals_ =
+                    core::eigen_converter::TensorToEigenVector3dVector(
+                            tmesh2.GetVertexNormals());
+        }
+    } else {
+        utility::LogWarning(
+                fmt::format("[CreateFromPointCloudAlphaShape] alpha shape "
+                            "reconstruction resulted in empty mesh. Alpha "
+                            "value ({}) could be too small.",
+                            alpha)
+                        .c_str());
     }
 
     return mesh;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #6086 
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

Surface reconstruction with alpha shapes by calling `create_from_point_cloud_alpha_shape` fails if the alpha value is too small for the internal constraint to become true.
https://github.com/isl-org/Open3D/blob/db00e339c1645440dea6951c2971ffa759934112/cpp/open3d/geometry/SurfaceReconstructionAlphaShape.cpp#L105-L110

There is currently no check if the reconstructed mesh is empty, thus the following call to 
https://github.com/isl-org/Open3D/blob/db00e339c1645440dea6951c2971ffa759934112/cpp/open3d/geometry/SurfaceReconstructionAlphaShape.cpp#L165-L168
leads to a non-descriptive unordered_map key error.

To reproduce, an easy test is to attempt surface reconstruction with the Bunny and the Armadillo Mesh.
While the bunny mesh works fine with the tutorial alpha shape values (e.g. 0.03), the Armadillo mesh fails.
This is a point scale issue, i.e. `max_bound` (Armadillo) is [62.1 96.4  56.8] and `max_bound` (Bunny) is [0.061 0.187 0.058]. If the alpha is large enough (e.g. 10), or the points are scaled down, it works again for the Armadillo.

To reproduce the error:
```python
bunny = o3d.data.BunnyMesh()
arma = o3d.data.ArmadilloMesh()
for m in [bunny, arma]:
    mesh = o3d.io.read_triangle_mesh(m.path)
    pcd = mesh.sample_points_poisson_disk(300)
    alpha = 0.03
    mesh = o3d.geometry.TriangleMesh.create_from_point_cloud_alpha_shape(pcd, alpha)
    mesh.compute_vertex_normals()
    o3d.visualization.draw_geometries([mesh], mesh_show_back_face=True)
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

To prevent the error, I've added a check if the mesh is empty after the alpha shape reconstruction is completed. If it is empty, a warning is logged and the empty mesh gets returned.