### PR TITLE
Fix packaged dlls not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Main
+-   Fix DLLs not being found in Python-package. Also prevent PATH from being searched for DLLs, except CUDA (PR #7108)
 -   Fix MSAA sample count not being copied when FilamentView is copied
 -   Fix TriangleMesh::SamplePointsUniformly and TriangleMesh::SamplePointsPoissonDisk now sampling colors from mesh if available (PR #6842)
 -   Fix TriangleMesh::SamplePointsUniformly not sampling triangle meshes uniformly (PR #6653)

--- a/python/open3d/__init__.py
+++ b/python/open3d/__init__.py
@@ -15,6 +15,7 @@
 # https://github.com/dmlc/xgboost/issues/1715
 import os
 import sys
+import re
 
 os.environ["KMP_DUPLICATE_LIB_OK"] = "True"
 # Enable thread composability manager to coordinate Intel OpenMP and TBB threads. Only works with Intel OpenMP.
@@ -26,22 +27,6 @@ from pathlib import Path
 import warnings
 from open3d._build_config import _build_config
 
-
-def load_cdll(path):
-    """
-    Wrapper around ctypes.CDLL to take care of Windows compatibility.
-    """
-    path = Path(path)
-    if not path.is_file():
-        raise FileNotFoundError(f"Shared library file not found: {path}.")
-
-    if sys.platform == "win32" and sys.version_info >= (3, 8):
-        # https://stackoverflow.com/a/64472088/1255535
-        return CDLL(str(path), winmode=0)
-    else:
-        return CDLL(str(path))
-
-
 if sys.platform == "win32":  # Unix: Use rpath to find libraries
     _win32_dll_dir = os.add_dll_directory(str(Path(__file__).parent))
 
@@ -50,7 +35,7 @@ if _build_config["BUILD_CUDA_MODULE"]:
     # Load CPU pybind dll gracefully without introducing new python variable.
     # Do this before loading the CUDA pybind dll to correctly resolve symbols
     try:  # StopIteration if cpu version not available
-        load_cdll(str(next((Path(__file__).parent / "cpu").glob("pybind*"))))
+        CDLL(str(next((Path(__file__).parent / "cpu").glob("pybind*"))))
     except StopIteration:
         warnings.warn(
             "Open3D was built with CUDA support, but Open3D CPU Python "
@@ -59,9 +44,23 @@ if _build_config["BUILD_CUDA_MODULE"]:
             ImportWarning,
         )
     try:
+        if sys.platform == "win32" and sys.version_info >= (3, 8):
+            # Since Python 3.8, the PATH environment variable is not used to find DLLs anymore.
+            # To allow Windows users to use Open3D with CUDA without running into dependency-problems,
+            # look for the CUDA bin directory in PATH and explicitly add it to the DLL search path.
+            cuda_bin_path = None
+            for path in os.environ['PATH'].split(';'):
+                # search heuristic: look for a path containing "cuda" and "bin" in this order.
+                if re.search(r'cuda.*bin', path, re.IGNORECASE):
+                    cuda_bin_path = path
+                    break
+
+            if cuda_bin_path:
+                os.add_dll_directory(cuda_bin_path)
+
         # Check CUDA availability without importing CUDA pybind symbols to
         # prevent "symbol already registered" errors if first import fails.
-        _pybind_cuda = load_cdll(
+        _pybind_cuda = CDLL(
             str(next((Path(__file__).parent / "cuda").glob("pybind*"))))
         if _pybind_cuda.open3d_core_cuda_device_count() > 0:
             from open3d.cuda.pybind import (
@@ -212,4 +211,4 @@ def _jupyter_nbextension_paths():
 
 if sys.platform == "win32":
     _win32_dll_dir.close()
-del os, sys, CDLL, load_cdll, find_library, Path, warnings, _insert_pybind_names
+del os, sys, CDLL, find_library, Path, warnings, _insert_pybind_names


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #7104 
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) -> see below for description

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

[This PR](https://github.com/isl-org/Open3D/pull/5259) introduced `winmode=0` for loading DLLs during import. This however leads to directories added via `os.add_dll_directory` not being considered, when loading DLLs (see [here](https://github.com/isl-org/Open3D/issues/7104#issuecomment-2556557535) or [here](https://stackoverflow.com/questions/59330863/cant-import-dll-module-in-python/59333711#59333711)). In particular this leads to `open3d/tbb12.dll` not being found.

Fix this by going back to the default DLL-search mode (`winmode=None`).

In order to still be able to find CUDA-DLLs, that are not part of the open3d-package, search their directory in PATH and explicitly add it to the DLL-search-locations for CUDA-builds.

Note that this PR results in DLLs generally not being searched in `PATH` anymore, when importing `open3d`, as is the default behaviour of Python-packages since 3.8. The exception are CUDA-libraries in the heuristically determined directory. If anyone relies on `PATH` being searched, this PR breaks functionality.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
