### PR TITLE
Fix bug in emissive color default value

### DIFF
--- a/cpp/open3d/visualization/rendering/Material.cpp
+++ b/cpp/open3d/visualization/rendering/Material.cpp
@@ -26,7 +26,7 @@ void Material::SetDefaultProperties() {
     SetTransmission(1.f);
     SetAbsorptionColor(Eigen::Vector4f(1.f, 1.f, 1.f, 1.f));
     SetAbsorptionDistance(1.f);
-    SetEmissiveColor(Eigen::Vector4f(1.f, 1.f, 1.f, 1.f));
+    SetEmissiveColor(Eigen::Vector4f(0.f, 0.f, 0.f, 1.f));
     SetPointSize(3.f);
     SetLineWidth(1.f);
 }


### PR DESCRIPTION
Emissive color default should be all zeros (black), instead of all ones (white).

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [ ] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [ ] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [ ] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
