### PR TITLE
fix infinite loop in segment_plane if num_points < ransac_n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 -   Fix tensor EstimatePointWiseNormalsWithFastEigen3x3 (PR #6980)
 -   Fix alpha shape reconstruction if alpha too small for point scale (PR #6998)
 -   Fix render to depth image on Apple Retina displays (PR #7001)
+-   Fix infinite loop in segment_plane if num_points < ransac_n (PR #7032)
 
 ## 0.13
 

--- a/cpp/open3d/geometry/PointCloudSegmentation.cpp
+++ b/cpp/open3d/geometry/PointCloudSegmentation.cpp
@@ -29,7 +29,6 @@ public:
     explicit RandomSampler(const size_t total_size) : total_size_(total_size) {}
 
     std::vector<T> operator()(size_t sample_size) {
-        std::lock_guard<std::mutex> lock(mutex_);
         std::vector<T> samples;
         samples.reserve(sample_size);
 
@@ -48,7 +47,6 @@ public:
 
 private:
     size_t total_size_;
-    std::mutex mutex_;
 };
 
 /// \class RANSACResult
@@ -172,6 +170,7 @@ std::tuple<Eigen::Vector4d, std::vector<size_t>> PointCloud::SegmentPlane(
     Eigen::Vector4d best_plane_model = Eigen::Vector4d(0, 0, 0, 0);
 
     RandomSampler<size_t> sampler(num_points);
+    // Pre-generate all random samples before entering the parallel region
     std::vector<std::vector<size_t>> all_sampled_indices;
     all_sampled_indices.reserve(num_iterations);
     for (int i = 0; i < num_iterations; i++) {

--- a/cpp/open3d/geometry/PointCloudSegmentation.cpp
+++ b/cpp/open3d/geometry/PointCloudSegmentation.cpp
@@ -43,7 +43,6 @@ public:
                 valid_sample++;
             }
         }
-
         return samples;
     }
 
@@ -156,21 +155,7 @@ std::tuple<Eigen::Vector4d, std::vector<size_t>> PointCloud::SegmentPlane(
         utility::LogError("Probability must be > 0 and <= 1.0");
     }
 
-    RANSACResult result;
-
-    // Initialize the best plane model.
-    Eigen::Vector4d best_plane_model = Eigen::Vector4d(0, 0, 0, 0);
-
     size_t num_points = points_.size();
-    RandomSampler<size_t> sampler(num_points);
-    // Pre-generate all random samples before entering the parallel region
-    std::vector<std::vector<size_t>> all_sampled_indices;
-    all_sampled_indices.reserve(num_iterations);
-    for (int i = 0; i < num_iterations; i++) {
-        all_sampled_indices.push_back(sampler(ransac_n));
-    }
-
-    // Return if ransac_n is less than the required plane model parameters.
     if (ransac_n < 3) {
         utility::LogError(
                 "ransac_n should be set to higher than or equal to 3.");
@@ -181,6 +166,16 @@ std::tuple<Eigen::Vector4d, std::vector<size_t>> PointCloud::SegmentPlane(
         utility::LogError("There must be at least 'ransac_n' points.");
         return std::make_tuple(Eigen::Vector4d(0, 0, 0, 0),
                                std::vector<size_t>{});
+    }
+
+    RANSACResult result;
+    Eigen::Vector4d best_plane_model = Eigen::Vector4d(0, 0, 0, 0);
+
+    RandomSampler<size_t> sampler(num_points);
+    std::vector<std::vector<size_t>> all_sampled_indices;
+    all_sampled_indices.reserve(num_iterations);
+    for (int i = 0; i < num_iterations; i++) {
+        all_sampled_indices.push_back(sampler(ransac_n));
     }
 
     // Use size_t here to avoid large integer which acceed max of int.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [X] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

Just a small fix, but if the number of points in the pointcloud is smaller than `ransac_n`, `segment_plane` is caught in an infinite loop and does not terminate.
It's a bit of an unlikely scenario, but I did stumble across it because I was fitting planes on clustering results, and one of those point clusters only had two points.

The reason for the infinite loop is because `RandomSampler` is called with `num_points`
https://github.com/isl-org/Open3D/blob/fcc396e494dd3f1204e53571f37400cac50976ef/cpp/open3d/geometry/PointCloudSegmentation.cpp#L164-L165

, so in the case of `num_points < ransac_n` the condition can never become true in `RandomSampler`:
https://github.com/isl-org/Open3D/blob/fcc396e494dd3f1204e53571f37400cac50976ef/cpp/open3d/geometry/PointCloudSegmentation.cpp#L37-L45

Code to reproduce:
```
import open3d as o3d
import numpy as np

num_points = 2
points = np.random.rand(num_points, 3)
pcd = o3d.geometry.PointCloud()
pcd.points = o3d.utility.Vector3dVector(points)
plane_model, inliers = pcd.segment_plane(distance_threshold=0.01,
                                         ransac_n=3,
                                         num_iterations=1000)
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [X] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [X] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [X] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

* I just moved the already existing checks for this to before the RandomSampler is called so this error can actually be caught
* I also removed some of the comments around this part of the code, as they are redundant in my opinion
