### PR TITLE
[Typo] Fix torch furthest_point_sampling argument typo

### DIFF
--- a/cpp/open3d/ml/pytorch/pointnet/SamplingOps.cpp
+++ b/cpp/open3d/ml/pytorch/pointnet/SamplingOps.cpp
@@ -63,7 +63,7 @@ torch::Tensor furthest_point_sampling(torch::Tensor points,
 }
 
 static auto registry_fp = torch::RegisterOperators(
-        "open3d::furthest_point_sampling(Tensor points, int sample_siz)"
+        "open3d::furthest_point_sampling(Tensor points, int sample_size)"
         " -> Tensor out",
         &furthest_point_sampling);
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

To fix pytorch `furthest_point_sampling` argument typo.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [ x For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
To fix pytorch `furthest_point_sampling` argument typo. Rename from `sample_siz` to `sample_size`.