### PR TITLE
Preserve the converge status for the latest RegistrationResult

### DIFF
--- a/cpp/open3d/t/pipelines/registration/Registration.cpp
+++ b/cpp/open3d/t/pipelines/registration/Registration.cpp
@@ -404,10 +404,12 @@ RegistrationResult MultiScaleICP(
         // To calculate final `fitness` and `inlier_rmse` for the current
         // `transformation` stored in `result`.
         if (scale_idx == num_scales - 1) {
+            bool preserved_converged_flag = result.converged_;
             result = ComputeRegistrationResult(
                     source_down_pyramid[scale_idx], target_nns,
                     max_correspondence_distances[scale_idx],
                     result.transformation_);
+            result.converged_ = preserved_converged_flag;
         }
 
         // No correspondences.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #7296
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->

- Related to issue #7296 
- I use a temporary bool variable to preserve the converged information and give it back to the new RegistrationResult.
