### PR TITLE
Fix ICP registration pipeline documentation

### DIFF
--- a/docs/jupyter/pipelines/icp_registration.ipynb
+++ b/docs/jupyter/pipelines/icp_registration.ipynb
@@ -107,7 +107,7 @@
    "source": [
     "The function `evaluate_registration` calculates two main metrics:\n",
     "\n",
-    "- `fitness`, which measures the overlapping area (# of inlier correspondences / # of points in target). The higher the better.\n",
+    "- `fitness`, which measures the overlapping area (# of inlier correspondences / # of points in source). The higher the better.\n",
     "- `inlier_rmse`, which measures the RMSE of all inlier correspondences. The lower the better."
    ]
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes discrepancy betweeen:
https://www.open3d.org/docs/latest/tutorial/Basic/icp_registration.html
and 
https://github.com/isl-org/Open3D/blob/main/cpp/open3d/pipelines/registration/Registration.cpp#L65


## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context


This commit updates the documentation to align with the implementation details.


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

The documentation says that the icp fitness is defined as the ratio between the number of inlier correspondences and the number of points in the target pointcloud. However, the current implementation in Registration.cpp defines the fitness as ratio between the number of inlier correspondences and the number of points in the source point cloud.