### PR TITLE
[BUG] Fixed ARM Builds

### DIFF
--- a/.github/workflows/ubuntu-openblas.yml
+++ b/.github/workflows/ubuntu-openblas.yml
@@ -1,3 +1,4 @@
+
 name: Ubuntu OpenBLAS
 permissions: {}
 
@@ -32,123 +33,68 @@ jobs:
           source util/ci_utils.sh
           maximize_ubuntu_github_actions_build_space
       - name: Docker build
-        run: docker/docker_build.sh openblas-amd64-py310-dev
+        run: docker/docker_build.sh openblas-amd64-py312-dev
 
       - name: Docker test
-        run: docker/docker_test.sh openblas-amd64-py310-dev
-
-  # With forked repo, the GitHub secret is not available.
-  skip-arm64-check-on-fork:
-    runs-on: ubuntu-latest
-    name: Skip job for forks
-    outputs:
-      skip: ${{ steps.check.outputs.skip }}
-    steps:
-      - name: Skip check
-        id: check
-        run: |
-          if [ "${GITHUB_REPOSITORY}" == "isl-org/Open3D" ] && [ -n "${GCE_GPU_CI_SA}" ] ; then
-            echo "Secrets available: performing GCE test"
-            echo "skip=no" >> $GITHUB_OUTPUT
-          else
-            echo "Secrets not available: skipping GCE test"
-            echo "skip=yes" >> $GITHUB_OUTPUT
-          fi
+        run: docker/docker_test.sh openblas-amd64-py312-dev
 
   openblas-arm64:
     permissions:
       contents: read
-    runs-on: ubuntu-latest
-    needs: [skip-arm64-check-on-fork]
-    if: needs.skip-arm64-check-on-fork.outputs.skip == 'no'
+    runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
+      matrix:
+        python_version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        is_main:
+          - ${{ github.ref == 'refs/heads/main' }}
+        exclude:
+          - is_main: false
+            python_version: '3.8'
+          - is_main: false
+            python_version: '3.9'
+          - is_main: false
+            python_version: '3.10'
+          - is_main: false
+            python_version: '3.11'
     env:
-      # Export everything from matrix to be easily used.
-      # Docker tag must be consistent with docker_build.sh
-      CI_CONFIG          : openblas-arm64-py310-dev
-      GCE_INSTANCE_PREFIX: open3d-ci-openblas-arm64-py310-dev
+      DEVELOPER_BUILD: ${{ github.event.inputs.developer_build || 'ON' }}
+      PYTHON_VERSION: ${{ matrix.python_version }}
+      CCACHE_TAR_NAME: open3d-ubuntu-2204-cuda-ci-ccache
+      OPEN3D_CPU_RENDERING: true
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
-      - name: Package code
+      - name: Maximize build space
         run: |
-          # GITHUB_WORKSPACE: /home/runner/work/Open3D/Open3D
-          cd "${GITHUB_WORKSPACE}/.."
-          tar -czvf Open3D.tar.gz Open3D
-          ls -alh
-      - name: GCloud CLI auth
-        uses: 'google-github-actions/auth@v2'
+          source util/ci_utils.sh
+          maximize_ubuntu_github_actions_build_space
+      # Be verbose and explicit here such that a developer can directly copy the
+      # `docker/docker_build.sh xxx` command to execute locally.
+      - name: Compute Docker tag for this matrix entry
+        run: |
+          # Strip the dot: 3.8 ➜ 38, 3.10 ➜ 310 …
+          PY_NO_DOT="${PYTHON_VERSION//./}"
+          # Add “-dev” only when requested
+          DEV_SUFFIX=$([ "${DEVELOPER_BUILD}" = "ON" ] && echo "-dev")
+          echo "DOCKER_TAG=openblas-arm64-py${PY_NO_DOT}${DEV_SUFFIX}" >> $GITHUB_ENV
+      - name: Docker build
+        run: |
+          docker/docker_build.sh "${DOCKER_TAG}"
+          # (wheel-name logic can stay as is)
+          PIP_PKG_NAME="$(basename ${GITHUB_WORKSPACE}/open3d-[0-9]*.whl)"
+          PIP_CPU_PKG_NAME="$(basename ${GITHUB_WORKSPACE}/open3d_cpu*.whl)"
+          echo "PIP_PKG_NAME=$PIP_PKG_NAME"       >> $GITHUB_ENV
+          echo "PIP_CPU_PKG_NAME=$PIP_CPU_PKG_NAME" >> $GITHUB_ENV
+
+      - name: Upload wheel to GitHub artifacts
+        uses: actions/upload-artifact@v4
         with:
