### PR TITLE
Changed lambda to lambda_penalty in orient_normals_consistent_tangent_plane

### DIFF
--- a/cpp/pybind/geometry/pointcloud.cpp
+++ b/cpp/pybind/geometry/pointcloud.cpp
@@ -150,7 +150,7 @@ void pybind_pointcloud_definitions(py::module &m) {
                  &PointCloud::OrientNormalsConsistentTangentPlane,
                  "Function to orient the normals with respect to consistent "
                  "tangent planes",
-                 "k"_a, "lambda"_a = 0.0, "cos_alpha_tol"_a = 1.0)
+                 "k"_a, "lambda_penalty"_a = 0.0, "cos_alpha_tol"_a = 1.0)
             .def("compute_point_cloud_distance",
                  &PointCloud::ComputePointCloudDistance,
                  "For each point in the source point cloud, compute the "

--- a/cpp/pybind/t/geometry/pointcloud.cpp
+++ b/cpp/pybind/t/geometry/pointcloud.cpp
@@ -331,17 +331,17 @@ Return:
     pointcloud.def(
             "orient_normals_consistent_tangent_plane",
             &PointCloud::OrientNormalsConsistentTangentPlane, "k"_a,
-            "lambda"_a = 0.0, "cos_alpha_tol"_a = 1.0,
+            "lambda_penalty"_a = 0.0, "cos_alpha_tol"_a = 1.0,
             R"(Function to consistently orient the normals of a point cloud based on tangent planes.
 
 The algorithm is described in Hoppe et al., "Surface Reconstruction from Unorganized Points", 1992.
-Additional information about the choice of lambda and cos_alpha_tol for complex
+Additional information about the choice of lambda_penalty and cos_alpha_tol for complex
 point clouds can be found in Piazza, Valentini, Varetti, "Mesh Reconstruction from Point Cloud", 2023
 (https://eugeniovaretti.github.io/meshreco/Piazza_Valentini_Varetti_MeshReconstructionFromPointCloud_2023.pdf).
 
 Args:
     k (int): Number of neighbors to use for tangent plane estimation.
-    lambda (float): A non-negative real parameter that influences the distance
+    lambda_penalty (float): A non-negative real parameter that influences the distance
         metric used to identify the true neighbors of a point in complex
         geometries. It penalizes the distance between a point and the tangent
         plane defined by the reference point and its normal vector, helping to
@@ -354,7 +354,7 @@ Args:
 Example:
     We use Bunny point cloud to compute its normals and orient them consistently.
     The initial reconstruction adheres to Hoppe's algorithm (raw), whereas the
-    second reconstruction utilises the lambda and cos_alpha_tol parameters.
+    second reconstruction utilises the lambda_penalty and cos_alpha_tol parameters.
     Due to the high density of the Bunny point cloud available in Open3D a larger
     value of the parameter k is employed to test the algorithm.  Usually you do
     not have at disposal such a refined point clouds, thus you cannot find a
@@ -379,7 +379,7 @@ Example:
         poisson_mesh.compute_vertex_normals()
         o3d.visualization.draw_geometries([poisson_mesh])
 
-        # Case 2, reconstruction using lambda and cos_alpha_tol parameters:
+        # Case 2, reconstruction using lambda_penalty and cos_alpha_tol parameters:
         pcd_robust = o3d.io.read_point_cloud(data.path)
 
         # Compute normals and orient them consistently, using k=100 neighbours


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

`lambda` is a [reserved keyword](https://docs.python.org/3/reference/lexical_analysis.html#keywords) in python.
Using it as a keyword argument causes an invalid syntax error:
```python
    import open3d as o3d
    p = o3d.t.geometry.PointCloud()
    p.point.positions = o3d.core.Tensor([[10, 10, 10], [1, 1, 1], [0, 0, 1], [0, 0, 0]], dtype=o3d.core.float64) 
    p.point.normals = o3d.core.Tensor([[1, 0, 0], [1, 0, 0], [1, 0, 0], [1, 0, 0]], dtype=o3d.core.float64) 
    p.orient_normals_consistent_tangent_plane(1, 10) # No error
    p.orient_normals_consistent_tangent_plane(1, lambda=10) # SyntaxError
                                                       ^
SyntaxError: invalid syntax
```
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [x] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
This PR replaces `lambda` with `lambda_penalty`
Existing code should usually not break (since using `lambda` as a keyword argument is already broken).
Except if somebody is using dict unpacking to populate parameters.
E.g., `p.orient_normals_consistent_tangent_plane(1, **{"lambda": 10})`.
This would have to be change to use `lambda_penalty`.

This is a fix used in  #6917 since mypy would complain about lambda in generated stubs.
