### PR TITLE
FarthestPointDownSample: arg to specify start index to start downsampling from

### DIFF
--- a/cpp/open3d/geometry/PointCloud.cpp
+++ b/cpp/open3d/geometry/PointCloud.cpp
@@ -523,9 +523,8 @@ std::shared_ptr<PointCloud> PointCloud::FarthestPointDownSample(
                 "Illegal number of samples: {}, must <= point size: {}",
                 num_samples, points_.size());
     } else if (start_index >= points_.size()) {
-        utility::LogError(
-                "Illegal start index: {}, must < point size: {}",
-                start_index, points_.size());
+        utility::LogError("Illegal start index: {}, must < point size: {}",
+                          start_index, points_.size());
     }
     // We can also keep track of the non-selected indices with unordered_set,
     // but since typically num_samples << num_points, it may not be worth it.

--- a/cpp/open3d/geometry/PointCloud.cpp
+++ b/cpp/open3d/geometry/PointCloud.cpp
@@ -508,6 +508,12 @@ std::shared_ptr<PointCloud> PointCloud::RandomDownSample(
 
 std::shared_ptr<PointCloud> PointCloud::FarthestPointDownSample(
         size_t num_samples) const {
+    constexpr size_t start_index = 0;
+    return FarthestPointDownSample(num_samples, start_index);
+}
+
+std::shared_ptr<PointCloud> PointCloud::FarthestPointDownSample(
+        size_t num_samples, const size_t start_index) const {
     if (num_samples == 0) {
         return std::make_shared<PointCloud>();
     } else if (num_samples == points_.size()) {
@@ -516,6 +522,10 @@ std::shared_ptr<PointCloud> PointCloud::FarthestPointDownSample(
         utility::LogError(
                 "Illegal number of samples: {}, must <= point size: {}",
                 num_samples, points_.size());
+    } else if (start_index >= points_.size()) {
+        utility::LogError(
+                "Illegal start index: {}, must < point size: {}",
+                start_index, points_.size());
     }
     // We can also keep track of the non-selected indices with unordered_set,
     // but since typically num_samples << num_points, it may not be worth it.
@@ -524,7 +534,7 @@ std::shared_ptr<PointCloud> PointCloud::FarthestPointDownSample(
     const size_t num_points = points_.size();
     std::vector<double> distances(num_points,
                                   std::numeric_limits<double>::infinity());
-    size_t farthest_index = 0;
+    size_t farthest_index = start_index;
     for (size_t i = 0; i < num_samples; i++) {
         selected_indices.push_back(farthest_index);
         const Eigen::Vector3d &selected = points_[farthest_index];

--- a/cpp/open3d/geometry/PointCloud.cpp
+++ b/cpp/open3d/geometry/PointCloud.cpp
@@ -507,13 +507,13 @@ std::shared_ptr<PointCloud> PointCloud::RandomDownSample(
 }
 
 std::shared_ptr<PointCloud> PointCloud::FarthestPointDownSample(
-        size_t num_samples) const {
+        const size_t num_samples) const {
     constexpr size_t start_index = 0;
     return FarthestPointDownSample(num_samples, start_index);
 }
 
 std::shared_ptr<PointCloud> PointCloud::FarthestPointDownSample(
-        size_t num_samples, const size_t start_index) const {
+        const size_t num_samples, const size_t start_index) const {
     if (num_samples == 0) {
         return std::make_shared<PointCloud>();
     } else if (num_samples == points_.size()) {

--- a/cpp/open3d/geometry/PointCloud.cpp
+++ b/cpp/open3d/geometry/PointCloud.cpp
@@ -507,12 +507,6 @@ std::shared_ptr<PointCloud> PointCloud::RandomDownSample(
 }
 
 std::shared_ptr<PointCloud> PointCloud::FarthestPointDownSample(
-        const size_t num_samples) const {
-    constexpr size_t start_index = 0;
-    return FarthestPointDownSample(num_samples, start_index);
-}
-
-std::shared_ptr<PointCloud> PointCloud::FarthestPointDownSample(
         const size_t num_samples, const size_t start_index) const {
     if (num_samples == 0) {
         return std::make_shared<PointCloud>();

--- a/cpp/open3d/geometry/PointCloud.h
+++ b/cpp/open3d/geometry/PointCloud.h
@@ -179,6 +179,17 @@ public:
     std::shared_ptr<PointCloud> FarthestPointDownSample(
             size_t num_samples) const;
 
+    /// \brief Function to downsample input pointcloud into output pointcloud
+    /// with a set of points has farthest distance.
+    ///
+    /// The sample is performed by selecting the farthest point from previous
+    /// selected points iteratively, starting from `start_index`.
+    ///
+    /// \param num_samples Number of points to be sampled.
+    /// \param start_index Index to start downsampling from.
+    std::shared_ptr<PointCloud> FarthestPointDownSample(
+            size_t num_samples, const size_t start_index) const;
+
     /// \brief Function to crop pointcloud into output pointcloud
     ///
     /// All points with coordinates outside the bounding box \p bbox are

--- a/cpp/open3d/geometry/PointCloud.h
+++ b/cpp/open3d/geometry/PointCloud.h
@@ -177,7 +177,7 @@ public:
     ///
     /// \param num_samples Number of points to be sampled.
     std::shared_ptr<PointCloud> FarthestPointDownSample(
-            size_t num_samples) const;
+            const size_t num_samples) const;
 
     /// \brief Function to downsample input pointcloud into output pointcloud
     /// with a set of points has farthest distance.
@@ -188,7 +188,7 @@ public:
     /// \param num_samples Number of points to be sampled.
     /// \param start_index Index to start downsampling from.
     std::shared_ptr<PointCloud> FarthestPointDownSample(
-            size_t num_samples, const size_t start_index) const;
+            const size_t num_samples, const size_t start_index) const;
 
     /// \brief Function to crop pointcloud into output pointcloud
     ///

--- a/cpp/open3d/geometry/PointCloud.h
+++ b/cpp/open3d/geometry/PointCloud.h
@@ -173,22 +173,12 @@ public:
     /// with a set of points has farthest distance.
     ///
     /// The sample is performed by selecting the farthest point from previous
-    /// selected points iteratively.
-    ///
-    /// \param num_samples Number of points to be sampled.
-    std::shared_ptr<PointCloud> FarthestPointDownSample(
-            const size_t num_samples) const;
-
-    /// \brief Function to downsample input pointcloud into output pointcloud
-    /// with a set of points has farthest distance.
-    ///
-    /// The sample is performed by selecting the farthest point from previous
     /// selected points iteratively, starting from `start_index`.
     ///
     /// \param num_samples Number of points to be sampled.
     /// \param start_index Index to start downsampling from.
     std::shared_ptr<PointCloud> FarthestPointDownSample(
-            const size_t num_samples, const size_t start_index) const;
+            const size_t num_samples, const size_t start_index = 0) const;
 
     /// \brief Function to crop pointcloud into output pointcloud
     ///

--- a/cpp/open3d/t/geometry/PointCloud.cpp
+++ b/cpp/open3d/t/geometry/PointCloud.cpp
@@ -384,11 +384,6 @@ PointCloud PointCloud::RandomDownSample(double sampling_ratio) const {
             false, false);
 }
 
-PointCloud PointCloud::FarthestPointDownSample(const size_t num_samples) const {
-    constexpr size_t start_index = 0;
-    return FarthestPointDownSample(num_samples, start_index);
-}
-
 PointCloud PointCloud::FarthestPointDownSample(const size_t num_samples,
                                                const size_t start_index) const {
     const core::Dtype dtype = GetPointPositions().GetDtype();

--- a/cpp/open3d/t/geometry/PointCloud.cpp
+++ b/cpp/open3d/t/geometry/PointCloud.cpp
@@ -389,8 +389,8 @@ PointCloud PointCloud::FarthestPointDownSample(const size_t num_samples) const {
     return FarthestPointDownSample(num_samples, start_index);
 }
 
-PointCloud PointCloud::FarthestPointDownSample(
-        const size_t num_samples, const size_t start_index) const {
+PointCloud PointCloud::FarthestPointDownSample(const size_t num_samples,
+                                               const size_t start_index) const {
     const core::Dtype dtype = GetPointPositions().GetDtype();
     const int64_t num_points = GetPointPositions().GetLength();
     if (num_samples == 0) {
@@ -402,13 +402,12 @@ PointCloud PointCloud::FarthestPointDownSample(
                 "Illegal number of samples: {}, must <= point size: {}",
                 num_samples, num_points);
     } else if (start_index >= size_t(num_points)) {
-        utility::LogError(
-                "Illegal start index: {}, must <= point size: {}",
-                start_index, num_points);
-    } else if (start_index > static_cast<size_t>(std::numeric_limits<int64_t>::max())) {
-        utility::LogError(
-                "Illegal start index: {}, must <= int64_t max: {}",
-                start_index, std::numeric_limits<int64_t>::max());
+        utility::LogError("Illegal start index: {}, must <= point size: {}",
+                          start_index, num_points);
+    } else if (start_index >
+               static_cast<size_t>(std::numeric_limits<int64_t>::max())) {
+        utility::LogError("Illegal start index: {}, must <= int64_t max: {}",
+                          start_index, std::numeric_limits<int64_t>::max());
     }
     core::Tensor selection_mask =
             core::Tensor::Zeros({num_points}, core::Bool, GetDevice());

--- a/cpp/open3d/t/geometry/PointCloud.cpp
+++ b/cpp/open3d/t/geometry/PointCloud.cpp
@@ -384,13 +384,13 @@ PointCloud PointCloud::RandomDownSample(double sampling_ratio) const {
             false, false);
 }
 
-PointCloud PointCloud::FarthestPointDownSample(size_t num_samples) const {
+PointCloud PointCloud::FarthestPointDownSample(const size_t num_samples) const {
     constexpr size_t start_index = 0;
     return FarthestPointDownSample(num_samples, start_index);
 }
 
 PointCloud PointCloud::FarthestPointDownSample(
-        size_t num_samples, const size_t start_index) const {
+        const size_t num_samples, const size_t start_index) const {
     const core::Dtype dtype = GetPointPositions().GetDtype();
     const int64_t num_points = GetPointPositions().GetLength();
     if (num_samples == 0) {

--- a/cpp/open3d/t/geometry/PointCloud.cpp
+++ b/cpp/open3d/t/geometry/PointCloud.cpp
@@ -399,10 +399,6 @@ PointCloud PointCloud::FarthestPointDownSample(const size_t num_samples,
     } else if (start_index >= size_t(num_points)) {
         utility::LogError("Illegal start index: {}, must <= point size: {}",
                           start_index, num_points);
-    } else if (start_index >
-               static_cast<size_t>(std::numeric_limits<int64_t>::max())) {
-        utility::LogError("Illegal start index: {}, must <= int64_t max: {}",
-                          start_index, std::numeric_limits<int64_t>::max());
     }
     core::Tensor selection_mask =
             core::Tensor::Zeros({num_points}, core::Bool, GetDevice());

--- a/cpp/open3d/t/geometry/PointCloud.h
+++ b/cpp/open3d/t/geometry/PointCloud.h
@@ -352,21 +352,12 @@ public:
     /// points has farthest distance.
     ///
     /// The sampling is performed by selecting the farthest point from previous
-    /// selected points iteratively.
-    ///
-    /// \param num_samples Number of points to be sampled.
-    PointCloud FarthestPointDownSample(const size_t num_samples) const;
-
-    /// \brief Downsample a pointcloud into output pointcloud with a set of
-    /// points has farthest distance.
-    ///
-    /// The sampling is performed by selecting the farthest point from previous
     /// selected points iteratively, starting from `start_index`.
     ///
     /// \param num_samples Number of points to be sampled.
     /// \param start_index Index to start downsampling from.
     PointCloud FarthestPointDownSample(const size_t num_samples,
-                                       const size_t start_index) const;
+                                       const size_t start_index = 0) const;
 
     /// \brief Remove points that have less than \p nb_points neighbors in a
     /// sphere of a given radius.

--- a/cpp/open3d/t/geometry/PointCloud.h
+++ b/cpp/open3d/t/geometry/PointCloud.h
@@ -357,6 +357,16 @@ public:
     /// \param num_samples Number of points to be sampled.
     PointCloud FarthestPointDownSample(size_t num_samples) const;
 
+    /// \brief Downsample a pointcloud into output pointcloud with a set of
+    /// points has farthest distance.
+    ///
+    /// The sampling is performed by selecting the farthest point from previous
+    /// selected points iteratively, starting from `start_index`.
+    ///
+    /// \param num_samples Number of points to be sampled.
+    /// \param start_index Index to start downsampling from.
+    PointCloud FarthestPointDownSample(size_t num_samples, const size_t start_index) const;
+
     /// \brief Remove points that have less than \p nb_points neighbors in a
     /// sphere of a given radius.
     ///

--- a/cpp/open3d/t/geometry/PointCloud.h
+++ b/cpp/open3d/t/geometry/PointCloud.h
@@ -355,7 +355,7 @@ public:
     /// selected points iteratively.
     ///
     /// \param num_samples Number of points to be sampled.
-    PointCloud FarthestPointDownSample(size_t num_samples) const;
+    PointCloud FarthestPointDownSample(const size_t num_samples) const;
 
     /// \brief Downsample a pointcloud into output pointcloud with a set of
     /// points has farthest distance.
@@ -365,7 +365,7 @@ public:
     ///
     /// \param num_samples Number of points to be sampled.
     /// \param start_index Index to start downsampling from.
-    PointCloud FarthestPointDownSample(size_t num_samples, const size_t start_index) const;
+    PointCloud FarthestPointDownSample(const size_t num_samples, const size_t start_index) const;
 
     /// \brief Remove points that have less than \p nb_points neighbors in a
     /// sphere of a given radius.

--- a/cpp/open3d/t/geometry/PointCloud.h
+++ b/cpp/open3d/t/geometry/PointCloud.h
@@ -365,7 +365,8 @@ public:
     ///
     /// \param num_samples Number of points to be sampled.
     /// \param start_index Index to start downsampling from.
-    PointCloud FarthestPointDownSample(const size_t num_samples, const size_t start_index) const;
+    PointCloud FarthestPointDownSample(const size_t num_samples,
+                                       const size_t start_index) const;
 
     /// \brief Remove points that have less than \p nb_points neighbors in a
     /// sphere of a given radius.

--- a/cpp/pybind/geometry/pointcloud.cpp
+++ b/cpp/pybind/geometry/pointcloud.cpp
@@ -85,16 +85,7 @@ void pybind_pointcloud_definitions(py::module &m) {
                  "sampling the indexes from the point cloud.",
                  "sampling_ratio"_a)
             .def("farthest_point_down_sample",
-                 py::overload_cast<size_t>(&PointCloud::FarthestPointDownSample,
-                                           py::const_),
-                 "Downsamples input pointcloud into output pointcloud with a "
-                 "set of points has farthest distance. The sample is performed "
-                 "by selecting the farthest point from previous selected "
-                 "points iteratively.",
-                 "num_samples"_a)
-            .def("farthest_point_down_sample",
-                 py::overload_cast<size_t, size_t>(
-                         &PointCloud::FarthestPointDownSample, py::const_),
+                 &PointCloud::FarthestPointDownSample,
                  "Downsamples input pointcloud into output pointcloud with a "
                  "set of points has farthest distance. The sample is performed "
                  "by selecting the farthest point from previous selected "
@@ -103,7 +94,7 @@ void pybind_pointcloud_definitions(py::module &m) {
                  "Index to start downsampling from. Valid index is a "
                  "non-negative number less than number of points in the "
                  "input pointcloud.",
-                 "start_index"_a)
+                 "start_index"_a = 0)
             .def("crop",
                  (std::shared_ptr<PointCloud>(PointCloud::*)(
                          const AxisAlignedBoundingBox &, bool) const) &

--- a/cpp/pybind/geometry/pointcloud.cpp
+++ b/cpp/pybind/geometry/pointcloud.cpp
@@ -85,12 +85,23 @@ void pybind_pointcloud_definitions(py::module &m) {
                  "sampling the indexes from the point cloud.",
                  "sampling_ratio"_a)
             .def("farthest_point_down_sample",
-                 &PointCloud::FarthestPointDownSample,
+                 py::overload_cast<size_t>(&PointCloud::FarthestPointDownSample, py::const_),
                  "Downsamples input pointcloud into output pointcloud with a "
                  "set of points has farthest distance. The sample is performed "
                  "by selecting the farthest point from previous selected "
                  "points iteratively.",
                  "num_samples"_a)
+            .def("farthest_point_down_sample",
+                 py::overload_cast<size_t, size_t>(&PointCloud::FarthestPointDownSample, py::const_),
+                 "Downsamples input pointcloud into output pointcloud with a "
+                 "set of points has farthest distance. The sample is performed "
+                 "by selecting the farthest point from previous selected "
+                 "points iteratively.",
+                 "num_samples"_a,
+                 "Index to start downsampling from. Valid index is a "
+                 "non-negative number less than number of points in the "
+                 "input pointcloud.",
+                 "start_index"_a)
             .def("crop",
                  (std::shared_ptr<PointCloud>(PointCloud::*)(
                          const AxisAlignedBoundingBox &, bool) const) &

--- a/cpp/pybind/geometry/pointcloud.cpp
+++ b/cpp/pybind/geometry/pointcloud.cpp
@@ -85,14 +85,16 @@ void pybind_pointcloud_definitions(py::module &m) {
                  "sampling the indexes from the point cloud.",
                  "sampling_ratio"_a)
             .def("farthest_point_down_sample",
-                 py::overload_cast<size_t>(&PointCloud::FarthestPointDownSample, py::const_),
+                 py::overload_cast<size_t>(&PointCloud::FarthestPointDownSample,
+                                           py::const_),
                  "Downsamples input pointcloud into output pointcloud with a "
                  "set of points has farthest distance. The sample is performed "
                  "by selecting the farthest point from previous selected "
                  "points iteratively.",
                  "num_samples"_a)
             .def("farthest_point_down_sample",
-                 py::overload_cast<size_t, size_t>(&PointCloud::FarthestPointDownSample, py::const_),
+                 py::overload_cast<size_t, size_t>(
+                         &PointCloud::FarthestPointDownSample, py::const_),
                  "Downsamples input pointcloud into output pointcloud with a "
                  "set of points has farthest distance. The sample is performed "
                  "by selecting the farthest point from previous selected "

--- a/cpp/pybind/t/geometry/pointcloud.cpp
+++ b/cpp/pybind/t/geometry/pointcloud.cpp
@@ -251,16 +251,7 @@ Example:
                    "and its attributes.",
                    "sampling_ratio"_a);
     pointcloud.def("farthest_point_down_sample",
-                   py::overload_cast<size_t>(
-                           &PointCloud::FarthestPointDownSample, py::const_),
-                   "Downsample a pointcloud into output pointcloud with a set "
-                   "of points has farthest distance.The sampling is performed "
-                   "by selecting the farthest point from previous selected "
-                   "points iteratively",
-                   "num_samples"_a);
-    pointcloud.def("farthest_point_down_sample",
-                   py::overload_cast<size_t, size_t>(
-                           &PointCloud::FarthestPointDownSample, py::const_),
+                   &PointCloud::FarthestPointDownSample,
                    "Downsample a pointcloud into output pointcloud with a set "
                    "of points has farthest distance.The sampling is performed "
                    "by selecting the farthest point from previous selected "
@@ -269,7 +260,7 @@ Example:
                    "Index to start downsampling from. Valid index is a "
                    "non-negative number less than number of points in the "
                    "input pointcloud.",
-                   "start_index"_a);
+                   "start_index"_a = 0);
     pointcloud.def("remove_radius_outliers", &PointCloud::RemoveRadiusOutliers,
                    "nb_points"_a, "search_radius"_a,
                    R"(Remove points that have less than nb_points neighbors in a

--- a/cpp/pybind/t/geometry/pointcloud.cpp
+++ b/cpp/pybind/t/geometry/pointcloud.cpp
@@ -251,14 +251,16 @@ Example:
                    "and its attributes.",
                    "sampling_ratio"_a);
     pointcloud.def("farthest_point_down_sample",
-                   py::overload_cast<size_t>(&PointCloud::FarthestPointDownSample, py::const_),
+                   py::overload_cast<size_t>(
+                           &PointCloud::FarthestPointDownSample, py::const_),
                    "Downsample a pointcloud into output pointcloud with a set "
                    "of points has farthest distance.The sampling is performed "
                    "by selecting the farthest point from previous selected "
                    "points iteratively",
                    "num_samples"_a);
     pointcloud.def("farthest_point_down_sample",
-                   py::overload_cast<size_t, size_t>(&PointCloud::FarthestPointDownSample, py::const_),
+                   py::overload_cast<size_t, size_t>(
+                           &PointCloud::FarthestPointDownSample, py::const_),
                    "Downsample a pointcloud into output pointcloud with a set "
                    "of points has farthest distance.The sampling is performed "
                    "by selecting the farthest point from previous selected "

--- a/cpp/pybind/t/geometry/pointcloud.cpp
+++ b/cpp/pybind/t/geometry/pointcloud.cpp
@@ -251,12 +251,23 @@ Example:
                    "and its attributes.",
                    "sampling_ratio"_a);
     pointcloud.def("farthest_point_down_sample",
-                   &PointCloud::FarthestPointDownSample,
+                   py::overload_cast<size_t>(&PointCloud::FarthestPointDownSample, py::const_),
                    "Downsample a pointcloud into output pointcloud with a set "
                    "of points has farthest distance.The sampling is performed "
                    "by selecting the farthest point from previous selected "
                    "points iteratively",
                    "num_samples"_a);
+    pointcloud.def("farthest_point_down_sample",
+                   py::overload_cast<size_t, size_t>(&PointCloud::FarthestPointDownSample, py::const_),
+                   "Downsample a pointcloud into output pointcloud with a set "
+                   "of points has farthest distance.The sampling is performed "
+                   "by selecting the farthest point from previous selected "
+                   "points iteratively",
+                   "num_samples"_a,
+                   "Index to start downsampling from. Valid index is a "
+                   "non-negative number less than number of points in the "
+                   "input pointcloud.",
+                   "start_index"_a);
     pointcloud.def("remove_radius_outliers", &PointCloud::RemoveRadiusOutliers,
                    "nb_points"_a, "search_radius"_a,
                    R"(Remove points that have less than nb_points neighbors in a

--- a/cpp/pybind/t/geometry/pointcloud.cpp
+++ b/cpp/pybind/t/geometry/pointcloud.cpp
@@ -667,7 +667,8 @@ Example:
               "in the pointcloud."}});
     docstring::ClassMethodDocInject(
             m, "PointCloud", "farthest_point_down_sample",
-            {{"num_samples", "Number of points to be sampled."}});
+            {{"num_samples", "Number of points to be sampled."},
+             {"start_index", "Index of point to start downsampling from."}});
     docstring::ClassMethodDocInject(
             m, "PointCloud", "remove_radius_outliers",
             {{"nb_points",

--- a/cpp/tests/geometry/PointCloud.cpp
+++ b/cpp/tests/geometry/PointCloud.cpp
@@ -882,7 +882,7 @@ TEST(PointCloud, FarthestPointDownSample) {
                                                               {1.0, 1.0, 0},
                                                               {1.0, 0, 1.0},
                                                               {0, 1.0, 1.0}}));
-}  // namespace tests
+}
 
 TEST(PointCloud, Crop_AxisAlignedBoundingBox) {
     geometry::AxisAlignedBoundingBox aabb({0, 0, 0}, {2, 2, 2});

--- a/cpp/tests/geometry/PointCloud.cpp
+++ b/cpp/tests/geometry/PointCloud.cpp
@@ -876,10 +876,8 @@ TEST(PointCloud, FarthestPointDownSample) {
                               {1.0, 0, 1.0},
                               {0, 1.0, 1.0},
                               {1.0, 1.0, 1.5}});
-    std::vector<Eigen::Vector3d> expected = {{0, 2.0, 0},
-                                             {1.0, 1.0, 0},
-                                             {1.0, 0, 1.0},
-                                             {0, 1.0, 1.0}};
+    std::vector<Eigen::Vector3d> expected = {
+            {0, 2.0, 0}, {1.0, 1.0, 0}, {1.0, 0, 1.0}, {0, 1.0, 1.0}};
     std::shared_ptr<geometry::PointCloud> pcd_down =
             pcd.FarthestPointDownSample(4);
     std::shared_ptr<geometry::PointCloud> pcd_down_2 =

--- a/cpp/tests/geometry/PointCloud.cpp
+++ b/cpp/tests/geometry/PointCloud.cpp
@@ -876,12 +876,16 @@ TEST(PointCloud, FarthestPointDownSample) {
                               {1.0, 0, 1.0},
                               {0, 1.0, 1.0},
                               {1.0, 1.0, 1.5}});
+    std::vector<Eigen::Vector3d> expected = {{0, 2.0, 0},
+                                             {1.0, 1.0, 0},
+                                             {1.0, 0, 1.0},
+                                             {0, 1.0, 1.0}};
     std::shared_ptr<geometry::PointCloud> pcd_down =
             pcd.FarthestPointDownSample(4);
-    ExpectEQ(pcd_down->points_, std::vector<Eigen::Vector3d>({{0, 2.0, 0},
-                                                              {1.0, 1.0, 0},
-                                                              {1.0, 0, 1.0},
-                                                              {0, 1.0, 1.0}}));
+    std::shared_ptr<geometry::PointCloud> pcd_down_2 =
+            pcd.FarthestPointDownSample(4, 0);
+    ExpectEQ(pcd_down->points_, expected);
+    ExpectEQ(pcd_down_2->points_, expected);
 }
 
 TEST(PointCloud, Crop_AxisAlignedBoundingBox) {

--- a/cpp/tests/geometry/PointCloud.cpp
+++ b/cpp/tests/geometry/PointCloud.cpp
@@ -876,14 +876,18 @@ TEST(PointCloud, FarthestPointDownSample) {
                               {1.0, 0, 1.0},
                               {0, 1.0, 1.0},
                               {1.0, 1.0, 1.5}});
-    std::vector<Eigen::Vector3d> expected = {
-            {0, 2.0, 0}, {1.0, 1.0, 0}, {1.0, 0, 1.0}, {0, 1.0, 1.0}};
     std::shared_ptr<geometry::PointCloud> pcd_down =
             pcd.FarthestPointDownSample(4);
+    std::vector<Eigen::Vector3d> expected = {
+            {0, 2.0, 0}, {1.0, 1.0, 0}, {1.0, 0, 1.0}, {0, 1.0, 1.0}};
+
     std::shared_ptr<geometry::PointCloud> pcd_down_2 =
-            pcd.FarthestPointDownSample(4, 0);
+            pcd.FarthestPointDownSample(4, 4);
+    std::vector<Eigen::Vector3d> expected_2 = {
+            {0, 2.0, 0}, {1.0, 1.0, 0}, {0, 0, 1.0}, {1.0, 1.0, 1.5}};
+
     ExpectEQ(pcd_down->points_, expected);
-    ExpectEQ(pcd_down_2->points_, expected);
+    ExpectEQ(pcd_down_2->points_, expected_2);
 }
 
 TEST(PointCloud, Crop_AxisAlignedBoundingBox) {

--- a/cpp/tests/t/geometry/PointCloud.cpp
+++ b/cpp/tests/t/geometry/PointCloud.cpp
@@ -954,11 +954,14 @@ TEST_P(PointCloudPermuteDevices, FarthestPointDownSample) {
                                        {0, 1.0, 1.0},
                                        {1.0, 1.0, 1.5}},
                                       device));
-    auto pcd_small_down = pcd_small.FarthestPointDownSample(4);
-    EXPECT_TRUE(pcd_small_down.GetPointPositions().AllClose(
-            core::Tensor::Init<float>(
+
+    auto expected = core::Tensor::Init<float>(
                     {{0, 2.0, 0}, {1.0, 1.0, 0}, {1.0, 0, 1.0}, {0, 1.0, 1.0}},
-                    device)));
+                    device);
+    auto pcd_small_down = pcd_small.FarthestPointDownSample(4);
+    auto pcd_small_down_2 = pcd_small.FarthestPointDownSample(4, 0);
+    EXPECT_TRUE(pcd_small_down.GetPointPositions().AllClose(expected));
+    EXPECT_TRUE(pcd_small_down_2.GetPointPositions().AllClose(expected));
 }
 
 TEST_P(PointCloudPermuteDevices, RemoveRadiusOutliers) {

--- a/cpp/tests/t/geometry/PointCloud.cpp
+++ b/cpp/tests/t/geometry/PointCloud.cpp
@@ -955,12 +955,16 @@ TEST_P(PointCloudPermuteDevices, FarthestPointDownSample) {
                                        {1.0, 1.0, 1.5}},
                                       device));
 
