### PR TITLE
 Fix: UniformIntGenerator range error

### DIFF
--- a/cpp/open3d/utility/Random.h
+++ b/cpp/open3d/utility/Random.h
@@ -68,7 +68,7 @@ public:
     ///
     /// \param low The lower bound (inclusive).
     /// \param high The upper bound (exclusive). \p high must be > \p low.
-    UniformIntGenerator(const T low, const T high) : distribution_(low, high) {
+    UniformIntGenerator(const T low, const T high) : distribution_(low, high-1) {
         if (low < 0) {
             utility::LogError("low must be > 0, but got {}.", low);
         }

--- a/cpp/open3d/utility/Random.h
+++ b/cpp/open3d/utility/Random.h
@@ -67,13 +67,13 @@ public:
     /// [low, low + 1, ... high].
     ///
     /// \param low The lower bound (inclusive).
-    /// \param high The upper bound (exclusive). \p high must be > \p low.
+    /// \param high The upper bound (inclusive). \p high must be >= \p low.
     UniformIntGenerator(const T low, const T high) : distribution_(low, high) {
         if (low < 0) {
             utility::LogError("low must be > 0, but got {}.", low);
         }
-        if (low >= high) {
-            utility::LogError("low must be < high, but got low={} and high={}.",
+        if (low > high) {
+            utility::LogError("low must be <= high, but got low={} and high={}.",
                               low, high);
         }
     }

--- a/cpp/open3d/utility/Random.h
+++ b/cpp/open3d/utility/Random.h
@@ -43,7 +43,7 @@ std::mutex* GetMutex();
 /// This function is automatically protected by the global random mutex.
 uint32_t RandUint32();
 
-/// Generate uniformly distributed random integers in [low, high).
+/// Generate uniformly distributed random integers in [low, high].
 /// This class is globally seeded by utility::random::Seed().
 /// This class is a wrapper around std::uniform_int_distribution.
 ///
@@ -54,7 +54,7 @@ uint32_t RandUint32();
 /// // Globally seed Open3D. This will affect all random functions.
 /// utility::random::Seed(0);
 ///
-/// // Generate a random int in [0, 100).
+/// // Generate a random int in [0, 100].
 /// utility::random::UniformIntGenerator<int> gen(0, 100);
 /// for (size_t i = 0; i < 10; i++) {
 ///     std::cout << gen() << std::endl;
@@ -64,11 +64,11 @@ template <typename T>
 class UniformIntGenerator {
 public:
     /// Generate uniformly distributed random integer from
-    /// [low, low + 1, ... high - 1].
+    /// [low, low + 1, ... high].
     ///
     /// \param low The lower bound (inclusive).
     /// \param high The upper bound (exclusive). \p high must be > \p low.
-    UniformIntGenerator(const T low, const T high) : distribution_(low, high-1) {
+    UniformIntGenerator(const T low, const T high) : distribution_(low, high) {
         if (low < 0) {
             utility::LogError("low must be > 0, but got {}.", low);
         }


### PR DESCRIPTION
Fix the UniformIntGenerator output range error. According to the function description, the output range should be [low, high), but the actual output range is [low, high].  This PR pdate the function description.
refer to: [uniform_int_distribution](https://en.cppreference.com/w/cpp/numeric/random/uniform_int_distribution)

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [ ] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [ ] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [ ] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
