### PR TITLE
CI OpenBlas ARM Runners

### DIFF
--- a/.github/workflows/ubuntu-openblas.yml
+++ b/.github/workflows/ubuntu-openblas.yml
@@ -32,123 +32,26 @@ jobs:
           source util/ci_utils.sh
           maximize_ubuntu_github_actions_build_space
       - name: Docker build
-        run: docker/docker_build.sh openblas-amd64-py310-dev
+        run: docker/docker_build.sh openblas-amd64-py312-dev
 
       - name: Docker test
-        run: docker/docker_test.sh openblas-amd64-py310-dev
-
-  # With forked repo, the GitHub secret is not available.
-  skip-arm64-check-on-fork:
-    runs-on: ubuntu-latest
-    name: Skip job for forks
-    outputs:
-      skip: ${{ steps.check.outputs.skip }}
-    steps:
-      - name: Skip check
-        id: check
-        run: |
-          if [ "${GITHUB_REPOSITORY}" == "isl-org/Open3D" ] && [ -n "${GCE_GPU_CI_SA}" ] ; then
-            echo "Secrets available: performing GCE test"
-            echo "skip=no" >> $GITHUB_OUTPUT
-          else
-            echo "Secrets not available: skipping GCE test"
-            echo "skip=yes" >> $GITHUB_OUTPUT
-          fi
+        run: docker/docker_test.sh openblas-amd64-py312-dev
 
   openblas-arm64:
     permissions:
       contents: read
-    runs-on: ubuntu-latest
-    needs: [skip-arm64-check-on-fork]
-    if: needs.skip-arm64-check-on-fork.outputs.skip == 'no'
+    runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
-    env:
-      # Export everything from matrix to be easily used.
-      # Docker tag must be consistent with docker_build.sh
-      CI_CONFIG          : openblas-arm64-py310-dev
-      GCE_INSTANCE_PREFIX: open3d-ci-openblas-arm64-py310-dev
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
-      - name: Package code
+      - name: Maximize build space
         run: |
