### PR TITLE
Fix remove to legacy in docs

### DIFF
--- a/docs/jupyter/t_geometry/pointcloud.ipynb
+++ b/docs/jupyter/t_geometry/pointcloud.ipynb
@@ -157,8 +157,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Conversion between tensor and legacy point cloud\n",
-    "PointCloud can be converted to/from legacy `open3d.geometry.PointCloud`."
+    "## Conversion between tensor and  point cloud\n",
+    "PointCloud can be converted to Tensor `open3d.geometry.PointCloud`."
    ]
   },
   {
@@ -167,14 +167,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "legacy_pcd = pcd.to_legacy()\n",
-    "print(legacy_pcd, \"\\n\")\n",
+    "#  PointCloud.to_legacy  has been moved from 0.14+\n",
+    "source_pcd = pcd\n",
+    "print(source_pcd, \"\\n\")\n",
     "\n",
-    "tensor_pcd = o3d.t.geometry.PointCloud.from_legacy(legacy_pcd)\n",
+    "tensor_pcd = o3d.t.geometry.PointCloud.from_legacy(source_pcd)\n",
     "print(tensor_pcd, \"\\n\")\n",
     "\n",
     "# Convert from legacy point cloud with data type of float64.\n",
-    "tensor_pcd_f64 = o3d.t.geometry.PointCloud.from_legacy(legacy_pcd, o3c.float64)\n",
+    "tensor_pcd_f64 = o3d.t.geometry.PointCloud.from_legacy(source_pcd, o3c.float64)\n",
     "print(tensor_pcd_f64, \"\\n\")"
    ]
   },
@@ -195,7 +196,9 @@
     "ply_point_cloud = o3d.data.PLYPointCloud()\n",
     "pcd = o3d.t.io.read_point_cloud(ply_point_cloud.path)\n",
     "print(pcd)\n",
-    "o3d.visualization.draw_geometries([pcd.to_legacy()],\n",
+    "# In Open3D 0.14+, PointCloud is directly compatible with draw_geometries.\n",
+    "# to_legacy() is deprecated and removed in later versions.\n",
+    "o3d.visualization.draw_geometries([pcd],\n",
     "                                  zoom=0.3412,\n",
     "                                  front=[0.4257, -0.2125, -0.8795],\n",
     "                                  lookat=[2.6172, 2.0475, 1.532],\n",
