### PR TITLE
add create_from_sparse_indices for VoxelGrid

### DIFF
--- a/cpp/open3d/geometry/VoxelGrid.h
+++ b/cpp/open3d/geometry/VoxelGrid.h
@@ -189,6 +189,18 @@ public:
                                                   double height,
                                                   double depth);
 
+    /// Creates a voxel grid given sparse 3d indices.
+    ///
+    /// \param indices 3d indices of each VoxelGrid.
+    /// \param colors Voxel colors for each voxel of the VoxelGrid.
+    /// \param origin Coordinate center of the VoxelGrid.
+    /// \param voxel_size Voxel size of of the VoxelGrid construction.
+    static std::shared_ptr<VoxelGrid> CreateFromSparseIndices(
+            const std::vector<Eigen::Vector3i>& indices,
+            const std::vector<Eigen::Vector3d>& colors,
+            const Eigen::Vector3d origin,
+            double voxel_size);
+
     /// \enum VoxelPoolingMode
     ///
     /// \brief Possible ways of determining voxel color from PointCloud.

--- a/cpp/open3d/geometry/VoxelGrid.h
+++ b/cpp/open3d/geometry/VoxelGrid.h
@@ -196,8 +196,8 @@ public:
     /// \param origin Coordinate center of the VoxelGrid.
     /// \param voxel_size Voxel size of of the VoxelGrid construction.
     static std::shared_ptr<VoxelGrid> CreateFromSparseIndices(
-            const std::vector<Eigen::Vector3i>& indices,
-            const std::vector<Eigen::Vector3d>& colors,
+            const std::vector<Eigen::Vector3i> &indices,
+            const std::vector<Eigen::Vector3d> &colors,
             const Eigen::Vector3d origin,
             double voxel_size);
 

--- a/cpp/open3d/geometry/VoxelGridFactory.cpp
+++ b/cpp/open3d/geometry/VoxelGridFactory.cpp
@@ -53,8 +53,7 @@ std::shared_ptr<VoxelGrid> VoxelGrid::CreateFromSparseIndices(
     output->origin_ = origin;
     output->voxel_size_ = voxel_size;
     for (size_t i = 0; i < indices.size(); ++i) {
-        Eigen::Vector3i grid_index(indices[i](0), indices[i](1), indices[i](2));
-        output->AddVoxel(geometry::Voxel(grid_index, colors[i]));
+        output->AddVoxel(geometry::Voxel(indices[i], colors[i]));
     }
     return output;
 }

--- a/cpp/open3d/geometry/VoxelGridFactory.cpp
+++ b/cpp/open3d/geometry/VoxelGridFactory.cpp
@@ -41,10 +41,9 @@ std::shared_ptr<VoxelGrid> VoxelGrid::CreateDense(const Eigen::Vector3d &origin,
     return output;
 }
 
