### PR TITLE
Changed draw_geometries to use default args instead of overload

### DIFF
--- a/cpp/open3d/visualization/utility/DrawGeometry.cpp
+++ b/cpp/open3d/visualization/utility/DrawGeometry.cpp
@@ -35,7 +35,7 @@ bool DrawGeometries(const std::vector<std::shared_ptr<const geometry::Geometry>>
                     Eigen::Vector3d *lookat /* = nullptr */,
                     Eigen::Vector3d *up /* = nullptr */,
                     Eigen::Vector3d *front /* = nullptr */,
-                    double *zoom /* = zoom */) {
+                    double *zoom /* = nullptr */) {
     Visualizer visualizer;
     if (!visualizer.CreateVisualizerWindow(window_name, width, height, left,
                                            top)) {

--- a/cpp/pybind/visualization/utility.cpp
+++ b/cpp/pybind/visualization/utility.cpp
@@ -133,22 +133,28 @@ void pybind_visualization_utility_definitions(py::module &m) {
                        &geometry_ptrs,
                const std::string &window_name, int width, int height, int left,
                int top, bool point_show_normal, bool mesh_show_wireframe,
-               bool mesh_show_back_face, Eigen::Vector3d lookat,
-               Eigen::Vector3d up, Eigen::Vector3d front, double zoom) {
+               bool mesh_show_back_face,
+               utility::optional<Eigen::Vector3d> lookat,
+               utility::optional<Eigen::Vector3d> up,
+               utility::optional<Eigen::Vector3d> front,
+               utility::optional<double> zoom) {
                 std::string current_dir =
                         utility::filesystem::GetWorkingDirectory();
                 DrawGeometries(geometry_ptrs, window_name, width, height, left,
                                top, point_show_normal, mesh_show_wireframe,
-                               mesh_show_back_face, &lookat, &up, &front,
-                               &zoom);
+                               mesh_show_back_face,
+                               lookat.has_value() ? &lookat.value() : nullptr,
+                               up.has_value() ? &up.value() : nullptr,
+                               front.has_value() ? &front.value() : nullptr,
+                               zoom.has_value() ? &zoom.value() : nullptr);
                 utility::filesystem::ChangeWorkingDirectory(current_dir);
             },
             "Function to draw a list of geometry::Geometry objects",
             "geometry_list"_a, "window_name"_a = "Open3D", "width"_a = 1920,
             "height"_a = 1080, "left"_a = 50, "top"_a = 50,
             "point_show_normal"_a = false, "mesh_show_wireframe"_a = false,
-            "mesh_show_back_face"_a = false, "lookat"_a, "up"_a, "front"_a,
-            "zoom"_a);
+            "mesh_show_back_face"_a = false, "lookat"_a = py::none(),
+            "up"_a = py::none(), "front"_a = py::none(), "zoom"_a = py::none());
     docstring::FunctionDocInject(m, "draw_geometries",
                                  map_shared_argument_docstrings);
 

--- a/cpp/pybind/visualization/utility.cpp
+++ b/cpp/pybind/visualization/utility.cpp
@@ -114,25 +114,6 @@ void pybind_visualization_utility_definitions(py::module &m) {
                        &geometry_ptrs,
                const std::string &window_name, int width, int height, int left,
                int top, bool point_show_normal, bool mesh_show_wireframe,
-               bool mesh_show_back_face) {
-                std::string current_dir =
-                        utility::filesystem::GetWorkingDirectory();
-                DrawGeometries(geometry_ptrs, window_name, width, height, left,
-                               top, point_show_normal, mesh_show_wireframe,
-                               mesh_show_back_face);
-                utility::filesystem::ChangeWorkingDirectory(current_dir);
-            },
-            "Function to draw a list of geometry::Geometry objects",
-            "geometry_list"_a, "window_name"_a = "Open3D", "width"_a = 1920,
-            "height"_a = 1080, "left"_a = 50, "top"_a = 50,
-            "point_show_normal"_a = false, "mesh_show_wireframe"_a = false,
-            "mesh_show_back_face"_a = false);
-    m.def(
-            "draw_geometries",
-            [](const std::vector<std::shared_ptr<const geometry::Geometry>>
-                       &geometry_ptrs,
-               const std::string &window_name, int width, int height, int left,
-               int top, bool point_show_normal, bool mesh_show_wireframe,
                bool mesh_show_back_face,
                utility::optional<Eigen::Vector3d> lookat,
                utility::optional<Eigen::Vector3d> up,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Currently, `o3d.visualization.draw_geometries` uses overloading to provide default values for `lookat`, `up`, `front`, and `zoom`. 
This causes two problems:
* It defines a function with default arguments before non-default arguments (forbidden by [The Python Language Reference](https://docs.python.org/3/reference/compound_stmts.html#function-definitions))
* It clutters the documentation with redundancy (see [docs/0.18.0/python_api/open3d.visualization.draw_geometries](https://www.open3d.org/docs/0.18.0/python_api/open3d.visualization.draw_geometries.html))
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [x] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
This PR uses `utility::optional` to provide a single binding function (no overload) with a clean argument list.
The arguments are in line with the cpp implementation (which also uses default args).
This solution avoids named args before positional args.

This is a fix used in #6917 since `mypy` would complain about `non-default argument follows default argument  [syntax]`.