### PR TITLE
Fixed corrupted default values in documentation

### DIFF
--- a/cpp/open3d/core/Device.cpp
+++ b/cpp/open3d/core/Device.cpp
@@ -32,13 +32,13 @@ static Device::DeviceType StringToDeviceType(const std::string& type_colon_id) {
         } else {
             utility::LogError(
                     "Invalid device string {}. Valid device strings are like "
-                    "\"CPU:0\" or \"CUDA:1\"",
+                    "\"CPU:0\", \"CUDA:1\" or \"SYCL:0\"",
                     type_colon_id);
         }
     } else {
         utility::LogError(
                 "Invalid device string {}. Valid device strings are like "
-                "\"CPU:0\" or \"CUDA:1\"",
+                "\"CPU:0\", \"CUDA:1\" or \"SYCL:0\"",
                 type_colon_id);
     }
 }
@@ -51,7 +51,7 @@ static int StringToDeviceId(const std::string& type_colon_id) {
     } else {
         utility::LogError(
                 "Invalid device string {}. Valid device strings are like "
-                "\"CPU:0\" or \"CUDA:1\"",
+                "\"CPU:0\", \"CUDA:1\" or \"SYCL:0\"",
                 type_colon_id);
     }
 }

--- a/cpp/pybind/core/device.cpp
+++ b/cpp/pybind/core/device.cpp
@@ -45,11 +45,10 @@ void pybind_core_device_definitions(py::module &m) {
                 device_type = "SYCL";
                 break;
             default:
-                utility::LogWarn("Unknown device type");
+                utility::LogError("Unknown device type");
                 return d.ToString();
         }
-        return fmt::format("open3d.core.Device({}, {})", device_type,
-                           d.GetID());
+        return fmt::format("Device({}, {})", device_type, d.GetID());
     });
     device.def("__str__", &Device::ToString);
     device.def("get_type", &Device::GetType);

--- a/cpp/pybind/core/device.cpp
+++ b/cpp/pybind/core/device.cpp
@@ -48,7 +48,9 @@ void pybind_core_device_definitions(py::module &m) {
                 utility::LogWarn("Unknown device type");
                 return d.ToString();
         }
-        return fmt::format("open3d.core.Device({}, {})", device_type, d.GetID()); });
+        return fmt::format("open3d.core.Device({}, {})", device_type,
+                           d.GetID());
+    });
     device.def("__str__", &Device::ToString);
     device.def("get_type", &Device::GetType);
     device.def("get_id", &Device::GetID);

--- a/cpp/pybind/core/device.cpp
+++ b/cpp/pybind/core/device.cpp
@@ -21,6 +21,7 @@ void pybind_core_device_declarations(py::module &m) {
     py::enum_<Device::DeviceType>(device, "DeviceType")
             .value("CPU", Device::DeviceType::CPU)
             .value("CUDA", Device::DeviceType::CUDA)
+            .value("SYCL", Device::DeviceType::SYCL)
             .export_values();
 }
 void pybind_core_device_definitions(py::module &m) {
@@ -31,7 +32,23 @@ void pybind_core_device_definitions(py::module &m) {
     device.def(py::init<const std::string &>());
     device.def("__eq__", &Device::operator==);
     device.def("__ene__", &Device::operator!=);
-    device.def("__repr__", &Device::ToString);
+    device.def("__repr__", [](const Device &d) {
+        std::string device_type;
+        switch (d.GetType()) {
+            case Device::DeviceType::CPU:
+                device_type = "CPU";
+                break;
+            case Device::DeviceType::CUDA:
+                device_type = "CUDA";
+                break;
+            case Device::DeviceType::SYCL:
+                device_type = "SYCL";
+                break;
+            default:
+                utility::LogWarn("Unknown device type");
+                return d.ToString();
+        }
+        return fmt::format("open3d.core.Device({}, {})", device_type, d.GetID()); });
     device.def("__str__", &Device::ToString);
     device.def("get_type", &Device::GetType);
     device.def("get_id", &Device::GetID);

--- a/cpp/pybind/core/device.cpp
+++ b/cpp/pybind/core/device.cpp
@@ -48,7 +48,7 @@ void pybind_core_device_definitions(py::module &m) {
                 utility::LogError("Unknown device type");
                 return d.ToString();
         }
-        return fmt::format("Device({}, {})", device_type, d.GetID());
+        return fmt::format("Device(\"{}\", {})", device_type, d.GetID());
     });
     device.def("__str__", &Device::ToString);
     device.def("get_type", &Device::GetType);

