### PR TITLE
Usability of non-default CUDA streams, per-stream synchronization, memory safety guards

### DIFF
--- a/cpp/benchmarks/core/HashMap.cpp
+++ b/cpp/benchmarks/core/HashMap.cpp
@@ -253,8 +253,8 @@ void HashReserveInt(benchmark::State& state,
 
 class Int3 {
 public:
-    Int3() : x_(0), y_(0), z_(0) {};
-    Int3(int k) : x_(k), y_(k * 2), z_(k * 4) {};
+    Int3() : x_(0), y_(0), z_(0){};
+    Int3(int k) : x_(k), y_(k * 2), z_(k * 4){};
     bool operator==(const Int3& other) const {
         return x_ == other.x_ && y_ == other.y_ && z_ == other.z_;
     }

--- a/cpp/open3d/core/CUDAUtils.cpp
+++ b/cpp/open3d/core/CUDAUtils.cpp
@@ -154,7 +154,7 @@ void Synchronize(const CUDAStream& stream) {
 CUDAStream& CUDAStream::GetInstance() {
     // The global stream state is given per thread like CUDA's internal
     // device state.
-    thread_local CUDAStream instance = cuda::GetDefaultStream();
+    thread_local CUDAStream instance = CUDAStream::Default();
     return instance;
 }
 
@@ -188,7 +188,7 @@ void CUDAStream::Set(cudaStream_t stream) { stream_ = stream; }
 void CUDAStream::Destroy() {
     OPEN3D_ASSERT(!IsDefaultStream());
     OPEN3D_CUDA_CHECK(cudaStreamDestroy(stream_));
-    *this = cuda::GetDefaultStream();
+    *this = CUDAStream::Default();
 }
 
 CUDAScopedDevice::CUDAScopedDevice(int device_id)

--- a/cpp/open3d/core/CUDAUtils.h
+++ b/cpp/open3d/core/CUDAUtils.h
@@ -70,6 +70,13 @@ public:
     /// calling Destroy().
     static CUDAStream CreateNew();
 
+    /// Explicitly constructs a default stream. The default constructor could be
+    /// used, but this is clearer and closer to the old API.
+    static CUDAStream Default() { return {}; }
+
+    /// Default constructor. Refers to the default CUDA stream.
+    CUDAStream() = default;
+
     /// Sets the flag indicating if all memory copy operations done within
     /// this stream from device -> host should be synchronized. True by
     /// default. The default CUDA stream is implicitly synchronized with every
@@ -311,7 +318,6 @@ bool SupportsMemoryPools(const Device& device);
 #ifdef BUILD_CUDA_MODULE
 
 int GetDevice();
-CUDAStream GetDefaultStream();
 
 /// Calls cudaStreamSynchronize() for the specified CUDA stream.
 /// \param stream The stream to be synchronized.

--- a/cpp/open3d/core/Indexer.h
+++ b/cpp/open3d/core/Indexer.h
@@ -638,7 +638,7 @@ protected:
 class IndexerIterator {
 public:
     struct Iterator {
-        Iterator() {};
+        Iterator(){};
         Iterator(const Indexer& indexer);
         Iterator(Iterator&& other) = default;
 

--- a/cpp/open3d/core/ParallelFor.h
+++ b/cpp/open3d/core/ParallelFor.h
@@ -61,8 +61,8 @@ void ParallelForCUDA_(const Device& device, int64_t n, const func_t& func) {
     int64_t grid_size = (n + items_per_block - 1) / items_per_block;
 
     ElementWiseKernel_<OPEN3D_PARFOR_BLOCK, OPEN3D_PARFOR_THREAD>
-            <<<grid_size, OPEN3D_PARFOR_BLOCK, 0, core::cuda::GetStream()>>>(
-                    n, func);
+            <<<grid_size, OPEN3D_PARFOR_BLOCK, 0,
+               CUDAStream::GetInstance().Get()>>>(n, func);
     OPEN3D_GET_LAST_CUDA_ERROR("ParallelFor failed.");
 }
 

--- a/cpp/open3d/core/hashmap/CUDA/CUDAHashBackendBuffer.cu
+++ b/cpp/open3d/core/hashmap/CUDA/CUDAHashBackendBuffer.cu
@@ -15,7 +15,8 @@ namespace open3d {
 namespace core {
 void CUDAResetHeap(Tensor &heap) {
     uint32_t *heap_ptr = heap.GetDataPtr<uint32_t>();
-    thrust::sequence(thrust::cuda::par.on(CUDAStream::GetInstance().Get()), heap_ptr, heap_ptr + heap.GetLength(), 0);
+    thrust::sequence(thrust::cuda::par.on(CUDAStream::GetInstance().Get()),
+                     heap_ptr, heap_ptr + heap.GetLength(), 0);
     OPEN3D_CUDA_CHECK(cudaGetLastError());
     cuda::Synchronize(CUDAStream::GetInstance());
 }

--- a/cpp/open3d/core/hashmap/CUDA/CUDAHashBackendBuffer.cu
+++ b/cpp/open3d/core/hashmap/CUDA/CUDAHashBackendBuffer.cu
@@ -15,8 +15,9 @@ namespace open3d {
 namespace core {
 void CUDAResetHeap(Tensor &heap) {
     uint32_t *heap_ptr = heap.GetDataPtr<uint32_t>();
-    thrust::sequence(thrust::device, heap_ptr, heap_ptr + heap.GetLength(), 0);
+    thrust::sequence(thrust::cuda::par.on(CUDAStream::GetInstance().Get()), heap_ptr, heap_ptr + heap.GetLength(), 0);
     OPEN3D_CUDA_CHECK(cudaGetLastError());
+    cuda::Synchronize(CUDAStream::GetInstance());
 }
 }  // namespace core
 }  // namespace open3d

--- a/cpp/open3d/core/hashmap/CUDA/CUDAHashBackendBufferAccessor.h
+++ b/cpp/open3d/core/hashmap/CUDA/CUDAHashBackendBufferAccessor.h
@@ -58,7 +58,9 @@ public:
         std::vector<uint8_t *> value_ptrs(n_values_);
         for (size_t i = 0; i < n_values_; ++i) {
             value_ptrs[i] = value_buffers[i].GetDataPtr<uint8_t>();
-            cudaMemset(value_ptrs[i], 0, capacity_ * value_dsizes_host[i]);
+            OPEN3D_CUDA_CHECK(cudaMemsetAsync(
+                    value_ptrs[i], 0, capacity_ * value_dsizes_host[i],
+                    core::CUDAStream::GetInstance().Get()));
         }
         values_ = static_cast<uint8_t **>(
                 MemoryManager::Malloc(n_values_ * sizeof(uint8_t *), device));
@@ -66,7 +68,7 @@ public:
                                       n_values_ * sizeof(uint8_t *));
 
         heap_top_ = hashmap_buffer.GetHeapTop().cuda.GetDataPtr<int>();
-        cuda::Synchronize();
+        cuda::Synchronize(CUDAStream::GetInstance());
         OPEN3D_CUDA_CHECK(cudaGetLastError());
     }
 

--- a/cpp/open3d/core/hashmap/CUDA/SlabHashBackend.h
+++ b/cpp/open3d/core/hashmap/CUDA/SlabHashBackend.h
@@ -97,15 +97,17 @@ void SlabHashBackend<Key, Hash, Eq>::Find(const void* input_keys,
     CUDAScopedDevice scoped_device(this->device_);
     if (count == 0) return;
 
-    OPEN3D_CUDA_CHECK(cudaMemset(output_masks, 0, sizeof(bool) * count));
-    cuda::Synchronize();
+    OPEN3D_CUDA_CHECK(cudaMemsetAsync(output_masks, 0, sizeof(bool) * count,
+                                      CUDAStream::GetInstance().Get()));
+    cuda::Synchronize(CUDAStream::GetInstance());
     OPEN3D_CUDA_CHECK(cudaGetLastError());
 
     const int64_t num_blocks =
             (count + kThreadsPerBlock - 1) / kThreadsPerBlock;
-    FindKernel<<<num_blocks, kThreadsPerBlock, 0, core::cuda::GetStream()>>>(
+    FindKernel<<<num_blocks, kThreadsPerBlock, 0,
+                 CUDAStream::GetInstance().Get()>>>(
             impl_, input_keys, output_buf_indices, output_masks, count);
-    cuda::Synchronize();
+    cuda::Synchronize(CUDAStream::GetInstance());
     OPEN3D_CUDA_CHECK(cudaGetLastError());
 }
 
@@ -116,8 +118,9 @@ void SlabHashBackend<Key, Hash, Eq>::Erase(const void* input_keys,
     CUDAScopedDevice scoped_device(this->device_);
     if (count == 0) return;
 
-    OPEN3D_CUDA_CHECK(cudaMemset(output_masks, 0, sizeof(bool) * count));
-    cuda::Synchronize();
+    OPEN3D_CUDA_CHECK(cudaMemsetAsync(output_masks, 0, sizeof(bool) * count,
+                                      CUDAStream::GetInstance().Get()));
+    cuda::Synchronize(CUDAStream::GetInstance());
     OPEN3D_CUDA_CHECK(cudaGetLastError());
     auto buf_indices = static_cast<buf_index_t*>(
             MemoryManager::Malloc(sizeof(buf_index_t) * count, this->device_));
@@ -125,12 +128,12 @@ void SlabHashBackend<Key, Hash, Eq>::Erase(const void* input_keys,
     const int64_t num_blocks =
             (count + kThreadsPerBlock - 1) / kThreadsPerBlock;
     EraseKernelPass0<<<num_blocks, kThreadsPerBlock, 0,
-                       core::cuda::GetStream()>>>(
+                       core::CUDAStream::GetInstance().Get()>>>(
             impl_, input_keys, buf_indices, output_masks, count);
     EraseKernelPass1<<<num_blocks, kThreadsPerBlock, 0,
-                       core::cuda::GetStream()>>>(impl_, buf_indices,
-                                                  output_masks, count);
-    cuda::Synchronize();
+                       core::CUDAStream::GetInstance().Get()>>>(
+            impl_, buf_indices, output_masks, count);
+    cuda::Synchronize(CUDAStream::GetInstance());
     OPEN3D_CUDA_CHECK(cudaGetLastError());
 
     MemoryManager::Free(buf_indices, this->device_);
@@ -142,18 +145,19 @@ int64_t SlabHashBackend<Key, Hash, Eq>::GetActiveIndices(
     CUDAScopedDevice scoped_device(this->device_);
     uint32_t* count = static_cast<uint32_t*>(
             MemoryManager::Malloc(sizeof(uint32_t), this->device_));
-    OPEN3D_CUDA_CHECK(cudaMemset(count, 0, sizeof(uint32_t)));
+    OPEN3D_CUDA_CHECK(cudaMemsetAsync(count, 0, sizeof(uint32_t),
+                                      CUDAStream::GetInstance().Get()));
 
-    cuda::Synchronize();
+    cuda::Synchronize(CUDAStream::GetInstance());
     OPEN3D_CUDA_CHECK(cudaGetLastError());
 
     const int64_t num_blocks =
             (impl_.bucket_count_ * kWarpSize + kThreadsPerBlock - 1) /
             kThreadsPerBlock;
     GetActiveIndicesKernel<<<num_blocks, kThreadsPerBlock, 0,
-                             core::cuda::GetStream()>>>(
+                             core::CUDAStream::GetInstance().Get()>>>(
             impl_, output_buf_indices, count);
-    cuda::Synchronize();
+    cuda::Synchronize(CUDAStream::GetInstance());
     OPEN3D_CUDA_CHECK(cudaGetLastError());
 
     uint32_t ret;
@@ -170,9 +174,10 @@ void SlabHashBackend<Key, Hash, Eq>::Clear() {
     this->buffer_->ResetHeap();
 
     // Clear the linked list heads
-    OPEN3D_CUDA_CHECK(cudaMemset(impl_.bucket_list_head_, 0xFF,
-                                 sizeof(Slab) * this->bucket_count_));
-    cuda::Synchronize();
+    OPEN3D_CUDA_CHECK(cudaMemsetAsync(impl_.bucket_list_head_, 0xFF,
+                                      sizeof(Slab) * this->bucket_count_,
+                                      CUDAStream::GetInstance().Get()));
+    cuda::Synchronize(CUDAStream::GetInstance());
     OPEN3D_CUDA_CHECK(cudaGetLastError());
 
     // Clear the linked list nodes
@@ -201,9 +206,9 @@ std::vector<int64_t> SlabHashBackend<Key, Hash, Eq>::BucketSizes() const {
             (impl_.buffer_accessor_.capacity_ + kThreadsPerBlock - 1) /
             kThreadsPerBlock;
     CountElemsPerBucketKernel<<<num_blocks, kThreadsPerBlock, 0,
-                                core::cuda::GetStream()>>>(
+                                core::CUDAStream::GetInstance().Get()>>>(
             impl_, thrust::raw_pointer_cast(elems_per_bucket.data()));
-    cuda::Synchronize();
+    cuda::Synchronize(CUDAStream::GetInstance());
     OPEN3D_CUDA_CHECK(cudaGetLastError());
 
     std::vector<int64_t> result(impl_.bucket_count_);
@@ -237,10 +242,10 @@ void SlabHashBackend<Key, Hash, Eq>::Insert(
     const int64_t num_blocks =
             (count + kThreadsPerBlock - 1) / kThreadsPerBlock;
     InsertKernelPass0<<<num_blocks, kThreadsPerBlock, 0,
-                        core::cuda::GetStream()>>>(
+                        core::CUDAStream::GetInstance().Get()>>>(
             impl_, input_keys, output_buf_indices, prev_heap_top, count);
     InsertKernelPass1<<<num_blocks, kThreadsPerBlock, 0,
-                        core::cuda::GetStream()>>>(
+                        core::CUDAStream::GetInstance().Get()>>>(
             impl_, input_keys, output_buf_indices, output_masks, count);
 
     thrust::device_vector<const void*> input_values_soa_device(
@@ -253,11 +258,11 @@ void SlabHashBackend<Key, Hash, Eq>::Insert(
             impl_.buffer_accessor_.common_block_size_, [&]() {
                 InsertKernelPass2<Key, Hash, Eq, block_t>
                         <<<num_blocks, kThreadsPerBlock, 0,
-                           core::cuda::GetStream()>>>(
+                           core::CUDAStream::GetInstance().Get()>>>(
                                 impl_, ptr_input_values_soa, output_buf_indices,
                                 output_masks, count, n_values);
             });
-    cuda::Synchronize();
+    cuda::Synchronize(CUDAStream::GetInstance());
     OPEN3D_CUDA_CHECK(cudaGetLastError());
 }
 
@@ -279,9 +284,10 @@ void SlabHashBackend<Key, Hash, Eq>::Allocate(int64_t capacity) {
     // Allocate linked list heads.
     impl_.bucket_list_head_ = static_cast<Slab*>(MemoryManager::Malloc(
             sizeof(Slab) * this->bucket_count_, this->device_));
-    OPEN3D_CUDA_CHECK(cudaMemset(impl_.bucket_list_head_, 0xFF,
-                                 sizeof(Slab) * this->bucket_count_));
-    cuda::Synchronize();
+    OPEN3D_CUDA_CHECK(cudaMemsetAsync(impl_.bucket_list_head_, 0xFF,
+                                      sizeof(Slab) * this->bucket_count_,
+                                      CUDAStream::GetInstance().Get()));
+    cuda::Synchronize(CUDAStream::GetInstance());
     OPEN3D_CUDA_CHECK(cudaGetLastError());
 
     impl_.Setup(this->bucket_count_, node_mgr_->impl_, buffer_accessor_);

--- a/cpp/open3d/core/hashmap/CUDA/SlabHashBackend.h
+++ b/cpp/open3d/core/hashmap/CUDA/SlabHashBackend.h
@@ -200,20 +200,21 @@ template <typename Key, typename Hash, typename Eq>
 std::vector<int64_t> SlabHashBackend<Key, Hash, Eq>::BucketSizes() const {
     CUDAScopedDevice scoped_device(this->device_);
     thrust::device_vector<int64_t> elems_per_bucket(impl_.bucket_count_);
-    thrust::fill(elems_per_bucket.begin(), elems_per_bucket.end(), 0);
+    thrust::fill(thrust::cuda::par.on(CUDAStream::GetInstance().Get()), elems_per_bucket.begin(), elems_per_bucket.end(), 0);
 
     const int64_t num_blocks =
             (impl_.buffer_accessor_.capacity_ + kThreadsPerBlock - 1) /
             kThreadsPerBlock;
     CountElemsPerBucketKernel<<<num_blocks, kThreadsPerBlock, 0,
-                                core::CUDAStream::GetInstance().Get()>>>(
+                                CUDAStream::GetInstance().Get()>>>(
             impl_, thrust::raw_pointer_cast(elems_per_bucket.data()));
     cuda::Synchronize(CUDAStream::GetInstance());
     OPEN3D_CUDA_CHECK(cudaGetLastError());
 
     std::vector<int64_t> result(impl_.bucket_count_);
-    thrust::copy(elems_per_bucket.begin(), elems_per_bucket.end(),
+    thrust::copy(thrust::cuda::par.on(CUDAStream::GetInstance().Get()), elems_per_bucket.begin(), elems_per_bucket.end(),
                  result.begin());
+    cuda::Synchronize(CUDAStream::GetInstance());
     return result;
 }
 
@@ -236,8 +237,8 @@ void SlabHashBackend<Key, Hash, Eq>::Insert(
     /// Increase heap_top to pre-allocate potential memory increment and
     /// avoid atomicAdd in kernel.
     int prev_heap_top = this->buffer_->GetHeapTopIndex();
-    *thrust::device_ptr<int>(impl_.buffer_accessor_.heap_top_) =
-            prev_heap_top + count;
+    int new_value = prev_heap_top + count;
+    thrust::fill_n(thrust::cuda::par.on(CUDAStream::GetInstance().Get()), thrust::device_pointer_cast(impl_.buffer_accessor_.heap_top_), 1, new_value);
 
     const int64_t num_blocks =
             (count + kThreadsPerBlock - 1) / kThreadsPerBlock;
@@ -248,8 +249,9 @@ void SlabHashBackend<Key, Hash, Eq>::Insert(
                         core::CUDAStream::GetInstance().Get()>>>(
             impl_, input_keys, output_buf_indices, output_masks, count);
 
-    thrust::device_vector<const void*> input_values_soa_device(
-            input_values_soa.begin(), input_values_soa.end());
+    thrust::device_vector<const void*> input_values_soa_device(input_values_soa.size());
+    thrust::copy(thrust::cuda::par.on(CUDAStream::GetInstance().Get()),
+            input_values_soa.begin(), input_values_soa.end(), input_values_soa_device.begin());
 
     int64_t n_values = input_values_soa.size();
     const void* const* ptr_input_values_soa =

--- a/cpp/open3d/core/hashmap/CUDA/SlabHashBackend.h
+++ b/cpp/open3d/core/hashmap/CUDA/SlabHashBackend.h
@@ -200,7 +200,8 @@ template <typename Key, typename Hash, typename Eq>
 std::vector<int64_t> SlabHashBackend<Key, Hash, Eq>::BucketSizes() const {
     CUDAScopedDevice scoped_device(this->device_);
     thrust::device_vector<int64_t> elems_per_bucket(impl_.bucket_count_);
-    thrust::fill(thrust::cuda::par.on(CUDAStream::GetInstance().Get()), elems_per_bucket.begin(), elems_per_bucket.end(), 0);
+    thrust::fill(thrust::cuda::par.on(CUDAStream::GetInstance().Get()),
+                 elems_per_bucket.begin(), elems_per_bucket.end(), 0);
 
     const int64_t num_blocks =
             (impl_.buffer_accessor_.capacity_ + kThreadsPerBlock - 1) /
@@ -212,7 +213,8 @@ std::vector<int64_t> SlabHashBackend<Key, Hash, Eq>::BucketSizes() const {
     OPEN3D_CUDA_CHECK(cudaGetLastError());
 
     std::vector<int64_t> result(impl_.bucket_count_);
-    thrust::copy(thrust::cuda::par.on(CUDAStream::GetInstance().Get()), elems_per_bucket.begin(), elems_per_bucket.end(),
+    thrust::copy(thrust::cuda::par.on(CUDAStream::GetInstance().Get()),
+                 elems_per_bucket.begin(), elems_per_bucket.end(),
                  result.begin());
     cuda::Synchronize(CUDAStream::GetInstance());
     return result;
@@ -238,7 +240,10 @@ void SlabHashBackend<Key, Hash, Eq>::Insert(
     /// avoid atomicAdd in kernel.
     int prev_heap_top = this->buffer_->GetHeapTopIndex();
     int new_value = prev_heap_top + count;
-    thrust::fill_n(thrust::cuda::par.on(CUDAStream::GetInstance().Get()), thrust::device_pointer_cast(impl_.buffer_accessor_.heap_top_), 1, new_value);
+    thrust::fill_n(
+            thrust::cuda::par.on(CUDAStream::GetInstance().Get()),
+            thrust::device_pointer_cast(impl_.buffer_accessor_.heap_top_), 1,
+            new_value);
 
     const int64_t num_blocks =
             (count + kThreadsPerBlock - 1) / kThreadsPerBlock;
@@ -249,9 +254,11 @@ void SlabHashBackend<Key, Hash, Eq>::Insert(
                         core::CUDAStream::GetInstance().Get()>>>(
             impl_, input_keys, output_buf_indices, output_masks, count);
 
-    thrust::device_vector<const void*> input_values_soa_device(input_values_soa.size());
+    thrust::device_vector<const void*> input_values_soa_device(
+            input_values_soa.size());
     thrust::copy(thrust::cuda::par.on(CUDAStream::GetInstance().Get()),
-            input_values_soa.begin(), input_values_soa.end(), input_values_soa_device.begin());
+                 input_values_soa.begin(), input_values_soa.end(),
+                 input_values_soa_device.begin());
 
     int64_t n_values = input_values_soa.size();
     const void* const* ptr_input_values_soa =

--- a/cpp/open3d/core/hashmap/CUDA/SlabNodeManager.h
+++ b/cpp/open3d/core/hashmap/CUDA/SlabNodeManager.h
@@ -253,7 +253,8 @@ public:
         const uint32_t num_super_blocks = kSuperBlocks;
 
         thrust::device_vector<uint32_t> slabs_per_superblock(kSuperBlocks);
-        thrust::fill(thrust::cuda::par.on(CUDAStream::GetInstance().Get()), slabs_per_superblock.begin(), slabs_per_superblock.end(),
+        thrust::fill(thrust::cuda::par.on(CUDAStream::GetInstance().Get()),
+                     slabs_per_superblock.begin(), slabs_per_superblock.end(),
                      0);
 
         // Counting total number of allocated memory units.
@@ -267,7 +268,11 @@ public:
         OPEN3D_CUDA_CHECK(cudaGetLastError());
 
         std::vector<int> result(num_super_blocks);
-        OPEN3D_CUDA_CHECK(cudaMemcpyAsync(result.data(), thrust::raw_pointer_cast(slabs_per_superblock.data()),num_super_blocks*sizeof(int),cudaMemcpyDeviceToHost, CUDAStream::GetInstance().Get()));
+        OPEN3D_CUDA_CHECK(cudaMemcpyAsync(
+                result.data(),
+                thrust::raw_pointer_cast(slabs_per_superblock.data()),
+                num_super_blocks * sizeof(int), cudaMemcpyDeviceToHost,
+                CUDAStream::GetInstance().Get()));
         if (!CUDAStream::GetInstance().IsDefaultStream()) {
             cuda::Synchronize(CUDAStream::GetInstance());
         }

--- a/cpp/open3d/core/hashmap/CUDA/StdGPUHashBackend.h
+++ b/cpp/open3d/core/hashmap/CUDA/StdGPUHashBackend.h
@@ -366,11 +366,12 @@ void StdGPUHashBackend<Key, Hash, Eq>::Insert(
     CUDAScopedDevice scoped_device(this->device_);
     uint32_t threads = 128;
     uint32_t blocks = (count + threads - 1) / threads;
-
-    thrust::device_vector<const void*> input_values_soa_device(
-            input_values_soa.begin(), input_values_soa.end());
-
     int64_t n_values = input_values_soa.size();
+
+    thrust::device_vector<const void*> input_values_soa_device(n_values);
+    thrust::copy(thrust::cuda::par.on(CUDAStream::GetInstance().Get()),
+            input_values_soa.begin(), input_values_soa.end(), input_values_soa_device.begin());
+
     const void* const* ptr_input_values_soa =
             thrust::raw_pointer_cast(input_values_soa_device.data());
 

--- a/cpp/open3d/core/hashmap/CUDA/StdGPUHashBackend.h
+++ b/cpp/open3d/core/hashmap/CUDA/StdGPUHashBackend.h
@@ -401,7 +401,7 @@ void StdGPUHashBackend<Key, Hash, Eq>::Allocate(int64_t capacity) {
     // stdgpu initializes on the default stream. Set the current stream to
     // ensure correct behavior.
     {
-        CUDAScopedStream scoped_stream(cuda::GetDefaultStream());
+        CUDAScopedStream scoped_stream(CUDAStream::Default());
 
         impl_ = InternalStdGPUHashBackend<Key, Hash, Eq>::createDeviceObject(
                 this->capacity_,
@@ -419,7 +419,7 @@ void StdGPUHashBackend<Key, Hash, Eq>::Free() {
     // stdgpu initializes on the default stream. Set the current stream to
     // ensure correct behavior.
     {
-        CUDAScopedStream scoped_stream(cuda::GetDefaultStream());
+        CUDAScopedStream scoped_stream(CUDAStream::Default());
 
         InternalStdGPUHashBackend<Key, Hash, Eq>::destroyDeviceObject(impl_);
     }

--- a/cpp/open3d/core/hashmap/CUDA/StdGPUHashBackend.h
+++ b/cpp/open3d/core/hashmap/CUDA/StdGPUHashBackend.h
@@ -370,7 +370,8 @@ void StdGPUHashBackend<Key, Hash, Eq>::Insert(
 
     thrust::device_vector<const void*> input_values_soa_device(n_values);
     thrust::copy(thrust::cuda::par.on(CUDAStream::GetInstance().Get()),
-            input_values_soa.begin(), input_values_soa.end(), input_values_soa_device.begin());
+                 input_values_soa.begin(), input_values_soa.end(),
+                 input_values_soa_device.begin());
 
     const void* const* ptr_input_values_soa =
             thrust::raw_pointer_cast(input_values_soa_device.data());

--- a/cpp/open3d/core/kernel/NonZeroCUDA.cu
+++ b/cpp/open3d/core/kernel/NonZeroCUDA.cu
@@ -70,9 +70,10 @@ Tensor NonZeroCUDA(const Tensor& src) {
         thrust::device_ptr<const scalar_t> src_ptr(
                 static_cast<const scalar_t*>(src_contiguous.GetDataPtr()));
 
-        auto it = thrust::copy_if(thrust::cuda::par.on(CUDAStream::GetInstance().Get()), index_first, index_last, src_ptr,
-                                  non_zero_indices.begin(),
-                                  NonZeroFunctor<scalar_t>());
+        auto it = thrust::copy_if(
+                thrust::cuda::par.on(CUDAStream::GetInstance().Get()),
+                index_first, index_last, src_ptr, non_zero_indices.begin(),
+                NonZeroFunctor<scalar_t>());
         cuda::Synchronize(CUDAStream::GetInstance());
         non_zero_indices.resize(thrust::distance(non_zero_indices.begin(), it));
     });

--- a/cpp/open3d/core/kernel/ReductionCUDA.cu
+++ b/cpp/open3d/core/kernel/ReductionCUDA.cu
@@ -959,8 +959,9 @@ private:
                     std::make_unique<Blob>(config.SemaphoreSize(), device);
             buffer = buffer_blob->GetDataPtr();
             semaphores = semaphores_blob->GetDataPtr();
-            OPEN3D_CUDA_CHECK(
-                    cudaMemset(semaphores, 0, config.SemaphoreSize()));
+            OPEN3D_CUDA_CHECK(cudaMemsetAsync(semaphores, 0,
+                                              config.SemaphoreSize(),
+                                              CUDAStream::GetInstance().Get()));
         }
 
         OPEN3D_ASSERT(can_use_32bit_indexing);
@@ -979,8 +980,8 @@ private:
         int shared_memory = config.SharedMemorySize();
         ReduceKernel<ReduceConfig::MAX_NUM_THREADS>
                 <<<config.GridDim(), config.BlockDim(), shared_memory,
-                   core::cuda::GetStream()>>>(reduce_op);
-        cuda::Synchronize();
+                   core::CUDAStream::GetInstance().Get()>>>(reduce_op);
+        cuda::Synchronize(CUDAStream::GetInstance());
         OPEN3D_CUDA_CHECK(cudaGetLastError());
     }
 

--- a/cpp/open3d/core/linalg/AddMMCUDA.cpp
+++ b/cpp/open3d/core/linalg/AddMMCUDA.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 // ----------------------------------------------------------------------------
 
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/core/linalg/AddMM.h"
 #include "open3d/core/linalg/BlasWrapper.h"
 #include "open3d/core/linalg/LinalgUtils.h"
@@ -29,6 +30,7 @@ void AddMMCUDA(void* A_data,
                Dtype dtype,
                const Device& device) {
     cublasHandle_t handle = CuBLASContext::GetInstance().GetHandle(device);
+    cublasSetStream(handle, CUDAStream::GetInstance().Get());
     DISPATCH_LINALG_DTYPE_TO_TEMPLATE(dtype, [&]() {
         scalar_t alpha_ = scalar_t(alpha);
         scalar_t beta_ = scalar_t(beta);

--- a/cpp/open3d/core/linalg/InverseCUDA.cpp
+++ b/cpp/open3d/core/linalg/InverseCUDA.cpp
@@ -6,6 +6,7 @@
 // ----------------------------------------------------------------------------
 
 #include "open3d/core/Blob.h"
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/core/linalg/Inverse.h"
 #include "open3d/core/linalg/LapackWrapper.h"
 #include "open3d/core/linalg/LinalgUtils.h"
@@ -21,6 +22,7 @@ void InverseCUDA(void* A_data,
                  const Device& device) {
     cusolverDnHandle_t handle =
             CuSolverContext::GetInstance().GetHandle(device);
+    cusolverDnSetStream(handle, CUDAStream::GetInstance().Get());
 
     DISPATCH_LINALG_DTYPE_TO_TEMPLATE(dtype, [&]() {
         int len;

--- a/cpp/open3d/core/linalg/LUCUDA.cpp
+++ b/cpp/open3d/core/linalg/LUCUDA.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 // ----------------------------------------------------------------------------
 
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/core/linalg/LUImpl.h"
 #include "open3d/core/linalg/LapackWrapper.h"
 #include "open3d/core/linalg/LinalgUtils.h"
@@ -20,6 +21,7 @@ void LUCUDA(void* A_data,
             const Device& device) {
     cusolverDnHandle_t handle =
             CuSolverContext::GetInstance().GetHandle(device);
+    cusolverDnSetStream(handle, CUDAStream::GetInstance().Get());
     DISPATCH_LINALG_DTYPE_TO_TEMPLATE(dtype, [&]() {
         int len;
         OPEN3D_CUSOLVER_CHECK(

--- a/cpp/open3d/core/linalg/LeastSquaresCUDA.cpp
+++ b/cpp/open3d/core/linalg/LeastSquaresCUDA.cpp
@@ -30,8 +30,10 @@ void LeastSquaresCUDA(void* A_data,
                       const Device& device) {
     cusolverDnHandle_t cusolver_handle =
             CuSolverContext::GetInstance().GetHandle(device);
+    cusolverDnSetStream(cusolver_handle, CUDAStream::GetInstance().Get());
     cublasHandle_t cublas_handle =
             CuBLASContext::GetInstance().GetHandle(device);
+    cublasSetStream(cublas_handle, CUDAStream::GetInstance().Get());
 
     DISPATCH_LINALG_DTYPE_TO_TEMPLATE(dtype, [&]() {
         int len_geqrf, len_ormqr, len;

--- a/cpp/open3d/core/linalg/MatmulCUDA.cpp
+++ b/cpp/open3d/core/linalg/MatmulCUDA.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 // ----------------------------------------------------------------------------
 
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/core/linalg/BlasWrapper.h"
 #include "open3d/core/linalg/LinalgUtils.h"
 #include "open3d/core/linalg/Matmul.h"
@@ -22,6 +23,7 @@ void MatmulCUDA(void* A_data,
                 Dtype dtype,
                 const Device& device) {
     cublasHandle_t handle = CuBLASContext::GetInstance().GetHandle(device);
+    cublasSetStream(handle, CUDAStream::GetInstance().Get());
     DISPATCH_LINALG_DTYPE_TO_TEMPLATE(dtype, [&]() {
         scalar_t alpha = 1, beta = 0;
         OPEN3D_CUBLAS_CHECK(

--- a/cpp/open3d/core/linalg/SVDCUDA.cpp
+++ b/cpp/open3d/core/linalg/SVDCUDA.cpp
@@ -6,6 +6,7 @@
 // ----------------------------------------------------------------------------
 
 #include "open3d/core/Blob.h"
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/core/linalg/LapackWrapper.h"
 #include "open3d/core/linalg/LinalgUtils.h"
 #include "open3d/core/linalg/SVD.h"
@@ -24,6 +25,7 @@ void SVDCUDA(const void* A_data,
              const Device& device) {
     cusolverDnHandle_t handle =
             CuSolverContext::GetInstance().GetHandle(device);
+    cusolverDnSetStream(handle, CUDAStream::GetInstance().Get());
 
     DISPATCH_LINALG_DTYPE_TO_TEMPLATE(dtype, [&]() {
         int len;

--- a/cpp/open3d/core/linalg/SolveCUDA.cpp
+++ b/cpp/open3d/core/linalg/SolveCUDA.cpp
@@ -26,6 +26,7 @@ void SolveCUDA(void* A_data,
                const Device& device) {
     cusolverDnHandle_t handle =
             CuSolverContext::GetInstance().GetHandle(device);
+    cusolverDnSetStream(handle, CUDAStream::GetInstance().Get());
 
     DISPATCH_LINALG_DTYPE_TO_TEMPLATE(dtype, [&]() {
         int len;

--- a/cpp/open3d/core/nns/FixedRadiusIndex.cpp
+++ b/cpp/open3d/core/nns/FixedRadiusIndex.cpp
@@ -15,7 +15,7 @@ namespace open3d {
 namespace core {
 namespace nns {
 
-FixedRadiusIndex::FixedRadiusIndex() {};
+FixedRadiusIndex::FixedRadiusIndex(){};
 
 FixedRadiusIndex::FixedRadiusIndex(const Tensor &dataset_points,
                                    double radius) {
@@ -31,7 +31,7 @@ FixedRadiusIndex::FixedRadiusIndex(const Tensor &dataset_points,
     SetTensorData(dataset_points, radius, index_dtype);
 };
 
-FixedRadiusIndex::~FixedRadiusIndex() {};
+FixedRadiusIndex::~FixedRadiusIndex(){};
 
 bool FixedRadiusIndex::SetTensorData(const Tensor &dataset_points,
                                      double radius,

--- a/cpp/open3d/core/nns/FixedRadiusSearchImpl.cuh
+++ b/cpp/open3d/core/nns/FixedRadiusSearchImpl.cuh
@@ -870,7 +870,7 @@ void SortPairs(const cudaStream_t& stream,
                 sort_temp.first, sort_temp.second, distances_unsorted,
                 distances_sorted, indices_unsorted, indices_sorted, num_indices,
                 num_segments, query_neighbors_row_splits,
-                query_neighbors_row_splits + 1);
+                query_neighbors_row_splits + 1, 0, sizeof(T) * 8, stream);
     }
     mem_temp.Free(sort_temp);
 

--- a/cpp/open3d/core/nns/FixedRadiusSearchImpl.cuh
+++ b/cpp/open3d/core/nns/FixedRadiusSearchImpl.cuh
@@ -853,17 +853,16 @@ void SortPairs(const cudaStream_t& stream,
 
     std::pair<void*, size_t> sort_temp(nullptr, 0);
 
-    // MUST synchronize non-default streams because InclusiveSum writes to the
-    // value we will be using
-    if (stream != nullptr) {
-        cudaStreamSynchronize(stream);
-    }
-
     cub::DeviceSegmentedRadixSort::SortPairs(
             sort_temp.first, sort_temp.second, distances_unsorted,
             distances_sorted, indices_unsorted, indices_sorted, num_indices,
             num_segments, query_neighbors_row_splits,
             query_neighbors_row_splits + 1, 0, sizeof(T) * 8, stream);
+    // MUST synchronize non-default streams because InclusiveSum writes to the
+    // value we will be using
+    if (stream != nullptr) {
+        cudaStreamSynchronize(stream);
+    }
     sort_temp = mem_temp.Alloc(sort_temp.second);
 
     if (!get_temp_size) {

--- a/cpp/open3d/core/nns/FixedRadiusSearchImpl.cuh
+++ b/cpp/open3d/core/nns/FixedRadiusSearchImpl.cuh
@@ -963,9 +963,7 @@ void FixedRadiusSearchCUDA(const cudaStream_t& stream,
             cudaMemcpyAsync(&last_prefix_sum_entry,
                             query_neighbors_row_splits + num_queries,
                             sizeof(int64_t), cudaMemcpyDeviceToHost, stream);
-            // wait for the async copies
-            while (cudaErrorNotReady == cudaStreamQuery(stream)) { /*empty*/
-            }
+            cudaStreamSynchronize(stream);
         }
         mem_temp.Free(inclusive_scan_temp);
     }

--- a/cpp/open3d/core/nns/FixedRadiusSearchOps.cu
+++ b/cpp/open3d/core/nns/FixedRadiusSearchOps.cu
@@ -25,7 +25,7 @@ void BuildSpatialHashTableCUDA(const Tensor& points,
                                Tensor& hash_table_index,
                                Tensor& hash_table_cell_splits) {
     CUDAScopedDevice scoped_device(points.GetDevice());
-    const cudaStream_t stream = 0;
+    cudaStream_t stream = CUDAStream::GetInstance().Get();
     int texture_alignment = 512;
 
     void* temp_ptr = nullptr;
@@ -74,7 +74,7 @@ void FixedRadiusSearchCUDA(const Tensor& points,
                            Tensor& neighbors_row_splits,
                            Tensor& neighbors_distance) {
     CUDAScopedDevice scoped_device(points.GetDevice());
-    const cudaStream_t stream = 0;
+    cudaStream_t stream = CUDAStream::GetInstance().Get();
     int texture_alignment = 512;
 
     Device device = points.GetDevice();
@@ -135,8 +135,8 @@ void FixedRadiusSearchCUDA(const Tensor& points,
         Tensor distances_sorted = Tensor::Empty({num_indices}, dtype, device);
 
         // Determine temp_size for sorting
-        impl::SortPairs(stream, temp_ptr, temp_size, texture_alignment, num_indices,
-                        num_segments,
+        impl::SortPairs(stream, temp_ptr, temp_size, texture_alignment,
+                        num_indices, num_segments,
                         neighbors_row_splits.GetDataPtr<int64_t>(),
                         indices_unsorted.GetDataPtr<TIndex>(),
                         distances_unsorted.GetDataPtr<T>(),
@@ -147,8 +147,8 @@ void FixedRadiusSearchCUDA(const Tensor& points,
         temp_ptr = temp_tensor.GetDataPtr();
 
         // Actually run the sorting.
-        impl::SortPairs(stream, temp_ptr, temp_size, texture_alignment, num_indices,
-                        num_segments,
+        impl::SortPairs(stream, temp_ptr, temp_size, texture_alignment,
+                        num_indices, num_segments,
                         neighbors_row_splits.GetDataPtr<int64_t>(),
                         indices_unsorted.GetDataPtr<TIndex>(),
                         distances_unsorted.GetDataPtr<T>(),
@@ -174,7 +174,7 @@ void HybridSearchCUDA(const Tensor& points,
                       Tensor& neighbors_count,
                       Tensor& neighbors_distance) {
     CUDAScopedDevice scoped_device(points.GetDevice());
-    const cudaStream_t stream = 0;
+    cudaStream_t stream = CUDAStream::GetInstance().Get();
 
     Device device = points.GetDevice();
 

--- a/cpp/open3d/core/nns/FixedRadiusSearchOps.cu
+++ b/cpp/open3d/core/nns/FixedRadiusSearchOps.cu
@@ -135,7 +135,7 @@ void FixedRadiusSearchCUDA(const Tensor& points,
         Tensor distances_sorted = Tensor::Empty({num_indices}, dtype, device);
 
         // Determine temp_size for sorting
-        impl::SortPairs(temp_ptr, temp_size, texture_alignment, num_indices,
+        impl::SortPairs(stream, temp_ptr, temp_size, texture_alignment, num_indices,
                         num_segments,
                         neighbors_row_splits.GetDataPtr<int64_t>(),
                         indices_unsorted.GetDataPtr<TIndex>(),
@@ -147,7 +147,7 @@ void FixedRadiusSearchCUDA(const Tensor& points,
         temp_ptr = temp_tensor.GetDataPtr();
 
         // Actually run the sorting.
-        impl::SortPairs(temp_ptr, temp_size, texture_alignment, num_indices,
+        impl::SortPairs(stream, temp_ptr, temp_size, texture_alignment, num_indices,
                         num_segments,
                         neighbors_row_splits.GetDataPtr<int64_t>(),
                         indices_unsorted.GetDataPtr<TIndex>(),

--- a/cpp/open3d/core/nns/KnnSearchOps.cu
+++ b/cpp/open3d/core/nns/KnnSearchOps.cu
@@ -34,7 +34,7 @@ void KnnSearchCUDABruteForce(const Tensor& points,
                              OUTPUT_ALLOCATOR& output_allocator,
                              Tensor& query_neighbors_row_splits) {
     CUDAScopedDevice scoped_device(points.GetDevice());
-    const cudaStream_t stream = cuda::GetStream();
+    const cudaStream_t stream = CUDAStream::GetInstance().Get();
     int num_points = points.GetShape(0);
     int num_queries = queries.GetShape(0);
 
@@ -157,8 +157,8 @@ void KnnSearchCUDAOptimized(const Tensor& points,
                 buf_distances.Slice(0, 0, num_queries_i);
         Tensor buf_indices_row_view = buf_indices.Slice(0, 0, num_queries_i);
         {
-            CUDAScopedStream scoped_stream(CUDAScopedStream::CreateNewStream);
-            cudaStream_t cur_stream = cuda::GetStream();
+            CUDAScopedStream scoped_stream(CUDAStream::CreateNew(), true);
+            cudaStream_t cur_stream = CUDAStream::GetInstance().Get();
             for (int j = 0; j < num_points; j += tile_cols) {
                 int num_points_j = std::min(tile_cols, num_points - j);
                 int col_j = j / tile_cols;

--- a/cpp/open3d/core/nns/KnnSearchOps.cu
+++ b/cpp/open3d/core/nns/KnnSearchOps.cu
@@ -157,8 +157,6 @@ void KnnSearchCUDAOptimized(const Tensor& points,
                 buf_distances.Slice(0, 0, num_queries_i);
         Tensor buf_indices_row_view = buf_indices.Slice(0, 0, num_queries_i);
         {
-            CUDAScopedStream scoped_stream(CUDAStream::CreateNew(), true);
-            cudaStream_t cur_stream = CUDAStream::GetInstance().Get();
             for (int j = 0; j < num_points; j += tile_cols) {
                 int num_points_j = std::min(tile_cols, num_points - j);
                 int col_j = j / tile_cols;

--- a/cpp/open3d/core/nns/NanoFlannIndex.cpp
+++ b/cpp/open3d/core/nns/NanoFlannIndex.cpp
@@ -19,7 +19,7 @@ namespace open3d {
 namespace core {
 namespace nns {
 
-NanoFlannIndex::NanoFlannIndex() {};
+NanoFlannIndex::NanoFlannIndex(){};
 
 NanoFlannIndex::NanoFlannIndex(const Tensor &dataset_points) {
     SetTensorData(dataset_points);
@@ -30,7 +30,7 @@ NanoFlannIndex::NanoFlannIndex(const Tensor &dataset_points,
     SetTensorData(dataset_points, index_dtype);
 };
 
-NanoFlannIndex::~NanoFlannIndex() {};
+NanoFlannIndex::~NanoFlannIndex(){};
 
 bool NanoFlannIndex::SetTensorData(const Tensor &dataset_points,
                                    const Dtype &index_dtype) {

--- a/cpp/open3d/core/nns/NearestNeighborSearch.cpp
+++ b/cpp/open3d/core/nns/NearestNeighborSearch.cpp
@@ -13,7 +13,7 @@ namespace open3d {
 namespace core {
 namespace nns {
 
-NearestNeighborSearch::~NearestNeighborSearch() {};
+NearestNeighborSearch::~NearestNeighborSearch(){};
 
 bool NearestNeighborSearch::SetIndex() {
     nanoflann_index_.reset(new NanoFlannIndex());

--- a/cpp/open3d/io/PointCloudIO.h
+++ b/cpp/open3d/io/PointCloudIO.h
@@ -44,7 +44,7 @@ struct ReadPointCloudOption {
           remove_nan_points(remove_nan_points),
           remove_infinite_points(remove_infinite_points),
           print_progress(print_progress),
-          update_progress(update_progress) {};
+          update_progress(update_progress){};
     ReadPointCloudOption(std::function<bool(double)> up)
         : ReadPointCloudOption() {
         update_progress = up;
@@ -101,7 +101,7 @@ struct WritePointCloudOption {
           write_ascii(write_ascii),
           compressed(compressed),
           print_progress(print_progress),
-          update_progress(update_progress) {};
+          update_progress(update_progress){};
     // for compatibility
     WritePointCloudOption(bool write_ascii,
                           bool compressed = false,
@@ -110,7 +110,7 @@ struct WritePointCloudOption {
         : write_ascii(IsAscii(write_ascii)),
           compressed(Compressed(compressed)),
           print_progress(print_progress),
-          update_progress(update_progress) {};
+          update_progress(update_progress){};
     // for compatibility
     WritePointCloudOption(std::string format,
                           bool write_ascii,
@@ -121,7 +121,7 @@ struct WritePointCloudOption {
           write_ascii(IsAscii(write_ascii)),
           compressed(Compressed(compressed)),
           print_progress(print_progress),
-          update_progress(update_progress) {};
+          update_progress(update_progress){};
     WritePointCloudOption(std::function<bool(double)> up)
         : WritePointCloudOption() {
         update_progress = up;

--- a/cpp/open3d/io/rpc/ConnectionBase.h
+++ b/cpp/open3d/io/rpc/ConnectionBase.h
@@ -21,8 +21,8 @@ namespace rpc {
 /// Base class for all connections
 class ConnectionBase {
 public:
-    ConnectionBase() {};
-    virtual ~ConnectionBase() {};
+    ConnectionBase(){};
+    virtual ~ConnectionBase(){};
 
     /// Function for sending data wrapped in a zmq message object.
     virtual std::shared_ptr<zmq::message_t> Send(zmq::message_t& send_msg) = 0;

--- a/cpp/open3d/io/sensor/RGBDSensor.h
+++ b/cpp/open3d/io/sensor/RGBDSensor.h
@@ -23,7 +23,7 @@ class RGBDSensor {
 public:
     RGBDSensor() {}
     virtual bool Connect(size_t sensor_index) = 0;
-    virtual ~RGBDSensor() {};
+    virtual ~RGBDSensor(){};
 
     /// Capture one frame, return an RGBDImage.
     /// If \p enable_align_depth_to_color is true, the depth image will be

--- a/cpp/open3d/ml/contrib/RoiPoolKernel.cu
+++ b/cpp/open3d/ml/contrib/RoiPoolKernel.cu
@@ -325,8 +325,9 @@ void roipool3dLauncher(int batch_size,
     cudaFree(pts_assign);
     cudaFree(pts_idx);
 
-#ifdef DEBUG
-    core::cuda::Synchronize();  // for using printf in kernel function
+#if defined(DEBUG) && BUILD_CUDA_MODULE
+    core::cuda::Synchronize(
+            CUDAStream::GetInstance());  // for using printf in kernel function
 #endif
 }
 

--- a/cpp/open3d/ml/impl/misc/InvertNeighborsList.cuh
+++ b/cpp/open3d/ml/impl/misc/InvertNeighborsList.cuh
@@ -274,6 +274,12 @@ void InvertNeighborsListCUDA(const cudaStream_t& stream,
                 tmp_neighbors_count.first, out_neighbors_row_splits + 1,
                 out_num_queries, stream);
 
+        // MUST synchronize non-default streams because InclusiveSum writes to
+        // the value we will be using
+        if (stream != nullptr) {
+            cudaStreamSynchronize(stream);
+        }
+
         inclusive_scan_temp = mem_temp.Alloc(inclusive_scan_temp.second);
 
         if (!get_temp_size) {

--- a/cpp/open3d/ml/impl/misc/Voxelize.cuh
+++ b/cpp/open3d/ml/impl/misc/Voxelize.cuh
@@ -788,7 +788,8 @@ void VoxelizeCUDA(const cudaStream_t& stream,
     std::pair<int64_t*, size_t> num_voxels_per_batch =
             mem_temp.Alloc<int64_t>(batch_size);
     if (!get_temp_size) {
-        cudaMemset(num_voxels_per_batch.first, 0, batch_size * sizeof(int64_t));
+        cudaMemsetAsync(num_voxels_per_batch.first, 0,
+                        batch_size * sizeof(int64_t), stream);
         ComputeVoxelPerBatch(stream, num_voxels_per_batch.first,
                              unique_batches_count.first, unique_batches.first,
                              num_batches);

--- a/cpp/open3d/ml/impl/misc/Voxelize.cuh
+++ b/cpp/open3d/ml/impl/misc/Voxelize.cuh
@@ -656,6 +656,11 @@ void VoxelizeCUDA(const cudaStream_t& stream,
         cub::DeviceRadixSort::SortPairs(
                 sort_pairs_temp.first, sort_pairs_temp.second, hashes_dbuf,
                 point_indices_dbuf, num_points, 0, sizeof(int64_t) * 8, stream);
+        // MUST synchronize non-default streams because InclusiveSum writes to
+        // the value we will be using
+        if (stream != nullptr) {
+            cudaStreamSynchronize(stream);
+        }
         sort_pairs_temp = mem_temp.Alloc(sort_pairs_temp.second);
         if (!get_temp_size) {
             cub::DeviceRadixSort::SortPairs(sort_pairs_temp.first,
@@ -684,6 +689,12 @@ void VoxelizeCUDA(const cudaStream_t& stream,
                 unique_hashes.first, unique_hashes_count.first,
                 num_voxels_mem.first, num_points, stream);
 
+        // MUST synchronize non-default streams because InclusiveSum writes to
+        // the value we will be using
+        if (stream != nullptr) {
+            cudaStreamSynchronize(stream);
+        }
+
         encode_temp = mem_temp.Alloc(encode_temp.second);
         if (!get_temp_size) {
             cub::DeviceRunLengthEncode::Encode(
@@ -700,8 +711,7 @@ void VoxelizeCUDA(const cudaStream_t& stream,
                             hashes_dbuf.Current() + hashes.second - 1,
                             sizeof(int64_t), cudaMemcpyDeviceToHost, stream);
             // wait for the async copies
-            while (cudaErrorNotReady == cudaStreamQuery(stream)) { /*empty*/
-            }
+            cudaStreamSynchronize(stream);
         }
         mem_temp.Free(encode_temp);
     }
@@ -723,6 +733,12 @@ void VoxelizeCUDA(const cudaStream_t& stream,
                 inclusive_scan_temp.first, inclusive_scan_temp.second,
                 unique_hashes_count.first, unique_hashes_count_prefix_sum.first,
                 unique_hashes_count.second, stream);
+
+        // MUST synchronize non-default streams because InclusiveSum writes to
+        // the value we will be using
+        if (stream != nullptr) {
+            cudaStreamSynchronize(stream);
+        }
 
         inclusive_scan_temp = mem_temp.Alloc(inclusive_scan_temp.second);
         if (!get_temp_size) {
@@ -766,6 +782,11 @@ void VoxelizeCUDA(const cudaStream_t& stream,
                 encode_temp.first, encode_temp.second, unique_hashes_batch_id,
                 unique_batches.first, unique_batches_count.first,
                 num_batches_mem.first, num_voxels, stream);
+        // MUST synchronize non-default streams because InclusiveSum writes to
+        // the value we will be using
+        if (stream != nullptr) {
+            cudaStreamSynchronize(stream);
+        }
         encode_temp = mem_temp.Alloc(encode_temp.second);
         if (!get_temp_size) {
             cub::DeviceRunLengthEncode::Encode(
@@ -809,6 +830,12 @@ void VoxelizeCUDA(const cudaStream_t& stream,
                 num_voxels_per_batch.first, num_voxels_prefix_sum.first,
                 num_voxels_per_batch.second, stream);
 
+        // MUST synchronize non-default streams because InclusiveSum writes to
+        // the value we will be using
+        if (stream != nullptr) {
+            cudaStreamSynchronize(stream);
+        }
+
         inclusive_scan_temp = mem_temp.Alloc(inclusive_scan_temp.second);
         if (!get_temp_size) {
             if (num_voxels > max_voxels) {
@@ -844,6 +871,12 @@ void VoxelizeCUDA(const cudaStream_t& stream,
                 inclusive_scan_temp.first, inclusive_scan_temp.second,
                 num_voxels_per_batch.first, out_batch_splits + 1,
                 num_voxels_per_batch.second, stream);
+
+        // MUST synchronize non-default streams because InclusiveSum writes to
+        // the value we will be using
+        if (stream != nullptr) {
+            cudaStreamSynchronize(stream);
+        }
 
         inclusive_scan_temp = mem_temp.Alloc(inclusive_scan_temp.second);
 
@@ -912,6 +945,12 @@ void VoxelizeCUDA(const cudaStream_t& stream,
                 inclusive_scan_temp.first, inclusive_scan_temp.second,
                 points_count.first, out_voxel_row_splits + 1, num_valid_voxels,
                 stream);
+
+        // MUST synchronize non-default streams because InclusiveSum writes to
+        // the value we will be using
+        if (stream != nullptr) {
+            cudaStreamSynchronize(stream);
+        }
 
         inclusive_scan_temp = mem_temp.Alloc(inclusive_scan_temp.second);
         if (!get_temp_size) {

--- a/cpp/open3d/pipelines/registration/ColoredICP.h
+++ b/cpp/open3d/pipelines/registration/ColoredICP.h
@@ -27,7 +27,7 @@ class RegistrationResult;
 
 class TransformationEstimationForColoredICP : public TransformationEstimation {
 public:
-    ~TransformationEstimationForColoredICP() override {};
+    ~TransformationEstimationForColoredICP() override{};
 
     TransformationEstimationType GetTransformationEstimationType()
             const override {

--- a/cpp/open3d/t/geometry/RGBDImage.h
+++ b/cpp/open3d/t/geometry/RGBDImage.h
@@ -53,7 +53,7 @@ public:
         return color_device;
     }
 
-    ~RGBDImage() override {};
+    ~RGBDImage() override{};
 
     /// Clear stored data.
     RGBDImage &Clear() override;

--- a/cpp/open3d/t/geometry/kernel/NPPImage.cpp
+++ b/cpp/open3d/t/geometry/kernel/NPPImage.cpp
@@ -23,7 +23,7 @@ namespace npp {
 
 static NppStreamContext MakeNPPContext() {
     NppStreamContext context;
-    context.hStream = core::cuda::GetStream();
+    context.hStream = core::CUDAStream::GetInstance().Get();
     context.nCudaDeviceId = core::cuda::GetDevice();
 
     cudaDeviceProp device_prop;
@@ -52,8 +52,7 @@ static NppStreamContext MakeNPPContext() {
 // to expose this member variable.
 #if NPP_VERSION >= 11100
     unsigned int stream_flags;
-    OPEN3D_CUDA_CHECK(
-            cudaStreamGetFlags(core::cuda::GetStream(), &stream_flags));
+    OPEN3D_CUDA_CHECK(cudaStreamGetFlags(context.hStream, &stream_flags));
     context.nStreamFlags = stream_flags;
 #endif
 

--- a/cpp/open3d/t/geometry/kernel/PointCloudImpl.h
+++ b/cpp/open3d/t/geometry/kernel/PointCloudImpl.h
@@ -125,8 +125,8 @@ void UnprojectCPU
     int total_pts_count = (*count_ptr).load();
 #endif
 
-#ifdef __CUDACC__
-    core::cuda::Synchronize();
+#if BUILD_CUDA_MODULE
+    core::cuda::Synchronize(core::CUDAStream::GetInstance());
 #endif
     points = points.Slice(0, 0, total_pts_count);
     if (have_colors) {
@@ -601,7 +601,9 @@ void EstimateCovariancesUsingHybridSearchCPU
                 });
     });
 
-    core::cuda::Synchronize(points.GetDevice());
+#if BUILD_CUDA_MODULE
+    core::cuda::Synchronize(core::CUDAStream::GetInstance());
+#endif
 }
 
 #if defined(__CUDACC__)
@@ -650,7 +652,9 @@ void EstimateCovariancesUsingRadiusSearchCPU
                 });
     });
 
-    core::cuda::Synchronize(points.GetDevice());
+#if BUILD_CUDA_MODULE
+    core::cuda::Synchronize(core::CUDAStream::GetInstance());
+#endif
 }
 
 #if defined(__CUDACC__)
@@ -703,7 +707,9 @@ void EstimateCovariancesUsingKNNSearchCPU
                 });
     });
 
-    core::cuda::Synchronize(points.GetDevice());
+#if defined(BUILD_CUDA_MODULE)
+    core::cuda::Synchronize(core::CUDAStream::GetInstance());
+#endif
 }
 
 template <typename scalar_t>
@@ -1022,7 +1028,9 @@ void EstimateNormalsFromCovariancesCPU
                 });
     });
 
-    core::cuda::Synchronize(covariances.GetDevice());
+#if defined(BUILD_CUDA_MODULE)
+    core::cuda::Synchronize(core::CUDAStream::GetInstance());
+#endif
 }
 
 template <typename scalar_t>
@@ -1174,7 +1182,9 @@ void EstimateColorGradientsUsingHybridSearchCPU
                 });
     });
 
-    core::cuda::Synchronize(points.GetDevice());
+#if defined(BUILD_CUDA_MODULE)
+    core::cuda::Synchronize(core::CUDAStream::GetInstance());
+#endif
 }
 
 #if defined(__CUDACC__)
@@ -1229,7 +1239,9 @@ void EstimateColorGradientsUsingKNNSearchCPU
                 });
     });
 
-    core::cuda::Synchronize(points.GetDevice());
+#if defined(BUILD_CUDA_MODULE)
+    core::cuda::Synchronize(core::CUDAStream::GetInstance());
+#endif
 }
 
 #if defined(__CUDACC__)
@@ -1284,7 +1296,9 @@ void EstimateColorGradientsUsingRadiusSearchCPU
                 });
     });
 
-    core::cuda::Synchronize(points.GetDevice());
+#if defined(BUILD_CUDA_MODULE)
+    core::cuda::Synchronize(core::CUDAStream::GetInstance());
+#endif
 }
 
 }  // namespace pointcloud

--- a/cpp/open3d/t/geometry/kernel/VoxelBlockGridImpl.h
+++ b/cpp/open3d/t/geometry/kernel/VoxelBlockGridImpl.h
@@ -288,8 +288,8 @@ void IntegrateCPU
         *weight_ptr = weight + 1;
     });
 
-#if defined(__CUDACC__)
-    core::cuda::Synchronize();
+#if defined(BUILD_CUDA_MODULE)
+    core::cuda::Synchronize(core::CUDAStream::GetInstance());
 #endif
 }
 
@@ -498,8 +498,8 @@ void EstimateRangeCPU
 #endif
             });
 
-#if defined(__CUDACC__)
-    core::cuda::Synchronize();
+#if defined(BUILD_CUDA_MODULE)
+    core::cuda::Synchronize(core::CUDAStream::GetInstance());
 #endif
 
     if (needed_frag_count != frag_count) {
@@ -1026,8 +1026,8 @@ void RayCastCPU
         }  // surface-found
     });
 
-#if defined(__CUDACC__)
-    core::cuda::Synchronize();
+#if defined(BUILD_CUDA_MODULE)
+    core::cuda::Synchronize(core::CUDAStream::GetInstance());
 #endif
 }
 
@@ -1284,7 +1284,7 @@ void ExtractPointCloudCPU
     valid_size = total_count;
 
 #if defined(BUILD_CUDA_MODULE) && defined(__CUDACC__)
-    core::cuda::Synchronize();
+    core::cuda::Synchronize(core::CUDAStream::GetInstance());
 #endif
 }
 

--- a/cpp/open3d/t/pipelines/kernel/RGBDOdometryCUDA.cu
+++ b/cpp/open3d/t/pipelines/kernel/RGBDOdometryCUDA.cu
@@ -116,12 +116,12 @@ void ComputeOdometryResultPointToPlaneCUDA(
 
     const dim3 blocks((rows * cols + kBlockSize - 1) / kBlockSize);
     const dim3 threads(kBlockSize);
-    ComputeOdometryResultPointToPlaneCUDAKernel<<<blocks, threads, 0,
-                                                  core::cuda::GetStream()>>>(
+    ComputeOdometryResultPointToPlaneCUDAKernel<<<
+            blocks, threads, 0, core::CUDAStream::GetInstance().Get()>>>(
             source_vertex_indexer, target_vertex_indexer, target_normal_indexer,
             ti, global_sum_ptr, rows, cols, depth_outlier_trunc,
             depth_huber_delta);
-    core::cuda::Synchronize();
+    core::cuda::Synchronize(core::CUDAStream::GetInstance());
     DecodeAndSolve6x6(global_sum, delta, inlier_residual, inlier_count);
 }
 
@@ -223,14 +223,14 @@ void ComputeOdometryResultIntensityCUDA(
 
     const dim3 blocks((cols * rows + kBlockSize - 1) / kBlockSize);
     const dim3 threads(kBlockSize);
-    ComputeOdometryResultIntensityCUDAKernel<<<blocks, threads, 0,
-                                               core::cuda::GetStream()>>>(
+    ComputeOdometryResultIntensityCUDAKernel<<<
+            blocks, threads, 0, core::CUDAStream::GetInstance().Get()>>>(
             source_depth_indexer, target_depth_indexer,
             source_intensity_indexer, target_intensity_indexer,
             target_intensity_dx_indexer, target_intensity_dy_indexer,
             source_vertex_indexer, ti, global_sum_ptr, rows, cols,
             depth_outlier_trunc, intensity_huber_delta);
-    core::cuda::Synchronize();
+    core::cuda::Synchronize(core::CUDAStream::GetInstance());
     DecodeAndSolve6x6(global_sum, delta, inlier_residual, inlier_count);
 }
 
@@ -344,15 +344,15 @@ void ComputeOdometryResultHybridCUDA(const core::Tensor& source_depth,
 
     const dim3 blocks((cols * rows + kBlockSize - 1) / kBlockSize);
     const dim3 threads(kBlockSize);
-    ComputeOdometryResultHybridCUDAKernel<<<blocks, threads, 0,
-                                            core::cuda::GetStream()>>>(
+    ComputeOdometryResultHybridCUDAKernel<<<
+            blocks, threads, 0, core::CUDAStream::GetInstance().Get()>>>(
             source_depth_indexer, target_depth_indexer,
             source_intensity_indexer, target_intensity_indexer,
             target_depth_dx_indexer, target_depth_dy_indexer,
             target_intensity_dx_indexer, target_intensity_dy_indexer,
             source_vertex_indexer, ti, global_sum_ptr, rows, cols,
             depth_outlier_trunc, depth_huber_delta, intensity_huber_delta);
-    core::cuda::Synchronize();
+    core::cuda::Synchronize(core::CUDAStream::GetInstance());
     DecodeAndSolve6x6(global_sum, delta, inlier_residual, inlier_count);
 }
 
@@ -422,11 +422,11 @@ void ComputeOdometryInformationMatrixCUDA(const core::Tensor& source_vertex_map,
 
     const dim3 blocks((cols * rows + kBlockSize - 1) / kBlockSize);
     const dim3 threads(kBlockSize);
-    ComputeOdometryInformationMatrixCUDAKernel<<<blocks, threads, 0,
-                                                 core::cuda::GetStream()>>>(
+    ComputeOdometryInformationMatrixCUDAKernel<<<
+            blocks, threads, 0, core::CUDAStream::GetInstance().Get()>>>(
             source_vertex_indexer, target_vertex_indexer, ti, global_sum_ptr,
             rows, cols, square_dist_thr);
-    core::cuda::Synchronize();
+    core::cuda::Synchronize(core::CUDAStream::GetInstance());
 
     // 21 => 6x6
     const core::Device host(core::Device("CPU:0"));

--- a/cpp/open3d/t/pipelines/kernel/TransformationConverter.cu
+++ b/cpp/open3d/t/pipelines/kernel/TransformationConverter.cu
@@ -31,14 +31,16 @@ template <>
 void PoseToTransformationCUDA<float>(float *transformation_ptr,
                                      const float *X_ptr) {
     PoseToTransformationKernel<float>
-            <<<1, 1, 0, core::cuda::GetStream()>>>(transformation_ptr, X_ptr);
+            <<<1, 1, 0, core::CUDAStream::GetInstance().Get()>>>(
+                    transformation_ptr, X_ptr);
 }
 
 template <>
 void PoseToTransformationCUDA<double>(double *transformation_ptr,
                                       const double *X_ptr) {
     PoseToTransformationKernel<double>
-            <<<1, 1, 0, core::cuda::GetStream()>>>(transformation_ptr, X_ptr);
+            <<<1, 1, 0, core::CUDAStream::GetInstance().Get()>>>(
+                    transformation_ptr, X_ptr);
 }
 
 template <typename scalar_t>
@@ -57,14 +59,16 @@ template <>
 void TransformationToPoseCUDA<float>(float *X_ptr,
                                      const float *transformation_ptr) {
     TransformationToPoseKernel<float>
-            <<<1, 1, 0, core::cuda::GetStream()>>>(X_ptr, transformation_ptr);
+            <<<1, 1, 0, core::CUDAStream::GetInstance().Get()>>>(
+                    X_ptr, transformation_ptr);
 }
 
 template <>
 void TransformationToPoseCUDA<double>(double *X_ptr,
                                       const double *transformation_ptr) {
     TransformationToPoseKernel<double>
-            <<<1, 1, 0, core::cuda::GetStream()>>>(X_ptr, transformation_ptr);
+            <<<1, 1, 0, core::CUDAStream::GetInstance().Get()>>>(
+                    X_ptr, transformation_ptr);
 }
 
 }  // namespace kernel

--- a/cpp/open3d/t/pipelines/registration/TransformationEstimation.h
+++ b/cpp/open3d/t/pipelines/registration/TransformationEstimation.h
@@ -225,7 +225,7 @@ private:
 /// Float64, on CPU device for colored-icp method.
 class TransformationEstimationForColoredICP : public TransformationEstimation {
 public:
-    ~TransformationEstimationForColoredICP() override {};
+    ~TransformationEstimationForColoredICP() override{};
 
     /// \brief Constructor.
     ///
@@ -307,7 +307,7 @@ private:
 /// Float64, on CPU device for DopplerICP method.
 class TransformationEstimationForDopplerICP : public TransformationEstimation {
 public:
-    ~TransformationEstimationForDopplerICP() override {};
+    ~TransformationEstimationForDopplerICP() override{};
 
     /// \brief Constructor.
     ///

--- a/cpp/open3d/utility/Optional.h
+++ b/cpp/open3d/utility/Optional.h
@@ -165,7 +165,7 @@ union storage_t {
     unsigned char dummy_;
     T value_;
 
-    constexpr storage_t(trivial_init_t) noexcept : dummy_() {};
+    constexpr storage_t(trivial_init_t) noexcept : dummy_(){};
 
     template <class... Args>
     constexpr storage_t(Args&&... args)
@@ -179,7 +179,7 @@ union constexpr_storage_t {
     unsigned char dummy_;
     T value_;
 
-    constexpr constexpr_storage_t(trivial_init_t) noexcept : dummy_() {};
+    constexpr constexpr_storage_t(trivial_init_t) noexcept : dummy_(){};
 
     template <class... Args>
     constexpr constexpr_storage_t(Args&&... args)
@@ -193,8 +193,7 @@ struct optional_base {
     bool init_;
     storage_t<T> storage_;
 
-    constexpr optional_base() noexcept
-        : init_(false), storage_(trivial_init) {};
+    constexpr optional_base() noexcept : init_(false), storage_(trivial_init){};
 
     explicit constexpr optional_base(const T& v) : init_(true), storage_(v) {}
 
@@ -225,7 +224,7 @@ struct constexpr_optional_base {
     constexpr_storage_t<T> storage_;
 
     constexpr constexpr_optional_base() noexcept
-        : init_(false), storage_(trivial_init) {};
+        : init_(false), storage_(trivial_init){};
 
     explicit constexpr constexpr_optional_base(const T& v)
         : init_(true), storage_(v) {}
@@ -315,8 +314,8 @@ public:
     typedef T value_type;
 
     // 20.5.5.1, constructors
-    constexpr optional() noexcept : OptionalBase<T>() {};
-    constexpr optional(nullopt_t) noexcept : OptionalBase<T>() {};
+    constexpr optional() noexcept : OptionalBase<T>(){};
+    constexpr optional(nullopt_t) noexcept : OptionalBase<T>(){};
 
     optional(const optional& rhs) : OptionalBase<T>() {
         if (rhs.initialized()) {

--- a/cpp/open3d/visualization/gui/Gui.h
+++ b/cpp/open3d/visualization/gui/Gui.h
@@ -76,7 +76,7 @@ enum class FontStyle {
 
 class FontContext {
 public:
-    virtual ~FontContext() {};
+    virtual ~FontContext(){};
 
     virtual void* GetFont(FontId font_id) = 0;
 };

--- a/cpp/open3d/visualization/gui/ImguiFilamentBridge.cpp
+++ b/cpp/open3d/visualization/gui/ImguiFilamentBridge.cpp
@@ -87,7 +87,7 @@ static Material* LoadMaterialTemplate(const std::string& path, Engine& engine) {
 
 class MaterialPool {
 public:
-    MaterialPool() {};
+    MaterialPool(){};
 
     MaterialPool(filament::Engine* engine,
                  filament::Material* material_template) {

--- a/cpp/open3d/visualization/gui/PickPointsInteractor.cpp
+++ b/cpp/open3d/visualization/gui/PickPointsInteractor.cpp
@@ -74,8 +74,7 @@ private:
         std::string name;
         size_t start_index;
 
-        Obj(const std::string &n, size_t start)
-            : name(n), start_index(start) {};
+        Obj(const std::string &n, size_t start) : name(n), start_index(start){};
         bool IsValid() const { return !name.empty(); }
     };
 

--- a/cpp/open3d/visualization/gui/WindowSystem.h
+++ b/cpp/open3d/visualization/gui/WindowSystem.h
@@ -28,7 +28,7 @@ class WindowSystem {
 public:
     using OSWindow = void*;
 
-    virtual ~WindowSystem() {};
+    virtual ~WindowSystem(){};
 
     virtual void Initialize() = 0;
     virtual void Uninitialize() = 0;

--- a/cpp/open3d/visualization/webrtc_server/PeerConnectionManager.h
+++ b/cpp/open3d/visualization/webrtc_server/PeerConnectionManager.h
@@ -120,7 +120,7 @@ class PeerConnectionManager {
                 webrtc::PeerConnectionInterface* pc,
                 std::promise<const webrtc::SessionDescriptionInterface*>&
                         promise)
-            : pc_(pc), promise_(promise) {};
+            : pc_(pc), promise_(promise){};
 
     private:
         webrtc::PeerConnectionInterface* pc_;
@@ -153,7 +153,7 @@ class PeerConnectionManager {
                 webrtc::PeerConnectionInterface* pc,
                 std::promise<const webrtc::SessionDescriptionInterface*>&
                         promise)
-            : pc_(pc), promise_(promise) {};
+            : pc_(pc), promise_(promise){};
 
     private:
         webrtc::PeerConnectionInterface* pc_;

--- a/cpp/pybind/core/cuda_utils.cpp
+++ b/cpp/pybind/core/cuda_utils.cpp
@@ -35,11 +35,13 @@ void pybind_cuda_utils_definitions(py::module& m) {
                     cuda::Synchronize();
                 }
             },
-            "Synchronizes CUDA devices. If no device is specified, all CUDA "
-            "devices will be synchronized. No effect if the specified device "
-            "is not a CUDA device. No effect if Open3D is not compiled with "
-            "CUDA support.",
-            "device"_a = py::none());
+            "Synchronizes a CUDA stream.");
+#if BUILD_CUDA_MODULE
+    m_cuda.def(
+            "synchronize_stream",
+            [](const CUDAStream& stream) { cuda::Synchronize(stream); },
+            "Synchronizes a CUDA stream.");
+#endif
 }
 
 }  // namespace core

--- a/cpp/tests/core/CUDAUtils.cpp
+++ b/cpp/tests/core/CUDAUtils.cpp
@@ -44,41 +44,44 @@ TEST(CUDAUtils, InitState) {
 void CheckScopedStreamManually() {
     int current_device = core::cuda::GetDevice();
 
-    ASSERT_EQ(core::cuda::GetStream(), core::cuda::GetDefaultStream());
+    ASSERT_EQ(core::CUDAStream::GetInstance().Get(),
+              core::cuda::GetDefaultStream().Get());
     ASSERT_EQ(core::cuda::GetDevice(), current_device);
 
-    cudaStream_t stream;
-    OPEN3D_CUDA_CHECK(cudaStreamCreate(&stream));
+    core::CUDAStream stream = core::CUDAStream::CreateNew();
 
     {
         core::CUDAScopedStream scoped_stream(stream);
 
-        ASSERT_EQ(core::cuda::GetStream(), stream);
-        ASSERT_NE(core::cuda::GetStream(), core::cuda::GetDefaultStream());
+        ASSERT_EQ(core::CUDAStream::GetInstance().Get(), stream.Get());
+        ASSERT_FALSE(core::CUDAStream::GetInstance().IsDefaultStream());
         ASSERT_EQ(core::cuda::GetDevice(), current_device);
     }
 
-    OPEN3D_CUDA_CHECK(cudaStreamDestroy(stream));
+    stream.Destroy();
 
-    ASSERT_EQ(core::cuda::GetStream(), core::cuda::GetDefaultStream());
+    ASSERT_TRUE(core::CUDAStream::GetInstance().IsDefaultStream());
     ASSERT_EQ(core::cuda::GetDevice(), current_device);
 }
 
 void CheckScopedStreamAutomatically() {
     int current_device = core::cuda::GetDevice();
 
-    ASSERT_EQ(core::cuda::GetStream(), core::cuda::GetDefaultStream());
+    ASSERT_EQ(core::CUDAStream::GetInstance().Get(),
+              core::cuda::GetDefaultStream());
     ASSERT_EQ(core::cuda::GetDevice(), current_device);
 
     {
         core::CUDAScopedStream scoped_stream(
                 core::CUDAScopedStream::CreateNewStream);
 
-        ASSERT_NE(core::cuda::GetStream(), core::cuda::GetDefaultStream());
+        ASSERT_NE(core::CUDAStream::GetInstance().Get(),
+                  core::cuda::GetDefaultStream());
         ASSERT_EQ(core::cuda::GetDevice(), current_device);
     }
 
-    ASSERT_EQ(core::cuda::GetStream(), core::cuda::GetDefaultStream());
+    ASSERT_EQ(core::CUDAStream::GetInstance().Get(),
+              core::cuda::GetDefaultStream());
     ASSERT_EQ(core::cuda::GetDevice(), current_device);
 }
 

--- a/cpp/tests/core/CUDAUtils.cpp
+++ b/cpp/tests/core/CUDAUtils.cpp
@@ -72,7 +72,8 @@ void CheckScopedStreamAutomatically() {
     ASSERT_EQ(core::cuda::GetDevice(), current_device);
 
     {
-        core::CUDAScopedStream scoped_stream(core::CUDAStream::CreateNew(), true);
+        core::CUDAScopedStream scoped_stream(core::CUDAStream::CreateNew(),
+                                             true);
 
         ASSERT_NE(core::CUDAStream::GetInstance().Get(),
                   core::CUDAStream::Default().Get());

--- a/cpp/tests/core/CUDAUtils.cpp
+++ b/cpp/tests/core/CUDAUtils.cpp
@@ -45,7 +45,7 @@ void CheckScopedStreamManually() {
     int current_device = core::cuda::GetDevice();
 
     ASSERT_EQ(core::CUDAStream::GetInstance().Get(),
-              core::cuda::GetDefaultStream().Get());
+              core::CUDAStream::Default().Get());
     ASSERT_EQ(core::cuda::GetDevice(), current_device);
 
     core::CUDAStream stream = core::CUDAStream::CreateNew();
@@ -68,7 +68,7 @@ void CheckScopedStreamAutomatically() {
     int current_device = core::cuda::GetDevice();
 
     ASSERT_EQ(core::CUDAStream::GetInstance().Get(),
-              core::cuda::GetDefaultStream());
+              core::CUDAStream::Default());
     ASSERT_EQ(core::cuda::GetDevice(), current_device);
 
     {
@@ -76,12 +76,12 @@ void CheckScopedStreamAutomatically() {
                 core::CUDAScopedStream::CreateNewStream);
 
         ASSERT_NE(core::CUDAStream::GetInstance().Get(),
-                  core::cuda::GetDefaultStream());
+                  core::CUDAStream::Default());
         ASSERT_EQ(core::cuda::GetDevice(), current_device);
     }
 
     ASSERT_EQ(core::CUDAStream::GetInstance().Get(),
-              core::cuda::GetDefaultStream());
+              core::CUDAStream::Default());
     ASSERT_EQ(core::cuda::GetDevice(), current_device);
 }
 

--- a/cpp/tests/core/CUDAUtils.cpp
+++ b/cpp/tests/core/CUDAUtils.cpp
@@ -68,20 +68,19 @@ void CheckScopedStreamAutomatically() {
     int current_device = core::cuda::GetDevice();
 
     ASSERT_EQ(core::CUDAStream::GetInstance().Get(),
-              core::CUDAStream::Default());
+              core::CUDAStream::Default().Get());
     ASSERT_EQ(core::cuda::GetDevice(), current_device);
 
     {
-        core::CUDAScopedStream scoped_stream(
-                core::CUDAScopedStream::CreateNewStream);
+        core::CUDAScopedStream scoped_stream(core::CUDAStream::CreateNew(), true);
 
         ASSERT_NE(core::CUDAStream::GetInstance().Get(),
-                  core::CUDAStream::Default());
+                  core::CUDAStream::Default().Get());
         ASSERT_EQ(core::cuda::GetDevice(), current_device);
     }
 
     ASSERT_EQ(core::CUDAStream::GetInstance().Get(),
-              core::CUDAStream::Default());
+              core::CUDAStream::Default().Get());
     ASSERT_EQ(core::cuda::GetDevice(), current_device);
 }
 

--- a/cpp/tests/core/HashMap.cpp
+++ b/cpp/tests/core/HashMap.cpp
@@ -367,8 +367,8 @@ TEST_P(HashMapPermuteDevices, Clear) {
 
 class int3 {
 public:
-    int3() : x_(0), y_(0), z_(0) {};
-    int3(int k) : x_(k), y_(k * 2), z_(k * 4) {};
+    int3() : x_(0), y_(0), z_(0){};
+    int3(int k) : x_(k), y_(k * 2), z_(k * 4){};
     bool operator==(const int3 &other) const {
         return x_ == other.x_ && y_ == other.y_ && z_ == other.z_;
     }

--- a/cpp/tests/core/ParallelFor.cu
+++ b/cpp/tests/core/ParallelFor.cu
@@ -45,5 +45,21 @@ TEST(ParallelFor, LambdaCUDA) {
     }
 }
 
+TEST(ParallelFor, LambdaCUDA_NonDefaultStream) {
+    const core::Device device("CUDA:0");
+    const size_t N = 10000000;
+
+    core::CUDAScopedStream s(core::CUDAStream::CreateNew(), true);
+
+    core::Tensor tensor({N, 1}, core::Int64, device);
+
+    RunParallelForOn(tensor);
+
+    core::Tensor tensor_cpu = tensor.To(core::Device("CPU:0"));
+    for (int64_t i = 0; i < tensor.NumElements(); ++i) {
+        ASSERT_EQ(tensor_cpu.GetDataPtr<int64_t>()[i], i);
+    }
+}
+
 }  // namespace tests
 }  // namespace open3d


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

In my experience, working with non-default CUDA streams is very dangerous in the current state of O3D.
A simple example that produces very unexpected behavior:
```cpp
ScopedCUDAStream scope(ScopedCUDAStream::CreateNew);
Tensor test = Tensor ::Init<float>({0.f}, "CUDA:0");
std::cout << test.ToString() << std::endl; // Uninitialized memory access!!
```
While a very similar looking piece of code doesn't have this issue:
```cpp
ScopedCUDAStream scope(cuda::GetDefaultStream());
Tensor test = Tensor ::Init<float>({0.f}, "CUDA:0");
std::cout << test.ToString() << std::endl; // OK!
```

The problem boils down to how the CUDA memory manager is implemented.
Issues are masked by the behavior of the CUDA default stream (different from non-default streams): https://docs.nvidia.com/cuda/cuda-driver-api/stream-sync-behavior.html

The CUDA memory manager Memcpy operation is implemented to perform async memcpy operations regardless of the direction of copy (device->device, device->host, host->device). This was a huge red flag when I first saw it, but the library worked, so I just assumed my imagined world was a lie and all is okay somehow.
My initial thinking was, if device->host is an async memcpy, wouldn't the library break pretty much all over the place, at every point where any operations are done on tensors of the sort `gpu_tensor.To("CPU:0").AnyOperationHere()`. Seems logical, as in such a case host-native operations would be done on top of memory which was yet to be filled. But in practice, this was not the case, so I went on with my life. Until eventually in my multi-threaded workflows, I was annoyed that the threads were implicitly being synchronized, because they shared the same CUDA stream, and thus were waiting on each other's work every time the stream needed to be synchronized. I then tried to use the scoped stream to create a new CUDA stream on each thread, so that they would not have to interfere with each other.
To my horror, that is when the exact behavior I initially pictured when looking at the memory manager manifested itself.
All memory accesses on tensors moved to the host device were done on uninitialized memory and the figurative explosions are quite spectacular.
This issue is also present in other cases too (eg. host->device async copy immediately followed by a host free).

Besides this, I later noticed the library does device-wide synchronization in many cases, instead of per-stream synchronization. This causes performance critical applications (where proper stream management is key) to suffer greatly.

I decided to fix my problems by tweaking the memory manager and adding the necessary stream management functionality to achieve my goals. I must stress that this was done in an effort to solve my problems , and not in the proper "contribute to the library" way. There are several reasons for this, primary of course being time, but secondary also being that my knowledge of O3D is nowhere near the level I'd want (yet) to be able to contribute in the way I'd like.

I'm providing this PR as a blueprint of what I believe needs to be done, and as an outline of the issue at hand.
I'm using the backing branch of the PR as a way to test solutions, and would welcome any input from O3D devs on how best to solve the limitations.

I understand the view point that in the end you could say this is a user-facing issue, and the user should make sure any memory copies go though by taking care of object lifetimes themselves. However, O3D has many cases where it just can't work in multi-cuda-stream mode, as these async memcpy operations break many other things.

It is also my opinion that there should be no way for users to introduce heavily undefined behavior into their applications that heavily warps the intuition of host data always being synchronous and safe to work with (it is not in the outlined use cases). So by this I mean, there should be no way to change the CUDA stream at all, as the library gives absolutely no guarantees that it will be able to live with that (the vast majority of workflows do not survive this change).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [ ] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

- Added a memory synchronization guard for non-default CUDA streams.
- Swapped-out all CUDA synchronization with per-stream synchronization
- changed cudaMemset to cudaMemsetAsync