-          # GITHUB_WORKSPACE: /home/runner/work/Open3D/Open3D
-          cd "${GITHUB_WORKSPACE}/.."
-          tar -czvf Open3D.tar.gz Open3D
-          ls -alh
-      - name: GCloud CLI auth
-        uses: 'google-github-actions/auth@v2'
-        with:
-          project_id: ${{ secrets.GCE_PROJECT }}
-          credentials_json: '${{ secrets.GCE_SA_KEY_GPU_CI }}'
-      - name: GCloud CLI setup
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: ${{ env.GCE_CLI_GHA_VERSION }}
-          project_id: ${{ secrets.GCE_PROJECT }}
-      - name: VM create
-        run: |
-          gcloud compute images list
-          gcloud container images list
-          INSTANCE_NAME="${GCE_INSTANCE_PREFIX}-${GITHUB_SHA::8}"
-          INSTANCE_ZONES=(us-central1-a
-                          us-central1-b
-                          us-central1-f
-                          asia-southeast1-b
-                          asia-southeast1-c
-                          europe-west4-a
-                          europe-west4-b)
-          ZONE_ID=0
-          until ((ZONE_ID >= ${#INSTANCE_ZONES[@]})) ||
-            gcloud compute instances create "$INSTANCE_NAME" \
-              --zone="${INSTANCE_ZONES[$ZONE_ID]}" \
-              --machine-type=t2a-standard-4 \
-              --boot-disk-size="128GB" \
-              --image-project="ubuntu-os-cloud" \
-              --image-family="ubuntu-2004-lts-arm64" \
-              --metadata-from-file=startup-script=./util/gcloud_auto_clean.sh \
-              --scopes="storage-full,compute-rw" \
-              --service-account="$GCE_GPU_CI_SA"; do
-              ((ZONE_ID = ZONE_ID + 1))
-          done
-          sleep 90
-          echo "GCE_ZONE=${INSTANCE_ZONES[$ZONE_ID]}" >> "${GITHUB_ENV}"
-          echo "INSTANCE_NAME=${INSTANCE_NAME}" >> "${GITHUB_ENV}"
-          exit $((ZONE_ID >= ${#INSTANCE_ZONES[@]})) # 0 => success
-      - name: VM copy code
-        run: |
-          gcloud compute scp \
-            "${GITHUB_WORKSPACE}/../Open3D.tar.gz" "${INSTANCE_NAME}":~ \
-            --zone "${GCE_ZONE}"
-          gcloud compute ssh "${INSTANCE_NAME}" \
-            --zone "${GCE_ZONE}" \
-            --command "ls -alh \
-                    && tar -xvzf Open3D.tar.gz \
-                    && ls -alh \
-                    && ls -alh Open3D"
-      - name: VM install docker
-        run: |
-          gcloud compute ssh "${INSTANCE_NAME}" \
-            --zone="${GCE_ZONE}" \
-            --command="sudo apt update \
-                    && curl -fsSL https://get.docker.com -o get-docker.sh \
-                    && sudo sh get-docker.sh"
-      - name: VM build docker
-        run: |
-          gcloud compute ssh "${INSTANCE_NAME}" \
-            --zone="${GCE_ZONE}" \
-            --command="sudo docker run --rm arm64v8/ubuntu:20.04 uname -p \
-                    && sudo Open3D/docker/docker_build.sh ${CI_CONFIG}"
-      - name: VM run docker
-        run: |
-          gcloud compute ssh "${INSTANCE_NAME}" \
-            --zone="${GCE_ZONE}" \
-            --command="sudo Open3D/docker/docker_test.sh ${CI_CONFIG}"
-      - name: VM delete
-        if: always()
-        run: |
-          gcloud compute instances delete "${INSTANCE_NAME}" --zone "${GCE_ZONE}"
-          ls -alh "${HOME}/.ssh"
-          gcloud compute os-login describe-profile
-          gcloud compute os-login ssh-keys remove --key-file "${HOME}/.ssh/google_compute_engine.pub"
+          source util/ci_utils.sh
+          maximize_ubuntu_github_actions_build_space
+      - name: Docker build
+        run: docker/docker_build.sh openblas-arm64-py312-dev
+
+      - name: Docker test
+        run: docker/docker_test.sh openblas-arm64-py312-dev

--- a/.github/workflows/ubuntu-wheel.yml
+++ b/.github/workflows/ubuntu-wheel.yml
@@ -123,7 +123,7 @@ jobs:
     name: Test wheel CPU
     permissions:
       contents: read
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [build-wheel]
     strategy:
       fail-fast: false

--- a/.github/workflows/vtk_packages.yml
+++ b/.github/workflows/vtk_packages.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
     # TODO: Convert to docker
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/3rdparty/openblas/openblas.cmake
+++ b/3rdparty/openblas/openblas.cmake
@@ -9,8 +9,8 @@ endif()
 ExternalProject_Add(
     ext_openblas
     PREFIX openblas
-    URL https://github.com/xianyi/OpenBLAS/releases/download/v0.3.20/OpenBLAS-0.3.20.tar.gz
-    URL_HASH SHA256=8495c9affc536253648e942908e88e097f2ec7753ede55aca52e5dead3029e3c
+    URL https://github.com/xianyi/OpenBLAS/releases/download/v0.3.29/OpenBLAS-0.3.29.tar.gz
+    URL_HASH SHA256=38240eee1b29e2bde47ebb5d61160207dc68668a54cac62c076bb5032013b1eb
     DOWNLOAD_DIR "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/openblas"
     CMAKE_ARGS
         ${ExternalProject_CMAKE_ARGS}

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -87,6 +87,9 @@ RUN apt-get update && apt-get install -y \
     libxmlsec1-dev \
     libffi-dev \
     liblzma-dev \
+    libcurl4-openssl-dev \
+    libidn2-dev \
+    libidn2-0 \
     && if [ $BUILD_SYCL_MODULE = "ON" ]; then apt-get install -y intel-level-zero-gpu-raytracing ; fi \
  && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile.openblas
+++ b/docker/Dockerfile.openblas
@@ -80,6 +80,9 @@ RUN which python \
 COPY . /root/Open3D
 WORKDIR /root/Open3D
 
+ENV LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libgomp.so.1
+ENV LD_LIBRARY_PATH=/usr/lib:/lib
+
 # Build
 RUN mkdir build \
  && cd build \

--- a/docker/Dockerfile.openblas
+++ b/docker/Dockerfile.openblas
@@ -97,9 +97,6 @@ COPY . /root/Open3D
 WORKDIR /root/Open3D
 
 # Build
-RUN if [ "$(uname -m)" = "aarch64" ]; then \
-      export LD_PRELOAD=/opt/conda/envs/open3d/lib/libgomp.so.1; \
-    fi \
 RUN mkdir build \
  && cd build \
  && cmake \

--- a/docker/Dockerfile.openblas
+++ b/docker/Dockerfile.openblas
@@ -1,17 +1,15 @@
-# FROM must be called before other ARGS except for ARG BASE_IMAGE
+# ARG BASE_IMAGE must be specified before any other ARGs
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-# For the rest of this Dockerfile
+# Use bash as the default shell for subsequent RUN commands
 SHELL ["/bin/bash", "-c"]
 
 # Required build args, should be specified in docker_build.sh
-ARG CONDA_SUFFIX
 ARG CMAKE_VERSION
 ARG PYTHON_VERSION
 ARG DEVELOPER_BUILD
-RUN if [ -z "${CONDA_SUFFIX}"    ]; then echo "Error: ARG CONDA_SUFFIX    not specified."; exit 1; fi \
- && if [ -z "${CMAKE_VERSION}"   ]; then echo "Error: ARG CMAKE_VERSION   not specified."; exit 1; fi \
+RUN if [ -z "${CMAKE_VERSION}"   ]; then echo "Error: ARG CMAKE_VERSION   not specified."; exit 1; fi \
  && if [ -z "${PYTHON_VERSION}"  ]; then echo "Error: ARG PYTHON_VERSION  not specified."; exit 1; fi \
  && if [ -z "${DEVELOPER_BUILD}" ]; then echo "Error: ARG DEVELOPER_BUILD not specified."; exit 1; fi
 
@@ -21,9 +19,6 @@ ENV TZ=America/Los_Angeles
 ENV SUDO=command
 
 # Minimal dependencies for running Docker
-# wget    : for downloading
-# libgl1  : available on Ubuntu ARM desktop by default
-# libgomp1: available on Ubuntu ARM desktop by default
 RUN apt-get update && apt-get install -y \
     wget \
     libgl1 \
@@ -36,20 +31,36 @@ RUN apt-get update && apt-get install -y \
     git \
  && rm -rf /var/lib/apt/lists/*
 
-# Miniconda
-ENV PATH="/root/miniconda3/bin:${PATH}"
-RUN wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-${CONDA_SUFFIX}.sh \
- && bash Miniconda3-latest-Linux-${CONDA_SUFFIX}.sh -b \
- && rm Miniconda3-latest-Linux-${CONDA_SUFFIX}.sh \
- && conda --version
-ENV PATH="/root/miniconda3/envs/open3d/bin:${PATH}"
-RUN conda create -y -n open3d python=${PYTHON_VERSION} \
- && source activate open3d
+# Additional dependencies for pyenv and building Python
+RUN apt-get update && apt-get install -y \
+    curl \
+    libssl-dev \
+    zlib1g-dev \
+    libbz2-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    llvm \
+    libncurses5-dev \
+    xz-utils \
+    tk-dev \
+    libxml2-dev \
+    libxmlsec1-dev \
+    libffi-dev \
+    liblzma-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install pyenv
+RUN curl https://pyenv.run | bash
+# Update PATH to include pyenv binaries and shims
+ENV PATH="/root/.pyenv/bin:/root/.pyenv/shims:$PATH"
+
+# Install desired Python version via pyenv and set it as global
+RUN pyenv install ${PYTHON_VERSION} \
+ && pyenv global ${PYTHON_VERSION}
 RUN which python \
  && python --version
 
-# CMake
-# PWD is /, cmake will be installed to /root/${CMAKE_VERSION}/bin/cmake
+# CMake installation: download, extract, and update PATH
 RUN CMAKE_VER_NUMBERS=$(echo "${CMAKE_VERSION}" | cut -d"-" -f2) \
  && wget -q https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER_NUMBERS}/${CMAKE_VERSION}.tar.gz \
  && tar -xf ${CMAKE_VERSION}.tar.gz \
@@ -57,7 +68,6 @@ RUN CMAKE_VER_NUMBERS=$(echo "${CMAKE_VERSION}" | cut -d"-" -f2) \
 ENV PATH=${HOME}/${CMAKE_VERSION}/bin:${PATH}
 
 # Install dependencies before copying the full Open3D directory for better Docker caching
-# Open3D C++ dependencies
 COPY ./util/install_deps_ubuntu.sh /root/Open3D/util/
 RUN /root/Open3D/util/install_deps_ubuntu.sh assume-yes \
  && rm -rf /var/lib/apt/lists/*
@@ -67,7 +77,7 @@ RUN echo ${PATH} \
  && echo "g++=$(which g++)" \
  && g++ --version
 
-# Python and dependencies
+# Install Python dependencies via pip
 COPY ./python/requirements*.txt /root/Open3D/python/
 RUN which python \
  && python --version \
@@ -75,15 +85,11 @@ RUN which python \
   -r /root/Open3D/python/requirements_build.txt \
   -r /root/Open3D/python/requirements_test.txt
 
-# Open3D repo
-# Always keep /root/Open3D as the WORKDIR
+# Copy the Open3D repository and set working directory
 COPY . /root/Open3D
 WORKDIR /root/Open3D
 
-ENV LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libgomp.so.1
-ENV LD_LIBRARY_PATH=/usr/lib:/lib
-
-# Build
+# Build Open3D: create build directory, run CMake configuration, build, and install
 RUN mkdir build \
  && cd build \
  && cmake \

--- a/docker/Dockerfile.openblas
+++ b/docker/Dockerfile.openblas
@@ -1,8 +1,8 @@
-# ARG BASE_IMAGE must be specified before any other ARGs
+# FROM must be called before other ARGS except for ARG BASE_IMAGE
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-# Use bash as the default shell for subsequent RUN commands
+# For the rest of this Dockerfile
 SHELL ["/bin/bash", "-c"]
 
 # Required build args, should be specified in docker_build.sh
@@ -19,6 +19,9 @@ ENV TZ=America/Los_Angeles
 ENV SUDO=command
 
 # Minimal dependencies for running Docker
+# wget    : for downloading
+# libgl1  : available on Ubuntu ARM desktop by default
+# libgomp1: available on Ubuntu ARM desktop by default
 RUN apt-get update && apt-get install -y \
     wget \
     libgl1 \
@@ -26,12 +29,6 @@ RUN apt-get update && apt-get install -y \
  && rm -rf /var/lib/apt/lists/*
 
 # Minimal dependencies for building
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    git \
- && rm -rf /var/lib/apt/lists/*
-
-# Additional dependencies for pyenv and building Python
 RUN apt-get update && apt-get install -y \
     curl \
     libssl-dev \
@@ -47,6 +44,7 @@ RUN apt-get update && apt-get install -y \
     libxmlsec1-dev \
     libffi-dev \
     liblzma-dev \
+    libidn2-dev \
  && rm -rf /var/lib/apt/lists/*
 
 # Install pyenv
@@ -60,7 +58,8 @@ RUN pyenv install ${PYTHON_VERSION} \
 RUN which python \
  && python --version
 
-# CMake installation: download, extract, and update PATH
+# CMake
+# PWD is /, cmake will be installed to /root/${CMAKE_VERSION}/bin/cmake
 RUN CMAKE_VER_NUMBERS=$(echo "${CMAKE_VERSION}" | cut -d"-" -f2) \
  && wget -q https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER_NUMBERS}/${CMAKE_VERSION}.tar.gz \
  && tar -xf ${CMAKE_VERSION}.tar.gz \
@@ -68,6 +67,7 @@ RUN CMAKE_VER_NUMBERS=$(echo "${CMAKE_VERSION}" | cut -d"-" -f2) \
 ENV PATH=${HOME}/${CMAKE_VERSION}/bin:${PATH}
 
 # Install dependencies before copying the full Open3D directory for better Docker caching
+# Open3D C++ dependencies
 COPY ./util/install_deps_ubuntu.sh /root/Open3D/util/
 RUN /root/Open3D/util/install_deps_ubuntu.sh assume-yes \
  && rm -rf /var/lib/apt/lists/*
@@ -77,7 +77,7 @@ RUN echo ${PATH} \
  && echo "g++=$(which g++)" \
  && g++ --version
 
-# Install Python dependencies via pip
+# Python and dependencies
 COPY ./python/requirements*.txt /root/Open3D/python/
 RUN which python \
  && python --version \
@@ -85,11 +85,15 @@ RUN which python \
   -r /root/Open3D/python/requirements_build.txt \
   -r /root/Open3D/python/requirements_test.txt
 
-# Copy the Open3D repository and set working directory
+# Open3D repo
+# Always keep /root/Open3D as the WORKDIR
 COPY . /root/Open3D
 WORKDIR /root/Open3D
 
-# Build Open3D: create build directory, run CMake configuration, build, and install
+# Build
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+      export LD_PRELOAD=/opt/conda/envs/open3d/lib/libgomp.so.1; \
+    fi \
 RUN mkdir build \
  && cd build \
  && cmake \

--- a/docker/Dockerfile.openblas
+++ b/docker/Dockerfile.openblas
@@ -81,9 +81,6 @@ COPY . /root/Open3D
 WORKDIR /root/Open3D
 
 # Build
-RUN if [ "$(uname -m)" = "aarch64" ]; then \
-      export LD_PRELOAD=/opt/conda/envs/open3d/lib/libgomp.so.1; \
-    fi \
 RUN mkdir build \
  && cd build \
  && cmake \

--- a/docker/Dockerfile.openblas
+++ b/docker/Dockerfile.openblas
@@ -6,10 +6,12 @@ FROM ${BASE_IMAGE}
 SHELL ["/bin/bash", "-c"]
 
 # Required build args, should be specified in docker_build.sh
+ARG CONDA_SUFFIX
 ARG CMAKE_VERSION
 ARG PYTHON_VERSION
 ARG DEVELOPER_BUILD
-RUN if [ -z "${CMAKE_VERSION}"   ]; then echo "Error: ARG CMAKE_VERSION   not specified."; exit 1; fi \
+RUN if [ -z "${CONDA_SUFFIX}"    ]; then echo "Error: ARG CONDA_SUFFIX    not specified."; exit 1; fi \
+ && if [ -z "${CMAKE_VERSION}"   ]; then echo "Error: ARG CMAKE_VERSION   not specified."; exit 1; fi \
  && if [ -z "${PYTHON_VERSION}"  ]; then echo "Error: ARG PYTHON_VERSION  not specified."; exit 1; fi \
  && if [ -z "${DEVELOPER_BUILD}" ]; then echo "Error: ARG DEVELOPER_BUILD not specified."; exit 1; fi
 
@@ -30,39 +32,46 @@ RUN apt-get update && apt-get install -y \
 
 # Minimal dependencies for building
 RUN apt-get update && apt-get install -y \
-    build-essential \
-    git \
- && rm -rf /var/lib/apt/lists/*
- 
-# Minimal dependencies for building
-RUN apt-get update && apt-get install -y \
+    git  \
+    wget \
     curl \
-    libssl-dev \
+    build-essential \
+    pkg-config \
+    zlib1g \
     zlib1g-dev \
+    libssl-dev \
     libbz2-dev \
     libreadline-dev \
     libsqlite3-dev \
-    llvm \
-    libncurses5-dev \
+    libncursesw5-dev \
     xz-utils \
     tk-dev \
     libxml2-dev \
     libxmlsec1-dev \
     libffi-dev \
     liblzma-dev \
+    libcurl4-openssl-dev \
     libidn2-dev \
+    libidn2-0 \
  && rm -rf /var/lib/apt/lists/*
 
-# Install pyenv
-RUN curl https://pyenv.run | bash
-# Update PATH to include pyenv binaries and shims
-ENV PATH="/root/.pyenv/bin:/root/.pyenv/shims:$PATH"
+# pyenv
+# The pyenv python paths are used during docker run, in this way docker run
+# does not need to activate the environment again.
+# The soft link from the python patch level version to the python mino version
+# ensures python wheel commands (i.e. open3d) are in PATH, since we don't know
+# which patch level pyenv will install (latest).
+ENV PYENV_ROOT=/root/.pyenv
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PYENV_ROOT/versions/$PYTHON_VERSION/bin:$PATH"
+RUN curl https://pyenv.run | bash \
+        && pyenv update \
+        && pyenv install $PYTHON_VERSION \
+        && pyenv global $PYTHON_VERSION \
+        && pyenv rehash \
+        && ln -s $PYENV_ROOT/versions/${PYTHON_VERSION}* $PYENV_ROOT/versions/${PYTHON_VERSION};
+RUN python --version && pip --version
 
-# Install desired Python version via pyenv and set it as global
-RUN pyenv install ${PYTHON_VERSION} \
- && pyenv global ${PYTHON_VERSION}
-RUN which python \
- && python --version
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # CMake
 # PWD is /, cmake will be installed to /root/${CMAKE_VERSION}/bin/cmake

--- a/docker/Dockerfile.openblas
+++ b/docker/Dockerfile.openblas
@@ -30,6 +30,12 @@ RUN apt-get update && apt-get install -y \
 
 # Minimal dependencies for building
 RUN apt-get update && apt-get install -y \
+    build-essential \
+    git \
+ && rm -rf /var/lib/apt/lists/*
+ 
+# Minimal dependencies for building
+RUN apt-get update && apt-get install -y \
     curl \
     libssl-dev \
     zlib1g-dev \

--- a/docker/Dockerfile.openblas
+++ b/docker/Dockerfile.openblas
@@ -81,6 +81,9 @@ COPY . /root/Open3D
 WORKDIR /root/Open3D
 
 # Build
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+      export LD_PRELOAD=/opt/conda/envs/open3d/lib/libgomp.so.1; \
+    fi \
 RUN mkdir build \
  && cd build \
  && cmake \

--- a/docker/Dockerfile.wheel
+++ b/docker/Dockerfile.wheel
@@ -83,17 +83,23 @@ RUN CCACHE_DIR=$(ccache -p | grep cache_dir | grep -oE "[^ ]+$") \
 RUN ccache -M 4G \
  && ccache -s
 
-# Miniconda
-ENV PATH="/root/miniconda3/bin:${PATH}"
-RUN wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
- && bash Miniconda3-latest-Linux-x86_64.sh -b \
- && rm Miniconda3-latest-Linux-x86_64.sh \
- && conda --version
-ENV PATH="/root/miniconda3/envs/open3d/bin:${PATH}"
-RUN conda create -y -n open3d python=${PYTHON_VERSION} \
- && source activate open3d
-RUN which python \
- && python --version
+# pyenv
+# The pyenv python paths are used during docker run, in this way docker run
+# does not need to activate the environment again.
+# The soft link from the python patch level version to the python mino version
+# ensures python wheel commands (i.e. open3d) are in PATH, since we don't know
+# which patch level pyenv will install (latest).
+ENV PYENV_ROOT=/root/.pyenv
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PYENV_ROOT/versions/$PYTHON_VERSION/bin:$PATH"
+RUN curl https://pyenv.run | bash \
+        && pyenv update \
+        && pyenv install $PYTHON_VERSION \
+        && pyenv global $PYTHON_VERSION \
+        && pyenv rehash \
+        && ln -s $PYENV_ROOT/versions/${PYTHON_VERSION}* $PYENV_ROOT/versions/${PYTHON_VERSION};
+RUN python --version && pip --version
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Checkout Open3D-ML main branch
 # TODO: We may add support for local Open3D-ML repo or pinned ML repo tag


### PR DESCRIPTION
This pull request includes several updates to the CI workflows and dependencies for the Open3D project. The most important modifying the CI workflows to use newer Ubuntu versions, and updating the OpenBLAS dependency.

CI Workflow Updates:

* [`.github/workflows/ubuntu-openblas.yml`](diffhunk://#diff-a12b06c3e3d08effd0c25d48e5687ee9d47ae5281b9cc035ed555a4bf260dc48L35-R57): Updated Docker build and test scripts to use `openblas-amd64-py312-dev` and `openblas-arm64-py312-dev`. Removed the `skip-arm64-check-on-fork` job and its dependencies. Changed the `runs-on` parameter for `openblas-arm64` to `ubuntu-24.04-arm`.
* [`.github/workflows/ubuntu-wheel.yml`](diffhunk://#diff-46cc987d405c948a64f0776e40bf10d4c2f5b7b9560b445aeb60ddcf561e349cL126-R126): Updated the `runs-on` parameter to use `ubuntu-22.04` instead of `ubuntu-20.04`.
* [`.github/workflows/vtk_packages.yml`](diffhunk://#diff-859438c3b9d1630cf9ccf35fcbb8024184b15ab18b57d59ec1cedaf1d1c06c24L14-R14): Updated the `runs-on` parameter to use `ubuntu-22.04` instead of `ubuntu-20.04`.

Dependency Update:

* [`3rdparty/openblas/openblas.cmake`](diffhunk://#diff-3fd79d95ed9f8a40b5c69a240f8855c3d0d21754b1657afa9e0d64e697cac2d3L12-R13): Updated the OpenBLAS version from `0.3.20` to `0.3.29` and the corresponding URL and SHA256 hash.