### PR TITLE
Download tarballs instead of Git repos for "3rdparty/uvatlas".

### DIFF
--- a/3rdparty/uvatlas/uvatlas.cmake
+++ b/3rdparty/uvatlas/uvatlas.cmake
@@ -4,9 +4,9 @@ include(ExternalProject)
 ExternalProject_Add(
     ext_directxheaders
     PREFIX uvatlas
-    GIT_REPOSITORY https://github.com/microsoft/DirectX-Headers.git
-    GIT_TAG v1.606.3
-    GIT_SHALLOW TRUE
+    URL https://github.com/microsoft/DirectX-Headers/archive/v1.606.3/DirectX-Headers-v1.606.3.tar.gz
+    URL_HASH
+    SHA256=bf0183981e505336e918609374907c934b99eb61c0826d75a5649f41568abc4b
     DOWNLOAD_DIR "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/uvatlas"
     UPDATE_COMMAND ""
     CMAKE_ARGS
@@ -22,9 +22,9 @@ ExternalProject_Add(
 ExternalProject_Add(
     ext_directxmath
     PREFIX uvatlas
-    GIT_REPOSITORY https://github.com/microsoft/DirectXMath.git
-    GIT_TAG may2022
-    GIT_SHALLOW TRUE
+    URL https://github.com/microsoft/DirectXMath/archive/may2022/DirectXMath-may2022.tar.gz
+    URL_HASH
+    SHA256=b2c5b419ca2c567860f7c204c9c0890573e8a58c8d877473e4f3ba6b851ca4ce
     DOWNLOAD_DIR "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/uvatlas"
     UPDATE_COMMAND ""
     CMAKE_ARGS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 -   Fix advanced indexing bug with sliced boolean masks on CUDA devices (PR #7340)
 -   Fix logic for adding -allow-unsupported-compiler to nvcc (PR #7337)
 -   Fix linker error "library limit of 65535 objects exceeded" with Ninja generator on MSVC (PR #7335)
+-   Download tarballs instead of Git repos for "3rdparty/uvatlas" (PR #7371)
 
 ## 0.13
 


### PR DESCRIPTION
This style adjustment makes uvatlas more consistent with the specification style of all the other third-party dependencies. Most importantly, it makes it possible to compile Open3D inside of a chroot jail by simply unpacking the tarballs of all third-party dependencies into the same workspace.

<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Building Open3D within a non-networked chroot jail is unnecessarily complicated when a git shallow-clone needs to be packaged for delivery into the jail.  This is fixed simply by specifying the tarball URL instead.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