-          project_id: ${{ secrets.GCE_PROJECT }}
-          credentials_json: '${{ secrets.GCE_SA_KEY_GPU_CI }}'
-      - name: GCloud CLI setup
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: ${{ env.GCE_CLI_GHA_VERSION }}
-          project_id: ${{ secrets.GCE_PROJECT }}
-      - name: VM create
-        run: |
-          gcloud compute images list
-          gcloud container images list
-          INSTANCE_NAME="${GCE_INSTANCE_PREFIX}-${GITHUB_SHA::8}"
-          INSTANCE_ZONES=(us-central1-a
-                          us-central1-b
-                          us-central1-f
-                          asia-southeast1-b
-                          asia-southeast1-c
-                          europe-west4-a
-                          europe-west4-b)
-          ZONE_ID=0
-          until ((ZONE_ID >= ${#INSTANCE_ZONES[@]})) ||
-            gcloud compute instances create "$INSTANCE_NAME" \
-              --zone="${INSTANCE_ZONES[$ZONE_ID]}" \
-              --machine-type=t2a-standard-4 \
-              --boot-disk-size="128GB" \
-              --image-project="ubuntu-os-cloud" \
-              --image-family="ubuntu-2004-lts-arm64" \
-              --metadata-from-file=startup-script=./util/gcloud_auto_clean.sh \
-              --scopes="storage-full,compute-rw" \
-              --service-account="$GCE_GPU_CI_SA"; do
-              ((ZONE_ID = ZONE_ID + 1))
-          done
-          sleep 90
-          echo "GCE_ZONE=${INSTANCE_ZONES[$ZONE_ID]}" >> "${GITHUB_ENV}"
-          echo "INSTANCE_NAME=${INSTANCE_NAME}" >> "${GITHUB_ENV}"
-          exit $((ZONE_ID >= ${#INSTANCE_ZONES[@]})) # 0 => success
-      - name: VM copy code
-        run: |
-          gcloud compute scp \
-            "${GITHUB_WORKSPACE}/../Open3D.tar.gz" "${INSTANCE_NAME}":~ \
-            --zone "${GCE_ZONE}"
-          gcloud compute ssh "${INSTANCE_NAME}" \
-            --zone "${GCE_ZONE}" \
-            --command "ls -alh \
-                    && tar -xvzf Open3D.tar.gz \
-                    && ls -alh \
-                    && ls -alh Open3D"
-      - name: VM install docker
-        run: |
-          gcloud compute ssh "${INSTANCE_NAME}" \
-            --zone="${GCE_ZONE}" \
-            --command="sudo apt update \
-                    && curl -fsSL https://get.docker.com -o get-docker.sh \
-                    && sudo sh get-docker.sh"
-      - name: VM build docker
-        run: |
-          gcloud compute ssh "${INSTANCE_NAME}" \
-            --zone="${GCE_ZONE}" \
-            --command="sudo docker run --rm arm64v8/ubuntu:20.04 uname -p \
-                    && sudo Open3D/docker/docker_build.sh ${CI_CONFIG}"
-      - name: VM run docker
-        run: |
-          gcloud compute ssh "${INSTANCE_NAME}" \
-            --zone="${GCE_ZONE}" \
-            --command="sudo Open3D/docker/docker_test.sh ${CI_CONFIG}"
-      - name: VM delete
-        if: always()
-        run: |
-          gcloud compute instances delete "${INSTANCE_NAME}" --zone "${GCE_ZONE}"
-          ls -alh "${HOME}/.ssh"
-          gcloud compute os-login describe-profile
-          gcloud compute os-login ssh-keys remove --key-file "${HOME}/.ssh/google_compute_engine.pub"
+          name: ${{ env.PIP_PKG_NAME }}
+          path: |
+            ${{ env.PIP_PKG_NAME }}
+            ${{ env.PIP_CPU_PKG_NAME }}
+          if-no-files-found: error
+
+      - name: Docker test
+        run: docker/docker_test.sh "${DOCKER_TAG}"

--- a/3rdparty/cutlass/cutlass.cmake
+++ b/3rdparty/cutlass/cutlass.cmake
@@ -1,15 +1,15 @@
 include(ExternalProject)
 
 ExternalProject_Add(
-    ext_cutlass
-    PREFIX cutlass
-    URL https://github.com/NVIDIA/cutlass/archive/refs/tags/v1.3.3.tar.gz
-    URL_HASH SHA256=12d5b4c913063625154019b0a03a253c5b9339c969939454b81f6baaf82b34ca
-    DOWNLOAD_DIR "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/cutlass"
-    UPDATE_COMMAND ""
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ""
-    INSTALL_COMMAND ""
+        ext_cutlass
+        PREFIX cutlass
+        URL https://github.com/NVIDIA/cutlass/archive/refs/tags/v3.9.2.tar.gz
+        URL_HASH SHA256=4b97bd6cece9701664eec3a634a1f2f2061d85bf76d843fa5799e1a692b4db0d
+        DOWNLOAD_DIR "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/cutlass"
+        UPDATE_COMMAND ""
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+        INSTALL_COMMAND ""
 )
 
 ExternalProject_Get_Property(ext_cutlass SOURCE_DIR)

--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -1658,12 +1658,16 @@ else(OPEN3D_USE_ONEAPI_PACKAGES)
                 # Find libgfortran.a and libgcc.a inside the gfortran library search
                 # directories. This ensures that the library matches the compiler.
                 # On ARM64 Ubuntu and ARM64 macOS, libgfortran.a is compiled with `-fPIC`.
-                find_library(gfortran_lib NAMES libgfortran.a PATHS ${gfortran_lib_dirs} REQUIRED)
-                find_library(gcc_lib      NAMES libgcc.a      PATHS ${gfortran_lib_dirs} REQUIRED)
-                target_link_libraries(3rdparty_blas INTERFACE
-                    ${gfortran_lib}
-                    ${gcc_lib}
-                )
+                # find_library(gfortran_lib NAMES libgfortran.a PATHS ${gfortran_lib_dirs} REQUIRED)
+                # find_library(gcc_lib      NAMES libgcc.a      PATHS ${gfortran_lib_dirs} REQUIRED)
+                # target_link_libraries(3rdparty_blas INTERFACE
+                #         ${gfortran_lib}
+                #         ${gcc_lib}
+                # )
+                # On some aarch64 systems, libgfortran.a is not compiled with -fPIC,
+                # which prevents it from being used in a shared library.
+                # We link the shared version (-lgfortran) instead. This also handles libgcc.
+                target_link_libraries(3rdparty_blas INTERFACE gfortran)
                 if(APPLE_AARCH64)
                     find_library(quadmath_lib NAMES libquadmath.a PATHS ${gfortran_lib_dirs} REQUIRED)
                     target_link_libraries(3rdparty_blas INTERFACE

--- a/3rdparty/openblas/openblas.cmake
+++ b/3rdparty/openblas/openblas.cmake
@@ -7,16 +7,16 @@ else()
 endif()
 
 ExternalProject_Add(
-    ext_openblas
-    PREFIX openblas
-    URL https://github.com/xianyi/OpenBLAS/releases/download/v0.3.20/OpenBLAS-0.3.20.tar.gz
-    URL_HASH SHA256=8495c9affc536253648e942908e88e097f2ec7753ede55aca52e5dead3029e3c
-    DOWNLOAD_DIR "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/openblas"
-    CMAKE_ARGS
+        ext_openblas
+        PREFIX openblas
+        URL https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.29/OpenBLAS-0.3.29.tar.gz
+        URL_HASH SHA256=38240eee1b29e2bde47ebb5d61160207dc68668a54cac62c076bb5032013b1eb
+        DOWNLOAD_DIR "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/openblas"
+        CMAKE_ARGS
         ${ExternalProject_CMAKE_ARGS}
         -DTARGET=${OPENBLAS_TARGET}
         -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-    BUILD_BYPRODUCTS 
+        BUILD_BYPRODUCTS
         <INSTALL_DIR>/${Open3D_INSTALL_LIB_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${lib_name}${lib_suffix}${CMAKE_STATIC_LIBRARY_SUFFIX}
 )
 

--- a/util/install_deps_ubuntu.sh
+++ b/util/install_deps_ubuntu.sh
@@ -21,6 +21,7 @@ deps=(
     libxcb-shm0
     libglu1-mesa-dev
     python3-dev
+    libssl-dev
     # filament linking
     libc++-dev
     libc++abi-dev

--- a/util/install_deps_ubuntu.sh
+++ b/util/install_deps_ubuntu.sh
@@ -59,6 +59,11 @@ if [ "$DISTRIB_ID" == "Ubuntu" -a "$DISTRIB_RELEASE" == "22.04" ]; then
     deps=("${deps[@]/libc++-dev/libc++-11-dev}")
     deps=("${deps[@]/libc++abi-dev/libc++abi-11-dev}")
 fi
+if [ "$DISTRIB_ID" == "Ubuntu" -a "$DISTRIB_RELEASE" == "24.04" ]; then
+    deps=("${deps[@]/clang/clang-14}")
+    deps=("${deps[@]/libc++-dev/libc++-14-dev}")
+    deps=("${deps[@]/libc++abi-dev/libc++abi-14-dev}")
+fi
 
 # Special case for ARM64
 if [ "$(uname -m)" == "aarch64" ]; then


### PR DESCRIPTION
FIXES: #7130 
ARM64 Linux builds are not available due to a runtime dynamic linker error: "cannot allocate memory in static TLS block"

Context:
```
Error migrate from 18.04 to 20.04 with glibc bugged.
```

Fixed:
```
Arm builds come back to build again without LTS Block problem.
```

Includes CUDA ARM Working again with >=12.1 cuda. Tested on Jetson and GH200

```bash
# On some aarch64 systems, libgfortran.a is not compiled with -fPIC,
# which prevents it from being used in a shared library.
# We link the shared version (-lgfortran) instead. This also handles libgcc.
```