+    auto pcd_small_down = pcd_small.FarthestPointDownSample(4);
     auto expected = core::Tensor::Init<float>(
             {{0, 2.0, 0}, {1.0, 1.0, 0}, {1.0, 0, 1.0}, {0, 1.0, 1.0}}, device);
-    auto pcd_small_down = pcd_small.FarthestPointDownSample(4);
-    auto pcd_small_down_2 = pcd_small.FarthestPointDownSample(4, 0);
+
+    auto pcd_small_down_2 = pcd_small.FarthestPointDownSample(4, 4);
+    auto expected_2 = core::Tensor::Init<float>(
+            {{0, 2.0, 0}, {1.0, 1.0, 0}, {0, 0, 1.0}, {1.0, 1.0, 1.5}}, device);
+
     EXPECT_TRUE(pcd_small_down.GetPointPositions().AllClose(expected));
-    EXPECT_TRUE(pcd_small_down_2.GetPointPositions().AllClose(expected));
+    EXPECT_TRUE(pcd_small_down_2.GetPointPositions().AllClose(expected_2));
 }
 
 TEST_P(PointCloudPermuteDevices, RemoveRadiusOutliers) {

--- a/cpp/tests/t/geometry/PointCloud.cpp
+++ b/cpp/tests/t/geometry/PointCloud.cpp
@@ -956,8 +956,7 @@ TEST_P(PointCloudPermuteDevices, FarthestPointDownSample) {
                                       device));
 
     auto expected = core::Tensor::Init<float>(
-                    {{0, 2.0, 0}, {1.0, 1.0, 0}, {1.0, 0, 1.0}, {0, 1.0, 1.0}},
-                    device);
+            {{0, 2.0, 0}, {1.0, 1.0, 0}, {1.0, 0, 1.0}, {0, 1.0, 1.0}}, device);
     auto pcd_small_down = pcd_small.FarthestPointDownSample(4);
     auto pcd_small_down_2 = pcd_small.FarthestPointDownSample(4, 0);
     EXPECT_TRUE(pcd_small_down.GetPointPositions().AllClose(expected));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes #7049.

