### PR TITLE
Copy SampleCount when making a copy of FilamentView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Main
+-   Fix MSAA sample count not being copied when FilamentView is copied
 -   Fix TriangleMesh::SamplePointsUniformly and TriangleMesh::SamplePointsPoissonDisk now sampling colors from mesh if available (PR #6842)
 -   Fix TriangleMesh::SamplePointsUniformly not sampling triangle meshes uniformly (PR #6653)
 -   Fix tensor based TSDF integration example.

--- a/cpp/open3d/visualization/rendering/filament/FilamentView.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentView.cpp
@@ -355,6 +355,7 @@ void FilamentView::CopySettingsFrom(const FilamentView& other) {
     if (other.color_grading_) {
         view_->setColorGrading(other.color_grading_);
     }
+    view_->setSampleCount(other.view_->getSampleCount());
     auto ao_options = other.view_->getAmbientOcclusionOptions();
     view_->setAmbientOcclusionOptions(ao_options);
     auto aa_mode = other.view_->getAntiAliasing();


### PR DESCRIPTION
If that function doesn't copy the sample count, the copied view will not be an exact copy - it'll contain the default sample count (=4), and not the sample count of the view it's copying from.

## Type

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes - separate issue not created, just see above problem & fix

## Motivation and Context

See above.

## Checklist:

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

See above.
