### PR TITLE
Expose the `get_plotly_fig` function, return fig from `draw_plotly` and `draw_plotly_server`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 -   Add optional indices arg for fast computation of a small subset of FPFH features (PR #7118).
 -   Fix CMake configuration summary incorrectly reporting `no` for system BLAS. (PR #7230)
 -   Add error handling for insufficient correspondences in AdvancedMatching (PR #7234)
+-   Exposed `get_plotly_fig` and modified `draw_plotly` to return the `Figure` it creates. (PR #7258)
 
 ## 0.13
 

--- a/python/open3d/visualization/__init__.py
+++ b/python/open3d/visualization/__init__.py
@@ -16,6 +16,7 @@ else:
     from open3d.cpu.pybind.visualization import *
 
 from ._external_visualizer import *
+from .draw_plotly import get_plotly_fig
 from .draw_plotly import draw_plotly
 from .draw_plotly import draw_plotly_server
 from .to_mitsuba import to_mitsuba

--- a/python/open3d/visualization/draw_plotly.py
+++ b/python/open3d/visualization/draw_plotly.py
@@ -274,7 +274,7 @@ def draw_plotly_server(geometry_list,
                        lookat=None,
                        up=None,
                        zoom=1.0,
-                      port=8050):
+                       port=8050):
     """Serves Open3D geometries via a Dash web application using Plotly.
 
     This function creates a Plotly figure and embeds it within a Dash web

--- a/python/open3d/visualization/draw_plotly.py
+++ b/python/open3d/visualization/draw_plotly.py
@@ -144,6 +144,39 @@ def get_plotly_fig(geometry_list,
                    lookat=None,
                    up=None,
                    zoom=1.0):
+    """Generates a Plotly Figure object for a list of Open3D geometries.
+
+    Args:
+        geometry_list (List[open3d.geometry.Geometry]): A list of Open3D
+            geometry objects (e.g., PointCloud, TriangleMesh, LineSet) to be
+            visualized.
+        width (int, optional): The width of the Plotly figure in pixels.
+            Defaults to 600.
+        height (int, optional): The height of the Plotly figure in pixels.
+            Defaults to 400.
+        mesh_show_wireframe (bool, optional): If True, a wireframe will be
+            rendered for TriangleMesh geometries in addition to the mesh
+            itself. Defaults to False.
+        point_sample_factor (float, optional): A factor between 0.0 and 1.0
+            that determines the fraction of points to sample from PointCloud
+            geometries. A value of 1.0 means all points are used.
+            Defaults to 1.0.
+        front (list of float, optional): A list of 3 floats representing the
+            camera's front vector (e.g., [x, y, z]). If None, a default
+            orientation is used. Defaults to None.
+        lookat (list of float, optional): A list of 3 floats representing the
+            point the camera is looking at (e.g., [x, y, z]). If None, the
+            camera looks at the center of the combined geometries.
+            Defaults to None.
+        up (list of float, optional): A list of 3 floats representing the
+            camera's up vector (e.g., [x, y, z]). Defaults to Plotly's default
+            (0,0,1) if None.
+        zoom (float, optional): The zoom level of the camera. Affects the
+            distance of the eye position from the center. Defaults to 1.0.
+
+    Returns:
+        plotly.graph_objects.Figure: The generated Plotly figure object.
+    """
     graph_objects = get_graph_objects(geometry_list, mesh_show_wireframe,
                                       point_sample_factor)
     geometry_center = get_geometry_center(geometry_list)
@@ -198,10 +231,37 @@ def draw_plotly(geometry_list,
                 lookat=None,
                 up=None,
                 zoom=1.0):
+    """Draws Open3D geometries using Plotly and displays them.
 
+    This function creates a Plotly figure from the provided geometries and
+    then calls `show()` to render it.
+
+    Args:
+        geometry_list (List[open3d.geometry.Geometry]): A list of Open3D
+            geometry objects.
+        window_name (str, optional): The title of the window where the figure is
+            displayed.
+        width (int, optional): The width of the Plotly figure in pixels.
+            Defaults to 600.
+        height (int, optional): The height of the Plotly figure in pixels.
+            Defaults to 400.
+        mesh_show_wireframe (bool, optional): If True, renders a wireframe for
+            TriangleMesh geometries. Defaults to False.
+        point_sample_factor (float, optional): Sampling factor for point clouds
+            (0.0 to 1.0). Defaults to 1.0.
+        front (list of float, optional): Camera's front vector. Defaults to None.
+        lookat (list of float, optional): Point camera is looking at.
+            Defaults to None.
+        up (list of float, optional): Camera's up vector. Defaults to None.
+        zoom (float, optional): Camera zoom level. Defaults to 1.0.
+
+    Returns:
+        plotly.graph_objects.Figure: The generated and displayed Plotly figure.
+    """
     fig = get_plotly_fig(geometry_list, width, height, mesh_show_wireframe,
                          point_sample_factor, front, lookat, up, zoom)
     fig.show()
+    return fig
 
 
 def draw_plotly_server(geometry_list,
@@ -214,8 +274,39 @@ def draw_plotly_server(geometry_list,
                        lookat=None,
                        up=None,
                        zoom=1.0,
-                       port=8050):
+                      port=8050):
+    """Serves Open3D geometries via a Dash web application using Plotly.
 
+    This function creates a Plotly figure and embeds it within a Dash web
+    application. The application is then run on a local development server,
+    making the visualization accessible through a web browser at the
+    specified port.
+
+    Args:
+        geometry_list (List[open3d.geometry.Geometry]): A list of Open3D
+            geometry objects.
+        window_name (str, optional): The title for the Dash application,
+            which also appears as the browser tab title. Defaults to 'Open3D'.
+        width (int, optional): The width of the Plotly figure in pixels.
+            Defaults to 1080.
+        height (int, optional): The height of the Plotly figure in pixels.
+            Defaults to 960.
+        mesh_show_wireframe (bool, optional): If True, renders a wireframe for
+            TriangleMesh geometries. Defaults to False.
+        point_sample_factor (float, optional): Sampling factor for point clouds
+            (0.0 to 1.0). Defaults to 1.0.
+        front (list of float, optional): Camera's front vector. Defaults to None.
+        lookat (list of float, optional): Point camera is looking at.
+            Defaults to None.
+        up (list of float, optional): Camera's up vector. Defaults to None.
+        zoom (float, optional): Camera zoom level. Defaults to 1.0.
+        port (int, optional): The port number on which the Dash application
+            will be served. Defaults to 8050.
+
+    Returns:
+        tuple[dash.Dash, plotly.graph_objects.Figure]: A tuple containing the
+        Dash application instance and the Plotly figure object.
+    """
     fig = get_plotly_fig(geometry_list, width, height, mesh_show_wireframe,
                          point_sample_factor, front, lookat, up, zoom)
     app = Dash(window_name)
@@ -233,3 +324,4 @@ def draw_plotly_server(geometry_list,
         ),
     ])
     app.run_server(debug=False, port=port)
+    return (app, fig)


### PR DESCRIPTION
## Type

-   [X] New feature (non-breaking change which adds functionality).

## Motivation and Context

When trying to use `draw_plotly` in Colab, it's impossible to modify things like the aspect ratio, and other aspects of the layout, since they aren't parameters to `draw_plotly`. It's also not possible to modify them *before* it is shown.

## Checklist:

-   [X] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [X] This PR changes Open3D behavior or adds new functionality.
    -   [X] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [X] I will follow up and update the code if CI fails.
-   [X] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

This change exports the `get_plotly_fig` function so that you can generate a `Figure`, set its layout parameters, and then show it.  It also modifies `draw_plotly` to return the `fig` object when called, so that if you capture the figure, you can modify its layout after it is shown.  Similarly, I modified `draw_plotly_server` to return the `app` and the `fig`, since those also allow configuration after the fact.

I also added missing documentation for the three functions.

## Tests

This PR doesn't change any functionality other than publicly exposing an existing function and returning values from functions that used to return nothing, so no unit tests were added.