### PR TITLE
fix X11 access on wayland

### DIFF
--- a/cpp/open3d/visualization/gui/NativeLinux.cpp
+++ b/cpp/open3d/visualization/gui/NativeLinux.cpp
@@ -10,6 +10,7 @@
 #include "Application.h"
 #include "Native.h"
 #define GLFW_EXPOSE_NATIVE_X11 1
+#define GLFW_EXPOSE_NATIVE_WAYLAND 1
 #include <GLFW/glfw3native.h>
 #include <memory.h>
 
@@ -18,20 +19,31 @@ namespace visualization {
 namespace gui {
 
 void* GetNativeDrawable(GLFWwindow* glfw_window) {
-    return (void*)glfwGetX11Window(glfw_window);
+    const int platform = glfwGetPlatform();
+    if (platform == GLFW_PLATFORM_X11) {
+        return (void*)glfwGetX11Window(glfw_window);
+    } else if (platform == GLFW_PLATFORM_WAYLAND) {
+        return (void*)glfwGetWaylandWindow(glfw_window);
+    } else {
+        return nullptr;
+    }
 }
 
 void PostNativeExposeEvent(GLFWwindow* glfw_window) {
-    Display* d = glfwGetX11Display();
-    auto x11win = glfwGetX11Window(glfw_window);
+    const int platform = glfwGetPlatform();
 
-    XEvent e;
-    memset(&e, 0, sizeof(e));
-    e.type = Expose;
-    e.xexpose.window = x11win;
+    if (platform == GLFW_PLATFORM_X11) {
+        Display* d = glfwGetX11Display();
+        auto x11win = glfwGetX11Window(glfw_window);
 
-    XSendEvent(d, x11win, False, ExposureMask, &e);
-    XFlush(d);
+        XEvent e;
+        memset(&e, 0, sizeof(e));
+        e.type = Expose;
+        e.xexpose.window = x11win;
+
+        XSendEvent(d, x11win, False, ExposureMask, &e);
+        XFlush(d);
+    }
 }
 
 void ShowNativeAlert(const char* message) {

--- a/cpp/open3d/visualization/visualizer/VisualizerRender.cpp
+++ b/cpp/open3d/visualization/visualizer/VisualizerRender.cpp
@@ -40,7 +40,7 @@ bool Visualizer::InitOpenGL() {
 
     glewExperimental = true;
     const GLenum init_ret = glewInit();
-    if (init_ret != GLEW_OK) {
+    if (init_ret != GLEW_OK && init_ret != GLEW_ERROR_NO_GLX_DISPLAY) {
         const std::string err_msg{
                 reinterpret_cast<const char *>(glewGetErrorString(init_ret))};
         utility::LogWarning("Failed to initialize GLEW: {} ({})", err_msg,

--- a/cpp/open3d/visualization/visualizer/VisualizerRender.cpp
+++ b/cpp/open3d/visualization/visualizer/VisualizerRender.cpp
@@ -39,8 +39,12 @@ bool Visualizer::InitOpenGL() {
 #endif
 
     glewExperimental = true;
-    if (glewInit() != GLEW_OK) {
-        utility::LogWarning("Failed to initialize GLEW.");
+    const GLenum init_ret = glewInit();
+    if (init_ret != GLEW_OK) {
+        const std::string err_msg{
+                reinterpret_cast<const char *>(glewGetErrorString(init_ret))};
+        utility::LogWarning("Failed to initialize GLEW: {} ({})", err_msg,
+                            init_ret);
         return false;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #7162
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

On Wayland, Open3D still calls X11 specific functions and dereferences NULL pointers. See #7162. This PR fixes this by checking the platform (X11 / Wayland) via `glfwGetPlatform()` and avoid using X11 specific functions.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [ ] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
