### PR TITLE
Fix  ground plane rendering by updating near_world convention in material

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/.github/workflows/update_release.sh
+++ b/.github/workflows/update_release.sh
@@ -10,18 +10,18 @@ for artifact in "$@"; do
 
     echo "Uploading $filename (pattern: $pattern)"
     # use normalized path for upload so single backslashes in Windows paths work
-    gh release upload main-devel "$norm_path" --clobber
+    gh -R isl-org/open3d release upload main-devel "$norm_path" --clobber
 
-    for old_asset in $(gh release view main-devel --json assets --jq '.assets[] | .name' || echo ""); do
+    for old_asset in $(gh -R isl-org/open3d release view main-devel --json assets --jq '.assets[] | .name' || echo ""); do
         # shellcheck disable=SC2254
         case "$old_asset" in
             $pattern)
                 if [[ "$old_asset" != "$filename" ]]; then
                     echo "Deleting old asset: $old_asset"
-                    gh release delete-asset main-devel "$old_asset" -y || true
+                    gh -R isl-org/open3d release delete-asset main-devel "$old_asset" -y || true
                 fi
                 ;;
         esac
     done
 done
-gh release view main-devel
+gh -R isl-org/open3d release view main-devel

--- a/.gitignore
+++ b/.gitignore
@@ -91,5 +91,3 @@ docs/Doxyfile
 docs/getting_started.rst
 docs/docker.rst
 docs/tensorboard.md
-
-resources

--- a/cmake/Open3DAddComputeShaders.cmake
+++ b/cmake/Open3DAddComputeShaders.cmake
@@ -39,10 +39,10 @@ function(open3d_add_compute_shaders target)
     find_program(OPEN3D_GLSLANG_VALIDATOR glslangValidator REQUIRED)
     if (APPLE)
         find_program(OPEN3D_SPIRV_CROSS spirv-cross REQUIRED)
-        # The scatter pass uses subgroup arithmetic (gl_SubgroupSize, subgroupAdd, etc.).
-        # Fixing the subgroup size to 32 (Apple Silicon SIMD width) lets the Metal compiler
+        # For shaders that use subgroup arithmetic (gl_SubgroupSize, subgroupAdd, etc.).
+        # fixing the subgroup size to 32 (Apple Silicon SIMD width) lets the Metal compiler
         # treat gl_SubgroupSize as a compile-time constant for loop unrolling.
-        set(SPIRV_CROSS_EXTRA_FLAGS_gaussian_radix_sort_scatter        "--msl-fixed-subgroup-size 32")
+        set(SPIRV_CROSS_EXTRA_FLAGS "--msl-fixed-subgroup-size 32")
         set(GAUSSIAN_METAL_BASENAMES "")
     endif()
 
@@ -79,7 +79,6 @@ function(open3d_add_compute_shaders target)
             VERBATIM
         )
         if (APPLE)
-            set(SPIRV_CROSS_EXTRA_FLAGS ${SPIRV_CROSS_EXTRA_FLAGS_${SHADER_BASENAME}})
             file(GENERATE OUTPUT run_spirv_cross_${SHADER_BASENAME}.sh CONTENT 
             "${OPEN3D_SPIRV_CROSS} \"${STAGED_SPIRV_FULL_PATH}\" --msl --msl-version 20400 --msl-decoration-binding ${SPIRV_CROSS_EXTRA_FLAGS} \
             --rename-entry-point main ${SHADER_BASENAME}_main comp --output \"${STAGED_METAL_FULL_PATH}\" 

--- a/cpp/open3d/visualization/gui/Materials/infiniteGroundPlane.mat
+++ b/cpp/open3d/visualization/gui/Materials/infiniteGroundPlane.mat
@@ -18,7 +18,14 @@ material {
 vertex {
     void materialVertex(inout MaterialVertexInputs material) {
          float4 p = getPosition();
-         material.near_world = getWorldFromClipMatrix() * float4(p.x, p.y, 0.0, 1.0);
+         // getWorldFromClipMatrix() expects z in "inverted DX" convention
+         // (Filament >= v1.10): near = 1.0, far = 0.0 in [0,1].
+         // Using z=1.0 gives the near-plane world position for this pixel
+         // direction, which is the ray origin for ground-plane intersection.
+         // (In Filament v1.9.9 the matrix used GL-standard z where z=0.0
+         // approximated the near plane; that no longer holds after the
+         // VERTEX_DOMAIN_DEVICE z-conversion was introduced.)
+         material.near_world = getWorldFromClipMatrix() * float4(p.x, p.y, 1.0, 1.0);
          material.near_world.xyz *= (1.0 / material.near_world.w);
     }
 }

--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
@@ -9,9 +9,9 @@
 
 #include <json/json.h>
 
+#include <execution>
 #include <set>
 #include <unordered_map>
-#include <unordered_set>
 
 #include "open3d/Open3DConfig.h"
 #include "open3d/geometry/Image.h"
@@ -2174,7 +2174,8 @@ Ctrl-alt-click to polygon select)";
                         size_t num_pixels = static_cast<size_t>(
                                 depth_float->GetMaxBound().prod());
                         float max_val =
-                                std::reduce(depth_data, depth_data + num_pixels,
+                                std::reduce(std::execution::par_unseq,
+                                            depth_data, depth_data + num_pixels,
                                             0.0f, [](float a, float b) {
                                                 if (!std::isfinite(a)) return b;
                                                 if (!std::isfinite(b)) return a;

--- a/docs/tutorial/visualization/web_visualizer.rst
+++ b/docs/tutorial/visualization/web_visualizer.rst
@@ -168,7 +168,7 @@ Then, run the example notebook
 `docs/jupyter/visualization/jupyter_visualization.ipynb <https://github.com/isl-org/Open3D/blob/main/docs/jupyter/visualization/jupyter_visualization.ipynb>`_.
 
 For **3D Gaussian splatting** (``.splat`` / Gaussian PLY) in Jupyter, see
-`docs/tutorial/visualization/gaussian_splatting_web_visualizer.ipynb <https://github.com/isl-org/Open3D/blob/main/docs/tutorial/visualization/gaussian_splatting_web_visualizer.ipynb>`_.
+`docs/jupyter/visualization/gaussian_splatting.ipynb <https://github.com/isl-org/Open3D/blob/main/docs/jupyter/visualization/gaussian_splatting.ipynb>`_.
 
 Unlike standalone mode, ``WEBRTC_IP`` and ``WEBRTC_PORT`` are not used in
 Jupyter mode. However, you might want to


### PR DESCRIPTION
## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

The ground plane is not visible after updating Filament from v1.9.9 to v1.54.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [ ] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

```
         // getWorldFromClipMatrix() expects z in "inverted DX" convention
         // (Filament >= v1.10): near = 1.0, far = 0.0 in [0,1].
         // Using z=1.0 gives the near-plane world position for this pixel
         // direction, which is the ray origin for ground-plane intersection.
         // (In Filament v1.9.9 the matrix used GL-standard z where z=0.0
         // approximated the near plane; that no longer holds after the
         // VERTEX_DOMAIN_DEVICE z-conversion was introduced.)
```

<img width="1052" height="834" alt="Screenshot from 2026-03-23 18-36-30" src="https://github.com/user-attachments/assets/ef71f99c-a305-4b5a-9656-5e49db486a3d" />