### PR TITLE
Add optional indices arg for fast computation of a small subset of FPFH features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 -   Fix render to depth image on Apple Retina displays (PR #7001)
 -   Fix infinite loop in segment_plane if num_points < ransac_n (PR #7032)
 -   Add select_by_index method to Feature class (PR #7039)
+-   Add optional indices arg for fast computation of a small subset of FPFH features (PR #7118).
 
 
 ## 0.13

--- a/cpp/benchmarks/t/pipelines/registration/Feature.cpp
+++ b/cpp/benchmarks/t/pipelines/registration/Feature.cpp
@@ -5,8 +5,6 @@
 // SPDX-License-Identifier: MIT
 // ----------------------------------------------------------------------------
 
-#include <map>
-
 #include "open3d/t/pipelines/registration/Feature.h"
 
 #include <benchmark/benchmark.h>

--- a/cpp/benchmarks/t/pipelines/registration/Feature.cpp
+++ b/cpp/benchmarks/t/pipelines/registration/Feature.cpp
@@ -5,6 +5,8 @@
 // SPDX-License-Identifier: MIT
 // ----------------------------------------------------------------------------
 
+#include <map>
+
 #include "open3d/t/pipelines/registration/Feature.h"
 
 #include <benchmark/benchmark.h>
@@ -26,22 +28,40 @@ static const std::string path = pointcloud_ply.GetPath();
 
 void LegacyComputeFPFHFeature(benchmark::State& state,
                               utility::optional<int> max_nn,
-                              utility::optional<double> radius) {
+                              utility::optional<double> radius,
+                              utility::optional<double> ratio_indices) {
     auto pcd = open3d::io::CreatePointCloudFromFile(path)->UniformDownSample(3);
     pcd->EstimateNormals();
+
+    utility::optional<std::vector<size_t>> indices = utility::nullopt;
+    if (ratio_indices.has_value()) {
+        std::vector<size_t> indices_tmp;
+        size_t step = 1.0 / ratio_indices.value();
+        size_t n_indices = pcd->points_.size() / step;
+        indices_tmp.reserve(n_indices);
+        for (size_t index = 0; index < pcd->points_.size(); index += step) {
+            indices_tmp.push_back(index);
+        }
+        indices.emplace(indices_tmp);
+    }
+
     for (auto _ : state) {
         if (max_nn.has_value() && radius.has_value()) {
             auto fpfh = open3d::pipelines::registration::ComputeFPFHFeature(
-                    *pcd, open3d::geometry::KDTreeSearchParamHybrid(
-                                  radius.value(), max_nn.value()));
+                    *pcd,
+                    open3d::geometry::KDTreeSearchParamHybrid(radius.value(),
+                                                              max_nn.value()),
+                    indices);
         } else if (max_nn.has_value() && !radius.has_value()) {
             auto fpfh = open3d::pipelines::registration::ComputeFPFHFeature(
                     *pcd,
-                    open3d::geometry::KDTreeSearchParamKNN(max_nn.value()));
+                    open3d::geometry::KDTreeSearchParamKNN(max_nn.value()),
+                    indices);
         } else if (!max_nn.has_value() && radius.has_value()) {
             auto fpfh = open3d::pipelines::registration::ComputeFPFHFeature(
                     *pcd,
-                    open3d::geometry::KDTreeSearchParamRadius(radius.value()));
+                    open3d::geometry::KDTreeSearchParamRadius(radius.value()),
+                    indices);
         }
     }
 }
@@ -50,20 +70,36 @@ void ComputeFPFHFeature(benchmark::State& state,
                         const core::Device& device,
                         const core::Dtype& dtype,
                         utility::optional<int> max_nn,
-                        utility::optional<double> radius) {
+                        utility::optional<double> radius,
+                        utility::optional<double> ratio_indices) {
     t::geometry::PointCloud pcd;
     t::io::ReadPointCloud(path, pcd);
     pcd = pcd.To(device).UniformDownSample(3);
     pcd.SetPointPositions(pcd.GetPointPositions().To(dtype));
     pcd.EstimateNormals();
 
+    utility::optional<core::Tensor> indices = utility::nullopt;
+    if (ratio_indices.has_value()) {
+        std::vector<int64_t> indices_tmp;
+        int64_t step = 1.0 / ratio_indices.value();
+        int64_t n_indices = pcd.GetPointPositions().GetLength() / step;
+        indices_tmp.reserve(n_indices);
+        for (int64_t index = 0; index < pcd.GetPointPositions().GetLength();
+             index += step) {
+            indices_tmp.push_back(index);
+        }
+        indices.emplace(core::Tensor(indices_tmp, {(int)indices_tmp.size()},
+                                     core::Int64, device));
+    }
+
     core::Tensor fpfh;
     // Warm up.
-    fpfh = t::pipelines::registration::ComputeFPFHFeature(pcd, max_nn, radius);
+    fpfh = t::pipelines::registration::ComputeFPFHFeature(pcd, max_nn, radius,
+                                                          indices);
 
     for (auto _ : state) {
         fpfh = t::pipelines::registration::ComputeFPFHFeature(pcd, max_nn,
-                                                              radius);
+                                                              radius, indices);
         core::cuda::Synchronize(device);
     }
 }
@@ -71,60 +107,155 @@ void ComputeFPFHFeature(benchmark::State& state,
 BENCHMARK_CAPTURE(LegacyComputeFPFHFeature,
                   Legacy Hybrid[0.01 | 100],
                   100,
-                  0.01)
+                  0.01,
+                  utility::nullopt)
         ->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(LegacyComputeFPFHFeature, Legacy Hybrid[0.02 | 50], 50, 0.02)
+BENCHMARK_CAPTURE(LegacyComputeFPFHFeature,
+                  Legacy Hybrid[0.02 | 50],
+                  50,
+                  0.02,
+                  utility::nullopt)
         ->Unit(benchmark::kMillisecond);
 BENCHMARK_CAPTURE(LegacyComputeFPFHFeature,
                   Legacy Hybrid[0.02 | 100],
                   100,
-                  0.02)
+                  0.02,
+                  utility::nullopt)
         ->Unit(benchmark::kMillisecond);
 BENCHMARK_CAPTURE(LegacyComputeFPFHFeature,
                   Legacy KNN[50],
                   50,
+                  utility::nullopt,
                   utility::nullopt)
         ->Unit(benchmark::kMillisecond);
 BENCHMARK_CAPTURE(LegacyComputeFPFHFeature,
                   Legacy KNN[100],
                   100,
+                  utility::nullopt,
                   utility::nullopt)
         ->Unit(benchmark::kMillisecond);
 BENCHMARK_CAPTURE(LegacyComputeFPFHFeature,
                   Legacy Radius[0.01],
                   utility::nullopt,
-                  0.01)
+                  0.01,
+                  utility::nullopt)
         ->Unit(benchmark::kMillisecond);
 BENCHMARK_CAPTURE(LegacyComputeFPFHFeature,
                   Legacy Radius[0.02],
                   utility::nullopt,
-                  0.02)
+                  0.02,
+                  utility::nullopt)
         ->Unit(benchmark::kMillisecond);
 
-#define ENUM_FPFH_METHOD_DEVICE(METHOD_NAME, MAX_NN, RADIUS, DEVICE)       \
-    BENCHMARK_CAPTURE(ComputeFPFHFeature, METHOD_NAME##_Float32,           \
-                      core::Device(DEVICE), core::Float32, MAX_NN, RADIUS) \
-            ->Unit(benchmark::kMillisecond);                               \
-    BENCHMARK_CAPTURE(ComputeFPFHFeature, DEVICE METHOD_NAME##_Float64,    \
-                      core::Device(DEVICE), core::Float32, MAX_NN, RADIUS) \
+BENCHMARK_CAPTURE(LegacyComputeFPFHFeature,
+                  Legacy Hybrid Indices[0.02 | 50 | null],
+                  50,
+                  0.02,
+                  utility::nullopt)
+        ->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(LegacyComputeFPFHFeature,
+                  Legacy Hybrid Indices[0.02 | 50 | 0.0001],
+                  50,
+                  0.02,
+                  0.0001)
+        ->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(LegacyComputeFPFHFeature,
+                  Legacy Hybrid Indices[0.02 | 50 | 0.001],
+                  50,
+                  0.02,
+                  0.001)
+        ->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(LegacyComputeFPFHFeature,
+                  Legacy Hybrid Indices[0.02 | 50 | 0.01],
+                  50,
+                  0.02,
+                  0.01)
+        ->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(LegacyComputeFPFHFeature,
+                  Legacy Hybrid Indices[0.02 | 50 | 0.1],
+                  50,
+                  0.02,
+                  0.1)
+        ->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(LegacyComputeFPFHFeature,
+                  Legacy Hybrid Indices[0.02 | 50 | 1.0],
+                  50,
+                  0.02,
+                  1.0)
+        ->Unit(benchmark::kMillisecond);
+
+#define ENUM_FPFH_METHOD_DEVICE(METHOD_NAME, MAX_NN, RADIUS, INDICES, DEVICE) \
+    BENCHMARK_CAPTURE(ComputeFPFHFeature, METHOD_NAME##_Float32,              \
+                      core::Device(DEVICE), core::Float32, MAX_NN, RADIUS,    \
+                      INDICES)                                                \
+            ->Unit(benchmark::kMillisecond);                                  \
+    BENCHMARK_CAPTURE(ComputeFPFHFeature, METHOD_NAME##_Float64,              \
+                      core::Device(DEVICE), core::Float64, MAX_NN, RADIUS,    \
+                      INDICES)                                                \
             ->Unit(benchmark::kMillisecond);
 
