### PR TITLE
support TSDF deintegration for a previously integrated RGBD image

### DIFF
--- a/cpp/open3d/pipelines/integration/ScalableTSDFVolume.cpp
+++ b/cpp/open3d/pipelines/integration/ScalableTSDFVolume.cpp
@@ -35,7 +35,8 @@ void ScalableTSDFVolume::Reset() { volume_units_.clear(); }
 void ScalableTSDFVolume::Integrate(
         const geometry::RGBDImage &image,
         const camera::PinholeCameraIntrinsic &intrinsic,
-        const Eigen::Matrix4d &extrinsic) {
+        const Eigen::Matrix4d &extrinsic,
+        bool deintegrate) {
     if ((image.depth_.num_of_channels_ != 1) ||
         (image.depth_.bytes_per_channel_ != 4) ||
         (color_type_ == TSDFVolumeColorType::RGB8 &&
@@ -89,7 +90,7 @@ void ScalableTSDFVolume::Integrate(
                         auto volume = OpenVolumeUnit(Eigen::Vector3i(x, y, z));
                         volume->IntegrateWithDepthToCameraDistanceMultiplier(
                                 image, intrinsic, extrinsic,
-                                *depth2cameradistance);
+                                *depth2cameradistance, deintegrate);
                     }
                 }
             }

--- a/cpp/open3d/pipelines/integration/ScalableTSDFVolume.h
+++ b/cpp/open3d/pipelines/integration/ScalableTSDFVolume.h
@@ -60,7 +60,8 @@ public:
     void Reset() override;
     void Integrate(const geometry::RGBDImage &image,
                    const camera::PinholeCameraIntrinsic &intrinsic,
-                   const Eigen::Matrix4d &extrinsic) override;
+                   const Eigen::Matrix4d &extrinsic,
+                   bool deintegrate = false) override;
     std::shared_ptr<geometry::PointCloud> ExtractPointCloud() override;
     std::shared_ptr<geometry::TriangleMesh> ExtractTriangleMesh() override;
     /// Debug function to extract the voxel data into a point cloud.

--- a/cpp/open3d/pipelines/integration/TSDFVolume.h
+++ b/cpp/open3d/pipelines/integration/TSDFVolume.h
@@ -61,7 +61,8 @@ public:
     /// Function to integrate an RGB-D image into the volume.
     virtual void Integrate(const geometry::RGBDImage &image,
                            const camera::PinholeCameraIntrinsic &intrinsic,
-                           const Eigen::Matrix4d &extrinsic) = 0;
+                           const Eigen::Matrix4d &extrinsic,
+                           bool deintegrate = false) = 0;
 
     /// Function to extract a point cloud with normals.
     virtual std::shared_ptr<geometry::PointCloud> ExtractPointCloud() = 0;

