### PR TITLE
Fix the reading error when PLY files use non-RGB color orders.

### DIFF
--- a/cpp/open3d/io/file_format/FilePLY.cpp
+++ b/cpp/open3d/io/file_format/FilePLY.cpp
@@ -78,16 +78,14 @@ int ReadColorCallback(p_ply_argument argument) {
     long index;
     ply_get_argument_user_data(argument, reinterpret_cast<void **>(&state_ptr),
                                &index);
-    if (state_ptr->color_index >= state_ptr->color_num) {
+    if (state_ptr->color_index >= state_ptr->color_num * 3) {
         return 0;
     }
 
     double value = ply_get_argument_value(argument);
-    state_ptr->pointcloud_ptr->colors_[state_ptr->color_index](index) =
+    state_ptr->pointcloud_ptr->colors_[state_ptr->color_index / 3](index) =
             value / 255.0;
-    if (index == 2) {  // reading 'blue'
-        state_ptr->color_index++;
-    }
+    ++state_ptr->color_index;
     return 1;
 }
 
@@ -150,16 +148,14 @@ int ReadColorCallback(p_ply_argument argument) {
     long index;
     ply_get_argument_user_data(argument, reinterpret_cast<void **>(&state_ptr),
                                &index);
-    if (state_ptr->color_index >= state_ptr->color_num) {
+    if (state_ptr->color_index >= state_ptr->color_num * 3) {
         return 0;
     }
 
     double value = ply_get_argument_value(argument);
-    state_ptr->mesh_ptr->vertex_colors_[state_ptr->color_index](index) =
+    state_ptr->mesh_ptr->vertex_colors_[state_ptr->color_index / 3](index) =
             value / 255.0;
-    if (index == 2) {  // reading 'blue'
-        state_ptr->color_index++;
-    }
+    ++state_ptr->color_index;
     return 1;
 }
 
@@ -248,15 +244,15 @@ int ReadColorCallback(p_ply_argument argument) {
     long index;
     ply_get_argument_user_data(argument, reinterpret_cast<void **>(&state_ptr),
                                &index);
-    if (state_ptr->color_index >= state_ptr->color_num) {
+    if (state_ptr->color_index >= state_ptr->color_num * 3) {
         return 0;
     }
 
     double value = ply_get_argument_value(argument);
-    state_ptr->lineset_ptr->colors_[state_ptr->color_index](index) =
+    state_ptr->lineset_ptr->colors_[state_ptr->color_index / 3](index) =
             value / 255.0;
-    if (index == 2) {  // reading 'blue'
-        state_ptr->color_index++;
+    ++state_ptr->color_index;
+    if (state_ptr->color_index % 3 == 0) {
         ++(*state_ptr->progress_bar);
     }
     return 1;
@@ -323,15 +319,15 @@ int ReadColorCallback(p_ply_argument argument) {
     long index;
     ply_get_argument_user_data(argument, reinterpret_cast<void **>(&state_ptr),
                                &index);
-    if (state_ptr->color_index >= state_ptr->color_num) {
+    if (state_ptr->color_index >= state_ptr->color_num * 3) {
         return 0;
     }
 
     double value = ply_get_argument_value(argument);
     auto &ptr = *(state_ptr->voxelgrid_ptr);
-    ptr[state_ptr->color_index].color_(index) = value / 255.0;
-    if (index == 2) {  // reading 'blue'
-        state_ptr->color_index++;
+    ptr[state_ptr->color_index / 3].color_(index) = value / 255.0;
+    ++state_ptr->color_index;
+    if (state_ptr->color_index % 3 == 0) {
         ++(*state_ptr->progress_bar);
     }
     return 1;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #5994
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

It seems that `open3d.io.read_point_cloud` assumes that the color properties end with the blue channel:
> https://github.com/isl-org/Open3D/blob/c6d474b3fa0b47adbcff51219f5928855c3bb806/cpp/open3d/io/file_format/FilePLY.cpp#L88-L90

If a PLY [file](https://drive.google.com/file/d/1OuFkeUZotm34VkbQvb0sb_wYE9pCnby_/view?usp=share_link) defines colors in other orders, e.g., GBR, the `color_index` is incorrectly incremented after reading the blue channel, causing all red values to be placed at the wrong positions.

However, `open3d.t.io.read_point_cloud` correctly handles this case:

> https://github.com/isl-org/Open3D/blob/c6d474b3fa0b47adbcff51219f5928855c3bb806/cpp/open3d/t/io/file_format/FilePLY.cpp#L52-L56


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [ ] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
I changed the meaning of `color_index` to track the number of processed channels (instead of the number of points), which allows for correct point indexing regardless of the channel order.

Here is an example using [this file](https://drive.google.com/file/d/1OuFkeUZotm34VkbQvb0sb_wYE9pCnby_/view?usp=share_link) :
```
import open3d as o3d
import numpy as np

pc = o3d.io.read_point_cloud("aaa.ply")   # Current version will produce  RPly: Aborted by user  [Open3D WARNING] Read PLY failed: unable to read file: aaa.ply
pc2 = o3d.t.io.read_point_cloud("aaa.ply")

print( ((pc2.point.colors).numpy() == np.asarray(pc.colors) * 255).all() )
```
