### PR TITLE
Fix thread safety of UniformTSDFVolume::ExtractVoxelGrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 -   Exposed `get_plotly_fig` and modified `draw_plotly` to return the `Figure` it creates. (PR #7258)
 -   Fix build with librealsense v2.44.0 and upcoming VS 2022 17.13 (PR #7074)
 -   Fix `deprecated-declarations` warnings when compiling code with C++20 standard (PR #7303)
+-   Fix thread safety of UniformTSDFVolume::ExtractVoxelGrid (PR #7314)
 
 ## 0.13
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #6712 
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

When calling [`UniformTSDFVolume::ExtractVoxelGrid`](https://github.com/isl-org/Open3D/blob/1c48fcd897d305a121f5a8db6cabde5dd2d6526e/cpp/open3d/pipelines/integration/UniformTSDFVolume.cpp#L254), a Segmentation Fault occurs, or the program hangs indefinitely.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

The issue is caused by accessing a `std::unordered_map` (`voxel_grid->voxels_`) which is not thread-safe, within an OpenMP for loop:
https://github.com/isl-org/Open3D/blob/1c48fcd897d305a121f5a8db6cabde5dd2d6526e/cpp/open3d/pipelines/integration/UniformTSDFVolume.cpp#L277
Fix of this PR: create per thread `std::vector<geometry::Voxel>` in parallel with OpenMP, and then insert the data into the `std::unordered_map` outside of the parallel section.