--- a/cpp/pybind/geometry/voxelgrid.cpp
+++ b/cpp/pybind/geometry/voxelgrid.cpp
@@ -28,6 +28,13 @@ void pybind_voxelgrid_declarations(py::module &m) {
             voxelgrid(m, "VoxelGrid",
                       "VoxelGrid is a collection of voxels which are aligned "
                       "in grid.");
+    py::enum_<VoxelGrid::VoxelPoolingMode>(
+            voxelgrid, "VoxelPoolingMode",
+            "Mode of determining color for each voxel.")
+            .value("AVG", VoxelGrid::VoxelPoolingMode::AVG)
+            .value("MIN", VoxelGrid::VoxelPoolingMode::MIN)
+            .value("MAX", VoxelGrid::VoxelPoolingMode::MAX)
+            .value("SUM", VoxelGrid::VoxelPoolingMode::SUM);
 }
 void pybind_voxelgrid_definitions(py::module &m) {
     auto voxel = static_cast<py::class_<Voxel, std::shared_ptr<Voxel>>>(
@@ -63,14 +70,6 @@ void pybind_voxelgrid_definitions(py::module &m) {
             static_cast<py::class_<VoxelGrid, PyGeometry3D<VoxelGrid>,
                                    std::shared_ptr<VoxelGrid>, Geometry3D>>(
                     m.attr("VoxelGrid"));
-
-    py::enum_<VoxelGrid::VoxelPoolingMode> pooling_mode(
-            voxelgrid, "VoxelPoolingMode",
-            "Mode of determining color for each voxel.");
-    pooling_mode.value("AVG", VoxelGrid::VoxelPoolingMode::AVG)
-            .value("MIN", VoxelGrid::VoxelPoolingMode::MIN)
-            .value("MAX", VoxelGrid::VoxelPoolingMode::MAX)
-            .value("SUM", VoxelGrid::VoxelPoolingMode::SUM);
 
     py::detail::bind_default_constructor<VoxelGrid>(voxelgrid);
     py::detail::bind_copy_functions<VoxelGrid>(voxelgrid);
@@ -135,26 +134,29 @@ void pybind_voxelgrid_definitions(py::module &m) {
                         "carving",
                         "origin"_a, "color"_a, "voxel_size"_a, "width"_a,
                         "height"_a, "depth"_a)
-            .def_static("create_from_point_cloud",
-                        &VoxelGrid::CreateFromPointCloud,
-                        "Creates a VoxelGrid from a given PointCloud. The "
-                        "color value of a given  voxel is determined by the "
-                        "VoxelPoolingMode, e.g. by default the average color "
-                        "value of the points that fall into it (if the "
-                        "PointCloud has colors). The bounds of the created "
-                        "VoxelGrid are computed from the PointCloud.",
-                        "input"_a, "voxel_size"_a,
-                        "pooling_mode"_a = VoxelGrid::VoxelPoolingMode::AVG)
-            .def_static("create_from_point_cloud_within_bounds",
-                        &VoxelGrid::CreateFromPointCloudWithinBounds,
-                        "Creates a VoxelGrid from a given PointCloud. The "
-                        "color value of a given voxel is determined by the "
-                        "VoxelPoolingMode, e.g. by default the average color "
-                        "value of the points that fall into it (if the "
-                        "PointCloud has colors). The bounds of the created "
-                        "VoxelGrid are defined by the given parameters.",
-                        "input"_a, "voxel_size"_a, "min_bound"_a, "max_bound"_a,
-                        "pooling_mode"_a = VoxelGrid::VoxelPoolingMode::AVG)
+            .def_static(
+                    "create_from_point_cloud", &VoxelGrid::CreateFromPointCloud,
+                    "Creates a VoxelGrid from a given PointCloud. The "
+                    "color value of a given  voxel is determined by the "
+                    "VoxelPoolingMode, e.g. by default the average color "
+                    "value of the points that fall into it (if the "
+                    "PointCloud has colors). The bounds of the created "
+                    "VoxelGrid are computed from the PointCloud.",
+                    "input"_a, "voxel_size"_a,
+                    py::arg_v("pooling_mode", VoxelGrid::VoxelPoolingMode::AVG,
+                              "VoxelPoolingMode.AVG"))
+            .def_static(
+                    "create_from_point_cloud_within_bounds",
+                    &VoxelGrid::CreateFromPointCloudWithinBounds,
+                    "Creates a VoxelGrid from a given PointCloud. The "
+                    "color value of a given voxel is determined by the "
+                    "VoxelPoolingMode, e.g. by default the average color "
+                    "value of the points that fall into it (if the "
+                    "PointCloud has colors). The bounds of the created "
+                    "VoxelGrid are defined by the given parameters.",
+                    "input"_a, "voxel_size"_a, "min_bound"_a, "max_bound"_a,
+                    py::arg_v("pooling_mode", VoxelGrid::VoxelPoolingMode::AVG,
+                              "VoxelPoolingMode.AVG"))
             .def_static("create_from_triangle_mesh",
                         &VoxelGrid::CreateFromTriangleMesh,
                         "Creates a VoxelGrid from a given TriangleMesh. No "
@@ -221,20 +223,20 @@ void pybind_voxelgrid_definitions(py::module &m) {
             m, "VoxelGrid", "create_dense",
             {{"origin", "Coordinate center of the VoxelGrid"},
              {"color", "Voxel color for all voxels if the VoxelGrid."},
-             {"voxel_size", "Voxel size of of the VoxelGrid construction."},
+             {"voxel_size", "Voxel size of the VoxelGrid construction."},
              {"width", "Spatial width extend of the VoxelGrid."},
              {"height", "Spatial height extend of the VoxelGrid."},
              {"depth", "Spatial depth extend of the VoxelGrid."}});
     docstring::ClassMethodDocInject(
             m, "VoxelGrid", "create_from_point_cloud",
             {{"input", "The input PointCloud"},
-             {"voxel_size", "Voxel size of of the VoxelGrid construction."},
+             {"voxel_size", "Voxel size of the VoxelGrid construction."},
              {"pooling_mode",
               "VoxelPoolingMode for determining voxel color."}});
     docstring::ClassMethodDocInject(
             m, "VoxelGrid", "create_from_point_cloud_within_bounds",
             {{"input", "The input PointCloud"},
-             {"voxel_size", "Voxel size of of the VoxelGrid construction."},
+             {"voxel_size", "Voxel size of the VoxelGrid construction."},
              {"min_bound",
               "Minimum boundary point for the VoxelGrid to create."},
              {"max_bound",
@@ -245,11 +247,11 @@ void pybind_voxelgrid_definitions(py::module &m) {
     docstring::ClassMethodDocInject(
             m, "VoxelGrid", "create_from_triangle_mesh",
             {{"input", "The input TriangleMesh"},
-             {"voxel_size", "Voxel size of of the VoxelGrid construction."}});
+             {"voxel_size", "Voxel size of the VoxelGrid construction."}});
     docstring::ClassMethodDocInject(
             m, "VoxelGrid", "create_from_triangle_mesh_within_bounds",
             {{"input", "The input TriangleMesh"},
-             {"voxel_size", "Voxel size of of the VoxelGrid construction."},
+             {"voxel_size", "Voxel size of the VoxelGrid construction."},
              {"min_bound",
               "Minimum boundary point for the VoxelGrid to create."},
              {"max_bound",

--- a/cpp/pybind/t/geometry/trianglemesh.cpp
+++ b/cpp/pybind/t/geometry/trianglemesh.cpp
@@ -220,7 +220,7 @@ Returns:
             R"(Compute the convex hull of a point cloud using qhull. This runs on the CPU.
 
 Args:
-    joggle_inputs (bool with default False): Handle precision problems by
+    joggle_inputs (bool, default=False): Handle precision problems by
         randomly perturbing the input data. Set to True if perturbing the input
         iis acceptable but you need convex simplicial output. If False,
         neighboring facets may be merged in case of precision problems. See
@@ -1147,17 +1147,17 @@ Example::
 
     triangle_mesh.def("compute_metrics", &TriangleMesh::ComputeMetrics,
                       "mesh2"_a, "metrics"_a, "params"_a,
-                      R"(Compute various metrics between two triangle meshes. 
-            
-This uses ray casting for distance computations between a sampled point cloud 
-and a triangle mesh.  Currently, Chamfer distance, Hausdorff distance  and 
-F-Score `[Knapitsch2017] <../tutorial/reference.html#Knapitsch2017>`_ are supported. 
+                      R"(Compute various metrics between two triangle meshes.
+
+This uses ray casting for distance computations between a sampled point cloud
+and a triangle mesh.  Currently, Chamfer distance, Hausdorff distance  and
+F-Score `[Knapitsch2017] <../tutorial/reference.html#Knapitsch2017>`_ are supported.
 The Chamfer distance is the sum of the mean distance to the nearest neighbor from
-the sampled surface points of the first mesh to the second mesh and vice versa. 
-The F-Score at the fixed threshold radius is the harmonic mean of the Precision 
-and Recall. Recall is the percentage of surface points from the first mesh that 
-have the second mesh within the threshold radius, while Precision is the 
-percentage of sampled points from the second mesh that have the first mesh 
+the sampled surface points of the first mesh to the second mesh and vice versa.
+The F-Score at the fixed threshold radius is the harmonic mean of the Precision
+and Recall. Recall is the percentage of surface points from the first mesh that
+have the second mesh within the threshold radius, while Precision is the
+percentage of sampled points from the second mesh that have the first mesh
 surface within the threhold radius.
 
 .. math::


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #7147

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Devices in default values cause corrupted rendering in the documentation as shown in #7147.
The reason is that `o3d.core.Device.__repr__` returns a string like this: `CPU:0`.
Sphinx docs generation seems to misinterpret `:` in default values.

Also, I found a similar problem with the enum VoxelPoolingMode.
The raw enum value also contains a `:` and causes faulty documentation.
![voxelpoolingmode](https://github.com/user-attachments/assets/24264334-5e98-401e-b24b-ac837164943d)


I found a similar issue here: sphinx-doc/sphinx#9266

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [x] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
In order to fix this, I changed `o3d.core.Device.__repr__`.
Instead of `CPU:0` it now returns `Device("CPU", 0)` (which is now also correct Python code).

![o3d_device_in_default](https://github.com/user-attachments/assets/5fa53091-ed92-43ee-ad60-63ed76974a74)

I fixed the VoxelPoolingMode issue using `py::arg_v` to define the Python representation explicitly.
![voxelpoolingmode_fixed](https://github.com/user-attachments/assets/73f5db64-7b17-48ca-acb9-5f0b49fa9e50)

I marked this as a breaking change because it changes the output of `o3d.core.Device.__repr__`.

Also, I fixed some minor typos, added mentioning of `SYCL` in some error messages and added the missing Python binding for `DeviceType.SYCL`.