### PR TITLE
Add use_normal_length_as_confidence parameter to Poisson surface reconstruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 -   macOS x86_64 not longer supported, only macOS arm64 is supported.
 -   Python 3.13+3.14 support
 -   Fix Windows build failure for PyTorch ops due to PyTorch's bundled fmt (v11+) requiring `/utf-8` with MSVC (PR #7447)
+-   Add `use_normal_length_as_confidence` boolean parameter to Poisson surface reconstruction
 
 
 ## 0.13

--- a/cpp/open3d/geometry/SurfaceReconstructionPoisson.cpp
+++ b/cpp/open3d/geometry/SurfaceReconstructionPoisson.cpp
@@ -720,13 +720,14 @@ void Execute(const open3d::geometry::PointCloud& pcd,
 }  // namespace
 
 std::tuple<std::shared_ptr<TriangleMesh>, std::vector<double>>
-TriangleMesh::CreateFromPointCloudPoisson(const PointCloud& pcd,
-                                          size_t depth,
-                                          float width,
-                                          float scale,
-                                          bool linear_fit,
-                                          bool use_normal_length_as_confidence,
-                                          int n_threads) {
+TriangleMesh::CreateFromPointCloudPoisson(
+        const PointCloud& pcd,
+        size_t depth,
+        float width,
+        float scale,
+        bool linear_fit,
+        int n_threads,
+        bool use_normal_length_as_confidence) {
     static const BoundaryType BType = DEFAULT_FEM_BOUNDARY;
     typedef IsotropicUIntPack<
             DIMENSION, FEMDegreeAndBType</* Degree */ 1, BType>::Signature>

--- a/cpp/open3d/geometry/SurfaceReconstructionPoisson.cpp
+++ b/cpp/open3d/geometry/SurfaceReconstructionPoisson.cpp
@@ -400,6 +400,7 @@ void Execute(const open3d::geometry::PointCloud& pcd,
              float width,
              float scale,
              bool linear_fit,
+             bool use_normal_length_as_confidence,
              UIntPack<FEMSigs...>) {
     static const int Dim = sizeof...(FEMSigs);
     typedef UIntPack<FEMSigs...> Sigs;
@@ -421,6 +422,9 @@ void Execute(const open3d::geometry::PointCloud& pcd,
     int base_depth = 0;
     int base_v_cycles = 1;
     float confidence = 0.f;
+    if (use_normal_length_as_confidence) {
+        confidence = 1.f;
+    }
     float point_weight = 2.f * DEFAULT_FEM_DEGREE;
     float confidence_bias = 0.f;
     float samples_per_node = 1.5f;
@@ -721,6 +725,7 @@ TriangleMesh::CreateFromPointCloudPoisson(const PointCloud& pcd,
                                           float width,
                                           float scale,
                                           bool linear_fit,
+                                          bool use_normal_length_as_confidence,
                                           int n_threads) {
     static const BoundaryType BType = DEFAULT_FEM_BOUNDARY;
     typedef IsotropicUIntPack<
@@ -746,7 +751,7 @@ TriangleMesh::CreateFromPointCloudPoisson(const PointCloud& pcd,
     auto mesh = std::make_shared<TriangleMesh>();
     std::vector<double> densities;
     Execute<float>(pcd, mesh, densities, static_cast<int>(depth), width, scale,
-                   linear_fit, FEMSigs());
+                   linear_fit, use_normal_length_as_confidence, FEMSigs());
 
     ThreadPool::Terminate();
 

--- a/cpp/open3d/geometry/TriangleMesh.h
+++ b/cpp/open3d/geometry/TriangleMesh.h
@@ -545,6 +545,8 @@ public:
     /// for reconstruction and the diameter of the samples' bounding cube.
     /// \param linear_fit If true, the reconstructor use linear interpolation to
     /// estimate the positions of iso-vertices.
+    /// \param use_normal_length_as_confidence If true, use the length (norm)
+    /// of normal vectors as point confidence.
     /// \param n_threads Number of threads used for reconstruction. Set to -1 to
     /// automatically determine it.
     /// \return The estimated TriangleMesh, and per vertex density values that
@@ -555,6 +557,7 @@ public:
                                 float width = 0.0f,
                                 float scale = 1.1f,
                                 bool linear_fit = false,
+                                bool use_normal_length_as_confidence = false,
                                 int n_threads = -1);
 
     /// Factory function to create a tetrahedron mesh (trianglemeshfactory.cpp).

--- a/cpp/open3d/geometry/TriangleMesh.h
+++ b/cpp/open3d/geometry/TriangleMesh.h
@@ -557,8 +557,8 @@ public:
                                 float width = 0.0f,
                                 float scale = 1.1f,
                                 bool linear_fit = false,
-                                bool use_normal_length_as_confidence = false,
-                                int n_threads = -1);
+                                int n_threads = -1,
+                                bool use_normal_length_as_confidence = false);
 
     /// Factory function to create a tetrahedron mesh (trianglemeshfactory.cpp).
     /// the mesh centroid will be at (0,0,0) and \p radius defines the

--- a/cpp/pybind/geometry/trianglemesh.cpp
+++ b/cpp/pybind/geometry/trianglemesh.cpp
@@ -350,9 +350,8 @@ void pybind_trianglemesh_definitions(py::module &m) {
                         "This function uses the original implementation by "
                         "Kazhdan. See https://github.com/mkazhdan/PoissonRecon",
                         "pcd"_a, "depth"_a = 8, "width"_a = 0, "scale"_a = 1.1,
-                        "linear_fit"_a = false,
-                        "use_normal_length_as_confidence"_a = false,
-                        "n_threads"_a = -1)
+                        "linear_fit"_a = false, "n_threads"_a = -1,
+                        "use_normal_length_as_confidence"_a = false)
             .def_static(
                     "create_from_oriented_bounding_box",
                     &TriangleMesh::CreateFromOrientedBoundingBox,
@@ -694,12 +693,12 @@ void pybind_trianglemesh_definitions(py::module &m) {
              {"linear_fit",
               "If true, the reconstructor will use linear interpolation to "
               "estimate the positions of iso-vertices."},
-             {"use_normal_length_as_confidence",
-              "If true, use the length (norm) of normal vectors as "
-              "point confidence"},
              {"n_threads",
               "Number of threads used for reconstruction. Set to -1 to "
-              "automatically determine it."}});
+              "automatically determine it."},
+             {"use_normal_length_as_confidence",
+              "If true, use the length (norm) of normal vectors as a per-point "
+              "confidence."}});
     docstring::ClassMethodDocInject(
             m, "TriangleMesh", "create_from_oriented_bounding_box",
             {{"obox", "OrientedBoundingBox object to create mesh of."},

--- a/cpp/pybind/geometry/trianglemesh.cpp
+++ b/cpp/pybind/geometry/trianglemesh.cpp
@@ -350,7 +350,9 @@ void pybind_trianglemesh_definitions(py::module &m) {
                         "This function uses the original implementation by "
                         "Kazhdan. See https://github.com/mkazhdan/PoissonRecon",
                         "pcd"_a, "depth"_a = 8, "width"_a = 0, "scale"_a = 1.1,
-                        "linear_fit"_a = false, "n_threads"_a = -1)
+                        "linear_fit"_a = false,
+                        "use_normal_length_as_confidence"_a = false,
+                        "n_threads"_a = -1)
             .def_static(
                     "create_from_oriented_bounding_box",
                     &TriangleMesh::CreateFromOrientedBoundingBox,
@@ -692,6 +694,9 @@ void pybind_trianglemesh_definitions(py::module &m) {
              {"linear_fit",
               "If true, the reconstructor will use linear interpolation to "
               "estimate the positions of iso-vertices."},
+             {"use_normal_length_as_confidence",
+              "If true, use the length (norm) of normal vectors as "
+              "point confidence"},
              {"n_threads",
               "Number of threads used for reconstruction. Set to -1 to "
               "automatically determine it."}});


### PR DESCRIPTION
## Type

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [x] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

Poisson surface reconstruction uses a confidence value to weight the influence of each point during reconstruction. By default, all points are weighted equally (confidence = 0). This change exposes a `use_normal_length_as_confidence` flag that passes the normal vector lengths as per-point confidence to the Poisson solver.

## Checklist:

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [x] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

Adds a `use_normal_length_as_confidence` boolean parameter (default false) to TriangleMesh.create_from_point_cloud_poisson(). When set to True, the Poisson solver uses confidence=1, which causes it to use the magnitude of each point's normal vector as a per-point confidence weight. This is a non-breaking change.
 
 No unit test was added as the change is a single boolean flag affecting a well tested solver, let me know if that's needed.