-ENUM_FPFH_METHOD_DEVICE(CPU[0.02 | 50] Hybrid, 100, 0.01, "CPU:0")
-ENUM_FPFH_METHOD_DEVICE(CPU[0.02 | 50] Hybrid, 50, 0.02, "CPU:0")
-ENUM_FPFH_METHOD_DEVICE(CPU[0.02 | 100] Hybrid, 100, 0.02, "CPU:0")
-ENUM_FPFH_METHOD_DEVICE(CPU[50] KNN, 50, utility::nullopt, "CPU:0")
-ENUM_FPFH_METHOD_DEVICE(CPU[100] KNN, 100, utility::nullopt, "CPU:0")
-ENUM_FPFH_METHOD_DEVICE(CPU[0.01] Radius, utility::nullopt, 0.01, "CPU:0")
-ENUM_FPFH_METHOD_DEVICE(CPU[0.02] Radius, utility::nullopt, 0.02, "CPU:0")
+ENUM_FPFH_METHOD_DEVICE(
+        CPU[0.01 | 100] Hybrid, 100, 0.01, utility::nullopt, "CPU:0")
+ENUM_FPFH_METHOD_DEVICE(
+        CPU[0.02 | 50] Hybrid, 50, 0.02, utility::nullopt, "CPU:0")
+ENUM_FPFH_METHOD_DEVICE(
+        CPU[0.02 | 100] Hybrid, 100, 0.02, utility::nullopt, "CPU:0")
+ENUM_FPFH_METHOD_DEVICE(
+        CPU[50] KNN, 50, utility::nullopt, utility::nullopt, "CPU:0")
+ENUM_FPFH_METHOD_DEVICE(
+        CPU[100] KNN, 100, utility::nullopt, utility::nullopt, "CPU:0")
+ENUM_FPFH_METHOD_DEVICE(
+        CPU[0.01] Radius, utility::nullopt, 0.01, utility::nullopt, "CPU:0")
+ENUM_FPFH_METHOD_DEVICE(
+        CPU[0.02] Radius, utility::nullopt, 0.02, utility::nullopt, "CPU:0")
+
+ENUM_FPFH_METHOD_DEVICE(CPU[0.02 | 50 | null] Hybrid Indices,
+                        50,
+                        0.02,
+                        utility::nullopt,
+                        "CPU:0")
+ENUM_FPFH_METHOD_DEVICE(
+        CPU[0.02 | 50 | 0.0001] Hybrid Indices, 50, 0.02, 0.0001, "CPU:0")
+ENUM_FPFH_METHOD_DEVICE(
+        CPU[0.02 | 50 | 0.001] Hybrid Indices, 50, 0.02, 0.001, "CPU:0")
+ENUM_FPFH_METHOD_DEVICE(
+        CPU[0.02 | 50 | 0.01] Hybrid Indices, 50, 0.02, 0.01, "CPU:0")
+ENUM_FPFH_METHOD_DEVICE(
+        CPU[0.02 | 50 | 0.1] Hybrid Indices, 50, 0.02, 0.1, "CPU:0")
+ENUM_FPFH_METHOD_DEVICE(
+        CPU[0.02 | 50 | 1.0] Hybrid Indices, 50, 0.02, 1.0, "CPU:0")
 
 #ifdef BUILD_CUDA_MODULE
-ENUM_FPFH_METHOD_DEVICE(CUDA[0.02 | 50] Hybrid, 100, 0.01, "CUDA:0")
-ENUM_FPFH_METHOD_DEVICE(CUDA[0.02 | 50] Hybrid, 50, 0.01, "CUDA:0")
-ENUM_FPFH_METHOD_DEVICE(CUDA[0.02 | 100] Hybrid, 100, 0.02, "CUDA:0")
-ENUM_FPFH_METHOD_DEVICE(CUDA[50] KNN, 50, utility::nullopt, "CUDA:0")
-ENUM_FPFH_METHOD_DEVICE(CUDA[100] KNN, 100, utility::nullopt, "CUDA:0")
-ENUM_FPFH_METHOD_DEVICE(CUDA[0.01] Radius, utility::nullopt, 0.01, "CUDA:0")
-ENUM_FPFH_METHOD_DEVICE(CUDA[0.02] Radius, utility::nullopt, 0.02, "CUDA:0")
+ENUM_FPFH_METHOD_DEVICE(
+        CUDA[0.01 | 100] Hybrid, 100, 0.01, utility::nullopt, "CUDA:0")
+ENUM_FPFH_METHOD_DEVICE(
+        CUDA[0.02 | 50] Hybrid, 50, 0.02, utility::nullopt, "CUDA:0")
+ENUM_FPFH_METHOD_DEVICE(
+        CUDA[0.02 | 100] Hybrid, 100, 0.02, utility::nullopt, "CUDA:0")
+ENUM_FPFH_METHOD_DEVICE(
+        CUDA[50] KNN, 50, utility::nullopt, utility::nullopt, "CUDA:0")
+ENUM_FPFH_METHOD_DEVICE(
+        CUDA[100] KNN, 100, utility::nullopt, utility::nullopt, "CUDA:0")
+ENUM_FPFH_METHOD_DEVICE(
+        CUDA[0.01] Radius, utility::nullopt, 0.01, utility::nullopt, "CUDA:0")
+ENUM_FPFH_METHOD_DEVICE(
+        CUDA[0.02] Radius, utility::nullopt, 0.02, utility::nullopt, "CUDA:0")
+
+ENUM_FPFH_METHOD_DEVICE(CUDA[0.02 | 50 | null] Hybrid Indices,
+                        50,
+                        0.02,
+                        utility::nullopt,
+                        "CUDA:0")
+ENUM_FPFH_METHOD_DEVICE(
+        CUDA[0.02 | 50 | 0.0001] Hybrid Indices, 50, 0.02, 0.0001, "CUDA:0")
+ENUM_FPFH_METHOD_DEVICE(
+        CUDA[0.02 | 50 | 0.001] Hybrid Indices, 50, 0.02, 0.001, "CUDA:0")
+ENUM_FPFH_METHOD_DEVICE(
+        CUDA[0.02 | 50 | 0.01] Hybrid Indices, 50, 0.02, 0.01, "CUDA:0")
+ENUM_FPFH_METHOD_DEVICE(
+        CUDA[0.02 | 50 | 0.1] Hybrid Indices, 50, 0.02, 0.1, "CUDA:0")
+ENUM_FPFH_METHOD_DEVICE(
+        CUDA[0.02 | 50 | 1.0] Hybrid Indices, 50, 0.02, 1.0, "CUDA:0")
 #endif
 
 }  // namespace registration