The function `PointCloud::FarthestPointDownSample()` is overloaded to accept a `start_index` in addition to the existing `num_samples`.


## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [x] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context
See ticket linked above.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [x] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [x] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
This PR overloads the existing `PointCloud::FarthestPointDownSample()` to accept `size_t start_index` as the desired index to start farthest point downsampling from. Both `geometry` and `t/geometry` have been updated and checks added to ensure `start_index` is valid. Input arguments `num_samples` and `start_index` are marked `const` (existing `num_samples` was previously not `const`).

Python bindings have been updated with `py::overload_cast`. Docstrings and unit tests have been modified accordingly.
<details>
  <summary>Output of unit tests</summary>

  ```
~/open3d/build$ ./bin/tests --gtest_filter=PointCloud.FarthestPointDownSample*
[Open3D INFO] CompilerInfo: C++ 17, GNU 11.4.0, CUDA disabled.
[Open3D INFO] CPUInfo: 8 cores, 16 threads.
[Open3D INFO] ISAInfo: AVX512SKX instruction set used in ISPC code.
Note: Google Test filter = PointCloud.FarthestPointDownSample*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from PointCloud
[ RUN      ] PointCloud.FarthestPointDownSample
[Open3D DEBUG] Pointcloud down sampled from 8 points to 4 points.
[Open3D DEBUG] Pointcloud down sampled from 8 points to 4 points.
[       OK ] PointCloud.FarthestPointDownSample (0 ms)
[----------] 1 test from PointCloud (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.



~/open3d/build$ ./bin/tests --gtest_filter=PointCloud/PointCloudPermuteDevices.FarthestPointDownSample*
[Open3D INFO] CompilerInfo: C++ 17, GNU 11.4.0, CUDA disabled.
[Open3D INFO] CPUInfo: 8 cores, 16 threads.
[Open3D INFO] ISAInfo: AVX512SKX instruction set used in ISPC code.
Note: Google Test filter = PointCloud/PointCloudPermuteDevices.FarthestPointDownSample*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from PointCloud/PointCloudPermuteDevices
[ RUN      ] PointCloud/PointCloudPermuteDevices.FarthestPointDownSample/0
[Open3D DEBUG] Pointcloud down sampled from 8 points to 4 points.
[Open3D DEBUG] Pointcloud down sampled from 8 points to 4 points.
[       OK ] PointCloud/PointCloudPermuteDevices.FarthestPointDownSample/0 (2 ms)
[----------] 1 test from PointCloud/PointCloudPermuteDevices (2 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.
  ```

</details>

