### PR TITLE
fix bug that cannot call torch/tf under open3d.ml

### DIFF
--- a/python/open3d/ml/__init__.py
+++ b/python/open3d/ml/__init__.py
@@ -7,6 +7,7 @@
 
 import os as _os
 import open3d as _open3d
+from open3d import _build_config
 if _open3d.__DEVICE_API__ == 'cuda':
     from open3d.cuda.pybind.ml import *
 else:
@@ -16,3 +17,7 @@ from . import configs
 from . import datasets
 from . import vis
 from . import utils
+if _build_config["BUILD_TENSORFLOW_OPS"]:
+    from . import tf
+if _build_config["BUILD_PYTORCH_OPS"]:
+    from . import torch


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [ ] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
At present, we can only directly import ml module via `import open3d.ml.torch`, but cannot call torch/tf under `open3d.ml` module. 
![e4aa23b249bf5fab17e84014c3997b16](https://github.com/user-attachments/assets/d0df3024-2ee7-4e96-97ee-03ce9e018f64)
This PR solve this problem by import torch if `BUILD_PYTORCH_OPS` is set as well as import tf if  `BUILD_TENSORFLOW_OPS` is set in `python\open3d\ml\__init__.py`.
After apply this change , torch can be find under `open3d.ml` when I built from source with `BUILD_PYTORCH_OPS` on.
![image](https://github.com/user-attachments/assets/fa4aba93-40c0-405b-b067-99a745708f36)

