### PR TITLE
Fix a bug in NonZeroCUDA not using the correct memory addresses

### DIFF
--- a/cpp/open3d/core/kernel/NonZeroCUDA.cu
+++ b/cpp/open3d/core/kernel/NonZeroCUDA.cu
@@ -70,7 +70,7 @@ Tensor NonZeroCUDA(const Tensor& src) {
     thrust::device_vector<int64_t> non_zero_indices(num_elements);
     DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(src.GetDtype(), [&]() {
         thrust::device_ptr<const scalar_t> src_ptr(static_cast<const scalar_t*>(
-                src_contiguous.GetBlob()->GetDataPtr()));
+                src_contiguous.GetDataPtr()));
 
         auto it = thrust::copy_if(index_first, index_last, src_ptr,
                                   non_zero_indices.begin(),

--- a/cpp/open3d/core/kernel/NonZeroCUDA.cu
+++ b/cpp/open3d/core/kernel/NonZeroCUDA.cu
@@ -69,8 +69,8 @@ Tensor NonZeroCUDA(const Tensor& src) {
     // Get flattened non-zero indices.
     thrust::device_vector<int64_t> non_zero_indices(num_elements);
     DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(src.GetDtype(), [&]() {
-        thrust::device_ptr<const scalar_t> src_ptr(static_cast<const scalar_t*>(
-                src_contiguous.GetDataPtr()));
+        thrust::device_ptr<const scalar_t> src_ptr(
+                static_cast<const scalar_t*>(src_contiguous.GetDataPtr()));
 
         auto it = thrust::copy_if(index_first, index_last, src_ptr,
                                   non_zero_indices.begin(),


### PR DESCRIPTION
When using any advanced indexing operations like IndexAdd, IndexSet, IndexGet with a boolean mask, the results are incorrect in the following case:
- the tensor is on a CUDA device, and
- the _data_ptr of the tensor is not equal to the start of the Blob data pointer (e.g. as a result of slicing)

The problems seems to be that inside NonZeroCuda.cu, GetBlob()->GetDataPtr() is being used, instead of just GetDataPtr.
There seems to be no other place such usage occurs, and other CUDA functions use Tensor::GetDataPtr(), so it seems to me it's very likely this is a bug.

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

In my application, I was using something like this (pseudocode):
```cpp
Tensor a = someDataSet; // let's say this is of shape {N} or {N, 1}
Tensor mask = a.Ge(0);
Tensor subsetA = a.Slice(0, 10, 20);
Tensor maskSubRange = mask.Slice(0, 10, 20);

Tensor maskedSubsetPart = subsetA.IndexGet({maskSubRange}); // here NonZeroNumpy will be called to convert the boolean mask to a list of indices, but it will use the blob's data pointer instead of the tensor's data pointer as the start of the search
Tensor maskedFullSet = a.IndexGet({mask});

// now I would expect this to be equal, but it's not
EXPECT_EQ(maskedFullSet.Slice(0, 10, 20), maskedSubsetPart)
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