-
 std::shared_ptr<VoxelGrid> VoxelGrid::CreateFromSparseIndices(
-        const std::vector<Eigen::Vector3i>& indices,
-        const std::vector<Eigen::Vector3d>& colors,
+        const std::vector<Eigen::Vector3i> &indices,
+        const std::vector<Eigen::Vector3d> &colors,
         const Eigen::Vector3d origin,
         double voxel_size) {
     if (indices.size() != colors.size()) {
@@ -59,7 +58,6 @@ std::shared_ptr<VoxelGrid> VoxelGrid::CreateFromSparseIndices(
     }
     return output;
 }
-
 
 std::shared_ptr<VoxelGrid> VoxelGrid::CreateFromPointCloudWithinBounds(
         const PointCloud &input,

--- a/cpp/open3d/geometry/VoxelGridFactory.cpp
+++ b/cpp/open3d/geometry/VoxelGridFactory.cpp
@@ -41,6 +41,26 @@ std::shared_ptr<VoxelGrid> VoxelGrid::CreateDense(const Eigen::Vector3d &origin,
     return output;
 }
 
+
+std::shared_ptr<VoxelGrid> VoxelGrid::CreateFromSparseIndices(
+        const std::vector<Eigen::Vector3i>& indices,
+        const std::vector<Eigen::Vector3d>& colors,
+        const Eigen::Vector3d origin,
+        double voxel_size) {
+    if (indices.size() != colors.size()) {
+        utility::LogError("Size of indices and colors are different");
+    }
+    auto output = std::make_shared<VoxelGrid>();
+    output->origin_ = origin;
+    output->voxel_size_ = voxel_size;
+    for (size_t i = 0; i < indices.size(); ++i) {
+        Eigen::Vector3i grid_index(indices[i](0), indices[i](1), indices[i](2));
+        output->AddVoxel(geometry::Voxel(grid_index, colors[i]));
+    }
+    return output;
+}
+
+
 std::shared_ptr<VoxelGrid> VoxelGrid::CreateFromPointCloudWithinBounds(
         const PointCloud &input,
         double voxel_size,

--- a/cpp/pybind/geometry/voxelgrid.cpp
+++ b/cpp/pybind/geometry/voxelgrid.cpp
@@ -135,6 +135,9 @@ void pybind_voxelgrid_definitions(py::module &m) {
                         "carving",
                         "origin"_a, "color"_a, "voxel_size"_a, "width"_a,
                         "height"_a, "depth"_a)
+            .def_static("create_from_sparse_indices", &VoxelGrid::CreateFromSparseIndices,
+                        "Creates a voxel grid given sparse 3d indices",
+                        "indices"_a, "colors"_a, "origin"_a, "voxel_size"_a)
             .def_static(
                     "create_from_point_cloud", &VoxelGrid::CreateFromPointCloud,
                     "Creates a VoxelGrid from a given PointCloud. The "
@@ -228,6 +231,12 @@ void pybind_voxelgrid_definitions(py::module &m) {
              {"width", "Spatial width extend of the VoxelGrid."},
              {"height", "Spatial height extend of the VoxelGrid."},
              {"depth", "Spatial depth extend of the VoxelGrid."}});
+    docstring::ClassMethodDocInject(
+            m, "VoxelGrid", "create_from_sparse_indices",
+            {{"indices", "3d indices of each VoxelGrid."},
+             {"colors", "Voxel colors for each voxel of the VoxelGrid."},
+             {"origin", "Coordinate center of the VoxelGrid."},
+             {"voxel_size", "Voxel size of of the VoxelGrid construction."}});
     docstring::ClassMethodDocInject(
             m, "VoxelGrid", "create_from_point_cloud",
             {{"input", "The input PointCloud"},

--- a/cpp/pybind/geometry/voxelgrid.cpp
+++ b/cpp/pybind/geometry/voxelgrid.cpp
@@ -135,7 +135,8 @@ void pybind_voxelgrid_definitions(py::module &m) {
                         "carving",
                         "origin"_a, "color"_a, "voxel_size"_a, "width"_a,
                         "height"_a, "depth"_a)
-            .def_static("create_from_sparse_indices", &VoxelGrid::CreateFromSparseIndices,
+            .def_static("create_from_sparse_indices",
+                        &VoxelGrid::CreateFromSparseIndices,
                         "Creates a voxel grid given sparse 3d indices",
                         "indices"_a, "colors"_a, "origin"_a, "voxel_size"_a)
             .def_static(

--- a/docs/jupyter/geometry/voxelization.ipynb
+++ b/docs/jupyter/geometry/voxelization.ipynb
@@ -281,6 +281,42 @@
     "print(voxel_grid)\n",
     "o3d.visualization.draw_geometries([voxel_grid])"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# From sparse indices"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The method `create_from_sparse_indices` creates voxels from sparse indices and colors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import open3d as o3d\n",
+    "import numpy as np\n",
+    "\n",
+    "indices = np.array([[0, 0, 0], [1, 1, 1]], dtype=np.int32)\n",
+    "colors = np.array([[1, 0, 0], [0, 0, 1]], dtype=np.float64)\n",
+    "\n",
+    "voxel_grids = o3d.geometry.VoxelGrid.create_from_sparse_indices(\n",
+    "    o3d.utility.Vector3iVector(indices),\n",
+    "    o3d.utility.Vector3dVector(colors),\n",
+    "    np.array([0, 0, 0]),\n",
+    "    1.0,\n",
+    ")\n",
+    "frame = o3d.geometry.TriangleMesh.create_coordinate_frame(0.8)\n",
+    "o3d.visualization.draw_geometries([frame, voxel_grids])"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## add create_from_sparse_indices for VoxelGrid

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [x] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

Motivation: I need to create voxel grid given sparse 3d indices but found it is not implemented.
It is implmented in this PR

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [ x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [x] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [x] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here. 
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

add create_from_sparse_indices for VoxelGrid
the result of my added python test is given in the image below
<img width="2970" height="1266" alt="2025-08-15 23-39-13屏幕截图" src="https://github.com/user-attachments/assets/61e12bd3-d343-43d8-b79b-9a60f7c74052" />

