### PR TITLE
Return OBB on same device as input points

### DIFF
--- a/cpp/open3d/t/geometry/kernel/MinimumOBB.cpp
+++ b/cpp/open3d/t/geometry/kernel/MinimumOBB.cpp
@@ -64,7 +64,8 @@ OrientedBoundingBox ComputeMinimumOBBJylanki(const core::Tensor& points_,
         utility::LogError("Input point set has less than 4 points.");
         return OrientedBoundingBox();
     }
-    PointCloud pcd(points_);
+    // copy to CPU here
+    PointCloud pcd(points_.To(core::Device()));
     auto hull_mesh = pcd.ComputeConvexHull(robust);
     if (hull_mesh.GetVertexPositions().NumElements() == 0) {
         utility::LogError("Failed to compute convex hull.");
@@ -1239,7 +1240,7 @@ OrientedBoundingBox ComputeMinimumOBBJylanki(const core::Tensor& points_,
         min_obb.R_.col(2) = -min_obb.R_.col(2);
     }
     mapOBBToClosestIdentity(min_obb);
-    return static_cast<OrientedBoundingBox>(min_obb);
+    return static_cast<OrientedBoundingBox>(min_obb).To(points_.GetDevice());
 }
 
 OrientedBoundingBox ComputeMinimumOBBApprox(const core::Tensor& points,
@@ -1254,7 +1255,8 @@ OrientedBoundingBox ComputeMinimumOBBApprox(const core::Tensor& points,
         return OrientedBoundingBox();
     }
 
-    PointCloud pcd(points);
+    // copy to cpu here
+    PointCloud pcd(points.To(core::Device()));
     auto hull_mesh = pcd.ComputeConvexHull(robust);
     if (hull_mesh.GetVertexPositions().NumElements() == 0) {
         utility::LogError("Failed to compute convex hull.");
@@ -1305,10 +1307,11 @@ OrientedBoundingBox ComputeMinimumOBBApprox(const core::Tensor& points,
             min_box.Rotate(rot, center);
         }
     }
+    auto device = points.GetDevice();
     auto dtype = points.GetDtype();
-    return OrientedBoundingBox(min_box.GetCenter().To(dtype),
-                               min_box.GetRotation().To(dtype),
-                               min_box.GetExtent().To(dtype));
+    return OrientedBoundingBox(min_box.GetCenter().To(device, dtype),
+                               min_box.GetRotation().To(device, dtype),
+                               min_box.GetExtent().To(device, dtype));
 }
 
 }  // namespace minimum_obb


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fix failing test OrientedBoundingBox/OrientedBoundingBoxPermuteDevices.CreateFromPoints

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [ ] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [ ] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
This patch copies the returned OBB to the same device as the inputs to align with the behavior of the PCA method.