### PR TITLE
Changed namespace fix to use Sphinx autodoc-process-* events

### DIFF
--- a/cpp/pybind/docstring.cpp
+++ b/cpp/pybind/docstring.cpp
@@ -289,17 +289,9 @@ std::string FunctionDoc::ToGoogleDocString() const {
     return rc.str();
 }
 
-std::string FunctionDoc::NamespaceFix(const std::string& s) {
-    std::string rc = std::regex_replace(s, std::regex("::(\\S)"), ".$1");
-    rc = std::regex_replace(rc, std::regex("open3d\\.(cpu|cuda)\\.pybind\\."),
-                            "open3d.");
-    return rc;
-}
-
 std::string FunctionDoc::StringCleanAll(std::string& s,
                                         const std::string& white_space) {
     std::string rc = utility::StripString(s, white_space);
-    rc = NamespaceFix(rc);
     return rc;
 }
 
@@ -313,7 +305,7 @@ ArgumentDoc FunctionDoc::ParseArgumentToken(const std::string& argument_token) {
     std::smatch matches;
     if (std::regex_search(argument_token, matches, rgx_with_default)) {
         argument_doc.name_ = matches[1].str();
-        argument_doc.type_ = NamespaceFix(matches[2].str());
+        argument_doc.type_ = matches[2].str();
         argument_doc.default_ = matches[3].str();
 
         // Handle long default value. Long default has multiple lines and thus
@@ -335,7 +327,7 @@ ArgumentDoc FunctionDoc::ParseArgumentToken(const std::string& argument_token) {
                 "([A-Za-z_][A-Za-z\\d_:\\.\\[\\]\\(\\) ,]*)");
         if (std::regex_search(argument_token, matches, rgx_without_default)) {
             argument_doc.name_ = matches[1].str();
-            argument_doc.type_ = NamespaceFix(matches[2].str());
+            argument_doc.type_ = matches[2].str();
         }
     }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -264,8 +264,31 @@ def skip(app, what, name, obj, would_skip, options):
     return would_skip
 
 
+def fix_namespace(text):
+    """Fixes namespace in a string by removing .[cpu|cuda].pybind."""
+    return (text.replace("open3d.cpu.pybind.", "open3d.").replace(
+        "open3d.cuda.pybind.cuda.", "open3d.") if text is not None else None)
+
+
+def process_signature(app, what, name, obj, options, signature,
+                      return_annotation):
+    """Fixes namespace in signature by removing .[cpu|cuda].pybind."""
+    return (
+        fix_namespace(signature),
+        fix_namespace(return_annotation),
+    )
+
+
+def process_docstring(app, what, name, obj, options, lines):
+    """Fixes namespace in docstring by removing .[cpu|cuda].pybind."""
+    for i, line in enumerate(lines):
+        lines[i] = fix_namespace(line)
+
+
 def setup(app):
     app.connect("autodoc-skip-member", skip)
+    app.connect("autodoc-process-signature", process_signature)
+    app.connect("autodoc-process-docstring", process_docstring)
     # Add Google analytics
     app.add_js_file("https://www.googletagmanager.com/gtag/js?id=G-3TQPKGV6Z3",
                     **{'async': 'async'})

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -267,7 +267,7 @@ def skip(app, what, name, obj, would_skip, options):
 def fix_namespace(text):
     """Fixes namespace in a string by removing .[cpu|cuda].pybind."""
     return (text.replace("open3d.cpu.pybind.", "open3d.").replace(
-        "open3d.cuda.pybind.cuda.", "open3d.") if text is not None else None)
+        "open3d.cuda.pybind.", "open3d.") if text is not None else None)
 
 
 def process_signature(app, what, name, obj, options, signature,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Open3D uses namespaces `open3d.cpu.pybind.` and `open3d.cuda.pybind.` to differentiate between both device builds.
This adds a lot of clutter to the documentation (see screenshots below).
There is already a partial fix for functions documented using `docstring::ClassMethodDocInject` and `docstring::FunctionDocInject`.
However, a big part of Open3D does not use those functions for documentation and #7081 removed those from the contribute docs (so they should probably be avoided in the future).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [x] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
This PR moves the namespace fix away from `docstring::ClassMethodDocInject` and `docstring::FunctionDocInject` to the sphinx documentation generation.
It uses the autodoc events `autodoc-process-signature` and `autodoc-process-docstring` to change namespaces to `open3d.` during doc generation.
With this PR all namespaces are fixed in the documentation (checked using the search function).

This is a fix used in https://github.com/isl-org/Open3D/pull/6917 since mypy would complain about missing imports for functions with fixed namespaces.

Notice in the following before/after screenshots that the namespaces in the `clear` function were already fixed due to using `docstring::ClassMethodDocInject`. This PR improves the namespaces in `__init__` and `as_tensor` though, resulting in better readability.

Here before:
![before](https://github.com/user-attachments/assets/8a71e43e-0687-4688-8f20-01d924cddaf1)
and after:
![after](https://github.com/user-attachments/assets/b4265605-f91b-4a1a-8482-f1068ffad1d1)