--- a/cpp/open3d/pipelines/integration/UniformTSDFVolume.cpp
+++ b/cpp/open3d/pipelines/integration/UniformTSDFVolume.cpp
@@ -41,7 +41,8 @@ void UniformTSDFVolume::Reset() { voxels_.clear(); }
 void UniformTSDFVolume::Integrate(
         const geometry::RGBDImage &image,
         const camera::PinholeCameraIntrinsic &intrinsic,
-        const Eigen::Matrix4d &extrinsic) {
+        const Eigen::Matrix4d &extrinsic,
+        bool deintegrate) {
     // This function goes through the voxels, and scan convert the relative
     // depth/color value into the voxel.
     // The following implementation is a highly optimized version.
@@ -78,8 +79,8 @@ void UniformTSDFVolume::Integrate(
     auto depth2cameradistance =
             geometry::Image::CreateDepthToCameraDistanceMultiplierFloatImage(
                     intrinsic);
-    IntegrateWithDepthToCameraDistanceMultiplier(image, intrinsic, extrinsic,
-                                                 *depth2cameradistance);
+    IntegrateWithDepthToCameraDistanceMultiplier(
+            image, intrinsic, extrinsic, *depth2cameradistance, deintegrate);
 }
 
 std::shared_ptr<geometry::PointCloud> UniformTSDFVolume::ExtractPointCloud() {
@@ -371,7 +372,8 @@ void UniformTSDFVolume::IntegrateWithDepthToCameraDistanceMultiplier(
         const geometry::RGBDImage &image,
         const camera::PinholeCameraIntrinsic &intrinsic,
         const Eigen::Matrix4d &extrinsic,
-        const geometry::Image &depth_to_camera_distance_multiplier) {
+        const geometry::Image &depth_to_camera_distance_multiplier,
+        bool deintegrate) {
     const float fx = static_cast<float>(intrinsic.GetFocalLength().first);
     const float fy = static_cast<float>(intrinsic.GetFocalLength().second);
     const float cx = static_cast<float>(intrinsic.GetPrincipalPoint().first);
@@ -430,31 +432,73 @@ void UniformTSDFVolume::IntegrateWithDepthToCameraDistanceMultiplier(
                         (*depth_to_camera_distance_multiplier.PointerAt<float>(
                                 u, v));
                 if (sdf > -sdf_trunc_f) {
-                    // integrate
                     float tsdf = std::min(1.0f, sdf * sdf_trunc_inv_f);
-                    voxels_[v_ind].tsdf_ =
-                            (voxels_[v_ind].tsdf_ * voxels_[v_ind].weight_ +
-                             tsdf) /
-                            (voxels_[v_ind].weight_ + 1.0f);
-                    if (color_type_ == TSDFVolumeColorType::RGB8) {
-                        const uint8_t *rgb =
-                                image.color_.PointerAt<uint8_t>(u, v, 0);
-                        Eigen::Vector3d rgb_f(rgb[0], rgb[1], rgb[2]);
-                        voxels_[v_ind].color_ =
-                                (voxels_[v_ind].color_ *
-                                         voxels_[v_ind].weight_ +
-                                 rgb_f) /
+                    if (!deintegrate) {
+                        // integrate
+                        voxels_[v_ind].tsdf_ =
+                                (voxels_[v_ind].tsdf_ * voxels_[v_ind].weight_ +
+                                 tsdf) /
                                 (voxels_[v_ind].weight_ + 1.0f);
-                    } else if (color_type_ == TSDFVolumeColorType::Gray32) {
-                        const float *intensity =
-                                image.color_.PointerAt<float>(u, v, 0);
-                        voxels_[v_ind].color_ =
-                                (voxels_[v_ind].color_.array() *
-                                         voxels_[v_ind].weight_ +
-                                 (*intensity)) /
-                                (voxels_[v_ind].weight_ + 1.0f);
+                        if (color_type_ == TSDFVolumeColorType::RGB8) {
+                            const uint8_t *rgb =
+                                    image.color_.PointerAt<uint8_t>(u, v, 0);
+                            Eigen::Vector3d rgb_f(rgb[0], rgb[1], rgb[2]);
+                            voxels_[v_ind].color_ =
+                                    (voxels_[v_ind].color_ *
+                                             voxels_[v_ind].weight_ +
+                                     rgb_f) /
+                                    (voxels_[v_ind].weight_ + 1.0f);
+                        } else if (color_type_ == TSDFVolumeColorType::Gray32) {
+                            const float *intensity =
+                                    image.color_.PointerAt<float>(u, v, 0);
+                            voxels_[v_ind].color_ =
+                                    (voxels_[v_ind].color_.array() *
+                                             voxels_[v_ind].weight_ +
+                                     (*intensity)) /
+                                    (voxels_[v_ind].weight_ + 1.0f);
+                        }
+                        voxels_[v_ind].weight_ += 1.0f;
+                    } else {
+                        // deintegrate
+                        if (voxels_[v_ind].weight_ > 1) {
+                            voxels_[v_ind].tsdf_ =
+                                    (voxels_[v_ind].tsdf_ *
+                                             voxels_[v_ind].weight_ -
+                                     tsdf) /
+                                    (voxels_[v_ind].weight_ - 1.0f);
+                            if (color_type_ == TSDFVolumeColorType::RGB8) {
+                                const uint8_t *rgb =
+                                        image.color_.PointerAt<uint8_t>(u, v,
+                                                                        0);
+                                Eigen::Vector3d rgb_f(rgb[0], rgb[1], rgb[2]);
+                                voxels_[v_ind].color_ =
+                                        (voxels_[v_ind].color_ *
+                                                 voxels_[v_ind].weight_ -
+                                         rgb_f) /
+                                        (voxels_[v_ind].weight_ - 1.0f);
+                            } else if (color_type_ ==
+                                       TSDFVolumeColorType::Gray32) {
+                                const float *intensity =
+                                        image.color_.PointerAt<float>(u, v, 0);
+                                voxels_[v_ind].color_ =
+                                        (voxels_[v_ind].color_.array() *
+                                                 voxels_[v_ind].weight_ -
+                                         (*intensity)) /
+                                        (voxels_[v_ind].weight_ - 1.0f);
+                            }
+                            voxels_[v_ind].weight_ -= 1.0f;
+                        } else if (voxels_[v_ind].weight_ == 1) {
+                            voxels_[v_ind].tsdf_ = 0.0f;
+                            voxels_[v_ind].color_ = Eigen::Vector3d(0, 0, 0);
+                            voxels_[v_ind].weight_ = 0.0f;
+                        } else {
+                            utility::LogError(
+                                    "Found no previous observation during "
+                                    "deintegration:"
+                                    "please make sure the image was integrated "
+                                    "before deintegration.");
+                        }
                     }
-                    voxels_[v_ind].weight_ += 1.0f;
                 }
             }
         }

--- a/cpp/open3d/pipelines/integration/UniformTSDFVolume.h
+++ b/cpp/open3d/pipelines/integration/UniformTSDFVolume.h
@@ -49,7 +49,8 @@ public:
     void Reset() override;
     void Integrate(const geometry::RGBDImage &image,
                    const camera::PinholeCameraIntrinsic &intrinsic,
-                   const Eigen::Matrix4d &extrinsic) override;
+                   const Eigen::Matrix4d &extrinsic,
+                   bool deintegrate = false) override;
     std::shared_ptr<geometry::PointCloud> ExtractPointCloud() override;
     std::shared_ptr<geometry::TriangleMesh> ExtractTriangleMesh() override;
 
@@ -72,7 +73,8 @@ public:
             const geometry::RGBDImage &image,
             const camera::PinholeCameraIntrinsic &intrinsic,
             const Eigen::Matrix4d &extrinsic,
-            const geometry::Image &depth_to_camera_distance_multiplier);
+            const geometry::Image &depth_to_camera_distance_multiplier,
+            bool deintegrate = false);
 
     inline int IndexOf(int x, int y, int z) const {
         return x * resolution_ * resolution_ + y * resolution_ + z;

--- a/cpp/pybind/pipelines/integration/integration.cpp
+++ b/cpp/pybind/pipelines/integration/integration.cpp
@@ -24,9 +24,10 @@ public:
     void Reset() override { PYBIND11_OVERLOAD_PURE(void, TSDFVolumeBase, ); }
     void Integrate(const geometry::RGBDImage &image,
                    const camera::PinholeCameraIntrinsic &intrinsic,
-                   const Eigen::Matrix4d &extrinsic) override {
+                   const Eigen::Matrix4d &extrinsic,
+                   bool deintegrate = false) override {
         PYBIND11_OVERLOAD_PURE(void, TSDFVolumeBase, image, intrinsic,
-                               extrinsic);
+                               extrinsic, deintegrate);
     }
     std::shared_ptr<geometry::PointCloud> ExtractPointCloud() override {
         PYBIND11_OVERLOAD_PURE(std::shared_ptr<geometry::PointCloud>,
@@ -103,8 +104,10 @@ void pybind_integration_definitions(py::module &m) {
             .def("reset", &TSDFVolume::Reset,
                  "Function to reset the TSDFVolume")
             .def("integrate", &TSDFVolume::Integrate,
-                 "Function to integrate an RGB-D image into the volume",
-                 "image"_a, "intrinsic"_a, "extrinsic"_a)
+                 "Function to integrate/deintegrate an RGB-D image into the "
+                 "volume",
+                 "image"_a, "intrinsic"_a, "extrinsic"_a,
+                 "deintegrate"_a = false)
             .def("extract_point_cloud", &TSDFVolume::ExtractPointCloud,
                  "Function to extract a point cloud with normals")
             .def("extract_triangle_mesh", &TSDFVolume::ExtractTriangleMesh,
@@ -123,9 +126,12 @@ void pybind_integration_definitions(py::module &m) {
                                     "extract_triangle_mesh");
     docstring::ClassMethodDocInject(
             m_integration, "TSDFVolume", "integrate",
-            {{"image", "RGBD image."},
-             {"intrinsic", "Pinhole camera intrinsic parameters."},
-             {"extrinsic", "Extrinsic parameters."}});
+            {
+                    {"image", "RGBD image."},
+                    {"intrinsic", "Pinhole camera intrinsic parameters."},
+                    {"extrinsic", "Extrinsic parameters."},
+                    {"deintegrate", "Deintegrate flag."},
+            });
     docstring::ClassMethodDocInject(m_integration, "TSDFVolume", "reset");
 
     // open3d.integration.UniformTSDFVolume: open3d.integration.TSDFVolume


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [x] New feature (non-breaking change which adds functionality). Resolves #2613 
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
It's common to deintegrate a previously integrated RGBD image in practice. Having the function with such flag will be helpful for downstream applications.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [x] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
Mathematically, the deintegration can be written as: `tsdf_new = (tsdf_old * w_old - tsdf_image) / (w_old - 1)`.

The PR was tested by following the [example](https://github.com/iammarvelous/Open3D/blob/main/examples/python/pipelines/rgbd_integration_uniform.py) to integrate RGBD images and deintegrate each frame afterwards.

```
import open3d as o3d
import numpy as np

import os, sys

pyexample_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
sys.path.append(pyexample_path)

from open3d_example import read_trajectory

if __name__ == "__main__":
    rgbd_data = o3d.data.SampleRedwoodRGBDImages()
    camera_poses = read_trajectory(rgbd_data.odometry_log_path)
    camera_intrinsics = o3d.camera.PinholeCameraIntrinsic(
        o3d.camera.PinholeCameraIntrinsicParameters.PrimeSenseDefault)
    volume = o3d.pipelines.integration.UniformTSDFVolume(
        length=4.0,
        resolution=512,
        sdf_trunc=0.04,
        color_type=o3d.pipelines.integration.TSDFVolumeColorType.RGB8,
    )

    for i in range(len(camera_poses)):
        print("Integrate {:d}-th image into the volume.".format(i))
        color = o3d.io.read_image(rgbd_data.color_paths[i])
        depth = o3d.io.read_image(rgbd_data.depth_paths[i])

        rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
            color, depth, depth_trunc=4.0, convert_rgb_to_intensity=False)
        volume.integrate(
            rgbd,
            camera_intrinsics,
            np.linalg.inv(camera_poses[i].pose),
        )

    print("Extract triangle mesh")
    mesh = volume.extract_triangle_mesh()
    mesh.compute_vertex_normals()
    o3d.visualization.draw_geometries([mesh])


    print("Extract voxel-aligned debugging point cloud")
    voxel_pcd = volume.extract_voxel_point_cloud()
    o3d.visualization.draw_geometries([voxel_pcd])

    print("Extract voxel-aligned debugging voxel grid")
    voxel_grid = volume.extract_voxel_grid()
    # o3d.visualization.draw_geometries([voxel_grid])

    # print("Extract point cloud")
    # pcd = volume.extract_point_cloud()
    # o3d.visualization.draw_geometries([pcd])

    for i in range(len(camera_poses)):
        print("Deintegrate {:d}-th image into the volume.".format(i))
        color = o3d.io.read_image(rgbd_data.color_paths[i])
        depth = o3d.io.read_image(rgbd_data.depth_paths[i])
        rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
            color, depth, depth_trunc=4.0, convert_rgb_to_intensity=False)
        volume.integrate(
            rgbd,
            camera_intrinsics,
            np.linalg.inv(camera_poses[i].pose),
            True
        )
        mesh = volume.extract_triangle_mesh()
        mesh.compute_vertex_normals()
        o3d.visualization.draw_geometries([mesh])

```