### PR TITLE
Optionally include CUDA DLLs in open3d-package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Main
+-   Allow bundling CUDA-DLLs into the pip-package on Windows with BUNDLE_CUDA_SHARED_LIBS.
 -   Corrected documentation for Link Open3D in C++ projects (broken links).
 -   Fix DLLs not being found in Python-package. Also prevent PATH from being searched for DLLs, except CUDA (PR #7108)
 -   Fix MSAA sample count not being copied when FilamentView is copied

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ option(BUILD_AZURE_KINECT         "Build support for Azure Kinect sensor"    OFF
 option(BUILD_TENSORFLOW_OPS       "Build ops for TensorFlow"                 OFF)
 option(BUILD_PYTORCH_OPS          "Build ops for PyTorch"                    OFF)
 option(BUNDLE_OPEN3D_ML           "Includes the Open3D-ML repo in the wheel" OFF)
+option(BUNDLE_CUDA_SHARED_LIBS    "Includes CUDA-DLLs in the wheel (win only)" OFF)
 
 # Release build options
 option(DEVELOPER_BUILD      "Add +commit_hash to the project version number" ON )

--- a/cpp/pybind/CMakeLists.txt
+++ b/cpp/pybind/CMakeLists.txt
@@ -127,6 +127,15 @@ install_name_tool -change $libomp_library @rpath/$(basename $libomp_library) \
         COMMAND bash update_pybind_libomp.sh
         COMMENT "Updating pybind to use packaged libomp")
 endif()
+if (WIN32 AND BUILD_CUDA_MODULE AND BUNDLE_CUDA_SHARED_LIBS)
+	# Just bundle all DLLs from CUDA to avoid having to update
+	# an explicit listing of required DLLs.
+	# Only bundling required DLLs would decrease the package size,
+	# but not by much, as cublas, cusparse and cusolver alone
+	# need about 1GB.
+	file(GLOB CUDA_DLLS "${CUDAToolkit_BIN_DIR}/*.dll")
+	list(APPEND PYTHON_EXTRA_LIBRARIES ${CUDA_DLLS})
+endif()
 
 # Use `make python-package` to create the python package in the build directory
 # The python package will be created at PYTHON_PACKAGE_DST_DIR. It contains:

--- a/python/open3d/__init__.py
+++ b/python/open3d/__init__.py
@@ -44,10 +44,12 @@ if _build_config["BUILD_CUDA_MODULE"]:
             ImportWarning,
         )
     try:
-        if sys.platform == "win32" and sys.version_info >= (3, 8):
+        if sys.platform == "win32" and sys.version_info >= (3, 8) and not _build_config["BUNDLE_CUDA_SHARED_LIBS"]:
             # Since Python 3.8, the PATH environment variable is not used to find DLLs anymore.
             # To allow Windows users to use Open3D with CUDA without running into dependency-problems,
             # look for the CUDA bin directory in PATH and explicitly add it to the DLL search path.
+            # Only do this if the CUDA shared libraries are not bundled with Open3D to prevent conflicts
+            # beteween bundled and system libraries.
             cuda_bin_path = None
             for path in os.environ['PATH'].split(';'):
                 # search heuristic: look for a path containing "cuda" and "bin" in this order.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [x] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

In order to have a self-contained Python package with GPU-support on Windows, allow bundling the CUDA DLLs with open3d. This is especially useful when deploying open3d to non-developer machines where you cannot assume that CUDA is installed. It also is a step towards an official Python package with CUDA-support for Windows, which would save the effort of building yourself.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [ x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ x] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [ x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [ x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->

Added CMake variable `BUNDLE_CUDA_SHARED_LIBS`, which causes all DLLs from the build system's CUDA-installation to be included in the wheel. Only works on Windows and only if `BUILD_CUDA_MODULE` is on.
