### PR TITLE
Fixed bug that caused Open3D to crash when geometries were frequently removed and added.

### DIFF
--- a/cpp/open3d/core/hashmap/CUDA/SlabNodeManager.h
+++ b/cpp/open3d/core/hashmap/CUDA/SlabNodeManager.h
@@ -111,7 +111,7 @@ public:
                         memory_block_bitmap_ | (1 << empty_lane));
                 if (read_bitmap == memory_block_bitmap_) {
                     // Successful attempt.
-                    memory_block_bitmap_ |= (1 << empty_lane);
+                    memory_block_bitmap_ = memory_block_bitmap_ |= (1 << empty_lane);
                     allocated_result =
                             (super_block_index_ << kSuperBlockMaskBits) |
                             (memory_block_index_ << kBlockMaskBits) |

--- a/cpp/open3d/visualization/rendering/RendererHandle.cpp
+++ b/cpp/open3d/visualization/rendering/RendererHandle.cpp
@@ -13,7 +13,7 @@ namespace open3d {
 namespace visualization {
 namespace rendering {
 
-std::array<std::uint16_t, static_cast<size_t>(EntityType::Count)>
+std::array<std::uint32_t, static_cast<size_t>(EntityType::Count)>
         REHandle_abstract::uid_table;
 
 std::ostream& operator<<(std::ostream& os, const REHandle_abstract& uid) {

--- a/cpp/open3d/visualization/rendering/RendererHandle.h
+++ b/cpp/open3d/visualization/rendering/RendererHandle.h
@@ -20,7 +20,7 @@ namespace visualization {
 namespace rendering {
 
 // If you add entry here, don't forget to update TypeToString!
-enum class EntityType : std::uint16_t {
+enum class EntityType : std::uint32_t {
     None = 0,
 
     View,
@@ -47,11 +47,11 @@ enum class EntityType : std::uint16_t {
 struct REHandle_abstract {
     static const char* TypeToString(EntityType type);
 
-    static const std::uint16_t kBadId = 0;
+    static const std::uint32_t kBadId = 0;
     const EntityType type = EntityType::None;
 
-    inline size_t Hash() const {
-        return static_cast<std::uint16_t>(type) << 16 | id;
+    inline uint64_t Hash() const {
+        return static_cast<std::uint64_t>(type) << 32 | id;
     }
 
     bool operator==(const REHandle_abstract& other) const {
@@ -70,16 +70,16 @@ struct REHandle_abstract {
 
     REHandle_abstract() : type(EntityType::None), id(kBadId) {}
 
-    std::uint16_t GetId() const { return id; }
+    std::uint32_t GetId() const { return id; }
 
 protected:
-    REHandle_abstract(const EntityType aType, const std::uint16_t aId)
+    REHandle_abstract(const EntityType aType, const std::uint32_t aId)
         : type(aType), id(aId) {}
 
-    static std::array<std::uint16_t, static_cast<size_t>(EntityType::Count)>
+    static std::array<std::uint32_t, static_cast<size_t>(EntityType::Count)>
             uid_table;
 
-    std::uint16_t id = kBadId;
+    std::uint32_t id = kBadId;
 };
 
 std::ostream& operator<<(std::ostream& os, const REHandle_abstract& uid);
@@ -91,7 +91,7 @@ struct REHandle : public REHandle_abstract {
     static const REHandle kBad;
 
     static REHandle Next() {
-        const auto index = static_cast<std::uint16_t>(entityType);
+        const auto index = static_cast<std::uint32_t>(entityType);
         auto id = ++uid_table[index];
         if (id == REHandle_abstract::kBadId) {
             uid_table[index] = REHandle_abstract::kBadId + 1;
@@ -113,7 +113,7 @@ struct REHandle : public REHandle_abstract {
     REHandle() : REHandle_abstract(entityType, REHandle_abstract::kBadId) {}
     REHandle(const REHandle& other) : REHandle_abstract(entityType, other.id) {}
     // Don't use this constructor unless you know what you are doing
-    explicit REHandle(std::uint16_t id) : REHandle_abstract(entityType, id) {}
+    explicit REHandle(std::uint32_t id) : REHandle_abstract(entityType, id) {}
 
     REHandle& operator=(const REHandle& other) {
         id = other.id;

--- a/cpp/open3d/visualization/rendering/filament/FilamentScene.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentScene.cpp
@@ -1919,7 +1919,9 @@ void FilamentScene::RenderableGeometry::ReleaseResources(
     destroy_map(mat.maps.anisotropy_map);
 
     manager.Destroy(mat.mat_instance);
-
+    
+    // destroy filament entity
+    utils::EntityManager::get().destroy(filament_entity);
     filament_entity.clear();
 }
 


### PR DESCRIPTION
Fixed bug that caused Open3D to crash when geometries were frequently removed and added.
-Changed variables in RendererHandle.h and .cpp from uint16_t to uint32_t to prvent overfow errors. 
-Fixed the bug that Filament entities were not destroyed. 
-Fixed a little bug in SlabNodeManager.h

<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #https://github.com/isl-org/Open3D/issues/7250 (maybe fixes this bug too?: Bug: Rendering becomes corrupted after a certain amount of frames #7129)
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
When geometries were added and removed in open3d as often as the size of a uint16, it crashed.
After fixing this error, a second bug occurred in that after approx. 130,000 geometry updates, these were not displayed.




<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->



-   [ ] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [ ] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description
There are two bugs:
1. A uint16 overflow in RendererHandle.h and .cpp
2. The filament entities were not destroyed (this error only occurs after 2x uint16 -> approx. 130,000 geometry updates and did not cause the program to crash, but rather meant that the new geometries were not displayed).

Solutions:
1. Change uint16 to uint32 -> The program can now update geometries as often as uint32 is large, instead of uint16. (This may not be enough for some applications. In that case, we should switch to 64-bit or add a reset.)
2. Added code line that destroys the filament entities.
(3. I probably found another error in SlabNodeManager.h. A value was calculated but not assigned.)
