### PR TITLE
increase voxel size to improve ICP test reliability

### DIFF
--- a/cpp/tests/t/pipelines/registration/Registration.cpp
+++ b/cpp/tests/t/pipelines/registration/Registration.cpp
@@ -63,8 +63,8 @@ GetRegistrationTestData(core::Dtype& dtype, core::Device& device) {
     data::DemoICPPointClouds pcd_fragments;
     t::io::ReadPointCloud(pcd_fragments.GetPaths()[0], source_tpcd);
     t::io::ReadPointCloud(pcd_fragments.GetPaths()[1], target_tpcd);
-    source_tpcd = source_tpcd.To(device).VoxelDownSample(0.02);
-    target_tpcd = target_tpcd.To(device).VoxelDownSample(0.02);
+    source_tpcd = source_tpcd.To(device).VoxelDownSample(0.05);
+    target_tpcd = target_tpcd.To(device).VoxelDownSample(0.05);
 
     // Convert color to float values.
     for (auto& kv : source_tpcd.GetPointAttr()) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [ ] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [ ] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [ ] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

This is an attempt to make `Registration/RegistrationPermuteDevices.ICPColored/0` more reliable.
Before the change we get 4 out of 100 test runs failed.
With the increased voxel size 0 out of 100 runs failed.