### PR TITLE
Feat: VoxelGrid transform, rotate, translate and scale

### DIFF
--- a/cpp/open3d/geometry/VoxelGrid.h
+++ b/cpp/open3d/geometry/VoxelGrid.h
@@ -111,10 +111,10 @@ public:
         auto it = voxels_.find(idx);
         if (it != voxels_.end()) {
             auto voxel = it->second;
-            return ((voxel.grid_index_.cast<double>() +
-                     Eigen::Vector3d(0.5, 0.5, 0.5)) *
-                    voxel_size_) +
-                   origin_;
+            Eigen::Vector3d local = (voxel.grid_index_.cast<double>() +
+                                     Eigen::Vector3d(0.5, 0.5, 0.5)) *
+                                    voxel_size_;
+            return origin_ + origin_rotation_ * local;
         } else {
             return Eigen::Vector3d::Zero();
         }
@@ -259,6 +259,9 @@ public:
     double voxel_size_ = 0.0;
     /// Coordinate of the origin point.
     Eigen::Vector3d origin_ = Eigen::Vector3d::Zero();
+    /// Orientation (rotation) of the voxel grid (world = origin_ +
+    /// origin_rotation_ * local)
+    Eigen::Matrix3d origin_rotation_ = Eigen::Matrix3d::Identity();
     /// Voxels contained in voxel grid
     std::unordered_map<Eigen::Vector3i,
                        Voxel,

