### PR TITLE
Replace usage of `std::is_pod` with `std::is_standard_layout && std::is_trivial`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 -   Add error handling for insufficient correspondences in AdvancedMatching (PR #7234)
 -   Exposed `get_plotly_fig` and modified `draw_plotly` to return the `Figure` it creates. (PR #7258)
 -   Fix build with librealsense v2.44.0 and upcoming VS 2022 17.13 (PR #7074)
+-   Fix `deprecated-declarations` warnings when compiling code with C++20 standard (PR #7303)
 
 ## 0.13
 

--- a/cpp/open3d/core/Tensor.h
+++ b/cpp/open3d/core/Tensor.h
@@ -62,8 +62,9 @@ public:
 
         // Check data types
         AssertTemplateDtype<T>();
-        if (!std::is_pod<T>()) {
-            utility::LogError("Object must be a POD.");
+        if (!(std::is_standard_layout<T>::value && std::is_trivial<T>::value)) {
+            utility::LogError(
+                    "Object must be a StandardLayout and TrivialType type.");
         }
 
         // Copy data to blob

--- a/cpp/open3d/ml/contrib/Cloud.cpp
+++ b/cpp/open3d/ml/contrib/Cloud.cpp
@@ -53,7 +53,9 @@ namespace open3d {
 namespace ml {
 namespace contrib {
 
-static_assert(std::is_pod<PointXYZ>(), "PointXYZ class must be a POD type.");
+static_assert(std::is_standard_layout<PointXYZ>::value &&
+                      std::is_trivial<PointXYZ>::value,
+              "PointXYZ class must be a StandardLayout and TrivialType type.");
 
 // Getters
 // *******

--- a/cpp/tests/core/TensorObject.cpp
+++ b/cpp/tests/core/TensorObject.cpp
@@ -48,7 +48,9 @@ private:
     void *ptr_;
 };
 
-static_assert(std::is_pod<TestObject>(), "TestObject must be a POD.");
+static_assert(std::is_standard_layout<TestObject>::value &&
+                      std::is_trivial<TestObject>::value,
+              "TestObject must be a StandardLayout and TrivialType type.");
 static const int64_t byte_size = sizeof(TestObject);
 static const std::string class_name = "TestObject";
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Replace usage of `std::is_pod` with `std::is_standard_layout && std::is_trivial`.

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #5405
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

std::is_pod` is deprecated in C++20, hence this replacement is necessary to make usage of open3d possible when client code is compiled with C++20.

Fixes part of https://github.com/isl-org/Open3D/issues/5405

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [ ] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->

Replaces usages of `std::is_pod` with the suggested alternative by gcc - `std::is_standard_layout && std::is_trivial`. `std::is_pod` is deprecated in C++20. This makes it possible to use `open3d::core::Tensor::Init` function from `Tensor.h` header file usable when compiling client application with C++20 or higher standard. 