--- a/cpp/open3d/pipelines/registration/Feature.cpp
+++ b/cpp/open3d/pipelines/registration/Feature.cpp
@@ -185,9 +185,9 @@ std::shared_ptr<Feature> ComputeFPFHFeature(
     std::vector<std::vector<double>> map_fpfh_idx_to_distance2;
     if (filter_fpfh) {
         // compute neighbors of the selected points
-        // using vector<u_int8_t> as a boolean mask for the parallel loop
+        // using vector<uint8_t> as a boolean mask for the parallel loop
         // since vector<bool> is not thread safe in writing.
-        std::vector<u_int8_t> mask_spfh(input.points_.size(), 0);
+        std::vector<uint8_t> mask_spfh(input.points_.size(), 0);
         map_fpfh_idx_to_indices = std::vector<std::vector<int>>(n_fpfh);
         map_fpfh_idx_to_distance2 = std::vector<std::vector<double>>(n_fpfh);
 #pragma omp parallel for schedule(static) \

--- a/cpp/open3d/pipelines/registration/Feature.cpp
+++ b/cpp/open3d/pipelines/registration/Feature.cpp
@@ -21,23 +21,38 @@ namespace registration {
 std::shared_ptr<Feature> Feature::SelectByIndex(
         const std::vector<size_t> &indices, bool invert /* = false */) const {
     auto output = std::make_shared<Feature>();
-    output->Resize(data_.rows(), indices.size());
 
     std::vector<bool> mask = std::vector<bool>(data_.cols(), invert);
+    size_t n_output_features = 0;
     for (size_t i : indices) {
-        mask[i] = !invert;
+        if (i < mask.size()) {
+            if (mask[i] == invert) {
+                mask[i] = !invert;
+                n_output_features++;
+            }
+        } else {
+            utility::LogWarning(
+                    "[SelectByIndex] contains index {} that is "
+                    "not within the bounds",
+                    (int)i);
+        }
+    }
+    if (invert) {
+        n_output_features = data_.cols() - n_output_features;
     }
 
-    size_t current_col_feature = 0;
-    for (size_t i = 0; i < static_cast<size_t>(data_.cols()); i++) {
+    output->Resize(data_.rows(), n_output_features);
+
+    for (size_t i = 0, current_col_feature = 0;
+         i < static_cast<size_t>(data_.cols()); i++) {
         if (mask[i]) {
-            output->data_.col(current_col_feature) = data_.col(i);
-            current_col_feature++;
+            output->data_.col(current_col_feature++) = data_.col(i);
         }
     }
 
     utility::LogDebug(
-            "Feature group down sampled from {:d} features to {:d} features.",
+            "[SelectByIndex] Feature group down sampled from {:d} features to "
+            "{:d} features.",
             (int)data_.cols(), (int)output->data_.cols());
 
     return output;
@@ -80,14 +95,23 @@ static Eigen::Vector4d ComputePairFeatures(const Eigen::Vector3d &p1,
 static std::shared_ptr<Feature> ComputeSPFHFeature(
         const geometry::PointCloud &input,
         const geometry::KDTreeFlann &kdtree,
-        const geometry::KDTreeSearchParam &search_param) {
+        const geometry::KDTreeSearchParam &search_param,
+        const utility::optional<std::vector<size_t>> &indices =
+                utility::nullopt) {
+    const bool filter_spfh = indices.has_value();
+    const auto spfh_indices = indices.value_or(std::vector<size_t>());
+
+    const size_t n_spfh =
+            filter_spfh ? spfh_indices.size() : input.points_.size();
     auto feature = std::make_shared<Feature>();
-    feature->Resize(33, (int)input.points_.size());
+    feature->Resize(33, (int)n_spfh);
+
 #pragma omp parallel for schedule(static) \
         num_threads(utility::EstimateMaxThreads())
-    for (int i = 0; i < (int)input.points_.size(); i++) {
-        const auto &point = input.points_[i];
-        const auto &normal = input.normals_[i];
+    for (int i = 0; i < (int)n_spfh; i++) {
+        const int point_idx = filter_spfh ? spfh_indices[i] : i;
+        const auto &point = input.points_[point_idx];
+        const auto &normal = input.normals_[point_idx];
         std::vector<int> indices;
         std::vector<double> distance2;
         if (kdtree.Search(point, search_param, indices, distance2) > 1) {
@@ -119,31 +143,129 @@ static std::shared_ptr<Feature> ComputeSPFHFeature(
 std::shared_ptr<Feature> ComputeFPFHFeature(
         const geometry::PointCloud &input,
         const geometry::KDTreeSearchParam
-                &search_param /* = geometry::KDTreeSearchParamKNN()*/) {
-    auto feature = std::make_shared<Feature>();
-    feature->Resize(33, (int)input.points_.size());
+                &search_param /* = geometry::KDTreeSearchParamKNN()*/,
+        const utility::optional<std::vector<size_t>>
+                &indices /* = utility::nullopt*/) {
     if (!input.HasNormals()) {
         utility::LogError("Failed because input point cloud has no normal.");
     }
+
+    const bool filter_fpfh = indices.has_value();
+    std::vector<int> fpfh_indices;
+    if (filter_fpfh) {
+        std::vector<bool> mask_fpfh(input.points_.size(), false);
+        for (auto idx : indices.value()) {
+            if (idx < mask_fpfh.size()) {
+                if (!mask_fpfh[idx]) {
+                    mask_fpfh[idx] = true;
+                }
+            } else {
+                utility::LogWarning(
+                        "[ComputeFPFHFeature] contains index {} that is "
+                        "not within the bounds",
+                        idx);
+            }
+        }
+        fpfh_indices.reserve(indices.value().size());
+        for (size_t i = 0; i < mask_fpfh.size(); i++) {
+            if (mask_fpfh[i]) {
+                fpfh_indices.push_back(i);
+            }
+        }
+    }
+
+    const size_t n_fpfh =
+            filter_fpfh ? fpfh_indices.size() : input.points_.size();
+
     geometry::KDTreeFlann kdtree(input);
-    auto spfh = ComputeSPFHFeature(input, kdtree, search_param);
+
+    std::vector<size_t> spfh_indices;
+    std::vector<int> map_point_idx_to_spfh_idx;
+    std::vector<std::vector<int>> map_fpfh_idx_to_indices;
+    std::vector<std::vector<double>> map_fpfh_idx_to_distance2;
+    if (filter_fpfh) {
+        // compute neighbors of the selected points
+        // using vector<u_int8_t> as a boolean mask for the parallel loop
+        // since vector<bool> is not thread safe in writing.
+        std::vector<u_int8_t> mask_spfh(input.points_.size(), 0);
+        map_fpfh_idx_to_indices = std::vector<std::vector<int>>(n_fpfh);
+        map_fpfh_idx_to_distance2 = std::vector<std::vector<double>>(n_fpfh);
+#pragma omp parallel for schedule(static) \
+        num_threads(utility::EstimateMaxThreads())
+        for (int i = 0; i < (int)n_fpfh; i++) {
+            const auto &point = input.points_[fpfh_indices[i]];
+            std::vector<int> p_indices;
+            std::vector<double> p_distance2;
+            kdtree.Search(point, search_param, p_indices, p_distance2);
+            for (size_t k = 0; k < p_indices.size(); k++) {
+                if (!mask_spfh[p_indices[k]]) {
+                    mask_spfh[p_indices[k]] = 1;
+                }
+            }
+            map_fpfh_idx_to_indices[i] = std::move(p_indices);
+            map_fpfh_idx_to_distance2[i] = std::move(p_distance2);
+        }
+        size_t spfh_indices_reserve_factor;
+        switch (search_param.GetSearchType()) {
+            case geometry::KDTreeSearchParam::SearchType::Knn:
+                spfh_indices_reserve_factor =
+                        ((const geometry::KDTreeSearchParamKNN &)search_param)
+                                .knn_;
+                break;
+            case geometry::KDTreeSearchParam::SearchType::Hybrid:
+                spfh_indices_reserve_factor =
+                        ((const geometry::KDTreeSearchParamHybrid &)
+                                 search_param)
+                                .max_nn_;
+                break;
+            default:
+                spfh_indices_reserve_factor = 30;
+        }
+        spfh_indices.reserve(spfh_indices_reserve_factor * fpfh_indices.size());
+        map_point_idx_to_spfh_idx = std::vector<int>(input.points_.size(), -1);
+        for (size_t i = 0; i < mask_spfh.size(); i++) {
+            if (mask_spfh[i]) {
+                map_point_idx_to_spfh_idx[i] = spfh_indices.size();
+                spfh_indices.push_back(i);
+            }
+        }
+    }
+
+    auto feature = std::make_shared<Feature>();
+    feature->Resize(33, (int)n_fpfh);
+
+    auto spfh = filter_fpfh ? ComputeSPFHFeature(input, kdtree, search_param,
+                                                 spfh_indices)
+                            : ComputeSPFHFeature(input, kdtree, search_param);
     if (spfh == nullptr) {
         utility::LogError("Internal error: SPFH feature is nullptr.");
     }
 #pragma omp parallel for schedule(static) \
         num_threads(utility::EstimateMaxThreads())
-    for (int i = 0; i < (int)input.points_.size(); i++) {
-        const auto &point = input.points_[i];
-        std::vector<int> indices;
-        std::vector<double> distance2;
-        if (kdtree.Search(point, search_param, indices, distance2) > 1) {
+    for (int i = 0; i < (int)n_fpfh; i++) {
+        int i_spfh;
+        std::vector<int> p_indices;
+        std::vector<double> p_distance2;
+        if (filter_fpfh) {
+            i_spfh = map_point_idx_to_spfh_idx[fpfh_indices[i]];
+            p_indices = std::move(map_fpfh_idx_to_indices[i]);
+            p_distance2 = std::move(map_fpfh_idx_to_distance2[i]);
+        } else {
+            i_spfh = i;
+            kdtree.Search(input.points_[i], search_param, p_indices,
+                          p_distance2);
+        }
+        if (p_indices.size() > 1) {
             double sum[3] = {0.0, 0.0, 0.0};
-            for (size_t k = 1; k < indices.size(); k++) {
+            for (size_t k = 1; k < p_indices.size(); k++) {
                 // skip the point itself
-                double dist = distance2[k];
+                double dist = p_distance2[k];
                 if (dist == 0.0) continue;
+                int p_index_k =
+                        filter_fpfh ? map_point_idx_to_spfh_idx[p_indices[k]]
+                                    : p_indices[k];
                 for (int j = 0; j < 33; j++) {
-                    double val = spfh->data_(j, indices[k]) / dist;
+                    double val = spfh->data_(j, p_index_k) / dist;
                     sum[j / 11] += val;
                     feature->data_(j, i) += val;
                 }
@@ -157,10 +279,16 @@ std::shared_ptr<Feature> ComputeFPFHFeature(
                 // Our initial test shows that the full fpfh function in the
                 // paper seems to be better than PCL implementation. Further
                 // test required.
-                feature->data_(j, i) += spfh->data_(j, i);
+                feature->data_(j, i) += spfh->data_(j, i_spfh);
             }
         }
     }
+
+    utility::LogDebug(
+            "[ComputeFPFHFeature] Computed {:d} features from "
+            "input point cloud with {:d} points.",
+            (int)feature->data_.cols(), (int)input.points_.size());
+
     return feature;
 }
 

--- a/cpp/open3d/pipelines/registration/Feature.h
+++ b/cpp/open3d/pipelines/registration/Feature.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "open3d/geometry/KDTreeSearchParam.h"
+#include "open3d/utility/Optional.h"
 
 namespace open3d {
 
@@ -59,10 +60,14 @@ public:
 ///
 /// \param input The Input point cloud.
 /// \param search_param KDTree KNN search parameter.
+/// \param indices Indices of the points to compute FPFH features on.
+/// If not set, compute features for the whole point cloud.
 std::shared_ptr<Feature> ComputeFPFHFeature(
         const geometry::PointCloud &input,
         const geometry::KDTreeSearchParam &search_param =
-                geometry::KDTreeSearchParamKNN());
+                geometry::KDTreeSearchParamKNN(),
+        const utility::optional<std::vector<size_t>> &indices =
+                utility::nullopt);
 
 /// \brief Function to find correspondences via 1-nearest neighbor feature
 /// matching. Target is used to construct a nearest neighbor search

--- a/cpp/open3d/t/pipelines/kernel/Feature.cpp
+++ b/cpp/open3d/t/pipelines/kernel/Feature.cpp
@@ -20,19 +20,38 @@ void ComputeFPFHFeature(const core::Tensor &points,
                         const core::Tensor &indices,
                         const core::Tensor &distance2,
                         const core::Tensor &counts,
-                        core::Tensor &fpfhs) {
-    core::AssertTensorShape(fpfhs, {points.GetLength(), 33});
+                        core::Tensor &fpfhs,
+                        const utility::optional<core::Tensor> &mask,
+                        const utility::optional<core::Tensor>
+                                &map_batch_info_idx_to_point_idx) {
+    if (mask.has_value()) {
+        const int64_t size =
+                mask.value().To(core::Int64).Sum({0}).Item<int64_t>();
+        core::AssertTensorShape(fpfhs, {size, 33});
+        core::AssertTensorShape(mask.value(), {points.GetLength()});
+    } else {
+        core::AssertTensorShape(fpfhs, {points.GetLength(), 33});
+    }
+    if (map_batch_info_idx_to_point_idx.has_value()) {
+        core::AssertTensorShape(map_batch_info_idx_to_point_idx.value(),
+                                {counts.GetLength()});
+    }
     const core::Tensor points_d = points.Contiguous();
     const core::Tensor normals_d = normals.Contiguous();
     const core::Tensor counts_d = counts.To(core::Int32);
     if (points_d.IsCPU()) {
         ComputeFPFHFeatureCPU(points_d, normals_d, indices, distance2, counts_d,
-                              fpfhs);
+                              fpfhs, mask, map_batch_info_idx_to_point_idx);
     } else {
         core::CUDAScopedDevice scoped_device(points.GetDevice());
         CUDA_CALL(ComputeFPFHFeatureCUDA, points_d, normals_d, indices,
-                  distance2, counts_d, fpfhs);
+                  distance2, counts_d, fpfhs, mask,
+                  map_batch_info_idx_to_point_idx);
     }
+    utility::LogDebug(
+            "[ComputeFPFHFeature] Computed {:d} features from "
+            "input point cloud with {:d} points.",
+            (int)fpfhs.GetLength(), (int)points.GetLength());
 }
 
 }  // namespace kernel

--- a/cpp/open3d/t/pipelines/kernel/Feature.cpp
+++ b/cpp/open3d/t/pipelines/kernel/Feature.cpp
@@ -15,15 +15,15 @@ namespace t {
 namespace pipelines {
 namespace kernel {
 
-void ComputeFPFHFeature(const core::Tensor &points,
-                        const core::Tensor &normals,
-                        const core::Tensor &indices,
-                        const core::Tensor &distance2,
-                        const core::Tensor &counts,
-                        core::Tensor &fpfhs,
-                        const utility::optional<core::Tensor> &mask,
-                        const utility::optional<core::Tensor>
-                                &map_batch_info_idx_to_point_idx) {
+void ComputeFPFHFeature(
+        const core::Tensor &points,
+        const core::Tensor &normals,
+        const core::Tensor &indices,
+        const core::Tensor &distance2,
+        const core::Tensor &counts,
+        core::Tensor &fpfhs,
+        const utility::optional<core::Tensor> &mask,
+        const utility::optional<core::Tensor> &map_info_idx_to_point_idx) {
     if (mask.has_value()) {
         const int64_t size =
                 mask.value().To(core::Int64).Sum({0}).Item<int64_t>();
@@ -32,21 +32,22 @@ void ComputeFPFHFeature(const core::Tensor &points,
     } else {
         core::AssertTensorShape(fpfhs, {points.GetLength(), 33});
     }
-    if (map_batch_info_idx_to_point_idx.has_value()) {
-        core::AssertTensorShape(map_batch_info_idx_to_point_idx.value(),
-                                {counts.GetLength()});
+    if (map_info_idx_to_point_idx.has_value()) {
+        const bool is_radius_search = indices.GetShape().size() == 1;
+        core::AssertTensorShape(
+                map_info_idx_to_point_idx.value(),
+                {counts.GetLength() - (is_radius_search ? 1 : 0)});
     }
     const core::Tensor points_d = points.Contiguous();
     const core::Tensor normals_d = normals.Contiguous();
     const core::Tensor counts_d = counts.To(core::Int32);
     if (points_d.IsCPU()) {
         ComputeFPFHFeatureCPU(points_d, normals_d, indices, distance2, counts_d,
-                              fpfhs, mask, map_batch_info_idx_to_point_idx);
+                              fpfhs, mask, map_info_idx_to_point_idx);
     } else {
         core::CUDAScopedDevice scoped_device(points.GetDevice());
         CUDA_CALL(ComputeFPFHFeatureCUDA, points_d, normals_d, indices,
-                  distance2, counts_d, fpfhs, mask,
-                  map_batch_info_idx_to_point_idx);
+                  distance2, counts_d, fpfhs, mask, map_info_idx_to_point_idx);
     }
     utility::LogDebug(
             "[ComputeFPFHFeature] Computed {:d} features from "

--- a/cpp/open3d/t/pipelines/kernel/Feature.h
+++ b/cpp/open3d/t/pipelines/kernel/Feature.h
@@ -7,33 +7,46 @@
 
 #include "open3d/core/CUDAUtils.h"
 #include "open3d/core/Tensor.h"
+#include "open3d/utility/Optional.h"
 
 namespace open3d {
 namespace t {
 namespace pipelines {
 namespace kernel {
 
-void ComputeFPFHFeature(const core::Tensor &points,
-                        const core::Tensor &normals,
-                        const core::Tensor &indices,
-                        const core::Tensor &distance2,
-                        const core::Tensor &counts,
-                        core::Tensor &fpfhs);
+void ComputeFPFHFeature(
+        const core::Tensor &points,
+        const core::Tensor &normals,
+        const core::Tensor &indices,
+        const core::Tensor &distance2,
+        const core::Tensor &counts,
+        core::Tensor &fpfhs,
+        const utility::optional<core::Tensor> &mask = utility::nullopt,
+        const utility::optional<core::Tensor> &map_batch_info_idx_to_point_idx =
+                utility::nullopt);
 
-void ComputeFPFHFeatureCPU(const core::Tensor &points,
-                           const core::Tensor &normals,
-                           const core::Tensor &indices,
-                           const core::Tensor &distance2,
-                           const core::Tensor &counts,
-                           core::Tensor &fpfhs);
+void ComputeFPFHFeatureCPU(
+        const core::Tensor &points,
+        const core::Tensor &normals,
+        const core::Tensor &indices,
+        const core::Tensor &distance2,
+        const core::Tensor &counts,
+        core::Tensor &fpfhs,
+        const utility::optional<core::Tensor> &mask = utility::nullopt,
+        const utility::optional<core::Tensor> &map_batch_info_idx_to_point_idx =
+                utility::nullopt);
 
 #ifdef BUILD_CUDA_MODULE
-void ComputeFPFHFeatureCUDA(const core::Tensor &points,
-                            const core::Tensor &normals,
-                            const core::Tensor &indices,
-                            const core::Tensor &distance2,
-                            const core::Tensor &counts,
-                            core::Tensor &fpfhs);
+void ComputeFPFHFeatureCUDA(
+        const core::Tensor &points,
+        const core::Tensor &normals,
+        const core::Tensor &indices,
+        const core::Tensor &distance2,
+        const core::Tensor &counts,
+        core::Tensor &fpfhs,
+        const utility::optional<core::Tensor> &mask = utility::nullopt,
+        const utility::optional<core::Tensor> &map_batch_info_idx_to_point_idx =
+                utility::nullopt);
 #endif
 
 }  // namespace kernel

--- a/cpp/open3d/t/pipelines/kernel/FeatureImpl.h
+++ b/cpp/open3d/t/pipelines/kernel/FeatureImpl.h
@@ -114,11 +114,69 @@ void ComputeFPFHFeatureCPU
          const core::Tensor &indices,
          const core::Tensor &distance2,
          const core::Tensor &counts,
-         core::Tensor &fpfhs) {
+         core::Tensor &fpfhs,
+         const utility::optional<core::Tensor> &mask,
+         const utility::optional<core::Tensor>
+                 &map_batch_info_idx_to_point_idx) {
     const core::Dtype dtype = points.GetDtype();
-    const int64_t n = points.GetLength();
+    const core::Device device = points.GetDevice();
+    const int64_t n_points = points.GetLength();
 
-    core::Tensor spfhs = fpfhs.Clone();
+    const bool filter_fpfh =
+            mask.has_value() & map_batch_info_idx_to_point_idx.has_value();
+    if (mask.has_value() ^ map_batch_info_idx_to_point_idx.has_value()) {
+        utility::LogError(
+                "Parameters mask and map_batch_info_idx_to_point_idx must be "
+                "both "
+                "provided or both not provided.");
+    }
+    if (filter_fpfh) {
+        if (mask.value().GetShape()[0] != n_points) {
+            utility::LogError(
+                    "Parameter mask was provided, but its size {:d} should"
+                    "be equal to the number of points {:d}.",
+                    (int)mask.value().GetShape()[0], n_points);
+        }
+        if (map_batch_info_idx_to_point_idx.value().GetShape()[0] !=
+            counts.GetShape()[0]) {
+            utility::LogError(
+                    "Parameter map_batch_info_idx_to_point_idx was provided, "
+                    "but its size"
+                    "{:d} should be equal to the size of counts {:d}.",
+                    (int)map_batch_info_idx_to_point_idx.value().GetShape()[0],
+                    (int)counts.GetShape()[0]);
+        }
+    }
+
+    core::Tensor map_spfh_info_idx_to_point_idx =
+            map_batch_info_idx_to_point_idx.value_or(
+                    core::Tensor::Empty({0}, core::Int64, device));
+
+    const core::Tensor map_fpfh_idx_to_point_idx =
+            filter_fpfh ? mask.value().NonZero().GetItem(
+                                  {core::TensorKey::Index(0)})
+                        : core::Tensor::Empty({0}, core::Int64, device);
+
+    const int32_t n_fpfh =
+            filter_fpfh ? map_fpfh_idx_to_point_idx.GetLength() : n_points;
+    const int32_t n_spfh =
+            filter_fpfh ? map_spfh_info_idx_to_point_idx.GetLength() : n_points;
+
+    core::Tensor spfhs =
+            core::Tensor::Zeros({n_spfh, 33}, dtype, fpfhs.GetDevice());
+
+    core::Tensor map_point_idx_to_spfh_idx;
+    if (filter_fpfh) {
+        map_point_idx_to_spfh_idx = core::Tensor::Full(
+                {n_points}, -1, core::Int64, fpfhs.GetDevice());
+        map_point_idx_to_spfh_idx.IndexSet(
+                {map_spfh_info_idx_to_point_idx},
+                core::Tensor::Arange(0, n_spfh, 1, core::Int64,
+                                     fpfhs.GetDevice()));
+    } else {
+        map_point_idx_to_spfh_idx =
+                core::Tensor::Empty({0}, core::Int64, fpfhs.GetDevice());
+    }
 
     // Check the nns type (knn = hybrid = false, radius = true).
     // The nns radius search mode will resulting a prefix sum 1D tensor.
@@ -139,11 +197,22 @@ void ComputeFPFHFeatureCPU
         const int32_t *counts_ptr = counts.GetDataPtr<int32_t>();
         scalar_t *spfhs_ptr = spfhs.GetDataPtr<scalar_t>();
         scalar_t *fpfhs_ptr = fpfhs.GetDataPtr<scalar_t>();
+        const int64_t *map_spfh_info_idx_to_point_idx_ptr =
+                map_spfh_info_idx_to_point_idx.GetDataPtr<int64_t>();
+        const int64_t *map_fpfh_idx_to_point_idx_ptr =
+                map_fpfh_idx_to_point_idx.GetDataPtr<int64_t>();
+        const int64_t *map_point_idx_to_spfh_idx_ptr =
+                map_point_idx_to_spfh_idx.GetDataPtr<int64_t>();
 
-        // Compute SPFH features for each point.
+        // Compute SPFH features for the points.
         core::ParallelFor(
-                points.GetDevice(), n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
-                    int64_t idx = 3 * workload_idx;
+                points.GetDevice(), n_spfh,
+                [=] OPEN3D_DEVICE(int64_t workload_idx) {
+                    int64_t workload_point_idx =
+                            filter_fpfh ? map_spfh_info_idx_to_point_idx_ptr
+                                                  [workload_idx]
+                                        : workload_idx;
+                    int64_t idx = 3 * workload_point_idx;
                     const scalar_t *point = points_ptr + idx;
                     const scalar_t *normal = normals_ptr + idx;
 
@@ -178,28 +247,36 @@ void ComputeFPFHFeatureCPU
                     }
                 });
 
-        // Compute FPFH features for each point.
+        // Compute FPFH features for the points.
         core::ParallelFor(
-                points.GetDevice(), n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
+                points.GetDevice(), n_fpfh,
+                [=] OPEN3D_DEVICE(int64_t workload_idx) {
+                    int64_t workload_spfh_idx =
+                            filter_fpfh ? map_point_idx_to_spfh_idx_ptr
+                                                  [map_fpfh_idx_to_point_idx_ptr
+                                                           [workload_idx]]
+                                        : workload_idx;
                     const int indice_size =
-                            is_radius_search ? (counts_ptr[workload_idx + 1] -
-                                                counts_ptr[workload_idx])
-                                             : counts_ptr[workload_idx];
-
+                            is_radius_search
+                                    ? (counts_ptr[workload_spfh_idx + 1] -
+                                       counts_ptr[workload_spfh_idx])
+                                    : counts_ptr[workload_spfh_idx];
                     if (indice_size > 1) {
                         scalar_t sum[3] = {0.0, 0.0, 0.0};
                         for (int i = 1; i < indice_size; i++) {
                             const int idx =
                                     is_radius_search
-                                            ? i + counts_ptr[workload_idx]
-                                            : workload_idx * nn_size + i;
+                                            ? i + counts_ptr[workload_spfh_idx]
+                                            : workload_spfh_idx * nn_size + i;
                             const scalar_t dist = distance2_ptr[idx];
                             if (dist == 0.0) continue;
-
+                            const int32_t spfh_idx =
+                                    filter_fpfh ? map_point_idx_to_spfh_idx_ptr
+                                                          [indices_ptr[idx]]
+                                                : indices_ptr[idx];
                             for (int j = 0; j < 33; j++) {
                                 const scalar_t val =
-                                        spfhs_ptr[indices_ptr[idx] * 33 + j] /
-                                        dist;
+                                        spfhs_ptr[spfh_idx * 33 + j] / dist;
                                 sum[j / 11] += val;
                                 fpfhs_ptr[workload_idx * 33 + j] += val;
                             }
@@ -210,12 +287,12 @@ void ComputeFPFHFeatureCPU
                         for (int j = 0; j < 33; j++) {
                             fpfhs_ptr[workload_idx * 33 + j] *= sum[j / 11];
                             fpfhs_ptr[workload_idx * 33 + j] +=
-                                    spfhs_ptr[workload_idx * 33 + j];
+                                    spfhs_ptr[workload_spfh_idx * 33 + j];
                         }
                     }
                 });
     });
-}  // namespace kernel
+}
 
 }  // namespace kernel
 }  // namespace pipelines

--- a/cpp/open3d/t/pipelines/kernel/FeatureImpl.h
+++ b/cpp/open3d/t/pipelines/kernel/FeatureImpl.h
@@ -116,19 +116,17 @@ void ComputeFPFHFeatureCPU
          const core::Tensor &counts,
          core::Tensor &fpfhs,
          const utility::optional<core::Tensor> &mask,
-         const utility::optional<core::Tensor>
-                 &map_batch_info_idx_to_point_idx) {
+         const utility::optional<core::Tensor> &map_info_idx_to_point_idx) {
     const core::Dtype dtype = points.GetDtype();
     const core::Device device = points.GetDevice();
     const int64_t n_points = points.GetLength();
 
     const bool filter_fpfh =
-            mask.has_value() && map_batch_info_idx_to_point_idx.has_value();
-    if (mask.has_value() ^ map_batch_info_idx_to_point_idx.has_value()) {
+            mask.has_value() && map_info_idx_to_point_idx.has_value();
+    if (mask.has_value() ^ map_info_idx_to_point_idx.has_value()) {
         utility::LogError(
-                "Parameters mask and map_batch_info_idx_to_point_idx must be "
-                "both "
-                "provided or both not provided.");
+                "Parameters mask and map_info_idx_to_point_idx must "
+                "either be both provided or both not provided.");
     }
     if (filter_fpfh) {
         if (mask.value().GetShape()[0] != n_points) {
@@ -137,19 +135,19 @@ void ComputeFPFHFeatureCPU
                     "be equal to the number of points {:d}.",
                     (int)mask.value().GetShape()[0], n_points);
         }
-        if (map_batch_info_idx_to_point_idx.value().GetShape()[0] !=
-            counts.GetShape()[0]) {
+        if (map_info_idx_to_point_idx.value().GetShape()[0] !=
+            counts.GetShape()[0] - (indices.GetShape().size() == 1 ? 1 : 0)) {
             utility::LogError(
-                    "Parameter map_batch_info_idx_to_point_idx was provided, "
+                    "Parameter map_info_idx_to_point_idx was provided, "
                     "but its size"
                     "{:d} should be equal to the size of counts {:d}.",
-                    (int)map_batch_info_idx_to_point_idx.value().GetShape()[0],
+                    (int)map_info_idx_to_point_idx.value().GetShape()[0],
                     (int)counts.GetShape()[0]);
         }
     }
 
     core::Tensor map_spfh_info_idx_to_point_idx =
-            map_batch_info_idx_to_point_idx.value_or(
+            map_info_idx_to_point_idx.value_or(
                     core::Tensor::Empty({0}, core::Int64, device));
 
     const core::Tensor map_fpfh_idx_to_point_idx =

--- a/cpp/open3d/t/pipelines/kernel/FeatureImpl.h
+++ b/cpp/open3d/t/pipelines/kernel/FeatureImpl.h
@@ -123,7 +123,7 @@ void ComputeFPFHFeatureCPU
     const int64_t n_points = points.GetLength();
 
     const bool filter_fpfh =
-            mask.has_value() & map_batch_info_idx_to_point_idx.has_value();
+            mask.has_value() && map_batch_info_idx_to_point_idx.has_value();
     if (mask.has_value() ^ map_batch_info_idx_to_point_idx.has_value()) {
         utility::LogError(
                 "Parameters mask and map_batch_info_idx_to_point_idx must be "

--- a/cpp/open3d/t/pipelines/registration/Feature.cpp
+++ b/cpp/open3d/t/pipelines/registration/Feature.cpp
@@ -7,6 +7,7 @@
 
 #include "open3d/t/pipelines/registration/Feature.h"
 
+#include "open3d/core/ParallelFor.h"
 #include "open3d/core/nns/NearestNeighborSearch.h"
 #include "open3d/t/geometry/PointCloud.h"
 #include "open3d/t/pipelines/kernel/Feature.h"
@@ -43,58 +44,138 @@ core::Tensor ComputeFPFHFeature(
                                           core::Int32);
     bool tree_set = false;
 
+    const bool filter_fpfh = indices.has_value();
+    // If we are computing a subset of the FPFH feature,
+    // cache some information to speed up the computation
+    // if the ratio of the indices to the total number of points is high.
+    const double cache_info_indices_ratio_thresh = 0.01;
+    bool cache_fpfh_info = true;
+
     core::Tensor mask_fpfh_points;
-    core::Tensor mask_required_points;
-    if (indices.has_value()) {
+    core::Tensor indices_fpfh_points;
+    core::Tensor map_point_idx_to_required_point_idx;
+    core::Tensor map_required_point_idx_to_point_idx;
+    core::Tensor save_p_indices, save_p_distance2, save_p_counts;
+    core::Tensor mask_spfh_points;
+
+    // If we are computing a subset of the FPFH feature, we need to find
+    // the subset of points (neighbors) required to compute the FPFH features.
+    if (filter_fpfh) {
+        if (indices.value().GetLength() == 0) {
+            return core::Tensor::Zeros({0, 33}, dtype, device);
+        }
         mask_fpfh_points =
                 core::Tensor::Zeros({num_points}, core::Bool, device);
-        mask_required_points =
-                core::Tensor::Zeros({num_points}, core::Bool, device);
-        core::Tensor indices_tmp, distance2_tmp, counts_tmp;
         mask_fpfh_points.IndexSet({indices.value()},
                                   core::Tensor::Ones({1}, core::Bool, device));
         const core::Tensor query_point_positions =
-                input.GetPointPositions().IndexGet({indices.value()});
+                input.GetPointPositions().IndexGet({mask_fpfh_points});
+        core::Tensor p_indices, p_distance2, p_counts;
         if (radius.has_value() && max_nn.has_value()) {
             tree_set = tree.HybridIndex(radius.value());
             if (!tree_set) {
                 utility::LogError("Building HybridIndex failed.");
             }
-            std::tie(indices_tmp, distance2_tmp, counts_tmp) =
-                    tree.HybridSearch(query_point_positions, radius.value(),
-                                      max_nn.value());
+            std::tie(p_indices, p_distance2, p_counts) = tree.HybridSearch(
+                    query_point_positions, radius.value(), max_nn.value());
         } else if (!radius.has_value() && max_nn.has_value()) {
             tree_set = tree.KnnIndex();
             if (!tree_set) {
                 utility::LogError("Building KnnIndex failed.");
             }
-            std::tie(indices_tmp, distance2_tmp) =
+            std::tie(p_indices, p_distance2) =
                     tree.KnnSearch(query_point_positions, max_nn.value());
+
+            // Make counts full with min(max_nn, num_points).
+            const int fill_value =
+                    max_nn.value() > num_points ? num_points : max_nn.value();
+            p_counts = core::Tensor::Full({query_point_positions.GetLength()},
+                                          fill_value, core::Int32, device);
         } else if (radius.has_value() && !max_nn.has_value()) {
             tree_set = tree.FixedRadiusIndex(radius.value());
             if (!tree_set) {
                 utility::LogError("Building RadiusIndex failed.");
             }
-            std::tie(indices_tmp, distance2_tmp, counts_tmp) =
-                    tree.FixedRadiusSearch(query_point_positions,
-                                           radius.value());
+            std::tie(p_indices, p_distance2, p_counts) = tree.FixedRadiusSearch(
+                    query_point_positions, radius.value());
         } else {
             utility::LogError("Both max_nn and radius are none.");
         }
 
-        indices_tmp = indices_tmp.To(core::Int64).View({-1});
+        core::Tensor mask_required_points =
+                core::Tensor::Zeros({num_points}, core::Bool, device);
         mask_required_points.IndexSet(
-                {indices_tmp}, core::Tensor::Ones({1}, core::Bool, device));
+                {p_indices.To(core::Int64).View({-1})},
+                core::Tensor::Ones({1}, core::Bool, device));
+        map_required_point_idx_to_point_idx =
+                mask_required_points.NonZero().GetItem(
+                        {core::TensorKey::Index(0)});
+        indices_fpfh_points =
+                mask_fpfh_points.NonZero().GetItem({core::TensorKey::Index(0)});
 
-    } else {
-        mask_fpfh_points = core::Tensor::Zeros({0}, core::Bool, device);
-        mask_required_points = core::Tensor::Zeros({0}, core::Bool, device);
+        const bool is_radius_search = p_indices.GetShape().size() == 1;
+
+        // Cache the info if the ratio of the indices to the total number of
+        // points is high and we are not doing a radius search. Radius search
+        // requires a different pipeline since tensor output p_counts is a
+        // prefix sum.
+        cache_fpfh_info = !is_radius_search &&
+                          (indices_fpfh_points.GetLength() >=
+                           cache_info_indices_ratio_thresh * num_points);
+
+        if (cache_fpfh_info) {
+            map_point_idx_to_required_point_idx =
+                    core::Tensor::Full({num_points}, -1, core::Int32, device);
+            map_point_idx_to_required_point_idx.IndexSet(
+                    {map_required_point_idx_to_point_idx},
+                    core::Tensor::Arange(
+                            0, map_required_point_idx_to_point_idx.GetLength(),
+                            1, core::Int32, device));
+
+            core::SizeVector save_p_indices_shape = p_indices.GetShape();
+            save_p_indices_shape[0] =
+                    map_required_point_idx_to_point_idx.GetLength();
+            save_p_indices = core::Tensor::Zeros(save_p_indices_shape,
+                                                 core::Int32, device);
+            save_p_distance2 = core::Tensor::Zeros(save_p_indices.GetShape(),
+                                                   dtype, device);
+            save_p_counts = core::Tensor::Zeros(
+                    {map_required_point_idx_to_point_idx.GetLength() +
+                     (is_radius_search ? 1 : 0)},
+                    core::Int32, device);
+
+            core::Tensor map_fpfh_point_idx_to_required_point_idx =
+                    map_point_idx_to_required_point_idx
+                            .IndexGet({indices_fpfh_points})
+                            .To(core::Int64);
+
+            save_p_indices.IndexSet({map_fpfh_point_idx_to_required_point_idx},
+                                    p_indices);
+            save_p_distance2.IndexSet(
+                    {map_fpfh_point_idx_to_required_point_idx}, p_distance2);
+            save_p_counts.IndexSet({map_fpfh_point_idx_to_required_point_idx},
+                                   p_counts);
+
+            // If we are filtering FPFH features, we have already computed some
+            // info about the FPFH points' neighbors. Now we just need to
+            // compute the info for the remaining required points, so skip the
+            // computation for the already computed info.
+            mask_spfh_points =
+                    core::Tensor::Zeros({num_points}, core::Bool, device);
+            mask_spfh_points.IndexSet(
+                    {map_required_point_idx_to_point_idx},
+                    core::Tensor::Ones({1}, core::Bool, device));
+            mask_spfh_points.IndexSet(
+                    {indices_fpfh_points},
+                    core::Tensor::Zeros({1}, core::Bool, device));
+        } else {
+            mask_spfh_points = mask_required_points;
+        }
     }
 
     const core::Tensor query_point_positions =
-            mask_required_points.GetShape()[0] > 0
-                    ? input.GetPointPositions().IndexGet({mask_required_points})
-                    : input.GetPointPositions();
+            filter_fpfh ? input.GetPointPositions().IndexGet({mask_spfh_points})
+                        : input.GetPointPositions();
 
     // Compute nearest neighbors and squared distances.
     core::Tensor p_indices, p_distance2, p_counts;
@@ -119,14 +200,25 @@ core::Tensor ComputeFPFHFeature(
                 utility::LogError("Building KnnIndex failed.");
             }
         }
-        std::tie(p_indices, p_distance2) =
-                tree.KnnSearch(query_point_positions, max_nn.value());
 
-        // Make counts full with min(max_nn, num_points).
-        const int fill_value =
-                max_nn.value() > num_points ? num_points : max_nn.value();
-        p_counts = core::Tensor::Full({query_point_positions.GetLength()},
-                                      fill_value, core::Int32, device);
+        // tree.KnnSearch complains if the query point cloud is empty.
+        if (query_point_positions.GetLength() > 0) {
+            std::tie(p_indices, p_distance2) =
+                    tree.KnnSearch(query_point_positions, max_nn.value());
+
+            const int fill_value =
+                    max_nn.value() > num_points ? num_points : max_nn.value();
+
+            p_counts = core::Tensor::Full({query_point_positions.GetLength()},
+                                          fill_value, core::Int32, device);
+        } else {
+            p_indices = core::Tensor::Zeros({0, max_nn.value()}, core::Int32,
+                                            device);
+            p_distance2 =
+                    core::Tensor::Zeros({0, max_nn.value()}, dtype, device);
+            p_counts = core::Tensor::Zeros({0}, core::Int32, device);
+        }
+
         utility::LogDebug(
                 "Use KNNSearch  [max_nn: {}] for computing FPFH feature.",
                 max_nn.value());
@@ -147,18 +239,33 @@ core::Tensor ComputeFPFHFeature(
     }
 
     core::Tensor fpfh;
-    if (indices.has_value()) {
-        const auto mask_fpfh_points_indices =
-                mask_fpfh_points.NonZero().GetItem({core::TensorKey::Index(0)});
-        const auto map_batch_info_idx_to_point_idx =
-                mask_required_points.NonZero().GetItem(
-                        {core::TensorKey::Index(0)});
-        fpfh = core::Tensor::Zeros({mask_fpfh_points_indices.GetLength(), 33},
-                                   dtype, device);
+    if (filter_fpfh) {
+        const int64_t size = indices_fpfh_points.GetLength();
+        fpfh = core::Tensor::Zeros({size, 33}, dtype, device);
+        core::Tensor final_p_indices, final_p_distance2, final_p_counts;
+        if (cache_fpfh_info) {
+            core::Tensor map_spfh_idx_to_required_point_idx =
+                    map_point_idx_to_required_point_idx
+                            .IndexGet({mask_spfh_points})
+                            .To(core::Int64);
+            save_p_indices.IndexSet({map_spfh_idx_to_required_point_idx},
+                                    p_indices);
+            save_p_distance2.IndexSet({map_spfh_idx_to_required_point_idx},
+                                      p_distance2);
+            save_p_counts.IndexSet({map_spfh_idx_to_required_point_idx},
+                                   p_counts);
+            final_p_indices = save_p_indices;
+            final_p_distance2 = save_p_distance2;
+            final_p_counts = save_p_counts;
+        } else {
+            final_p_indices = p_indices;
+            final_p_distance2 = p_distance2;
+            final_p_counts = p_counts;
+        }
         pipelines::kernel::ComputeFPFHFeature(
-                input.GetPointPositions(), input.GetPointNormals(), p_indices,
-                p_distance2, p_counts, fpfh, mask_fpfh_points,
-                map_batch_info_idx_to_point_idx);
+                input.GetPointPositions(), input.GetPointNormals(),
+                final_p_indices, final_p_distance2, final_p_counts, fpfh,
+                mask_fpfh_points, map_required_point_idx_to_point_idx);
     } else {
         const int64_t size = input.GetPointPositions().GetLength();
         fpfh = core::Tensor::Zeros({size, 33}, dtype, device);

--- a/cpp/open3d/t/pipelines/registration/Feature.h
+++ b/cpp/open3d/t/pipelines/registration/Feature.h
@@ -30,12 +30,15 @@ namespace registration {
 /// 100].
 /// \param radius [optional] Neighbor search radius parameter. [Recommended ~5x
 /// voxel size].
+/// \param indices [optional] Tensor with the indices of the points to compute "
+/// FPFH features on. [Default = None].
 /// \return A Tensor of FPFH feature of the input point cloud with
 /// shape {N, 33}, data type and device same as input.
 core::Tensor ComputeFPFHFeature(
         const geometry::PointCloud &input,
         const utility::optional<int> max_nn = 100,
-        const utility::optional<double> radius = utility::nullopt);
+        const utility::optional<double> radius = utility::nullopt,
+        const utility::optional<core::Tensor> &indices = utility::nullopt);
 
 /// \brief Function to find correspondences via 1-nearest neighbor feature
 /// matching. Target is used to construct a nearest neighbor search

--- a/cpp/pybind/pipelines/registration/feature.cpp
+++ b/cpp/pybind/pipelines/registration/feature.cpp
@@ -7,6 +7,7 @@
 
 #include "open3d/pipelines/registration/Feature.h"
 
+#include "open3d/geometry/KDTreeSearchParam.h"
 #include "open3d/geometry/PointCloud.h"
 #include "pybind/docstring.h"
 #include "pybind/pipelines/registration/registration.h"
@@ -63,11 +64,15 @@ void pybind_feature_definitions(py::module &m_registration) {
               "Set to ``True`` to invert the selection of indices."}});
     m_registration.def("compute_fpfh_feature", &ComputeFPFHFeature,
                        "Function to compute FPFH feature for a point cloud",
-                       "input"_a, "search_param"_a);
+                       "input"_a, "search_param"_a, "indices"_a = py::none());
     docstring::FunctionDocInject(
             m_registration, "compute_fpfh_feature",
-            {{"input", "The Input point cloud."},
-             {"search_param", "KDTree KNN search parameter."}});
+            {
+                    {"input", "The Input point cloud."},
+                    {"search_param", "KDTree KNN search parameter."},
+                    {"indices",
+                     "Indices to select points for feature computation."},
+            });
 
     m_registration.def(
             "correspondences_from_features", &CorrespondencesFromFeatures,

--- a/cpp/pybind/t/pipelines/registration/feature.cpp
+++ b/cpp/pybind/t/pipelines/registration/feature.cpp
@@ -23,8 +23,11 @@ void pybind_feature_definitions(py::module &m_registration) {
                        R"(Function to compute FPFH feature for a point cloud.
 It uses KNN search (Not recommended to use on GPU) if only max_nn parameter
 is provided, Radius search (Not recommended to use on GPU) if only radius
-parameter is provided, and Hybrid search (Recommended) if both are provided.)",
-                       "input"_a, "max_nn"_a = 100, "radius"_a = py::none());
+parameter is provided, and Hybrid search (Recommended) if both are provided.
+If indices is provided, the function will compute FPFH features only on the
+selected points.)",
+                       "input"_a, "max_nn"_a = 100, "radius"_a = py::none(),
+                       "indices"_a = py::none());
     docstring::FunctionDocInject(
             m_registration, "compute_fpfh_feature",
             {{"input",
@@ -34,7 +37,10 @@ parameter is provided, and Hybrid search (Recommended) if both are provided.)",
               "100]"},
              {"radius",
               "[optional] Neighbor search radius parameter. [Recommended ~5x "
-              "voxel size]"}});
+              "voxel size]"},
+             {"indices",
+              "[optional] Tensor with the indices of the points to compute "
+              "FPFH features on. [Default = None]"}});
 
     m_registration.def(
             "correspondences_from_features", &CorrespondencesFromFeatures,

--- a/cpp/pybind/t/pipelines/registration/feature.cpp
+++ b/cpp/pybind/t/pipelines/registration/feature.cpp
@@ -19,49 +19,97 @@ namespace registration {
 
 void pybind_feature_definitions(py::module &m_registration) {
     m_registration.def("compute_fpfh_feature", &ComputeFPFHFeature,
-                       py::call_guard<py::gil_scoped_release>(),
+                       py::call_guard<py::gil_scoped_release>(), "input"_a,
+                       "max_nn"_a = 100, "radius"_a = py::none(),
+                       "indices"_a = py::none(),
                        R"(Function to compute FPFH feature for a point cloud.
+
 It uses KNN search (Not recommended to use on GPU) if only max_nn parameter
 is provided, Radius search (Not recommended to use on GPU) if only radius
 parameter is provided, and Hybrid search (Recommended) if both are provided.
 If indices is provided, the function will compute FPFH features only on the
-selected points.)",
-                       "input"_a, "max_nn"_a = 100, "radius"_a = py::none(),
-                       "indices"_a = py::none());
-    docstring::FunctionDocInject(
-            m_registration, "compute_fpfh_feature",
-            {{"input",
-              "The input point cloud with data type float32 or float64."},
-             {"max_nn",
-              "[optional] Neighbor search max neighbors parameter.[Default = "
-              "100]"},
-             {"radius",
-              "[optional] Neighbor search radius parameter. [Recommended ~5x "
-              "voxel size]"},
-             {"indices",
-              "[optional] Tensor with the indices of the points to compute "
-              "FPFH features on. [Default = None]"}});
+selected points.
+
+Args:
+    input (open3d.core.Tensor): The input point cloud with data type float32 or float64.
+    max_nn (int, optional): Neighbor search max neighbors parameter.
+        Default is 100.
+    radius (float, optional): Neighbor search radius parameter.
+        Recommended value is ~5x voxel size.
+    indices (open3d.core.Tensor, optional): Tensor with the indices of the points to
+        compute FPFH features on. Default is None.
+
+Returns:
+    The FPFH feature tensor with shape (N, 33).
+
+Example:
+    This example shows how to compute the features and correspondences for two 
+    point clouds::
+
+        import open3d as o3d
+        # read and downsample point clouds
+        paths = o3d.data.DemoICPPointClouds().paths
+        voxel_size = 0.01
+        pcd = o3d.t.io.read_point_cloud(paths[0]).voxel_down_sample(voxel_size)
+
+        # compute FPFH features
+        pcd_fpfh = o3d.t.pipelines.registration.compute_fpfh_feature(pcd, radius=5*voxel_size)
+    )"
+
+    );
 
     m_registration.def(
             "correspondences_from_features", &CorrespondencesFromFeatures,
-            py::call_guard<py::gil_scoped_release>(),
-            R"(Function to query nearest neighbors of source_features in target_features.)",
-            "source_features"_a, "target_features"_a, "mutual_filter"_a = false,
-            "mutual_consistency_ratio"_a = 0.1f);
-    docstring::FunctionDocInject(
-            m_registration, "correspondences_from_features",
-            {{"source_features", "The source features in shape (N, dim)."},
-             {"target_features", "The target features in shape (M, dim)."},
-             {"mutual_filter",
-              "filter correspondences and return the collection of (i, j) "
-              "s.t. "
-              "source_features[i] and target_features[j] are mutually the "
-              "nearest neighbor."},
-             {"mutual_consistency_ratio",
-              "Threshold to decide whether the number of filtered "
-              "correspondences is sufficient. Only used when "
-              "mutual_filter is "
-              "enabled."}});
+            py::call_guard<py::gil_scoped_release>(), "source_features"_a,
+            "target_features"_a, "mutual_filter"_a = false,
+            "mutual_consistency_ratio"_a = 0.1f,
+            R"(Function to query nearest neighbors of source_features in target_features.
+            
+Args:
+    source_features (open3d.core.Tensor): The source features in shape (N, dim).
+    target_features (open3d.core.Tensor): The target features in shape (M, dim).
+    mutual_filter (bool, optional): Filter correspondences and return the 
+        collection of (i, j) s.t. source_features[i] and target_features[j] are 
+        mutually the nearest neighbor. Default is False.
+    mutual_consistency_ratio (float, optional): Threshold to decide whether the 
+        number of filtered correspondences is sufficient. Only used when 
+        `mutual_filter` is enabled. Default is 0.1.
+
+Returns:
+    Tensor with shape (K,2) of source_indices and target_indices with K as the 
+    number of correspondences.
+
+Example:
+
+    This example shows how to compute the features and correspondences for two point clouds::
+
+        import open3d as o3d
+
+        # read and downsample point clouds
+        paths = o3d.data.DemoICPPointClouds().paths
+        voxel_size = 0.01
+        pcd1 = o3d.t.io.read_point_cloud(paths[0]).voxel_down_sample(voxel_size)
+        pcd2 = o3d.t.io.read_point_cloud(paths[1]).voxel_down_sample(voxel_size)
+
+        # compute FPFH features
+        pcd1_fpfh = o3d.t.pipelines.registration.compute_fpfh_feature(pcd1, radius=5*voxel_size)
+        pcd2_fpfh = o3d.t.pipelines.registration.compute_fpfh_feature(pcd2, radius=5*voxel_size)
+
+        # compute correspondences
+        matches = o3d.t.pipelines.registration.correspondences_from_features(pcd1_fpfh, pcd2_fpfh, mutual_filter=True)
+
+        # visualize correspondences
+        matches = matches[::500]
+        pcd2.translate([0,2,0]) # translate pcd2 for the visualization
+        lines = o3d.t.geometry.LineSet()
+        lines.point.positions = o3d.core.Tensor.zeros((matches.num_elements(), 3))
+        lines.point.positions[0::2] = pcd1.point.positions[matches[:,0]]
+        lines.point.positions[1::2] = pcd2.point.positions[matches[:,1]]
+        lines.line.indices = o3d.core.Tensor.arange(matches.num_elements()).reshape((-1,2))
+
+        o3d.visualization.draw([pcd1, pcd2, lines])
+
+)");
 }
 
 }  // namespace registration

--- a/cpp/pybind/t/pipelines/registration/feature.cpp
+++ b/cpp/pybind/t/pipelines/registration/feature.cpp
@@ -43,8 +43,7 @@ Returns:
     The FPFH feature tensor with shape (N, 33).
 
 Example:
-    This example shows how to compute the features and correspondences for two 
-    point clouds::
+    This example shows how to compute the FPFH features for a point cloud::
 
         import open3d as o3d
         # read and downsample point clouds


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [x] New feature (non-breaking change which adds functionality). Resolves #7089
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Allows optional selection of specific points when computing FPFH features for a point cloud. Previously, if you only needed FPFH features from a small subset of points (e.g., ISS keypoints), you had to compute the features for the entire point cloud (which was slow and unnecessary) and then select the relevant features. Now, you can directly compute the FPFH features for just the selected points, resulting in faster performance.

Unrelated, also fixed a bug in #7039 when calling SelectByIndex with `invert=true`.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [x] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [x] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

Made significant modifications to multiple files. Extra processing for a correct dataflow was needed when the user provides the required point indices. 

An optional argument `indices` is added to [`ComputeFPFHFeature`](https://github.com/isl-org/Open3D/blob/583eaa3351f9411f2d2f1faf7ac17479cc11975b/cpp/open3d/pipelines/registration/Feature.h#L69) and [`t\ComputeFPFHFeature`](https://github.com/isl-org/Open3D/blob/583eaa3351f9411f2d2f1faf7ac17479cc11975b/cpp/open3d/t/pipelines/registration/Feature.h#L41). If `indices` is provided, the function computes and returns the FPFH features for only the selected points. Some additional processing is performed to prepare the data. The catch is that even if the user selects _n_ points, to compute the corresponding _n_ FPFH features, the SPFH features of all the neighbors of each selected point must first be computed. And to compute the SPFH feature for a point, you need the data of its neighbors.

This means that selecting 1% or 10% of the points will not result in a 100x or 10x speed-up, because the many SPFH features of all the neighbors still need to be computed. Moreover, the new inner pipelines within the FPFH functions are optimized for selecting a small fraction of indices (around 0-10%). If the fraction of selected indices is large, the speed-up will be minimal. In fact, if the fraction of selected points approaches 100%, calling the function without specifying indices (i.e., computing FPFH features for the entire point cloud) will actually be faster. In the next days I can add benchmark tests too.