--- a/cpp/open3d/io/file_format/FilePLY.cpp
+++ b/cpp/open3d/io/file_format/FilePLY.cpp
@@ -266,6 +266,7 @@ struct PLYReaderState {
     utility::ProgressBar *progress_bar;
     std::vector<geometry::Voxel> *voxelgrid_ptr;
     Eigen::Vector3d origin;
+    Eigen::Matrix3d origin_rotation;
     double voxel_size;
     long voxel_index;
     long voxel_num;
@@ -281,6 +282,19 @@ int ReadOriginCallback(p_ply_argument argument) {
 
     double value = ply_get_argument_value(argument);
     state_ptr->origin(index) = value;
+    return 1;
+}
+
+int ReadOriginRotationCallback(p_ply_argument argument) {
+    PLYReaderState *state_ptr;
+    long index;
+    ply_get_argument_user_data(argument, reinterpret_cast<void **>(&state_ptr),
+                               &index);
+
+    double value = ply_get_argument_value(argument);
+    int row = index / 3;
+    int col = index % 3;
+    state_ptr->origin_rotation(row, col) = value;
     return 1;
 }
 
@@ -874,6 +888,24 @@ bool ReadVoxelGridFromPLY(const std::string &filename,
     ply_set_read_cb(ply_file, "origin", "x", ReadOriginCallback, &state, 0);
     ply_set_read_cb(ply_file, "origin", "y", ReadOriginCallback, &state, 1);
     ply_set_read_cb(ply_file, "origin", "z", ReadOriginCallback, &state, 2);
+    ply_set_read_cb(ply_file, "origin_rotation", "r00",
+                    ReadOriginRotationCallback, &state, 0);
+    ply_set_read_cb(ply_file, "origin_rotation", "r01",
+                    ReadOriginRotationCallback, &state, 1);
+    ply_set_read_cb(ply_file, "origin_rotation", "r02",
+                    ReadOriginRotationCallback, &state, 2);
+    ply_set_read_cb(ply_file, "origin_rotation", "r10",
+                    ReadOriginRotationCallback, &state, 3);
+    ply_set_read_cb(ply_file, "origin_rotation", "r11",
+                    ReadOriginRotationCallback, &state, 4);
+    ply_set_read_cb(ply_file, "origin_rotation", "r12",
+                    ReadOriginRotationCallback, &state, 5);
+    ply_set_read_cb(ply_file, "origin_rotation", "r20",
+                    ReadOriginRotationCallback, &state, 6);
+    ply_set_read_cb(ply_file, "origin_rotation", "r21",
+                    ReadOriginRotationCallback, &state, 7);
+    ply_set_read_cb(ply_file, "origin_rotation", "r22",
+                    ReadOriginRotationCallback, &state, 8);
     ply_set_read_cb(ply_file, "voxel_size", "val", ReadScaleCallback, &state,
                     0);
 
@@ -901,6 +933,7 @@ bool ReadVoxelGridFromPLY(const std::string &filename,
             voxelgrid.AddVoxel(geometry::Voxel(it.grid_index_));
     }
     voxelgrid.origin_ = state.origin;
+    voxelgrid.origin_rotation_ = state.origin_rotation;
     voxelgrid.voxel_size_ = state.voxel_size;
 
     ply_close(ply_file);
@@ -930,6 +963,16 @@ bool WriteVoxelGridToPLY(const std::string &filename,
     ply_add_property(ply_file, "x", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
     ply_add_property(ply_file, "y", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
     ply_add_property(ply_file, "z", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
+    ply_add_element(ply_file, "origin_rotation", 1);
+    ply_add_property(ply_file, "r00", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
+    ply_add_property(ply_file, "r01", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
+    ply_add_property(ply_file, "r02", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
+    ply_add_property(ply_file, "r10", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
+    ply_add_property(ply_file, "r11", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
+    ply_add_property(ply_file, "r12", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
+    ply_add_property(ply_file, "r20", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
+    ply_add_property(ply_file, "r21", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
+    ply_add_property(ply_file, "r22", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
     ply_add_element(ply_file, "voxel_size", 1);
     ply_add_property(ply_file, "val", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
 
@@ -960,6 +1003,17 @@ bool WriteVoxelGridToPLY(const std::string &filename,
     ply_write(ply_file, origin(0));
     ply_write(ply_file, origin(1));
     ply_write(ply_file, origin(2));
+    const Eigen::Matrix3d &origin_rotation = voxelgrid.origin_rotation_;
+    ply_write(ply_file, origin_rotation(0, 0));
+    ply_write(ply_file, origin_rotation(0, 1));
+    ply_write(ply_file, origin_rotation(0, 2));
+    ply_write(ply_file, origin_rotation(1, 0));
+    ply_write(ply_file, origin_rotation(1, 1));
+    ply_write(ply_file, origin_rotation(1, 2));
+    ply_write(ply_file, origin_rotation(2, 0));
+    ply_write(ply_file, origin_rotation(2, 1));
+    ply_write(ply_file, origin_rotation(2, 2));
+
     ply_write(ply_file, voxelgrid.voxel_size_);
 
     for (auto &it : voxelgrid.voxels_) {

--- a/cpp/open3d/visualization/rendering/filament/FilamentGeometryBuffersBuilder.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentGeometryBuffersBuilder.cpp
@@ -98,12 +98,14 @@ static std::shared_ptr<geometry::TriangleMesh> CreateTriangleMeshFromVoxelGrid(
         vertices.clear();
         const geometry::Voxel& voxel = it.second;
         // 8 vertices in a voxel
+        const Eigen::Matrix3d scaled_rot =
+                voxel_grid.origin_rotation_ * voxel_grid.voxel_size_;
         Eigen::Vector3d base_vertex =
                 voxel_grid.origin_ +
-                voxel.grid_index_.cast<double>() * voxel_grid.voxel_size_;
+                scaled_rot * voxel.grid_index_.cast<double>();
         for (const Eigen::Vector3i& vertex_offset : kCuboidVertexOffsets) {
-            vertices.push_back(base_vertex + vertex_offset.cast<double>() *
-                                                     voxel_grid.voxel_size_);
+            vertices.push_back(base_vertex +
+                               scaled_rot * vertex_offset.cast<double>());
         }
 
         // Voxel color (applied to all points)

--- a/cpp/open3d/visualization/shader/SimpleShader.cpp
+++ b/cpp/open3d/visualization/shader/SimpleShader.cpp
@@ -537,13 +537,16 @@ bool SimpleShaderForVoxelGridLine::PrepareBinding(
     for (auto &it : voxel_grid.voxels_) {
         const geometry::Voxel &voxel = it.second;
         // 8 vertices in a voxel
+        const Eigen::Matrix3f scaled_rot =
+                voxel_grid.origin_rotation_.cast<float>() *
+                voxel_grid.voxel_size_;
         Eigen::Vector3f base_vertex =
                 voxel_grid.origin_.cast<float>() +
-                voxel.grid_index_.cast<float>() * voxel_grid.voxel_size_;
+                scaled_rot * voxel.grid_index_.cast<float>();
         std::vector<Eigen::Vector3f> vertices;
         for (const Eigen::Vector3i &vertex_offset : cuboid_vertex_offsets) {
-            vertices.push_back(base_vertex + vertex_offset.cast<float>() *
-                                                     voxel_grid.voxel_size_);
+            vertices.push_back(base_vertex +
+                               scaled_rot * vertex_offset.cast<float>());
         }
 
         // Voxel color (applied to all points)
@@ -628,13 +631,16 @@ bool SimpleShaderForVoxelGridFace::PrepareBinding(
     for (auto &it : voxel_grid.voxels_) {
         const geometry::Voxel &voxel = it.second;
         // 8 vertices in a voxel
+        const Eigen::Matrix3f scaled_rot =
+                voxel_grid.origin_rotation_.cast<float>() *
+                voxel_grid.voxel_size_;
         Eigen::Vector3f base_vertex =
                 voxel_grid.origin_.cast<float>() +
-                voxel.grid_index_.cast<float>() * voxel_grid.voxel_size_;
+                scaled_rot * voxel.grid_index_.cast<float>();
         std::vector<Eigen::Vector3f> vertices;
         for (const Eigen::Vector3i &vertex_offset : cuboid_vertex_offsets) {
-            vertices.push_back(base_vertex + vertex_offset.cast<float>() *
-                                                     voxel_grid.voxel_size_);
+            vertices.push_back(base_vertex +
+                               scaled_rot * vertex_offset.cast<float>());
         }
 
         // Voxel color (applied to all points)

--- a/cpp/pybind/geometry/voxelgrid.cpp
+++ b/cpp/pybind/geometry/voxelgrid.cpp
@@ -176,6 +176,9 @@ void pybind_voxelgrid_definitions(py::module &m) {
             .def_readwrite("origin", &VoxelGrid::origin_,
                            "``float64`` vector of length 3: Coordinate of the "
                            "origin point.")
+            .def_readwrite("origin_rotation", &VoxelGrid::origin_rotation_,
+                           "``float64`` 3x3 matrix: Rotation matrix of the "
+                           "origin point.")
             .def_readwrite("voxel_size", &VoxelGrid::voxel_size_,
                            "``float64`` Size of the voxel.");
 

--- a/cpp/tests/geometry/VoxelGrid.cpp
+++ b/cpp/tests/geometry/VoxelGrid.cpp
@@ -8,7 +8,9 @@
 #include "open3d/geometry/VoxelGrid.h"
 
 #include "open3d/geometry/LineSet.h"
+#include "open3d/geometry/PointCloud.h"
 #include "open3d/geometry/TriangleMesh.h"
+#include "open3d/io/PointCloudIO.h"
 #include "open3d/visualization/utility/DrawGeometry.h"
 #include "tests/Tests.h"
 
@@ -54,6 +56,160 @@ TEST(VoxelGrid, Visualization) {
 
     // Uncomment the line below for visualization test
     // visualization::DrawGeometries({voxel_grid});
+}
+
+TEST(VoxelGrid, Scale) {
+    open3d::geometry::PointCloud pcd;
+    open3d::data::PLYPointCloud pointcloud_ply;
+    open3d::io::ReadPointCloud(pointcloud_ply.GetPath(), pcd);
+
+    double voxel_size = 0.01;
+    auto voxel_grid = std::make_shared<geometry::VoxelGrid>();
+    voxel_grid = geometry::VoxelGrid::CreateFromPointCloud(
+            pcd, voxel_size, geometry::VoxelGrid::VoxelPoolingMode::AVG);
+
+    Eigen::Vector3d original_center = voxel_grid->GetCenter();
+
+    // Get original current voxels centers
+    std::vector<Eigen::Vector3d> original_centers;
+    for (const auto &it : voxel_grid->voxels_) {
+        original_centers.push_back(
+                voxel_grid->GetVoxelCenterCoordinate(it.second.grid_index_));
+    }
+
+    // Scale the voxel grid by 2x
+    double scale = 2.0;
+    voxel_grid->Scale(scale, voxel_grid->GetCenter());
+    EXPECT_NEAR(voxel_grid->voxel_size_, voxel_size * scale, 1e-6);
+    // Get new current voxels centers
+    std::vector<Eigen::Vector3d> new_centers;
+    for (const auto &it : voxel_grid->voxels_) {
+        new_centers.push_back(
+                voxel_grid->GetVoxelCenterCoordinate(it.second.grid_index_));
+    }
+    // Check that the new centers are scaled by 2x
+    EXPECT_EQ(original_centers.size(), new_centers.size());
+    for (size_t i = 0; i < original_centers.size(); i++) {
+        Eigen::Vector3d vec = new_centers[i] - voxel_grid->GetCenter();
+        Eigen::Vector3d vec_orig = original_centers[i] - original_center;
+        ExpectEQ(vec, (vec_orig * scale).eval());
+    }
+}
+
+TEST(VoxelGrid, Translate) {
+    open3d::geometry::PointCloud pcd;
+    open3d::data::PLYPointCloud pointcloud_ply;
+    open3d::io::ReadPointCloud(pointcloud_ply.GetPath(), pcd);
+
+    double voxel_size = 0.01;
+    auto voxel_grid = std::make_shared<geometry::VoxelGrid>();
+    voxel_grid = geometry::VoxelGrid::CreateFromPointCloud(
+            pcd, voxel_size, geometry::VoxelGrid::VoxelPoolingMode::AVG);
+
+    Eigen::Vector3d original_center = voxel_grid->GetCenter();
+
+    // Get original current voxels centers
+    std::vector<Eigen::Vector3d> original_centers;
+    for (const auto &it : voxel_grid->voxels_) {
+        original_centers.push_back(
+                voxel_grid->GetVoxelCenterCoordinate(it.second.grid_index_));
+    }
+
+    // Translate by (1, 2, 3)
+    Eigen::Vector3d translation(1, 2, 3);
+    voxel_grid->Translate(translation, true);
+    EXPECT_NEAR(voxel_grid->voxel_size_, voxel_size, 1e-6);
+    ExpectEQ(voxel_grid->GetCenter(), (original_center + translation).eval());
+    // Get new current voxels centers
+    std::vector<Eigen::Vector3d> new_centers;
+    for (const auto &it : voxel_grid->voxels_) {
+        new_centers.push_back(
+                voxel_grid->GetVoxelCenterCoordinate(it.second.grid_index_));
+    }
+    // Check that the new centers are translated by (1, 2, 3)
+    EXPECT_EQ(original_centers.size(), new_centers.size());
+    for (size_t i = 0; i < original_centers.size(); i++) {
+        ExpectEQ(new_centers[i], (original_centers[i] + translation).eval());
+    }
+}
+
+TEST(VoxelGrid, Rotate) {
+    open3d::geometry::PointCloud pcd;
+    open3d::data::PLYPointCloud pointcloud_ply;
+    open3d::io::ReadPointCloud(pointcloud_ply.GetPath(), pcd);
+
+    double voxel_size = 0.01;
+    auto voxel_grid = std::make_shared<geometry::VoxelGrid>();
+    voxel_grid = geometry::VoxelGrid::CreateFromPointCloud(
+            pcd, voxel_size, geometry::VoxelGrid::VoxelPoolingMode::AVG);
+
+    Eigen::Vector3d original_center = voxel_grid->GetCenter();
+
+    // Get original current voxels centers
+    std::vector<Eigen::Vector3d> original_centers;
+    for (const auto &it : voxel_grid->voxels_) {
+        original_centers.push_back(
+                voxel_grid->GetVoxelCenterCoordinate(it.second.grid_index_));
+    }
+
+    // Rotate by 90 degrees around Z axis
+    Eigen::Matrix3d R;
+    R = Eigen::AngleAxisd(M_PI / 2, Eigen::Vector3d::UnitZ());
+    voxel_grid->Rotate(R, original_center);
+    EXPECT_NEAR(voxel_grid->voxel_size_, voxel_size, 1e-6);
+    // Get new current voxels centers
+    std::vector<Eigen::Vector3d> new_centers;
+    for (const auto &it : voxel_grid->voxels_) {
+        new_centers.push_back(
+                voxel_grid->GetVoxelCenterCoordinate(it.second.grid_index_));
+    }
+    // Check that the new centers are rotated by R
+    EXPECT_EQ(original_centers.size(), new_centers.size());
+    for (size_t i = 0; i < original_centers.size(); i++) {
+        ExpectEQ(new_centers[i],
+                 (R * (original_centers[i] - original_center) + original_center)
+                         .eval());
+    }
+}
+
+TEST(VoxelGrid, Transform) {
+    open3d::geometry::PointCloud pcd;
+    open3d::data::PLYPointCloud pointcloud_ply;
+    open3d::io::ReadPointCloud(pointcloud_ply.GetPath(), pcd);
+
+    double voxel_size = 0.01;
+    auto voxel_grid = std::make_shared<geometry::VoxelGrid>();
+    voxel_grid = geometry::VoxelGrid::CreateFromPointCloud(
+            pcd, voxel_size, geometry::VoxelGrid::VoxelPoolingMode::AVG);
+
+    // Get original current voxels centers
+    std::vector<Eigen::Vector3d> original_centers;
+    for (const auto &it : voxel_grid->voxels_) {
+        original_centers.push_back(
+                voxel_grid->GetVoxelCenterCoordinate(it.second.grid_index_));
+    }
+
+    // Transform
+    Eigen::Matrix4d transformation;
+    transformation << 0.10, 0.20, 0.30, 0.40, 0.50, 0.60, 0.70, 0.80, 0.90,
+            0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16;
+    voxel_grid->Transform(transformation);
+    EXPECT_NEAR(voxel_grid->voxel_size_, voxel_size, 1e-6);
+    // Get new current voxels centers
+    std::vector<Eigen::Vector3d> new_centers;
+    for (const auto &it : voxel_grid->voxels_) {
+        new_centers.push_back(
+                voxel_grid->GetVoxelCenterCoordinate(it.second.grid_index_));
+    }
+    // Check that the new centers are transformed by transformation
+    EXPECT_EQ(original_centers.size(), new_centers.size());
+    for (size_t i = 0; i < original_centers.size(); i++) {
+        Eigen::Vector4d vec;
+        vec << original_centers[i](0), original_centers[i](1),
+                original_centers[i](2), 1;
+        vec = transformation * vec;
+        ExpectEQ(new_centers[i], vec.head<3>().eval());
+    }
 }
 
 }  // namespace tests


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [x] New feature (non-breaking change which adds functionality). Resolves https://github.com/isl-org/Open3D/issues/3361 
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
It was not possible to move around this type of geometry before.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [x] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [x] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [ ] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
This pr implements the `Transform`, `Rotate`, `Translate` and `Scale` methods for the `VoxelGrid` object in cpp.
It introduces an `origin_transform_` attribute to be able to rotate the grid origin easily and efficiently, keeping all voxels indexes the same.
Python bindings and docs seem to be already done for these methods.