@@ -258,7 +261,9 @@
    "source": [
     "print(\"Downsample the point cloud with a voxel of 0.03\")\n",
     "downpcd = pcd.voxel_down_sample(voxel_size=0.03)\n",
-    "o3d.visualization.draw_geometries([downpcd.to_legacy()],\n",
+    "# In Open3D 0.14+, PointCloud is directly compatible with draw_geometries.\n",
+    "# to_legacy() is deprecated and removed in later versions.\n",
+    "o3d.visualization.draw_geometries([downpcd],\n",
     "                                  zoom=0.3412,\n",
     "                                  front=[0.4257, -0.2125, -0.8795],\n",
     "                                  lookat=[2.6172, 2.0475, 1.532],\n",
@@ -281,7 +286,7 @@
    "source": [
     "print(\"Downsample the point cloud by selecting 5000 farthest points.\")\n",
     "downpcd_farthest = pcd.farthest_point_down_sample(5000)\n",
-    "o3d.visualization.draw_geometries([downpcd_farthest.to_legacy()],\n",
+    "o3d.visualization.draw_geometries([downpcd_farthest],\n",
     "                                  zoom=0.3412,\n",
     "                                  front=[0.4257, -0.2125, -0.8795],\n",
     "                                  lookat=[2.6172, 2.0475, 1.532],\n",
@@ -312,7 +317,7 @@
    "source": [
     "print(\"Recompute the normal of the downsampled point cloud using hybrid nearest neighbor search with 30 max_nn and radius of 0.1m.\")\n",
     "downpcd.estimate_normals(max_nn=30, radius=0.1)\n",
-    "o3d.visualization.draw_geometries([downpcd.to_legacy()],\n",
+    "o3d.visualization.draw_geometries([downpcd],\n",
     "                                  zoom=0.3412,\n",
     "                                  front=[0.4257, -0.2125, -0.8795],\n",
     "                                  lookat=[2.6172, 2.0475, 1.532],\n",
@@ -381,7 +386,7 @@
     "demo_crop_data = o3d.data.DemoCropPointCloud()\n",
     "pcd = o3d.t.io.read_point_cloud(demo_crop_data.point_cloud_path)\n",
     "vol = o3d.visualization.read_selection_polygon_volume(demo_crop_data.cropped_json_path)\n",
-    "chair = vol.crop_point_cloud(pcd.to_legacy())\n",
+    "chair = vol.crop_point_cloud(pcd)\n",
     "o3d.visualization.draw_geometries([chair],\n",
     "                                  zoom=0.7,\n",
     "                                  front=[0.5439, -0.2333, -0.8060],\n",
@@ -404,7 +409,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "indices = vol.crop_in_polygon(pcd.to_legacy())\n",
+    "indices = vol.crop_in_polygon(pcd)\n",
     "print(f\"Cropped indices length: {len(indices)}\") "
    ]
   },
@@ -423,7 +428,7 @@
    "source": [
     "print(\"Paint point cloud.\")\n",
     "pcd.paint_uniform_color([1, 0.706, 0])\n",
-    "o3d.visualization.draw_geometries([pcd.to_legacy()],\n",
+    "o3d.visualization.draw_geometries([pcd],\n",
     "                                  zoom=0.7,\n",
     "                                  front=[0.5439, -0.2333, -0.8060],\n",
     "                                  lookat=[2.4615, 2.1331, 1.338],\n",
@@ -456,8 +461,8 @@
     "obb = pcd.get_oriented_bounding_box()\n",
     "obb.set_color(o3c.Tensor([0, 1, 0], o3c.float32))\n",
     "o3d.visualization.draw_geometries(\n",
-    "    [pcd.to_legacy(), aabb.to_legacy(),\n",
-    "     obb.to_legacy()],\n",
+    "    [pcd, aabb,\n",
+    "     obb],\n",
     "    zoom=0.7,\n",
     "    front=[0.5439, -0.2333, -0.8060],\n",
     "    lookat=[2.4615, 2.1331, 1.338],\n",
@@ -484,7 +489,7 @@
     "print(\"Load a ply point cloud, print it, and render it\")\n",
     "sample_pcd_data = o3d.data.PCDPointCloud()\n",
     "pcd = o3d.t.io.read_point_cloud(sample_pcd_data.path)\n",
-    "o3d.visualization.draw_geometries([pcd.to_legacy()],\n",
+    "o3d.visualization.draw_geometries([pcd],\n",
     "                                  zoom=0.3412,\n",
     "                                  front=[0.4257, -0.2125, -0.8795],\n",
     "                                  lookat=[2.6172, 2.0475, 1.532],\n",
@@ -492,7 +497,7 @@
     "\n",
     "print(\"Downsample the point cloud with a voxel of 0.02\")\n",
     "voxel_down_pcd = pcd.voxel_down_sample(voxel_size=0.02)\n",
-    "o3d.visualization.draw_geometries([voxel_down_pcd.to_legacy()],\n",
+    "o3d.visualization.draw_geometries([voxel_down_pcd],\n",
     "                                  zoom=0.3412,\n",
     "                                  front=[0.4257, -0.2125, -0.8795],\n",
     "                                  lookat=[2.6172, 2.0475, 1.532],\n",
@@ -514,7 +519,7 @@
    "source": [
     "print(\"Every 5th points are selected\")\n",
     "uni_down_pcd = pcd.uniform_down_sample(every_k_points=5)\n",
-    "o3d.visualization.draw_geometries([uni_down_pcd.to_legacy()],\n",
+    "o3d.visualization.draw_geometries([uni_down_pcd],\n",
     "                                  zoom=0.3412,\n",
     "                                  front=[0.4257, -0.2125, -0.8795],\n",
     "                                  lookat=[2.6172, 2.0475, 1.532],\n",
@@ -542,7 +547,7 @@
     "    print(\"Showing outliers (red) and inliers (gray): \")\n",
     "    outlier_cloud = outlier_cloud.paint_uniform_color([1.0, 0, 0])\n",
     "    inlier_cloud.paint_uniform_color([0.8, 0.8, 0.8])\n",
-    "    inlier_cloud = o3d.visualization.draw_geometries([inlier_cloud.to_legacy(), outlier_cloud.to_legacy()],\n",
+    "    inlier_cloud = o3d.visualization.draw_geometries([inlier_cloud, outlier_cloud],\n",
     "                                      zoom=0.3412,\n",
     "                                      front=[0.4257, -0.2125, -0.8795],\n",
     "                                      lookat=[2.6172, 2.0475, 1.532],\n",
@@ -614,9 +619,9 @@
     "pcd = o3d.t.io.read_point_cloud(bunny.path)\n",
     "\n",
     "hull = pcd.compute_convex_hull()\n",
-    "hull_ls = o3d.geometry.LineSet.create_from_triangle_mesh(hull.to_legacy())\n",
+    "hull_ls = o3d.geometry.LineSet.create_from_triangle_mesh(hull)\n",
     "hull_ls.paint_uniform_color((1, 0, 0))\n",
-    "o3d.visualization.draw_geometries([pcd.to_legacy(), hull_ls])"
+    "o3d.visualization.draw_geometries([pcd, hull_ls])"
    ]
   },
   {
@@ -647,7 +652,7 @@
     "colors = o3c.Tensor(colors[:, :3], o3c.float32)\n",
     "colors[labels < 0] = 0\n",
     "pcd.point.colors = colors\n",
-    "o3d.visualization.draw_geometries([pcd.to_legacy()],\n",
+    "o3d.visualization.draw_geometries([pcd],\n",
     "                                  zoom=0.455,\n",
     "                                  front=[-0.4999, -0.1659, -0.8499],\n",
     "                                  lookat=[2.1813, 2.0619, 2.0999],\n",
@@ -693,7 +698,7 @@
     "inlier_cloud = pcd.select_by_index(inliers)\n",
     "inlier_cloud = inlier_cloud.paint_uniform_color([1.0, 0, 0])\n",
     "outlier_cloud = pcd.select_by_index(inliers, invert=True)\n",
-    "o3d.visualization.draw_geometries([inlier_cloud.to_legacy(), outlier_cloud.to_legacy()],\n",
+    "o3d.visualization.draw_geometries([inlier_cloud, outlier_cloud],\n",
     "                                  zoom=0.8,\n",
     "                                  front=[-0.4999, -0.1659, -0.8499],\n",
     "                                  lookat=[2.1813, 2.0619, 2.0999],\n",
@@ -761,7 +766,7 @@
     "pcd = pcd.select_by_index(pt_map)\n",
     "\n",
     "print(\"Visualize result\")\n",
-    "o3d.visualization.draw_geometries([pcd.to_legacy()])"
+    "o3d.visualization.draw_geometries([pcd])"
    ]
   },
   {
@@ -787,7 +792,7 @@
     "\n",
     "boundarys = boundarys.paint_uniform_color([1.0, 0.0, 0.0])\n",
     "pcd = pcd.paint_uniform_color([0.6, 0.6, 0.6])\n",
-    "o3d.visualization.draw_geometries([pcd.to_legacy(), boundarys.to_legacy()],\n",
+    "o3d.visualization.draw_geometries([pcd, boundarys],\n",
     "                                      zoom=0.3412,\n",
     "                                      front=[0.3257, -0.2125, -0.8795],\n",
     "                                      lookat=[2.6172, 2.0475, 1.532],\n",

--- a/docs/jupyter/t_geometry/pointcloud.ipynb
+++ b/docs/jupyter/t_geometry/pointcloud.ipynb
@@ -158,7 +158,7 @@
    "metadata": {},
    "source": [
     "## Conversion between tensor and  point cloud\n",
-    "PointCloud can be converted to Tensor `open3d.geometry.PointCloud`."
+    "PointCloud can be converted to Tensor."
    ]
   },
   {


### PR DESCRIPTION
just one file docs/jupyter/t_geometry/pointcloud.ipynb 
1,  
remove  pointcloud.to_legacy method  
2,
Conversion between tensor and legacy point cloud  ===>Conversion between tensor and point cloud 
PointCloud can be converted to/from legacy open3d.geometry.PointCloud.====>PointCloud can be converted to Tensor