### PR TITLE
Build CI docs with ubuntu 22.04 instead of Ubuntu 24.04

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -22,7 +22,7 @@ jobs:
   headless-docs:   # Build headless and docs
     permissions:
       contents: write  # Artifact upload and release upload
-    runs-on: ubuntu-latest  # Warn about build issues in new versions
+    runs-on: ubuntu-22.04  # Ubuntu 24.04 pytorch 2.2 ops build error with gcc-13.
     env:
       OPEN3D_ML_ROOT: ${{ github.workspace }}/Open3D-ML
       DEVELOPER_BUILD: ${{ github.event.inputs.developer_build || 'ON' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.24)
-# If you're using Ubuntu 20.04, we suggest you install the latest CMake from the
-# official repository https://apt.kitware.com/.
+# If you're not using the latest Ubuntu / distro LTS release, we suggest you
+# install the latest CMake from the official repository https://apt.kitware.com/.
 # CMake 3.24+ is required for CUDA native arch selection
 # CMake 3.22+ is required by Assimp v5.4.2
 # CMake 3.20+ is required to detect IntelLLVM compiler for SYCL

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 docutils==0.20.1
 furo==2023.9.10
-jinja2==3.1.4
+jinja2==3.1.5
 m2r2==0.3.3.post2
 matplotlib==3.7.3
 nbsphinx==0.9.3

--- a/util/ci_utils.sh
+++ b/util/ci_utils.sh
@@ -340,6 +340,9 @@ test_cpp_example() {
 install_docs_dependencies() {
     echo
     echo Install ubuntu dependencies
+    echo "Update cmake needed in Ubuntu < 24.04"
+    $SUDO apt-key adv --fetch-keys https://apt.kitware.com/keys/kitware-archive-latest.asc
+    (source /etc/os-release && $SUDO apt-add-repository --yes "deb https://apt.kitware.com/ubuntu/ $VERSION_CODENAME main")
     ./util/install_deps_ubuntu.sh assume-yes
     $SUDO apt-get install --yes ccache \
         cmake \

--- a/util/ci_utils.sh
+++ b/util/ci_utils.sh
@@ -340,18 +340,16 @@ test_cpp_example() {
 install_docs_dependencies() {
     echo
     echo Install ubuntu dependencies
-    echo Update cmake needed in Ubuntu 20.04
-    sudo apt-key adv --fetch-keys https://apt.kitware.com/keys/kitware-archive-latest.asc
-    sudo apt-add-repository --yes 'deb https://apt.kitware.com/ubuntu/ focal main'
     ./util/install_deps_ubuntu.sh assume-yes
-    sudo apt-get install --yes cmake
-    sudo apt-get install --yes libxml2-dev libxslt-dev python3-dev
-    sudo apt-get install --yes doxygen
-    sudo apt-get install --yes texlive
-    sudo apt-get install --yes texlive-latex-extra
-    sudo apt-get install --yes ghostscript
-    sudo apt-get install --yes pandoc
-    sudo apt-get install --yes ccache
+    $SUDO apt-get install --yes ccache \
+        cmake \
+        doxygen \
+        ghostscript \
+        libxml2-dev \
+        libxslt-dev \
+        pandoc \
+        texlive \
+        texlive-latex-extra
     echo
     echo Install Python dependencies for building docs
     command -v python


### PR DESCRIPTION
Fix documentation CI.
Build docs on Ubuntu 24.04 has errors due to glfw + gcc 13. 

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [ ] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [ ] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [ ] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
