### PR TITLE
Tensor mesh IO (via Assimp): gtlf, obj, stl, fbx

### DIFF
--- a/3rdparty/assimp/assimp.cmake
+++ b/3rdparty/assimp/assimp.cmake
@@ -19,6 +19,9 @@ endif()
 # Assimp import/export toggles aligned with Open3D mesh I/O (see TriangleMeshIO and
 # FileASSIMP). Native Open3D readers/writers handle ply and legacy off read; assimp
 # is enabled only for the formats below.
+#
+# Importers: obj, stl, off, gltf/glb, fbx, usd
+# Exporters: gltf/glb (embedded textures), obj, stl, fbx (best-effort geometry)
 
 ExternalProject_Add(
     ext_assimp
@@ -60,6 +63,9 @@ ExternalProject_Add(
         -DASSIMP_BUILD_FBX_IMPORTER=ON
         -DASSIMP_BUILD_USD_IMPORTER=ON   # USD (tinyusdz)
         -DASSIMP_BUILD_GLTF_EXPORTER=ON
+        -DASSIMP_BUILD_OBJ_EXPORTER=ON
+        -DASSIMP_BUILD_STL_EXPORTER=ON
+        -DASSIMP_BUILD_FBX_EXPORTER=ON
     BUILD_BYPRODUCTS
         <INSTALL_DIR>/${Open3D_INSTALL_LIB_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${lib_name}${CMAKE_STATIC_LIBRARY_SUFFIX}
         <INSTALL_DIR>/${Open3D_INSTALL_LIB_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}IrrXML${CMAKE_STATIC_LIBRARY_SUFFIX}

--- a/cpp/open3d/io/ImageIO.cpp
+++ b/cpp/open3d/io/ImageIO.cpp
@@ -22,20 +22,21 @@ namespace {
 
 struct ImageSignatureDecoder {
     std::string signature;
-    std::function<bool(const std::string &, geometry::Image &)> read_from_file;
-    std::function<bool(const unsigned char *, size_t, geometry::Image &)>
+    std::function<bool(const std::string&, geometry::Image&)> read_from_file;
+    std::function<bool(const unsigned char*, size_t, geometry::Image&)>
             read_from_memory;
 };
 
 static const std::array<ImageSignatureDecoder, 2> kImageSignatureDecoders{{
-        {"\x89\x50\x4e\x47\xd\xa\x1a\xa", ReadImageFromPNG, ReadPNGFromMemory},
+        {"\x89\x50\x4e\x47\x0d\x0a\x1a\x0a", ReadImageFromPNG,
+         ReadPNGFromMemory},
         {"\xFF\xD8\xFF", ReadImageFromJPG, ReadJPGFromMemory},
 }};
 static constexpr uint8_t MAX_SIGNATURE_LEN = 8;
 
 static const std::unordered_map<
         std::string,
-        std::function<bool(const std::string &, const geometry::Image &, int)>>
+        std::function<bool(const std::string&, const geometry::Image&, int)>>
         file_extension_to_image_write_function{
                 {"png", WriteImageToPNG},
                 {"jpg", WriteImageToJPG},
@@ -44,13 +45,13 @@ static const std::unordered_map<
 }  // unnamed namespace
 
 std::shared_ptr<geometry::Image> CreateImageFromFile(
-        const std::string &filename) {
+        const std::string& filename) {
     auto image = std::make_shared<geometry::Image>();
     ReadImage(filename, *image);
     return image;
 }
 
-bool ReadImage(const std::string &filename, geometry::Image &image) {
+bool ReadImage(const std::string& filename, geometry::Image& image) {
     std::string signature_buffer(MAX_SIGNATURE_LEN, 0);
     std::ifstream file(filename, std::ios::binary);
     file.read(&signature_buffer[0], MAX_SIGNATURE_LEN);
@@ -59,7 +60,7 @@ bool ReadImage(const std::string &filename, geometry::Image &image) {
         err_msg = "Read geometry::Image failed for file {}. I/O error.";
     } else {
         file.close();
-        for (const auto &decoder : kImageSignatureDecoders) {
+        for (const auto& decoder : kImageSignatureDecoders) {
             if (signature_buffer.compare(0, decoder.signature.size(),
                                          decoder.signature) == 0) {
                 return decoder.read_from_file(filename, image);
@@ -74,8 +75,8 @@ bool ReadImage(const std::string &filename, geometry::Image &image) {
     return false;
 }
 
-bool WriteImage(const std::string &filename,
-                const geometry::Image &image,
+bool WriteImage(const std::string& filename,
+                const geometry::Image& image,
                 int quality /* = kOpen3DImageIODefaultQuality*/) {
     std::string filename_ext =
             utility::filesystem::GetFileExtensionInLowerCase(filename);
@@ -95,18 +96,18 @@ bool WriteImage(const std::string &filename,
 }
 
 std::shared_ptr<geometry::Image> CreateImageFromMemory(
-        const std::string &image_format,
-        const unsigned char *image_data_ptr,
+        const std::string& image_format,
+        const unsigned char* image_data_ptr,
         size_t image_data_size) {
     auto image = std::make_shared<geometry::Image>();
     ReadImageFromMemory(image_format, image_data_ptr, image_data_size, *image);
     return image;
 }
 
-bool ReadImageFromMemory(const std::string &image_format,
-                         const unsigned char *image_data_ptr,
+bool ReadImageFromMemory(const std::string& image_format,
+                         const unsigned char* image_data_ptr,
                          size_t image_data_size,
-                         geometry::Image &image) {
+                         geometry::Image& image) {
     (void)image_format;
     if (image_data_ptr == nullptr || image_data_size == 0) {
         utility::LogWarning(
@@ -114,8 +115,8 @@ bool ReadImageFromMemory(const std::string &image_format,
         image.Clear();
         return false;
     }
-    for (const auto &decoder : kImageSignatureDecoders) {
-        const auto &magic = decoder.signature;
+    for (const auto& decoder : kImageSignatureDecoders) {
+        const auto& magic = decoder.signature;
         if (image_data_size >= magic.size() &&
             std::memcmp(image_data_ptr, magic.data(), magic.size()) == 0) {
             return decoder.read_from_memory(image_data_ptr, image_data_size,

--- a/cpp/open3d/io/file_format/FileJPG.cpp
+++ b/cpp/open3d/io/file_format/FileJPG.cpp
@@ -164,7 +164,7 @@ bool WriteImageToJPG(const std::string &filename,
         return true;
     } catch (const std::runtime_error &err) {
         fclose(file_out);
-        utility::LogWarning(err.what());
+        utility::LogWarning("libjpeg error: {}", err.what());
         return false;
     }
 }

--- a/cpp/open3d/io/file_format/FilePNG.cpp
+++ b/cpp/open3d/io/file_format/FilePNG.cpp
@@ -7,6 +7,8 @@
 
 #include <png.h>
 
+#include <string>
+
 #include "open3d/io/ImageIO.h"
 #include "open3d/utility/Logging.h"
 
@@ -14,6 +16,14 @@ namespace open3d {
 
 namespace {
 using namespace io;
+
+void LogLibPNGError(const png_image &pngimage, const char *fallback) {
+    if (pngimage.message[0] != '\0') {
+        utility::LogWarning("{}", pngimage.message);
+    } else {
+        utility::LogWarning("PNG error: {}.", fallback);
+    }
+}
 
 void SetPNGImageFromImage(const geometry::Image &image,
                           int quality,
@@ -45,7 +55,7 @@ bool ReadImageFromPNG(const std::string &filename, geometry::Image &image) {
     memset(&pngimage, 0, sizeof(pngimage));
     pngimage.version = PNG_IMAGE_VERSION;
     if (png_image_begin_read_from_file(&pngimage, filename.c_str()) == 0) {
-        utility::LogWarning("Read PNG failed: unable to parse header.");
+        LogLibPNGError(pngimage, "Read PNG failed: unable to parse header");
         return false;
     }
 
@@ -61,9 +71,9 @@ bool ReadImageFromPNG(const std::string &filename, geometry::Image &image) {
 
     if (png_image_finish_read(&pngimage, NULL, image.data_.data(), 0, NULL) ==
         0) {
-        utility::LogWarning("Read PNG failed: unable to read file: {}",
-                            filename);
-        utility::LogWarning("PNG error: {}", pngimage.message);
+        const std::string fallback =
+                std::string("unable to read file: ") + filename;
+        LogLibPNGError(pngimage, fallback.c_str());
         return false;
     }
     return true;
@@ -90,8 +100,9 @@ bool WriteImageToPNG(const std::string &filename,
     SetPNGImageFromImage(image, quality, pngimage);
     if (png_image_write_to_file(&pngimage, filename.c_str(), 0,
                                 image.data_.data(), 0, NULL) == 0) {
-        utility::LogWarning("Write PNG failed: unable to write file: {}",
-                            filename);
+        const std::string fallback =
+                std::string("unable to write file: ") + filename;
+        LogLibPNGError(pngimage, fallback.c_str());
         return false;
     }
     return true;
@@ -105,7 +116,7 @@ bool ReadPNGFromMemory(const unsigned char *image_data_ptr,
     pngimage.version = PNG_IMAGE_VERSION;
     if (png_image_begin_read_from_memory(&pngimage, image_data_ptr,
                                          image_data_size) == 0) {
-        utility::LogWarning("Read PNG failed: unable to parse header.");
+        LogLibPNGError(pngimage, "Read PNG failed: unable to parse header");
         image.Clear();
         return false;
     }
@@ -122,7 +133,7 @@ bool ReadPNGFromMemory(const unsigned char *image_data_ptr,
 
     if (png_image_finish_read(&pngimage, NULL, image.data_.data(), 0, NULL) ==
         0) {
-        utility::LogWarning("PNG error: {}", pngimage.message);
+        LogLibPNGError(pngimage, "Read PNG failed: unable to read from memory");
         image.Clear();
         return false;
     }

--- a/cpp/open3d/t/geometry/kernel/MinimumOBE.cpp
+++ b/cpp/open3d/t/geometry/kernel/MinimumOBE.cpp
@@ -52,8 +52,8 @@ void MapOBEToClosestIdentity(EigenOBE& obe) {
     Eigen::Vector3d& radii = obe.radii_;
     Eigen::Vector3d col[3] = {R.col(0), R.col(1), R.col(2)};
     double best_score = -1e9;
-    Eigen::Matrix3d best_R;
-    Eigen::Vector3d best_radii;
+    Eigen::Matrix3d best_R = Eigen::Matrix3d::Identity();
+    Eigen::Vector3d best_radii = Eigen::Vector3d::Zero();
 
     // Hard-coded permutations of indices [0,1,2]
     static const std::array<std::array<int, 3>, 6> permutations = {

--- a/cpp/open3d/t/io/ImageIO.cpp
+++ b/cpp/open3d/t/io/ImageIO.cpp
@@ -30,22 +30,22 @@ namespace io {
 namespace {
 using signature_decoder_t =
         std::pair<std::string,
-                  std::function<bool(const std::string &, geometry::Image &)>>;
+                  std::function<bool(const std::string&, geometry::Image&)>>;
 static const std::array<signature_decoder_t, 2> signature_decoder_list{
-        {{"\x89\x50\x4e\x47\xd\xa\x1a\xa", ReadImageFromPNG},
+        {{"\x89\x50\x4e\x47\x0d\x0a\x1a\x0a", ReadImageFromPNG},
          {"\xFF\xD8\xFF", ReadImageFromJPG}}};
 static constexpr uint8_t MAX_SIGNATURE_LEN = 8;
 
 using mem_signature_decoder_t = std::pair<
         std::string,
-        std::function<bool(const uint8_t *, size_t, geometry::Image &)>>;
+        std::function<bool(const uint8_t*, size_t, geometry::Image&)>>;
 static const std::array<mem_signature_decoder_t, 2> mem_signature_decoder_list{
-        {{"\x89\x50\x4e\x47\xd\xa\x1a\xa", ReadImageFromPNGInMemory},
+        {{"\x89\x50\x4e\x47\x0d\x0a\x1a\x0a", ReadImageFromPNGInMemory},
          {"\xFF\xD8\xFF", ReadImageFromJPGInMemory}}};
 
 static const std::unordered_map<
         std::string,
-        std::function<bool(const std::string &, const geometry::Image &, int)>>
+        std::function<bool(const std::string&, const geometry::Image&, int)>>
         file_extension_to_image_write_function{
                 {"png", WriteImageToPNG},
                 {"jpg", WriteImageToJPG},
@@ -54,13 +54,13 @@ static const std::unordered_map<
 }  // namespace
 
 std::shared_ptr<geometry::Image> CreateImageFromFile(
-        const std::string &filename) {
+        const std::string& filename) {
     auto image = std::make_shared<geometry::Image>();
     ReadImage(filename, *image);
     return image;
 }
 
-bool ReadImage(const std::string &filename, geometry::Image &image) {
+bool ReadImage(const std::string& filename, geometry::Image& image) {
     std::string signature_buffer(MAX_SIGNATURE_LEN, 0);
     std::ifstream file(filename, std::ios::binary);
     file.read(&signature_buffer[0], MAX_SIGNATURE_LEN);
@@ -69,7 +69,7 @@ bool ReadImage(const std::string &filename, geometry::Image &image) {
         err_msg = "Read geometry::Image failed for file {}. I/O error.";
     } else {
         file.close();
-        for (const auto &signature_decoder : signature_decoder_list) {
+        for (const auto& signature_decoder : signature_decoder_list) {
             if (signature_buffer.compare(0, signature_decoder.first.size(),
                                          signature_decoder.first) == 0) {
                 return signature_decoder.second(filename, image);
@@ -84,17 +84,17 @@ bool ReadImage(const std::string &filename, geometry::Image &image) {
     return false;
 }
 
-bool ReadImageFromMemory(const uint8_t *data,
+bool ReadImageFromMemory(const uint8_t* data,
                          size_t size,
-                         geometry::Image &image) {
+                         geometry::Image& image) {
     if (data == nullptr || size == 0) {
         utility::LogWarning(
                 "ReadImageFromMemory failed: null or empty buffer.");
         image.Clear();
         return false;
     }
-    for (const auto &sig_dec : mem_signature_decoder_list) {
-        const auto &sig = sig_dec.first;
+    for (const auto& sig_dec : mem_signature_decoder_list) {
+        const auto& sig = sig_dec.first;
         if (size >= sig.size() &&
             std::memcmp(data, sig.data(), sig.size()) == 0) {
             return sig_dec.second(data, size, image);
@@ -107,8 +107,8 @@ bool ReadImageFromMemory(const uint8_t *data,
     return false;
 }
 
-bool WriteImage(const std::string &filename,
-                const geometry::Image &image,
+bool WriteImage(const std::string& filename,
+                const geometry::Image& image,
                 int quality /* = kOpen3DImageIODefaultQuality*/) {
     std::string filename_ext =
             utility::filesystem::GetFileExtensionInLowerCase(filename);
@@ -127,7 +127,7 @@ bool WriteImage(const std::string &filename,
     return map_itr->second(filename, image.To(core::Device("CPU:0")), quality);
 }
 
-DepthNoiseSimulator::DepthNoiseSimulator(const std::string &noise_model_path) {
+DepthNoiseSimulator::DepthNoiseSimulator(const std::string& noise_model_path) {
     // data = np.loadtxt(fname, comments='%', skiprows=5)
     const char comment_prefix = '%';
     const int skip_first_n_lines = 5;
@@ -137,7 +137,7 @@ DepthNoiseSimulator::DepthNoiseSimulator(const std::string &noise_model_path) {
                           noise_model_path);
     }
     std::vector<float> data;
-    const char *line_buffer;
+    const char* line_buffer;
     for (int i = 0; i < skip_first_n_lines; ++i) {
         if (!(line_buffer = file.ReadLine())) {
             utility::LogError(
@@ -186,7 +186,7 @@ DepthNoiseSimulator::DepthNoiseSimulator(const std::string &noise_model_path) {
     }
 }
 
-geometry::Image DepthNoiseSimulator::Simulate(const geometry::Image &im_src,
+geometry::Image DepthNoiseSimulator::Simulate(const geometry::Image& im_src,
                                               float depth_scale) {
     // Sanity checks.
     if (im_src.GetDtype() == core::Float32) {
@@ -207,8 +207,8 @@ geometry::Image DepthNoiseSimulator::Simulate(const geometry::Image &im_src,
     }
 
     core::Tensor im_src_tensor = im_src.AsTensor();
-    const core::Device &original_device = im_src_tensor.GetDevice();
-    const core::Dtype &original_dtype = im_src_tensor.GetDtype();
+    const core::Device& original_device = im_src_tensor.GetDevice();
+    const core::Dtype& original_dtype = im_src_tensor.GetDtype();
     int width = im_src.GetCols();
     int height = im_src.GetRows();
 

--- a/cpp/open3d/t/io/ImageIO.cpp
+++ b/cpp/open3d/t/io/ImageIO.cpp
@@ -87,6 +87,12 @@ bool ReadImage(const std::string &filename, geometry::Image &image) {
 bool ReadImageFromMemory(const uint8_t *data,
                          size_t size,
                          geometry::Image &image) {
+    if (data == nullptr || size == 0) {
+        utility::LogWarning(
+                "ReadImageFromMemory failed: null or empty buffer.");
+        image.Clear();
+        return false;
+    }
     for (const auto &sig_dec : mem_signature_decoder_list) {
         const auto &sig = sig_dec.first;
         if (size >= sig.size() &&

--- a/cpp/open3d/t/io/ImageIO.cpp
+++ b/cpp/open3d/t/io/ImageIO.cpp
@@ -10,12 +10,14 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstring>
 #include <fstream>
+#include <functional>
+#include <sstream>
 #include <unordered_map>
 #include <vector>
 
 #include "open3d/core/ParallelFor.h"
-#include "open3d/io/ImageIO.h"
 #include "open3d/t/geometry/kernel/GeometryIndexer.h"
 #include "open3d/utility/FileSystem.h"
 #include "open3d/utility/Logging.h"
@@ -33,6 +35,13 @@ static const std::array<signature_decoder_t, 2> signature_decoder_list{
         {{"\x89\x50\x4e\x47\xd\xa\x1a\xa", ReadImageFromPNG},
          {"\xFF\xD8\xFF", ReadImageFromJPG}}};
 static constexpr uint8_t MAX_SIGNATURE_LEN = 8;
+
+using mem_signature_decoder_t = std::pair<
+        std::string,
+        std::function<bool(const uint8_t *, size_t, geometry::Image &)>>;
+static const std::array<mem_signature_decoder_t, 2> mem_signature_decoder_list{
+        {{"\x89\x50\x4e\x47\xd\xa\x1a\xa", ReadImageFromPNGInMemory},
+         {"\xFF\xD8\xFF", ReadImageFromJPGInMemory}}};
 
 static const std::unordered_map<
         std::string,
@@ -72,6 +81,23 @@ bool ReadImage(const std::string &filename, geometry::Image &image) {
     }
     image.Clear();
     utility::LogWarning(err_msg.c_str(), filename);
+    return false;
+}
+
+bool ReadImageFromMemory(const uint8_t *data,
+                         size_t size,
+                         geometry::Image &image) {
+    for (const auto &sig_dec : mem_signature_decoder_list) {
+        const auto &sig = sig_dec.first;
+        if (size >= sig.size() &&
+            std::memcmp(data, sig.data(), sig.size()) == 0) {
+            return sig_dec.second(data, size, image);
+        }
+    }
+    image.Clear();
+    utility::LogWarning(
+            "ReadImageFromMemory: unknown image format "
+            "(only PNG and JPG are supported).");
     return false;
 }
 

--- a/cpp/open3d/t/io/ImageIO.h
+++ b/cpp/open3d/t/io/ImageIO.h
@@ -7,9 +7,11 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <string>
+#include <vector>
 
-#include "open3d/io/ImageIO.h"
 #include "open3d/t/geometry/Image.h"
 
 namespace open3d {
@@ -57,6 +59,12 @@ bool WriteImage(const std::string &filename,
 
 bool ReadImageFromPNG(const std::string &filename, geometry::Image &image);
 
+/// Decode a PNG image from a memory buffer (no file I/O).
+/// Supports the same formats as ReadImageFromPNG.
+bool ReadImageFromPNGInMemory(const uint8_t *data,
+                              size_t size,
+                              geometry::Image &image);
+
 bool WriteImageToPNG(const std::string &filename,
                      const geometry::Image &image,
                      int quality = kOpen3DImageIODefaultQuality);
@@ -66,6 +74,17 @@ bool WriteImageToPNGInMemory(std::vector<uint8_t> &output_buffer,
                              int quality = kOpen3DImageIODefaultQuality);
 
 bool ReadImageFromJPG(const std::string &filename, geometry::Image &image);
+
+/// Decode a JPEG image from a memory buffer (no file I/O).
+bool ReadImageFromJPGInMemory(const uint8_t *data,
+                              size_t size,
+                              geometry::Image &image);
+
+/// Decode a PNG or JPEG image from a memory buffer, auto-detected by magic
+/// bytes. Used for embedded textures in 3D model files (e.g. GLB via ASSIMP).
+bool ReadImageFromMemory(const uint8_t *data,
+                         size_t size,
+                         geometry::Image &image);
 
 bool WriteImageToJPG(const std::string &filename,
                      const geometry::Image &image,

--- a/cpp/open3d/t/io/TriangleMeshIO.cpp
+++ b/cpp/open3d/t/io/TriangleMeshIO.cpp
@@ -12,7 +12,9 @@
 
 #include "open3d/t/io/NumpyIO.h"
 #include "open3d/utility/FileSystem.h"
+#include "open3d/utility/Helper.h"
 #include "open3d/utility/Logging.h"
+#include "open3d/utility/ProgressBar.h"
 
 namespace open3d {
 namespace t {
@@ -87,6 +89,16 @@ bool ReadTriangleMesh(const std::string &filename,
     auto map_itr =
             file_extension_to_trianglemesh_read_function.find(filename_ext);
     bool success = false;
+    if (params.print_progress) {
+        auto progress_text = std::string("Reading ") +
+                             utility::ToUpper(filename_ext) +
+                             " file: " + filename;
+        auto pbar = utility::ProgressBar(100, progress_text, true);
+        params.update_progress = [pbar](double percent) mutable -> bool {
+            pbar.SetCurrentCount(size_t(percent));
+            return true;
+        };
+    }
     if (map_itr == file_extension_to_trianglemesh_read_function.end()) {
         open3d::geometry::TriangleMesh legacy_mesh;
         success = open3d::io::ReadTriangleMesh(filename, legacy_mesh, params);

--- a/cpp/open3d/t/io/TriangleMeshIO.cpp
+++ b/cpp/open3d/t/io/TriangleMeshIO.cpp
@@ -45,7 +45,14 @@ static const std::unordered_map<
                            const bool)>>
         file_extension_to_trianglemesh_write_function{
                 {"npz", WriteTriangleMeshToNPZ},
+                // ASSIMP-based writers: full PBR material support.
+                // OBJ/FBX write external PNG sidecars for texture maps.
+                // GLB embeds textures. STL is geometry-only.
                 {"glb", WriteTriangleMeshUsingASSIMP},
+                {"gltf", WriteTriangleMeshUsingASSIMP},
+                {"obj", WriteTriangleMeshUsingASSIMP},
+                {"stl", WriteTriangleMeshUsingASSIMP},
+                {"fbx", WriteTriangleMeshUsingASSIMP},
         };
 
 std::shared_ptr<geometry::TriangleMesh> CreateMeshFromFile(
@@ -57,18 +64,13 @@ std::shared_ptr<geometry::TriangleMesh> CreateMeshFromFile(
     return mesh;
 }
 
-// TODO:
-// 1. Currently, the tensor triangle mesh implementation has no provision for
-// triangle_uvs,  materials, triangle_material_ids and textures which are
-// supported by the legacy. These can be added as custom attributes (level 2)
-// approach. Please check legacy file formats(e.g. FileOBJ.cpp) for more
-// information.
-// 2. Add these properties to the legacy to tensor mesh and tensor to legacy
-// mesh conversion.
-// 3. Update the documentation with information on how to access these
-// additional attributes from tensor based triangle mesh.
-// 4. Implement read/write tensor triangle mesh with various file formats.
-// 5. Compare with legacy triangle mesh and add corresponding unit tests.
+// Status of tensor TriangleMesh I/O features:
+// - Supported: vertex positions/normals/colors, triangle indices, per-triangle
+//   UV coordinates (triangle attribute "texture_uvs", shape [T, 3, 2]), one
+//   material (PBR scalars + albedo/normal/AO/roughness/metallic/ao_rough_metal
+//   texture maps). FromLegacy/ToLegacy conversion includes all of the above.
+// - Not supported: multiple materials, triangle_material_ids, per-triangle
+//   normals export, additional UV sets, skeleton/animation/cameras/lights.
 
 bool ReadTriangleMesh(const std::string &filename,
                       geometry::TriangleMesh &mesh,

--- a/cpp/open3d/t/io/TriangleMeshIO.h
+++ b/cpp/open3d/t/io/TriangleMeshIO.h
@@ -23,23 +23,38 @@ std::shared_ptr<geometry::TriangleMesh> CreateMeshFromFile(
 
 /// The general entrance for reading a TriangleMesh from a file.
 /// The function calls read functions based on the extension name of filename.
-/// Supported formats are \c obj,ply,stl,off,gltf,glb,fbx .
+/// \par Supported read formats:
+///   - \c ply  -- native Open3D reader (geometry + colors/normals)
+///   - \c npz  -- Open3D NPZ format (full round-trip incl. materials)
+///   - \c obj, stl, off, gltf, glb, fbx -- via ASSIMP
+///     (geometry + vertex normals/colors + UV coordinates + single material
+///      with PBR scalar and texture-map properties)
 /// \param filename Path to the mesh file.
 /// \param mesh Output parameter for the mesh.
 /// \param params Additional read options to enable post-processing or progress
-/// reporting. \return return true if the read function is successful, false
-/// otherwise.
+///              reporting.
+/// \return true if the read function is successful, false otherwise.
 bool ReadTriangleMesh(const std::string &filename,
                       geometry::TriangleMesh &mesh,
                       open3d::io::ReadTriangleMeshOptions params = {});
 
-/// The general entrance for writing a TriangleMesh to a file
+/// The general entrance for writing a TriangleMesh to a file.
 /// The function calls write functions based on the extension name of filename.
-/// If the write function supports binary encoding and compression, the later
-/// two parameters will be used. Otherwise they will be ignored.
-/// At current only .obj format supports uv coordinates (triangle_uvs) and
-/// textures.
-/// \return return true if the write function is successful, false otherwise.
+/// \par Supported write formats and material/texture export:
+///   - \c npz  -- full round-trip (geometry + material + all texture maps)
+///   - \c glb  -- via ASSIMP; full PBR single material with embedded textures
+///   - \c gltf -- via ASSIMP; full PBR single material with external textures
+///   - \c obj  -- via ASSIMP; single material with external PNG sidecar
+///   textures
+///               (albedo, normal, AO, roughness, metallic)
+///   - \c fbx  -- via ASSIMP; geometry + best-effort material (textures not
+///               guaranteed by the ASSIMP FBX exporter)
+///   - \c stl  -- via ASSIMP; geometry only (positions, faces, normals)
+///   - \c ply, off -- via legacy Open3D writer; geometry + colors/normals only
+/// \note Only a single material per mesh is supported. Multiple materials,
+///       triangle_material_ids, per-triangle normals, and animation are not
+///       supported.
+/// \return true if the write function is successful, false otherwise.
 bool WriteTriangleMesh(const std::string &filename,
                        const geometry::TriangleMesh &mesh,
                        bool write_ascii = false,

--- a/cpp/open3d/t/io/TriangleMeshIO.h
+++ b/cpp/open3d/t/io/TriangleMeshIO.h
@@ -26,9 +26,9 @@ std::shared_ptr<geometry::TriangleMesh> CreateMeshFromFile(
 /// \par Supported read formats:
 ///   - \c ply  -- native Open3D reader (geometry + colors/normals)
 ///   - \c npz  -- Open3D NPZ format (full round-trip incl. materials)
-///   - \c obj, stl, off, gltf, glb, fbx -- via ASSIMP
-///     (geometry + vertex normals/colors + UV coordinates + single material
-///      with PBR scalar and texture-map properties)
+///   - \c obj, stl, off, gltf, glb, fbx -- via ASSIMP (geometry; optional
+///     vertex normals/colors, UVs, and material/PBR data depending on format,
+///     e.g. STL is geometry-only)
 /// \param filename Path to the mesh file.
 /// \param mesh Output parameter for the mesh.
 /// \param params Additional read options to enable post-processing or progress

--- a/cpp/open3d/t/io/TriangleMeshIO.h
+++ b/cpp/open3d/t/io/TriangleMeshIO.h
@@ -51,6 +51,9 @@ bool ReadTriangleMesh(const std::string &filename,
 ///               guaranteed by the ASSIMP FBX exporter)
 ///   - \c stl  -- via ASSIMP; geometry only (positions, faces, normals)
 ///   - \c ply, off -- via legacy Open3D writer; geometry + colors/normals only
+/// \note For ASSIMP writers, \p write_ascii is format-specific: it selects
+///       ASCII vs binary STL and is ignored for \c glb / \c gltf (encoding
+///       follows the file extension), \c obj, and \c fbx as documented in logs.
 /// \note Only a single material per mesh is supported. Multiple materials,
 ///       triangle_material_ids, per-triangle normals, and animation are not
 ///       supported.

--- a/cpp/open3d/t/io/file_format/FileASSIMP.cpp
+++ b/cpp/open3d/t/io/file_format/FileASSIMP.cpp
@@ -10,7 +10,6 @@
 #include <assimp/postprocess.h>
 #include <assimp/scene.h>
 
-#include <algorithm>
 #include <assimp/Exporter.hpp>
 #include <assimp/Importer.hpp>
 #include <assimp/ProgressHandler.hpp>
@@ -450,12 +449,11 @@ struct TexExport {
 };
 
 // Collect the textures present in `mat` into a list ready for export.
-// embed=true  → GLB/GLTF: combined roughness+metallic map via ASSIMP 6's
-//               primary metallicRoughness slot
-//               (aiTextureType_DIFFUSE_ROUGHNESS).
-// embed=false → sidecar PNGs for formats that support separate roughness /
-//               metallic maps (GLTF, FBX).  supports_roughness_metallic must
-//               be false for OBJ, which has no PBR material properties.
+// Combined ao_rough_metal uses ASSIMP 6's primary metallicRoughness slot
+// (aiTextureType_DIFFUSE_ROUGHNESS) for GLB embed and GLTF/FBX sidecars.
+// When only separate roughness/metallic maps exist, embed combines them;
+// sidecar export writes separate PNGs.  supports_roughness_metallic must be
+// false for OBJ, which has no PBR material properties.
 std::vector<TexExport> CollectTextures(
         const visualization::rendering::Material& mat,
         bool embed,
@@ -480,10 +478,7 @@ std::vector<TexExport> CollectTextures(
         return out;
     }
 
-    // ASSIMP 6 glTF2 exporter checks aiTextureType_DIFFUSE_ROUGHNESS (primary)
-    // for metallicRoughnessTexture.  Use the combined map when embedding; use
-    // separate per-channel maps when writing sidecars (GLTF, FBX).
-    if (embed && mat.HasAORoughnessMetalMap()) {
+    if (mat.HasAORoughnessMetalMap()) {
         out.push_back({"ao_rough_metal",
                        mat.GetAORoughnessMetalMap(),
                        {aiTextureType_DIFFUSE_ROUGHNESS}});
@@ -733,8 +728,8 @@ bool WriteTriangleMeshUsingASSIMP(const std::string& filename,
     // Derive extension and export format.
     const std::filesystem::path filepath(filename);
     std::string ext = filepath.extension().string();
-    if (!ext.empty()) ext = ext.substr(1);  // strip leading '.'
-    std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+    if (!ext.empty() && ext[0] == '.') ext = ext.substr(1);
+    ext = utility::ToLower(ext);
     WarnIfWriteAsciiMismatch(ext, write_ascii);
     const ExportFormat fmt = ResolveExportFormat(ext, write_ascii);
 

--- a/cpp/open3d/t/io/file_format/FileASSIMP.cpp
+++ b/cpp/open3d/t/io/file_format/FileASSIMP.cpp
@@ -10,10 +10,15 @@
 #include <assimp/postprocess.h>
 #include <assimp/scene.h>
 
+#include <algorithm>
 #include <assimp/Exporter.hpp>
 #include <assimp/Importer.hpp>
 #include <assimp/ProgressHandler.hpp>
+#include <filesystem>
+#include <memory>
+#include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "open3d/core/ParallelFor.h"
@@ -26,9 +31,7 @@ namespace open3d {
 namespace t {
 namespace io {
 
-// Split all polygons with more than 3 edges into triangles.
-// Ref:
-// https://github.com/assimp/assimp/blob/master/include/assimp/postprocess.h
+// Post-process flags for ASSIMP import.
 const unsigned int kPostProcessFlags_compulsory =
         aiProcess_JoinIdenticalVertices | aiProcess_Triangulate |
         aiProcess_SortByPType | aiProcess_PreTransformVertices;
@@ -38,6 +41,428 @@ const unsigned int kPostProcessFlags_fast =
         aiProcess_GenUVCoords | aiProcess_RemoveRedundantMaterials |
         aiProcess_OptimizeMeshes;
 
+namespace {  // internal helpers — not part of the public API
+
+// ---------------------------------------------------------------------------
+// Reader helpers
+// ---------------------------------------------------------------------------
+
+// Decode an ASSIMP embedded texture into a tensor Image.
+// mHeight==0 means the raw bytes are a compressed PNG/JPEG; otherwise the
+// data is uncompressed RGBA texels (4 bytes per pixel).
+geometry::Image DecodeEmbeddedTexture(const aiTexture* tex) {
+    if (tex->mHeight == 0) {
+        geometry::Image img;
+        if (ReadImageFromMemory(reinterpret_cast<const uint8_t*>(tex->pcData),
+                                tex->mWidth, img)) {
+            return img;
+        }
+        utility::LogWarning("Could not decode embedded texture '{}'.",
+                            tex->mFilename.C_Str());
+    } else {
+        // Uncompressed RGBA: mWidth * mHeight * sizeof(aiTexel) bytes.
+        const size_t nbytes = static_cast<size_t>(tex->mWidth) *
+                              static_cast<size_t>(tex->mHeight) * 4;
+        auto t = core::Tensor::Empty({static_cast<int64_t>(tex->mHeight),
+                                      static_cast<int64_t>(tex->mWidth), 4},
+                                     core::UInt8);
+        std::memcpy(t.GetDataPtr(),
+                    reinterpret_cast<const unsigned char*>(tex->pcData),
+                    nbytes);
+        return geometry::Image(t);
+    }
+    return {};
+}
+
+// Load a single texture at (type, slot) from the ASSIMP material into
+// o3d_mat.  Handles both embedded textures (via aiScene::GetEmbeddedTexture)
+// and external file references resolved relative to the model directory.
+void LoadMaterialTexture(const std::string& filename,
+                         const aiScene* scene,
+                         const aiMaterial* mat,
+                         aiTextureType type,
+                         unsigned int slot,
+                         const std::string& key,
+                         visualization::rendering::Material& o3d_mat) {
+    if (mat->GetTextureCount(type) <= slot) return;
+    aiString path;
+    mat->GetTexture(type, slot, &path);
+
+    if (const aiTexture* embedded = scene->GetEmbeddedTexture(path.C_Str())) {
+        auto img = DecodeEmbeddedTexture(embedded);
+        if (!img.IsEmpty()) {
+            o3d_mat.SetTextureMap(key, img);
+        }
+        return;
+    }
+
+    // External texture path: normalize separators, then resolve relative to
+    // the model file's directory.  If the stored path is absolute (from
+    // another machine), strip to just the filename to keep a working guess.
+    std::string strpath(path.C_Str());
+    for (auto& c : strpath) {
+        if (c == '\\') c = '/';
+    }
+    namespace fs = std::filesystem;
+    const fs::path fpath(strpath);
+    const auto resolved =
+            fpath.is_absolute()
+                    ? (fs::path(filename).parent_path() / fpath.filename())
+                    : (fs::path(filename).parent_path() / fpath);
+    geometry::Image img;
+    if (ReadImage(resolved.string(), img)) {
+        o3d_mat.SetTextureMap(key, img);
+    }
+}
+
+// Load all PBR texture maps for one aiMaterial into o3d_mat, trying the
+// correct ASSIMP slot for each map type (some vary by format).
+void LoadMaterialTextures(const std::string& filename,
+                          const aiScene* scene,
+                          const aiMaterial* mat,
+                          visualization::rendering::Material& o3d_mat) {
+    // Capture the four repeated args so each call is just (type, slot, key).
+    auto load = [&](aiTextureType type, unsigned int slot,
+                    const std::string& key) {
+        LoadMaterialTexture(filename, scene, mat, type, slot, key, o3d_mat);
+    };
+    auto has = [&](aiTextureType type) {
+        return mat->GetTextureCount(type) > 0;
+    };
+
+    // Albedo: prefer PBR BASE_COLOR, fall back to legacy DIFFUSE.
+    load(has(aiTextureType_BASE_COLOR) ? aiTextureType_BASE_COLOR
+                                       : aiTextureType_DIFFUSE,
+         0, "albedo");
+    load(aiTextureType_NORMALS, 0, "normal");
+
+    // AO: different formats use different slots — try in priority order.
+    if (has(aiTextureType_AMBIENT_OCCLUSION))
+        load(aiTextureType_AMBIENT_OCCLUSION, 0, "ambient_occlusion");
+    else if (has(aiTextureType_LIGHTMAP))
+        load(aiTextureType_LIGHTMAP, 0, "ambient_occlusion");
+    else
+        load(aiTextureType_AMBIENT, 0, "ambient_occlusion");
+
+    // ASSIMP 6 uses aiTextureType_GLTF_METALLIC_ROUGHNESS for the glTF combined
+    // metallicRoughness texture.  When that type is present this is a combined
+    // map (G=roughness, B=metallic); individual roughness/metallic types then
+    // point to the same image and must be skipped to avoid double-loading.
+    if (has(aiTextureType_GLTF_METALLIC_ROUGHNESS)) {
+        load(aiTextureType_GLTF_METALLIC_ROUGHNESS, 0, "ao_rough_metal");
+    } else {
+        load(aiTextureType_METALNESS, 0, "metallic");
+
+        // Roughness: DIFFUSE_ROUGHNESS preferred, SHININESS fallback (FBX).
+        if (has(aiTextureType_DIFFUSE_ROUGHNESS))
+            load(aiTextureType_DIFFUSE_ROUGHNESS, 0, "roughness");
+        else if (has(aiTextureType_SHININESS))
+            load(aiTextureType_SHININESS, 0, "roughness");
+    }
+    load(aiTextureType_REFLECTION, 0, "reflectance");
+    load(aiTextureType_CLEARCOAT, 0, "clear_coat");
+    load(aiTextureType_CLEARCOAT, 1, "clear_coat_roughness");
+    load(aiTextureType_ANISOTROPY, 0, "anisotropy");
+}
+
+// ---------------------------------------------------------------------------
+// Writer helpers
+// ---------------------------------------------------------------------------
+
+// Per-format export settings: ASSIMP exporter ID, texture embedding mode,
+// and which texture/material features the format supports.
+struct ExportFormat {
+    std::string assimp_id;
+    bool embed_textures;  // true → "*N" embedded URIs (GLB); false → sidecar
+                          // PNGs
+    bool supports_materials;  // false for STL (geometry-only)
+    // OBJ/MTL does not have PBR material properties (roughness, metallic).
+    // Set false for such formats so roughness/metallic maps are skipped on
+    // export instead of writing unreferenced sidecar files.
+    bool supports_roughness_metallic;
+};
+
+ExportFormat ResolveExportFormat(const std::string& ext, bool write_ascii) {
+    //                             assimp_id          embed  mat    pbr
+    if (ext == "glb") return {"glb2", true, true, true};
+    if (ext == "gltf") return {"gltf2", false, true, true};
+    if (ext == "obj") return {"obj", false, true, false};
+    if (ext == "fbx") return {"fbx", false, true, true};
+    if (ext == "stl")
+        return {write_ascii ? "stl" : "stlb", false, false, false};
+    utility::LogError("Unsupported ASSIMP export extension: {}", ext);
+}
+
+// Register a texture URI (embedded "*N" or a relative sidecar filename) in
+// one material texture slot.
+void SetMaterialTextureURI(aiMaterial* mat,
+                           aiTextureType tt,
+                           const std::string& uri) {
+    const aiString ai_uri(uri.c_str());
+    const int uv_index = 0;
+    const aiTextureMapMode mode = aiTextureMapMode_Wrap;
+    mat->AddProperty(&ai_uri, AI_MATKEY_TEXTURE(tt, 0));
+    mat->AddProperty(&uv_index, 1, AI_MATKEY_UVWSRC(tt, 0));
+    mat->AddProperty(&mode, 1, AI_MATKEY_MAPPINGMODE_U(tt, 0));
+    mat->AddProperty(&mode, 1, AI_MATKEY_MAPPINGMODE_V(tt, 0));
+}
+
+// Write sidecar PNG next to the mesh file, set the material URI, and return
+// the relative filename.  Returns "" on write failure.
+std::string WriteSidecarTexture(const std::filesystem::path& dir,
+                                const std::string& stem,
+                                const std::string& map_name,
+                                const geometry::Image& img,
+                                aiMaterial* mat,
+                                aiTextureType tt) {
+    const std::string relative = stem + "_" + map_name + ".png";
+    if (!WriteImage((dir / relative).string(), img)) {
+        utility::LogWarning("Could not write texture sidecar {}", relative);
+        return "";
+    }
+    SetMaterialTextureURI(mat, tt, relative);
+    return relative;
+}
+
+// Encode a tensor Image as PNG and embed it in an aiScene texture slot.
+// Returns the "*N" URI string used to reference the embedded texture.
+// Assimp takes ownership of the `aiTexture*` and its pcData buffer.
+std::string EmbedTexturePNG(aiScene* scene,
+                            int idx,
+                            const geometry::Image& img) {
+    std::vector<uint8_t> buf;
+    WriteImageToPNGInMemory(buf, img, 6);
+
+    auto* tex = scene->mTextures[idx];
+    const std::string uri = std::string("*") + std::to_string(idx);
+    tex->mFilename = uri.c_str();
+    tex->mHeight = 0;
+    tex->mWidth = static_cast<unsigned int>(buf.size());
+    // Assimp frees pcData with delete[] in ~aiTexture, so allocate with new[].
+    uint8_t* data = new uint8_t[buf.size()];
+    std::memcpy(data, buf.data(), buf.size());
+    tex->pcData = reinterpret_cast<aiTexel*>(data);
+    std::strcpy(tex->achFormatHint, "png");
+    return uri;
+}
+
+// Combine roughness (→ G channel) and metallic (→ B channel) into a single
+// RGBA image for the glTF combined roughness/metallic (UNKNOWN) texture slot.
+geometry::Image CombineRoughnessMetallic(
+        const visualization::rendering::Material& mat) {
+    auto rough = mat.GetRoughnessMap().AsTensor();
+    auto metal = mat.GetMetallicMap().AsTensor();
+    if (rough.GetShape() != metal.GetShape()) {
+        utility::LogError(
+                "RoughnessMap (shape={}) and MetallicMap (shape={}) must "
+                "have the same shape.",
+                rough.GetShape(), metal.GetShape());
+    }
+    auto combined = core::Tensor::Full(
+            {rough.GetShape(0), rough.GetShape(1), 4}, 255, core::UInt8);
+    combined.Slice(2, 1, 2) = rough.Slice(2, 0, 1);  // G = roughness
+    combined.Slice(2, 2, 3) = metal.Slice(2, 0, 1);  // B = metallic
+    return geometry::Image(combined);
+}
+
+// ---------------------------------------------------------------------------
+// UV deduplication  (per-triangle UVs → per-vertex UVs required by ASSIMP)
+// ---------------------------------------------------------------------------
+
+// Hash for (vertex_index, u, v) tuples; keys are always int64_t so the hash
+// works regardless of the mesh's index dtype.
+struct UVTupleHash {
+    size_t operator()(const std::tuple<int64_t, float, float>& t) const {
+        size_t h1 = std::hash<int64_t>{}(std::get<0>(t));
+        size_t h2 = std::hash<float>{}(std::get<1>(t));
+        size_t h3 = std::hash<float>{}(std::get<2>(t));
+        return h1 ^ (h2 << 1) ^ (h3 << 2);
+    }
+};
+using UVKey = std::tuple<int64_t, float, float>;
+
+// Split vertices that appear in multiple triangles with different UV
+// coordinates, producing a mesh where per-vertex UVs are unique.
+// Stores the result in the vertex attribute "texture_uvs".
+geometry::TriangleMesh MakeVertexUVsUnique(const geometry::TriangleMesh& mesh) {
+    if (!mesh.HasTriangleAttr("texture_uvs")) return mesh;
+
+    auto vertices = mesh.GetVertexPositions().Contiguous();
+    auto indices = mesh.GetTriangleIndices().Contiguous();
+    auto triangle_uvs =
+            mesh.GetTriangleAttr("texture_uvs").To(core::Float32).Contiguous();
+
+    const bool has_normals = mesh.HasVertexNormals();
+    const bool has_colors = mesh.HasVertexColors();
+    core::Tensor normals, colors;
+    if (has_normals) normals = mesh.GetVertexNormals().Contiguous();
+    if (has_colors) colors = mesh.GetVertexColors().Contiguous();
+
+    geometry::TriangleMesh new_mesh;
+    bool need_split = false;
+    core::Tensor new_vertices, new_faces, new_normals, new_colors, vertex_uvs;
+
+    DISPATCH_INT_DTYPE_PREFIX_TO_TEMPLATE(indices.GetDtype(), int, [&]() {
+        using idx_t = scalar_int_t;
+        int64_t next_idx = 0;
+        std::unordered_map<UVKey, int64_t, UVTupleHash> uv_to_new;
+
+        const auto* pi = indices.GetDataPtr<idx_t>();
+        const auto* pu = triangle_uvs.GetDataPtr<float>();
+        for (int64_t i = 0; i < indices.GetShape(0); ++i) {
+            for (int j = 0; j < 3; ++j) {
+                UVKey key{static_cast<int64_t>(*pi++), *pu, *(pu + 1)};
+                pu += 2;
+                if (uv_to_new.find(key) == uv_to_new.end()) {
+                    uv_to_new[key] = next_idx++;
+                }
+            }
+        }
+
+        int64_t n = next_idx;
+        vertex_uvs = core::Tensor::Empty({n, 2}, core::Float32);
+
+        if (n == vertices.GetShape(0)) {
+            // No vertex splitting needed: each vertex has a unique UV.
+            // Index vertex_uvs by the original vertex id so the existing
+            // face indices remain valid.
+            for (const auto& entry : uv_to_new) {
+                int64_t orig = std::get<0>(entry.first);
+                vertex_uvs[orig][0] = std::get<1>(entry.first);
+                vertex_uvs[orig][1] = std::get<2>(entry.first);
+            }
+            // new_vertices / new_faces stay empty → reuse originals below.
+            return;
+        }
+
+        need_split = true;
+        new_vertices = core::Tensor::Empty({n, 3}, vertices.GetDtype());
+        if (has_normals)
+            new_normals = core::Tensor::Empty({n, 3}, normals.GetDtype());
+        if (has_colors)
+            new_colors = core::Tensor::Empty({n, colors.GetShape(1)},
+                                             colors.GetDtype());
+
+        for (const auto& entry : uv_to_new) {
+            int64_t orig = std::get<0>(entry.first);
+            float u = std::get<1>(entry.first);
+            float v = std::get<2>(entry.first);
+            int64_t nv = entry.second;
+            new_vertices[nv] = vertices[orig];
+            if (has_normals) new_normals[nv] = normals[orig];
+            if (has_colors) new_colors[nv] = colors[orig];
+            vertex_uvs[nv][0] = u;
+            vertex_uvs[nv][1] = v;
+        }
+
+        new_faces = core::Tensor::Empty({indices.GetShape(0), 3},
+                                        indices.GetDtype());
+        const auto* pf_in = indices.GetDataPtr<idx_t>();
+        const auto* pu_in = triangle_uvs.GetDataPtr<float>();
+        auto* pf_out = new_faces.GetDataPtr<idx_t>();
+        for (int64_t i = 0; i < indices.GetShape(0); ++i) {
+            for (int j = 0; j < 3; ++j) {
+                float u2 = *pu_in++;
+                float v2 = *pu_in++;
+                *pf_out++ = static_cast<idx_t>(
+                        uv_to_new.at({static_cast<int64_t>(*pf_in++), u2, v2}));
+            }
+        }
+    });
+
+    // Always produce a new mesh with a vertex "texture_uvs" attribute.
+    // When no splits were needed the original tensors are reused (zero copy).
+    if (need_split) {
+        new_mesh.SetVertexPositions(new_vertices);
+        new_mesh.SetTriangleIndices(new_faces);
+        if (has_normals) new_mesh.SetVertexNormals(new_normals);
+        if (has_colors) new_mesh.SetVertexColors(new_colors);
+    } else {
+        new_mesh.SetVertexPositions(vertices);
+        new_mesh.SetTriangleIndices(indices);
+        if (has_normals) new_mesh.SetVertexNormals(normals);
+        if (has_colors) new_mesh.SetVertexColors(colors);
+    }
+    new_mesh.SetVertexAttr("texture_uvs", vertex_uvs);
+    if (mesh.HasMaterial()) new_mesh.SetMaterial(mesh.GetMaterial());
+    return new_mesh;
+}
+
+// ---------------------------------------------------------------------------
+// Texture collection (table-driven, format-aware)
+// ---------------------------------------------------------------------------
+
+// Texture export entry: map name, owned image copy, and ASSIMP type slot(s).
+// ai_types[0] is the primary slot; any additional entries are aliases that
+// point to the same image (e.g. both DIFFUSE and BASE_COLOR for albedo).
+struct TexExport {
+    std::string name;
+    geometry::Image img;
+    std::vector<aiTextureType> ai_types;
+};
+
+// Collect the textures present in `mat` into a list ready for export.
+// embed=true  → GLB/GLTF: combined roughness+metallic map via ASSIMP 6's
+//               primary metallicRoughness slot
+//               (aiTextureType_DIFFUSE_ROUGHNESS).
+// embed=false → sidecar PNGs for formats that support separate roughness /
+//               metallic maps (GLTF, FBX).  supports_roughness_metallic must
+//               be false for OBJ, which has no PBR material properties.
+std::vector<TexExport> CollectTextures(
+        const visualization::rendering::Material& mat,
+        bool embed,
+        bool supports_roughness_metallic) {
+    std::vector<TexExport> out;
+
+    if (mat.HasAlbedoMap())
+        out.push_back({"albedo",
+                       mat.GetAlbedoMap(),
+                       {aiTextureType_DIFFUSE, aiTextureType_BASE_COLOR}});
+    if (mat.HasNormalMap())
+        out.push_back({"normal", mat.GetNormalMap(), {aiTextureType_NORMALS}});
+    if (mat.HasAOMap())
+        out.push_back({"ambient_occlusion",
+                       mat.GetAOMap(),
+                       {aiTextureType_LIGHTMAP}});
+
+    if (!supports_roughness_metallic) {
+        // Format has no PBR material properties (e.g. OBJ/MTL).  Skip
+        // roughness/metallic to avoid writing sidecar PNGs that can never be
+        // referenced by the exported file.
+        return out;
+    }
+
+    // ASSIMP 6 glTF2 exporter checks aiTextureType_DIFFUSE_ROUGHNESS (primary)
+    // for metallicRoughnessTexture.  Use the combined map when embedding; use
+    // separate per-channel maps when writing sidecars (GLTF, FBX).
+    if (embed && mat.HasAORoughnessMetalMap()) {
+        out.push_back({"ao_rough_metal",
+                       mat.GetAORoughnessMetalMap(),
+                       {aiTextureType_DIFFUSE_ROUGHNESS}});
+    } else if (embed && mat.HasRoughnessMap() && mat.HasMetallicMap()) {
+        out.push_back({"ao_rough_metal",
+                       CombineRoughnessMetallic(mat),
+                       {aiTextureType_DIFFUSE_ROUGHNESS}});
+    } else if (!embed) {
+        if (mat.HasRoughnessMap())
+            out.push_back({"roughness",
+                           mat.GetRoughnessMap(),
+                           {aiTextureType_DIFFUSE_ROUGHNESS}});
+        if (mat.HasMetallicMap())
+            out.push_back({"metallic",
+                           mat.GetMetallicMap(),
+                           {aiTextureType_METALNESS}});
+    }
+
+    return out;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Reader
+// ---------------------------------------------------------------------------
+
 bool ReadTriangleMeshUsingASSIMP(
         const std::string& filename,
         geometry::TriangleMesh& mesh,
@@ -45,7 +470,6 @@ bool ReadTriangleMeshUsingASSIMP(
     Assimp::Importer importer;
 
     unsigned int post_process_flags = kPostProcessFlags_compulsory;
-
     if (params.enable_post_processing) {
         post_process_flags = kPostProcessFlags_fast;
     }
@@ -68,300 +492,176 @@ bool ReadTriangleMeshUsingASSIMP(
     size_t count_mesh_with_colors = 0;
     size_t count_mesh_with_uvs = 0;
 
-    // Merge individual meshes in aiScene into a single TriangleMesh
+    // Merge all aiMeshes in the scene into a single tensor TriangleMesh.
+    // Only the first material is loaded; all sub-meshes share it.
     for (size_t midx = 0; midx < scene->mNumMeshes; ++midx) {
         const auto* assimp_mesh = scene->mMeshes[midx];
 
         core::Tensor vertices = core::Tensor::Empty(
                 {assimp_mesh->mNumVertices, 3}, core::Dtype::Float32);
-        auto vertices_ptr = vertices.GetDataPtr<float>();
-        std::memcpy(vertices_ptr, assimp_mesh->mVertices,
+        std::memcpy(vertices.GetDataPtr(), assimp_mesh->mVertices,
                     3 * assimp_mesh->mNumVertices * sizeof(float));
         mesh_vertices.push_back(vertices);
 
-        core::Tensor vertex_normals;
-        core::Tensor vertex_colors;
-        core::Tensor triangle_uvs;
         if (assimp_mesh->mNormals) {
-            // Loop fusion for performance optimization.
-            vertex_normals = core::Tensor::Empty({assimp_mesh->mNumVertices, 3},
-                                                 core::Dtype::Float32);
-            auto vertex_normals_ptr = vertex_normals.GetDataPtr<float>();
-            std::memcpy(vertex_normals_ptr, assimp_mesh->mNormals,
+            core::Tensor normals = core::Tensor::Empty(
+                    {assimp_mesh->mNumVertices, 3}, core::Dtype::Float32);
+            std::memcpy(normals.GetDataPtr(), assimp_mesh->mNormals,
                         3 * assimp_mesh->mNumVertices * sizeof(float));
-            mesh_vertex_normals.push_back(vertex_normals);
+            mesh_vertex_normals.push_back(normals);
             count_mesh_with_normals++;
         }
 
         if (assimp_mesh->HasVertexColors(0)) {
-            vertex_colors = core::Tensor::Empty({assimp_mesh->mNumVertices, 3},
-                                                core::Dtype::Float32);
-            auto vertex_colors_ptr = vertex_colors.GetDataPtr<float>();
+            core::Tensor colors = core::Tensor::Empty(
+                    {assimp_mesh->mNumVertices, 3}, core::Dtype::Float32);
+            auto* p = colors.GetDataPtr<float>();
             for (unsigned int i = 0; i < assimp_mesh->mNumVertices; ++i) {
-                *vertex_colors_ptr++ = assimp_mesh->mColors[0][i].r;
-                *vertex_colors_ptr++ = assimp_mesh->mColors[0][i].g;
-                *vertex_colors_ptr++ = assimp_mesh->mColors[0][i].b;
+                *p++ = assimp_mesh->mColors[0][i].r;
+                *p++ = assimp_mesh->mColors[0][i].g;
+                *p++ = assimp_mesh->mColors[0][i].b;
             }
-            mesh_vertex_colors.push_back(vertex_colors);
+            mesh_vertex_colors.push_back(colors);
             count_mesh_with_colors++;
         }
 
         core::Tensor faces = core::Tensor::Empty({assimp_mesh->mNumFaces, 3},
                                                  core::Dtype::Int64);
-        auto faces_ptr = faces.GetDataPtr<int64_t>();
+        auto* fp = faces.GetDataPtr<int64_t>();
         core::ParallelFor(
                 core::Device("CPU:0"), assimp_mesh->mNumFaces,
                 [&](size_t fidx) {
                     const auto& face = assimp_mesh->mFaces[fidx];
-                    faces_ptr[3 * fidx] = face.mIndices[0] + current_vidx;
-                    faces_ptr[3 * fidx + 1] = face.mIndices[1] + current_vidx;
-                    faces_ptr[3 * fidx + 2] = face.mIndices[2] + current_vidx;
+                    fp[3 * fidx + 0] = face.mIndices[0] + current_vidx;
+                    fp[3 * fidx + 1] = face.mIndices[1] + current_vidx;
+                    fp[3 * fidx + 2] = face.mIndices[2] + current_vidx;
                 });
-
         mesh_faces.push_back(faces);
 
         if (assimp_mesh->HasTextureCoords(0)) {
-            auto vertex_uvs = core::Tensor::Empty(
+            core::Tensor vertex_uvs = core::Tensor::Empty(
                     {assimp_mesh->mNumVertices, 2}, core::Dtype::Float32);
-            auto uvs_ptr = vertex_uvs.GetDataPtr<float>();
-            // NOTE: Can't just memcpy because ASSIMP UVs are 3 element and
-            // TriangleMesh wants 2 element UVs.
-            for (int i = 0; i < (int)assimp_mesh->mNumVertices; ++i) {
-                *uvs_ptr++ = assimp_mesh->mTextureCoords[0][i].x;
-                *uvs_ptr++ = assimp_mesh->mTextureCoords[0][i].y;
+            auto* up = vertex_uvs.GetDataPtr<float>();
+            // Can't memcpy: ASSIMP UV coords are 3-element (w component
+            // unused).
+            for (unsigned int i = 0; i < assimp_mesh->mNumVertices; ++i) {
+                *up++ = assimp_mesh->mTextureCoords[0][i].x;
+                *up++ = assimp_mesh->mTextureCoords[0][i].y;
             }
-            triangle_uvs = vertex_uvs.IndexGet({faces});
-            mesh_uvs.push_back(triangle_uvs);
+            // Index vertex UVs by the face array to get per-triangle UVs.
+            mesh_uvs.push_back(vertex_uvs.IndexGet({faces}));
             count_mesh_with_uvs++;
         }
-        // Adjust face indices to index into combined mesh vertex array
-        current_vidx += static_cast<int>(assimp_mesh->mNumVertices);
+
+        current_vidx += assimp_mesh->mNumVertices;
     }
 
     mesh.Clear();
-    if (scene->mNumMeshes > 1) {
-        mesh.SetVertexPositions(core::Concatenate(mesh_vertices));
-        mesh.SetTriangleIndices(core::Concatenate(mesh_faces));
-        // NOTE: For objects with multiple meshes we only store normals, colors,
-        // and uvs if every mesh in the object had them. Mesh class does not
-        // support some vertices having normals/colors/uvs and some not having
-        // them.
-        if (count_mesh_with_normals == scene->mNumMeshes) {
-            mesh.SetVertexNormals(core::Concatenate(mesh_vertex_normals));
+    const bool multi = scene->mNumMeshes > 1;
+    mesh.SetVertexPositions(multi ? core::Concatenate(mesh_vertices)
+                                  : mesh_vertices[0]);
+    mesh.SetTriangleIndices(multi ? core::Concatenate(mesh_faces)
+                                  : mesh_faces[0]);
+
+    // Only store an attribute when every sub-mesh provides it; warn otherwise
+    // so the caller knows data was silently dropped.
+    auto warn_partial = [&](const char* name, size_t have) {
+        if (have > 0 && have < scene->mNumMeshes) {
+            utility::LogWarning(
+                    "{}: {} skipped — only {}/{} sub-meshes have this "
+                    "attribute.",
+                    filename, name, have, scene->mNumMeshes);
         }
-        if (count_mesh_with_colors == scene->mNumMeshes) {
-            mesh.SetVertexColors(core::Concatenate(mesh_vertex_colors));
+    };
+    warn_partial("vertex normals", count_mesh_with_normals);
+    warn_partial("vertex colors", count_mesh_with_colors);
+    warn_partial("texture UVs", count_mesh_with_uvs);
+
+    if (count_mesh_with_normals == scene->mNumMeshes) {
+        mesh.SetVertexNormals(multi ? core::Concatenate(mesh_vertex_normals)
+                                    : mesh_vertex_normals[0]);
+    }
+    if (count_mesh_with_colors == scene->mNumMeshes) {
+        mesh.SetVertexColors(multi ? core::Concatenate(mesh_vertex_colors)
+                                   : mesh_vertex_colors[0]);
+    }
+    if (count_mesh_with_uvs == scene->mNumMeshes) {
+        mesh.SetTriangleAttr("texture_uvs",
+                             multi ? core::Concatenate(mesh_uvs) : mesh_uvs[0]);
+    }
+
+    // Load one material into the tensor mesh.  Only one is supported.
+    // Use the material referenced by the first sub-mesh rather than blindly
+    // taking index 0: some formats (OBJ) prepend a "DefaultMaterial" at
+    // index 0, pushing our PBR material to a higher index.
+    const unsigned int mat_idx =
+            (scene->mNumMeshes > 0) ? scene->mMeshes[0]->mMaterialIndex : 0u;
+    if (mat_idx < scene->mNumMaterials) {
+        const auto* mat = scene->mMaterials[mat_idx];
+        auto& o3d_mat = mesh.GetMaterial();
+        o3d_mat.SetDefaultProperties();
+        const std::string mat_name = mat->GetName().C_Str();
+        if (!mat_name.empty()) {
+            o3d_mat.SetMaterialName(mat_name);
         }
-        if (count_mesh_with_uvs == scene->mNumMeshes) {
-            mesh.SetTriangleAttr("texture_uvs", core::Concatenate(mesh_uvs));
+
+        // Scalar / color properties
+        aiColor4D base_color4(1.f, 1.f, 1.f, 1.f);
+        if (mat->Get(AI_MATKEY_BASE_COLOR, base_color4) != AI_SUCCESS) {
+            aiColor3D c(1.f, 1.f, 1.f);
+            mat->Get(AI_MATKEY_COLOR_DIFFUSE, c);
+            base_color4 = aiColor4D(c.r, c.g, c.b, 1.f);
         }
-    } else {
-        mesh.SetVertexPositions(mesh_vertices[0]);
-        mesh.SetTriangleIndices(mesh_faces[0]);
-        if (count_mesh_with_normals > 0) {
-            mesh.SetVertexNormals(mesh_vertex_normals[0]);
+        o3d_mat.SetBaseColor(Eigen::Vector4f(base_color4.r, base_color4.g,
+                                             base_color4.b, base_color4.a));
+
+        float metallic = 0.f, roughness = 1.f, reflectance = 0.5f;
+        float clearcoat = 0.f, clearcoat_roughness = 0.f, anisotropy = 0.f;
+        mat->Get(AI_MATKEY_METALLIC_FACTOR, metallic);
+        mat->Get(AI_MATKEY_ROUGHNESS_FACTOR, roughness);
+        mat->Get(AI_MATKEY_REFLECTIVITY, reflectance);
+        mat->Get(AI_MATKEY_CLEARCOAT_FACTOR, clearcoat);
+        mat->Get(AI_MATKEY_CLEARCOAT_ROUGHNESS_FACTOR, clearcoat_roughness);
+        mat->Get(AI_MATKEY_ANISOTROPY_FACTOR, anisotropy);
+        o3d_mat.SetBaseMetallic(metallic);
+        o3d_mat.SetBaseRoughness(roughness);
+        o3d_mat.SetBaseReflectance(reflectance);
+        o3d_mat.SetBaseClearcoat(clearcoat);
+        o3d_mat.SetBaseClearcoatRoughness(clearcoat_roughness);
+        o3d_mat.SetAnisotropy(anisotropy);
+
+        // Opacity (OBJ 'd' / FBX Opacity) maps to alpha in base color.
+        float opacity = 1.f;
+        mat->Get(AI_MATKEY_OPACITY, opacity);
+        if (opacity < 1.f) {
+            auto c = o3d_mat.GetBaseColor();
+            o3d_mat.SetBaseColor(Eigen::Vector4f(c.x(), c.y(), c.z(), opacity));
         }
-        if (count_mesh_with_colors > 0) {
-            mesh.SetVertexColors(mesh_vertex_colors[0]);
+
+        LoadMaterialTextures(filename, scene, mat, o3d_mat);
+
+        // Warn only when sub-meshes reference more than one distinct material,
+        // meaning some face data is genuinely dropped.  A higher mNumMaterials
+        // count alone is not sufficient: formats like OBJ always include an
+        // unreferenced "DefaultMaterial" that is never assigned to any face.
+        std::unordered_set<unsigned int> used_mat_ids;
+        for (unsigned int i = 0; i < scene->mNumMeshes; ++i) {
+            used_mat_ids.insert(scene->mMeshes[i]->mMaterialIndex);
         }
-        if (count_mesh_with_uvs > 0) {
-            mesh.SetTriangleAttr("texture_uvs", mesh_uvs[0]);
+        if (used_mat_ids.size() > 1) {
+            utility::LogWarning(
+                    "{}: mesh faces reference {} materials; only one material "
+                    "is supported — loading material {}.",
+                    filename, used_mat_ids.size(), mat_idx);
         }
     }
 
     return true;
 }
 
-static void SetTextureMaterialProperty(aiMaterial* mat,
-                                       aiScene* scene,
-                                       int texture_idx,
-                                       aiTextureType tt,
-                                       t::geometry::Image& img) {
-    // Encode image as PNG
-    std::vector<uint8_t> img_buffer;
-    WriteImageToPNGInMemory(img_buffer, img, 6);
-
-    // Fill in Assimp's texture class and add to its material
-    auto tex = scene->mTextures[texture_idx];
-    std::string tex_id("*");
-    tex_id += std::to_string(texture_idx);
-    tex->mFilename = tex_id.c_str();
-    tex->mHeight = 0;
-    tex->mWidth = img_buffer.size();
-    // NOTE: Assimp takes ownership of the data so we need to copy it
-    // into a separate buffer that Assimp can take care of delete []-ing
-    uint8_t* img_data = new uint8_t[img_buffer.size()];
-    memcpy(img_data, img_buffer.data(), img_buffer.size());
-    tex->pcData = reinterpret_cast<aiTexel*>(img_data);
-    strcpy(tex->achFormatHint, "png");
-    aiString uri(tex_id);
-    const int uv_index = 0;
-    const aiTextureMapMode mode = aiTextureMapMode_Wrap;
-    mat->AddProperty(&uri, AI_MATKEY_TEXTURE(tt, 0));
-    mat->AddProperty(&uv_index, 1, AI_MATKEY_UVWSRC(tt, 0));
-    mat->AddProperty(&mode, 1, AI_MATKEY_MAPPINGMODE_U(tt, 0));
-    mat->AddProperty(&mode, 1, AI_MATKEY_MAPPINGMODE_V(tt, 0));
-}
-
-namespace {
-// Add hash function for tuple key
-struct TupleHash {
-    size_t operator()(const std::tuple<int64_t, float, float>& t) const {
-        auto h1 = std::hash<int64_t>{}(std::get<0>(t));
-        auto h2 = std::hash<float>{}(std::get<1>(t));
-        auto h3 = std::hash<float>{}(std::get<2>(t));
-        return h1 ^ (h2 << 1) ^ (h3 << 2);
-    }
-};
-
-/// @brief Given a triangle mesh with per triangle UV coordinates, convert to
-/// per vertex UVs. This is useful for meshes that have non-unique UVs per
-/// vertex, which can happen when the same vertex is used in multiple triangles
-/// with different UVs. The function will create a new mesh with unique vertex
-/// UVs and update the triangle UVs accordingly.
-/// @param mesh Input triangle mesh with per triangle UVs.
-/// @param update_triangle_uvs Should the triangle UVs be updated to match the
-/// new vertex UVs. Else triangle_uvs will be dropped
-/// @return Updated triangle mesh with unique vertex UVs.
-geometry::TriangleMesh MakeVertexUVsUnique(const geometry::TriangleMesh& mesh,
-                                           bool update_triangle_uvs) {
-    if (!mesh.HasTriangleAttr("texture_uvs")) {
-        return mesh;
-    }
-    auto vertices = mesh.GetVertexPositions().Contiguous();
-    auto indices = mesh.GetTriangleIndices().Contiguous();
-    auto triangle_uvs =
-            mesh.GetTriangleAttr("texture_uvs").To(core::Float32).Contiguous();
-
-    bool has_normals = mesh.HasVertexNormals();
-    bool has_colors = mesh.HasVertexColors();
-    core::Tensor normals, colors;
-    if (has_normals) {
-        normals = mesh.GetVertexNormals().Contiguous();
-    }
-    if (has_colors) {
-        colors = mesh.GetVertexColors().Contiguous();
-    }
-    geometry::TriangleMesh new_mesh;
-    core::Tensor new_vertices, new_faces, new_normals, new_colors, vertex_uvs;
-    bool need_updates = true;
-
-    DISPATCH_INT_DTYPE_PREFIX_TO_TEMPLATE(indices.GetDtype(), int, [&]() {
-        scalar_int_t next_vertex_idx = 0;
-        // Map to track unique (vertex_idx, uv) combinations
-        std::unordered_map<std::tuple<scalar_int_t, float, float>, scalar_int_t,
-                           TupleHash>
-                vertex_uv_to_new_idx;
-        // First pass: collect all unique vertex-UV combinations
-        auto p_indices = indices.GetDataPtr<scalar_int_t>();
-        auto p_uvs = triangle_uvs.GetDataPtr<float>();
-        for (int64_t i = 0; i < indices.GetShape(0); i++) {
-            for (int j = 0; j < 3; j++) {
-                auto orig_vertex_idx = *p_indices++;
-                float u = *p_uvs++;
-                float v = *p_uvs++;
-                auto key = std::make_tuple(orig_vertex_idx, u, v);
-                if (vertex_uv_to_new_idx.find(key) ==
-                    vertex_uv_to_new_idx.end()) {
-                    vertex_uv_to_new_idx[key] = next_vertex_idx++;
-                }
-            }
-        }
-        // Create new tensors with the correct size
-        int64_t num_new_vertices = next_vertex_idx;
-        if (num_new_vertices == vertices.GetShape(0)) {
-            need_updates = false;
-            return;  // No duplicate UVs found return the original mesh.
-        }
-        new_vertices =
-                core::Tensor::Empty({num_new_vertices, 3}, vertices.GetDtype());
-
-        if (has_normals) {
-            new_normals = core::Tensor::Empty({num_new_vertices, 3},
-                                              normals.GetDtype());
-        }
-        if (has_colors) {
-            int color_dims = colors.GetShape(1);
-            new_colors = core::Tensor::Empty({num_new_vertices, color_dims},
-                                             colors.GetDtype());
-        }
-        vertex_uvs = core::Tensor::Empty({num_new_vertices, 2}, core::Float32);
-
-        // Fill the new vertex data
-        for (const auto& entry : vertex_uv_to_new_idx) {
-            auto [orig_vertex_idx, u, v] = entry.first;
-            auto new_vertex_idx = entry.second;
-            // Copy vertex position
-            new_vertices[new_vertex_idx] = vertices[orig_vertex_idx];
-            if (has_normals) {  // Copy vertex normal if available
-                new_normals[new_vertex_idx] = normals[orig_vertex_idx];
-            }
-            if (has_colors) {  // Copy vertex color if available
-                new_colors[new_vertex_idx] = colors[orig_vertex_idx];
-            }
-            // Store UV coordinates
-            vertex_uvs[new_vertex_idx][0] = u;
-            vertex_uvs[new_vertex_idx][1] = v;
-        }
-
-        // Second pass: build face indices with new vertex indices
-        new_faces = core::Tensor::Empty({indices.GetShape(0), 3},
-                                        indices.GetDtype());
-        auto faces_ptr = indices.GetDataPtr<scalar_int_t>();
-        auto new_faces_ptr = new_faces.GetDataPtr<scalar_int_t>();  // {F, 3}
-        auto triangle_uvs_ptr = triangle_uvs.GetDataPtr<float>();   // {F, 3, 2}
-        for (int64_t i = 0; i < indices.GetShape(0); i++) {
-            for (int j = 0; j < 3; j++) {
-                auto idx = *faces_ptr++;
-                auto u = *triangle_uvs_ptr++;
-                auto v = *triangle_uvs_ptr++;
-                *new_faces_ptr++ = vertex_uv_to_new_idx[{idx, u, v}];
-            }
-        }
-    });
-    if (!need_updates) {
-        return mesh;
-    }
-
-    new_mesh.SetVertexPositions(new_vertices);
-    new_mesh.SetTriangleIndices(new_faces);
-    if (has_normals) {
-        new_mesh.SetVertexNormals(new_normals);
-    }
-    if (has_colors) {
-        new_mesh.SetVertexColors(new_colors);
-    }
-    new_mesh.SetVertexAttr("texture_uvs", vertex_uvs);
-
-    // Convert vertex UVs back to triangle UVs for the new mesh. Not used by
-    // ASSIMP.
-    if (update_triangle_uvs) {
-        auto new_triangle_uvs =
-                core::Tensor::Empty({indices.GetShape(0), 3, 2}, core::Float32);
-        DISPATCH_INT_DTYPE_PREFIX_TO_TEMPLATE(indices.GetDtype(), int, [&]() {
-            scalar_int_t vertex_idx;
-            auto new_faces_ptr = new_faces.GetDataPtr<scalar_int_t>();
-            auto new_triangle_uvs_ptr = new_triangle_uvs.GetDataPtr<float>();
-            auto vertex_uvs_ptr = vertex_uvs.GetDataPtr<float>();
-            for (int64_t i = 0; i < indices.GetShape(0); i++) {
-                for (int j = 0; j < 3; j++) {
-                    vertex_idx = *new_faces_ptr++;
-                    *new_triangle_uvs_ptr++ = vertex_uvs_ptr[2 * vertex_idx];
-                    *new_triangle_uvs_ptr++ =
-                            vertex_uvs_ptr[2 * vertex_idx + 1];
-                }
-            }
-        });
-        new_mesh.SetTriangleAttr("texture_uvs", new_triangle_uvs);
-    }
-    // Copy material if present
-    if (mesh.HasMaterial()) {
-        new_mesh.SetMaterial(mesh.GetMaterial());
-    }
-
-    return new_mesh;
-}
-}  // namespace
+// ---------------------------------------------------------------------------
+// Writer
+// ---------------------------------------------------------------------------
 
 bool WriteTriangleMeshUsingASSIMP(const std::string& filename,
                                   const geometry::TriangleMesh& mesh,
@@ -371,290 +671,211 @@ bool WriteTriangleMeshUsingASSIMP(const std::string& filename,
                                   const bool write_vertex_colors,
                                   const bool write_triangle_uvs,
                                   const bool print_progress) {
-    // Sanity checks...
-    if (write_ascii) {
-        utility::LogWarning(
-                "TriangleMesh can't be saved in ASCII format as .glb");
-        return false;
-    }
-    if (compressed) {
-        utility::LogWarning(
-                "TriangleMesh can't be saved in compressed format as .glb");
-        return false;
-    }
     if (!mesh.HasVertexPositions()) {
         utility::LogWarning(
-                "TriangleMesh has no vertex positions and can't be saved as "
-                ".glb");
+                "TriangleMesh has no vertex positions and can't be saved.");
         return false;
     }
-    // Check for unsupported features
-    if (mesh.HasTriangleNormals()) {
-        utility::LogWarning(
-                "Exporting triangle normals is not supported. Please convert "
-                "to vertex normals or export to a format that supports it.");
+
+    // Derive extension and export format.
+    const std::filesystem::path filepath(filename);
+    std::string ext = filepath.extension().string();
+    if (!ext.empty()) ext = ext.substr(1);  // strip leading '.'
+    std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+    const ExportFormat fmt = ResolveExportFormat(ext, write_ascii);
+
+    if (!fmt.supports_materials) {
+        if (write_triangle_uvs && mesh.HasTriangleAttr("texture_uvs"))
+            utility::LogWarning("{} does not support UV coordinates.", ext);
+        if (write_vertex_colors && mesh.HasVertexColors())
+            utility::LogWarning("{} does not support vertex colors.", ext);
+        if (mesh.HasMaterial())
+            utility::LogWarning("{} does not support materials.", ext);
     }
-    if (mesh.HasTriangleColors()) {
+    if (write_ascii && (ext == "glb" || ext == "gltf")) {
         utility::LogWarning(
-                "Exporting triangle colors is not supported. Please convert to "
-                "vertex colors or export to a format that supports it.");
+                "TriangleMesh cannot be saved in ASCII format as .{}.", ext);
+        return false;
     }
 
-    geometry::TriangleMesh w_mesh = mesh;  // writeable mesh copy
-    if (write_triangle_uvs && mesh.HasTriangleAttr("texture_uvs")) {
-        if (!write_vertex_normals && w_mesh.HasVertexNormals()) {
-            w_mesh.RemoveVertexAttr("normals");
-        }
-        if (!write_vertex_colors && w_mesh.HasVertexColors()) {
-            w_mesh.RemoveVertexAttr("colors");
-        }
-        w_mesh = MakeVertexUVsUnique(w_mesh, /*update_triangle_uvs=*/false);
-    }
+    // Convert per-triangle UVs to per-vertex UVs (ASSIMP requirement).
+    geometry::TriangleMesh w_mesh =
+            (fmt.supports_materials && write_triangle_uvs &&
+             mesh.HasTriangleAttr("texture_uvs"))
+                    ? MakeVertexUVsUnique(mesh)
+                    : mesh;
+
     Assimp::Exporter exporter;
     auto ai_scene = std::unique_ptr<aiScene>(new aiScene);
 
-    // Fill mesh data...
+    // ----- Geometry -----
     ai_scene->mNumMeshes = 1;
     ai_scene->mMeshes = new aiMesh*[1];
-    auto ai_mesh = new aiMesh;
+    auto* ai_mesh = new aiMesh;
     ai_mesh->mName.Set("Object1");
     ai_mesh->mPrimitiveTypes = aiPrimitiveType_TRIANGLE;
-    // Guaranteed to have both vertex positions and triangle indices
+
     auto vertices = w_mesh.GetVertexPositions().Contiguous();
+    // ASSIMP face indices must be unsigned int; get a contiguous buffer.
     auto indices =
             w_mesh.GetTriangleIndices().To(core::Dtype::UInt32).Contiguous();
-    ai_mesh->mNumVertices = vertices.GetShape(0);
+    ai_mesh->mNumVertices = static_cast<unsigned int>(vertices.GetShape(0));
+    ai_mesh->mNumFaces = static_cast<unsigned int>(indices.GetShape(0));
+
     ai_mesh->mVertices = new aiVector3D[ai_mesh->mNumVertices];
-    memcpy(&ai_mesh->mVertices->x, vertices.GetDataPtr(),
-           sizeof(float) * ai_mesh->mNumVertices * 3);
-    ai_mesh->mNumFaces = indices.GetShape(0);
+    std::memcpy(&ai_mesh->mVertices->x, vertices.GetDataPtr(),
+                sizeof(float) * ai_mesh->mNumVertices * 3);
+
+    // Build aiFace array. ASSIMP's aiFace destructor calls delete[] on
+    // mIndices, so each face must own its allocation via new unsigned int[].
     ai_mesh->mFaces = new aiFace[ai_mesh->mNumFaces];
+    const auto* ind_ptr = indices.GetDataPtr<unsigned int>();
     for (unsigned int i = 0; i < ai_mesh->mNumFaces; ++i) {
         ai_mesh->mFaces[i].mNumIndices = 3;
-        // NOTE: Yes, dynamically allocating 3 ints for each face is inefficient
-        // but this is what Assimp seems to require as it deletes each mIndices
-        // on destruction. We could block allocate space for all the faces,
-        // assign pointers here then zero out the pointers before destruction so
-        // the delete becomes a no-op, but that seems error prone. Could revisit
-        // if this becomes an IO bottleneck.
-        ai_mesh->mFaces[i].mIndices = new unsigned int[3];  // triangles
-        ai_mesh->mFaces[i].mIndices[0] = indices[i][0].Item<unsigned int>();
-        ai_mesh->mFaces[i].mIndices[1] = indices[i][1].Item<unsigned int>();
-        ai_mesh->mFaces[i].mIndices[2] = indices[i][2].Item<unsigned int>();
+        ai_mesh->mFaces[i].mIndices = new unsigned int[3];
+        ai_mesh->mFaces[i].mIndices[0] = ind_ptr[i * 3 + 0];
+        ai_mesh->mFaces[i].mIndices[1] = ind_ptr[i * 3 + 1];
+        ai_mesh->mFaces[i].mIndices[2] = ind_ptr[i * 3 + 2];
     }
 
     if (write_vertex_normals && w_mesh.HasVertexNormals()) {
         auto normals = w_mesh.GetVertexNormals().Contiguous();
-        auto m_normals = normals.GetShape(0);
-        ai_mesh->mNormals = new aiVector3D[m_normals];
-        memcpy(&ai_mesh->mNormals->x, normals.GetDataPtr(),
-               sizeof(float) * m_normals * 3);
+        ai_mesh->mNormals = new aiVector3D[ai_mesh->mNumVertices];
+        std::memcpy(&ai_mesh->mNormals->x, normals.GetDataPtr(),
+                    sizeof(float) * ai_mesh->mNumVertices * 3);
     }
 
-    if (write_vertex_colors && w_mesh.HasVertexColors()) {
+    if (fmt.supports_materials && write_vertex_colors &&
+        w_mesh.HasVertexColors()) {
         auto colors = w_mesh.GetVertexColors().Contiguous();
-        auto m_colors = colors.GetShape(0);
-        ai_mesh->mColors[0] = new aiColor4D[m_colors];
+        ai_mesh->mColors[0] = new aiColor4D[ai_mesh->mNumVertices];
         if (colors.GetShape(1) == 4) {
-            memcpy(&ai_mesh->mColors[0][0].r, colors.GetDataPtr(),
-                   sizeof(float) * m_colors * 4);
-        } else {  // must be 3 components
-            auto color_ptr = reinterpret_cast<float*>(colors.GetDataPtr());
-            for (unsigned int i = 0; i < m_colors; ++i) {
-                ai_mesh->mColors[0][i].r = *color_ptr++;
-                ai_mesh->mColors[0][i].g = *color_ptr++;
-                ai_mesh->mColors[0][i].b = *color_ptr++;
-                ai_mesh->mColors[0][i].a = 1.0f;
+            std::memcpy(&ai_mesh->mColors[0][0].r, colors.GetDataPtr(),
+                        sizeof(float) * ai_mesh->mNumVertices * 4);
+        } else {
+            auto* cp = colors.GetDataPtr<float>();
+            for (unsigned int i = 0; i < ai_mesh->mNumVertices; ++i) {
+                ai_mesh->mColors[0][i] = {*cp++, *cp++, *cp++, 1.f};
             }
         }
     }
 
-    if (write_triangle_uvs &&
-        w_mesh.HasVertexAttr(
-                "texture_uvs")) {  // Save vertex UVs converted earlier
-        auto vertex_uvs = w_mesh.GetVertexAttr("texture_uvs").Contiguous();
-        auto uv_ptr = vertex_uvs.GetDataPtr<float>();
-        auto n_uvs = vertex_uvs.GetShape(0);
+    if (fmt.supports_materials && write_triangle_uvs &&
+        w_mesh.HasVertexAttr("texture_uvs")) {
+        auto vuv = w_mesh.GetVertexAttr("texture_uvs").Contiguous();
         ai_mesh->mNumUVComponents[0] = 2;
-        ai_mesh->mTextureCoords[0] = new aiVector3D[n_uvs];
-        for (unsigned int i = 0; i < n_uvs; ++i) {
-            ai_mesh->mTextureCoords[0][i].x = *uv_ptr++;
-            ai_mesh->mTextureCoords[0][i].y = *uv_ptr++;
+        ai_mesh->mTextureCoords[0] = new aiVector3D[ai_mesh->mNumVertices];
+        auto* up = vuv.GetDataPtr<float>();
+        for (unsigned int i = 0; i < ai_mesh->mNumVertices; ++i) {
+            ai_mesh->mTextureCoords[0][i] = {*up++, *up++, 0.f};
         }
-    } else if (write_triangle_uvs && w_mesh.HasTriangleAttr("texture_uvs")) {
-        auto triangle_uvs = w_mesh.GetTriangleAttr("texture_uvs").Contiguous();
-        auto vertex_uvs = core::Tensor::Empty({ai_mesh->mNumVertices, 2},
-                                              core::Dtype::Float32);
-        auto n_uvs = ai_mesh->mNumVertices;
-        for (int64_t i = 0; i < indices.GetShape(0); i++) {
-            vertex_uvs[indices[i][0].Item<uint32_t>()] = triangle_uvs[i][0];
-            vertex_uvs[indices[i][1].Item<uint32_t>()] = triangle_uvs[i][1];
-            vertex_uvs[indices[i][2].Item<uint32_t>()] = triangle_uvs[i][2];
-        }
-        ai_mesh->mTextureCoords[0] = new aiVector3D[n_uvs];
-        auto uv_ptr = reinterpret_cast<float*>(vertex_uvs.GetDataPtr());
-        for (unsigned int i = 0; i < n_uvs; ++i) {
-            ai_mesh->mTextureCoords[0][i].x = *uv_ptr++;
-            ai_mesh->mTextureCoords[0][i].y = *uv_ptr++;
-        }
-        ai_mesh->mNumUVComponents[0] = 2;
     }
     ai_scene->mMeshes[0] = ai_mesh;
 
-    // Fill material data...
+    // ----- Material and textures -----
     ai_scene->mNumMaterials = 1;
-    ai_scene->mMaterials = new aiMaterial*[ai_scene->mNumMaterials];
-    auto ai_mat = new aiMaterial;
-    if (w_mesh.HasMaterial()) {
-        ai_mat->GetName().Set("mat1");
-        auto shading_mode = aiShadingMode_PBR_BRDF;
-        ai_mat->AddProperty(&shading_mode, 1, AI_MATKEY_SHADING_MODEL);
+    ai_scene->mMaterials = new aiMaterial*[1];
+    auto* ai_mat = new aiMaterial;
 
-        // Set base material properties
-        // NOTE: not all properties supported by Open3D are supported by Assimp.
-        // Those properties (reflectivity, anisotropy) are not exported
-        if (w_mesh.GetMaterial().HasBaseColor()) {
-            auto c = w_mesh.GetMaterial().GetBaseColor();
+    if (fmt.supports_materials && w_mesh.HasMaterial()) {
+        auto shading = aiShadingMode_PBR_BRDF;
+        ai_mat->AddProperty(&shading, 1, AI_MATKEY_SHADING_MODEL);
+
+        const auto& mat = w_mesh.GetMaterial();
+        if (mat.HasBaseColor()) {
+            auto c = mat.GetBaseColor();
             auto ac = aiColor4D(c.x(), c.y(), c.z(), c.w());
             ai_mat->AddProperty(&ac, 1, AI_MATKEY_COLOR_DIFFUSE);
             ai_mat->AddProperty(&ac, 1, AI_MATKEY_BASE_COLOR);
-            // Set glTF alpha mode so importers treat the mesh as transparent
             if (c.w() < 1.f) {
-                aiString alpha_mode("BLEND");
-                ai_mat->AddProperty(&alpha_mode, AI_MATKEY_GLTF_ALPHAMODE);
+                aiString am("BLEND");
+                ai_mat->AddProperty(&am, AI_MATKEY_GLTF_ALPHAMODE);
             }
         }
-        if (w_mesh.GetMaterial().HasBaseRoughness()) {
-            auto r = w_mesh.GetMaterial().GetBaseRoughness();
+        // AI_MATKEY_* macros expand to (name, type, idx), so each property
+        // must be set via a direct AddProperty call.
+        if (mat.HasBaseRoughness()) {
+            auto r = mat.GetBaseRoughness();
             ai_mat->AddProperty(&r, 1, AI_MATKEY_ROUGHNESS_FACTOR);
         }
-        if (w_mesh.GetMaterial().HasBaseMetallic()) {
-            auto m = w_mesh.GetMaterial().GetBaseMetallic();
+        if (mat.HasBaseMetallic()) {
+            auto m = mat.GetBaseMetallic();
             ai_mat->AddProperty(&m, 1, AI_MATKEY_METALLIC_FACTOR);
         }
-        if (w_mesh.GetMaterial().HasBaseClearcoat()) {
-            auto c = w_mesh.GetMaterial().GetBaseClearcoat();
+        if (mat.HasBaseClearcoat()) {
+            auto c = mat.GetBaseClearcoat();
             ai_mat->AddProperty(&c, 1, AI_MATKEY_CLEARCOAT_FACTOR);
         }
-        if (w_mesh.GetMaterial().HasBaseClearcoatRoughness()) {
-            auto r = w_mesh.GetMaterial().GetBaseClearcoatRoughness();
-            ai_mat->AddProperty(&r, 1, AI_MATKEY_CLEARCOAT_ROUGHNESS_FACTOR);
+        if (mat.HasBaseClearcoatRoughness()) {
+            auto cr = mat.GetBaseClearcoatRoughness();
+            ai_mat->AddProperty(&cr, 1, AI_MATKEY_CLEARCOAT_ROUGHNESS_FACTOR);
         }
-        if (w_mesh.GetMaterial().HasEmissiveColor()) {
-            auto c = w_mesh.GetMaterial().GetEmissiveColor();
-            auto ac = aiColor4D(c.x(), c.y(), c.z(), c.w());
-            ai_mat->AddProperty(&ac, 1, AI_MATKEY_COLOR_EMISSIVE);
+        if (mat.HasEmissiveColor()) {
+            auto e = mat.GetEmissiveColor();
+            auto ae = aiColor4D(e.x(), e.y(), e.z(), e.w());
+            ai_mat->AddProperty(&ae, 1, AI_MATKEY_COLOR_EMISSIVE);
         }
 
-        // Count texture maps...
-        // NOTE: GLTF2 expects a single combined roughness/metal map. If the
-        // model has one we just export it, otherwise if both roughness and
-        // metal maps are available we combine them, otherwise if only one or
-        // the other is available we just export the one map.
-        int n_textures = 0;
-        if (w_mesh.GetMaterial().HasAlbedoMap()) ++n_textures;
-        if (w_mesh.GetMaterial().HasNormalMap()) ++n_textures;
-        if (w_mesh.GetMaterial().HasAOMap()) ++n_textures;
-        if (w_mesh.GetMaterial().HasAORoughnessMetalMap()) {
-            ++n_textures;
-        } else if (w_mesh.GetMaterial().HasRoughnessMap() &&
-                   w_mesh.GetMaterial().HasMetallicMap()) {
-            ++n_textures;
-        } else {
-            if (w_mesh.GetMaterial().HasRoughnessMap()) ++n_textures;
-            if (w_mesh.GetMaterial().HasMetallicMap()) ++n_textures;
+        // Warn when the mesh carries roughness/metallic maps but the target
+        // format has no PBR material properties (e.g. OBJ/MTL).
+        if (!fmt.supports_roughness_metallic &&
+            (mat.HasRoughnessMap() || mat.HasMetallicMap() ||
+             mat.HasAORoughnessMetalMap())) {
+            utility::LogWarning(
+                    "{}: {} format does not support PBR roughness/metallic "
+                    "texture maps; they will be skipped.",
+                    filename, ext);
         }
-        if (n_textures > 0) {
-            ai_scene->mTextures = new aiTexture*[n_textures];
-            for (int i = 0; i < n_textures; ++i) {
+
+        // Collect all textures to export (table-driven, format-aware).
+        std::vector<TexExport> textures = CollectTextures(
+                mat, fmt.embed_textures, fmt.supports_roughness_metallic);
+
+        if (fmt.embed_textures && !textures.empty()) {
+            // GLB: allocate scene texture slots then embed each PNG.
+            const auto n = static_cast<int>(textures.size());
+            ai_scene->mTextures = new aiTexture*[n];
+            for (int i = 0; i < n; ++i)
                 ai_scene->mTextures[i] = new aiTexture();
+            ai_scene->mNumTextures = n;
+            for (int i = 0; i < n; ++i) {
+                const std::string uri =
+                        EmbedTexturePNG(ai_scene.get(), i, textures[i].img);
+                for (auto tt : textures[i].ai_types) {
+                    SetMaterialTextureURI(ai_mat, tt, uri);
+                }
             }
-            ai_scene->mNumTextures = n_textures;
-        }
-
-        // Now embed the textures that are available...
-        int current_idx = 0;
-        if (w_mesh.GetMaterial().HasAlbedoMap()) {
-            auto img = w_mesh.GetMaterial().GetAlbedoMap();
-            SetTextureMaterialProperty(ai_mat, ai_scene.get(), current_idx,
-                                       aiTextureType_DIFFUSE, img);
-            SetTextureMaterialProperty(ai_mat, ai_scene.get(), current_idx,
-                                       aiTextureType_BASE_COLOR, img);
-            ++current_idx;
-        }
-        if (w_mesh.GetMaterial().HasAOMap()) {
-            auto img = w_mesh.GetMaterial().GetAOMap();
-            SetTextureMaterialProperty(ai_mat, ai_scene.get(), current_idx,
-                                       aiTextureType_LIGHTMAP, img);
-            ++current_idx;
-        }
-        if (w_mesh.GetMaterial().HasAORoughnessMetalMap()) {
-            auto img = w_mesh.GetMaterial().GetAORoughnessMetalMap();
-            SetTextureMaterialProperty(ai_mat, ai_scene.get(), current_idx,
-                                       aiTextureType_UNKNOWN, img);
-            ++current_idx;
-        } else if (w_mesh.GetMaterial().HasRoughnessMap() &&
-                   w_mesh.GetMaterial().HasMetallicMap()) {
-            auto rough = w_mesh.GetMaterial().GetRoughnessMap().AsTensor();
-            auto metal = w_mesh.GetMaterial().GetMetallicMap().AsTensor();
-            if (rough.GetShape() != metal.GetShape()) {
-                utility::LogError(
-                        "RoughnessMap (shape={}) and MetallicMap (shape={}) "
-                        "must have the same shape.",
-                        rough.GetShape(), metal.GetShape());
-            }
-            auto rows = rough.GetShape(0);
-            auto cols = rough.GetShape(1);
-            auto rough_metal = core::Tensor::Full({rows, cols, 4}, 255,
-                                                  core::Dtype::UInt8);
-            rough_metal.Slice(2, 2, 3) =
-                    metal.Slice(2, 0, 1);  // blue channel is metal
-            rough_metal.Slice(2, 1, 2) =
-                    rough.Slice(2, 0, 1);  // green channel is roughness
-
-            geometry::Image rough_metal_img(rough_metal);
-            SetTextureMaterialProperty(ai_mat, ai_scene.get(), current_idx,
-                                       aiTextureType_UNKNOWN, rough_metal_img);
-            ++current_idx;
         } else {
-            if (w_mesh.GetMaterial().HasRoughnessMap()) {
-                auto img = w_mesh.GetMaterial().GetRoughnessMap();
-                SetTextureMaterialProperty(ai_mat, ai_scene.get(), current_idx,
-                                           aiTextureType_UNKNOWN, img);
-                ++current_idx;
+            // OBJ / FBX: write PNG sidecars next to the mesh file.
+            const auto dir = filepath.parent_path();
+            const std::string stem = filepath.stem().string();
+            for (const auto& tex : textures) {
+                const std::string uri = WriteSidecarTexture(
+                        dir, stem, tex.name, tex.img, ai_mat, tex.ai_types[0]);
+                // Register any additional ASSIMP type aliases.
+                for (size_t i = 1; !uri.empty() && i < tex.ai_types.size();
+                     ++i) {
+                    SetMaterialTextureURI(ai_mat, tex.ai_types[i], uri);
+                }
             }
-            if (w_mesh.GetMaterial().HasMetallicMap()) {
-                auto img = w_mesh.GetMaterial().GetMetallicMap();
-                SetTextureMaterialProperty(ai_mat, ai_scene.get(), current_idx,
-                                           aiTextureType_UNKNOWN, img);
-                ++current_idx;
-            }
-        }
-        if (w_mesh.GetMaterial().HasNormalMap()) {
-            auto img = w_mesh.GetMaterial().GetNormalMap();
-            SetTextureMaterialProperty(ai_mat, ai_scene.get(), current_idx,
-                                       aiTextureType_NORMALS, img);
-            ++current_idx;
         }
     }
     ai_scene->mMaterials[0] = ai_mat;
 
-    auto root_node = new aiNode;
-    root_node->mName.Set("root");
-    root_node->mNumMeshes = 1;
-    root_node->mMeshes = new unsigned int[root_node->mNumMeshes];
-    root_node->mMeshes[0] = 0;
-    ai_scene->mRootNode = root_node;
+    // ----- Scene graph -----
+    auto* root = new aiNode;
+    root->mName.Set("root");
+    root->mNumMeshes = 1;
+    root->mMeshes = new unsigned int[1]{0};
+    ai_scene->mRootNode = root;
 
-    // Export
-    if (exporter.Export(ai_scene.get(), "glb2", filename.c_str()) ==
-        AI_FAILURE) {
-        utility::LogWarning(
-                "Got error: ({}) while writing TriangleMesh to file {}.",
-                exporter.GetErrorString(), filename);
+    // ----- Export -----
+    if (exporter.Export(ai_scene.get(), fmt.assimp_id.c_str(),
+                        filename.c_str()) == AI_FAILURE) {
+        utility::LogWarning("ASSIMP export error for {}: {}", filename,
+                            exporter.GetErrorString());
         return false;
     }
-
     return true;
 }
 

--- a/cpp/open3d/t/io/file_format/FileASSIMP.cpp
+++ b/cpp/open3d/t/io/file_format/FileASSIMP.cpp
@@ -23,7 +23,6 @@
 #include <unordered_set>
 #include <vector>
 
-#include "open3d/core/ParallelFor.h"
 #include "open3d/core/TensorFunction.h"
 #include "open3d/t/io/ImageIO.h"
 #include "open3d/t/io/TriangleMeshIO.h"
@@ -576,14 +575,12 @@ bool ReadTriangleMeshUsingASSIMP(
         core::Tensor faces = core::Tensor::Empty({assimp_mesh->mNumFaces, 3},
                                                  core::Dtype::Int64);
         auto* fp = faces.GetDataPtr<int64_t>();
-        core::ParallelFor(
-                core::Device("CPU:0"), assimp_mesh->mNumFaces,
-                [&](size_t fidx) {
-                    const auto& face = assimp_mesh->mFaces[fidx];
-                    fp[3 * fidx + 0] = face.mIndices[0] + current_vidx;
-                    fp[3 * fidx + 1] = face.mIndices[1] + current_vidx;
-                    fp[3 * fidx + 2] = face.mIndices[2] + current_vidx;
-                });
+        for (unsigned int fidx = 0; fidx < assimp_mesh->mNumFaces; ++fidx) {
+            const auto& face = assimp_mesh->mFaces[fidx];
+            fp[3 * fidx + 0] = face.mIndices[0] + current_vidx;
+            fp[3 * fidx + 1] = face.mIndices[1] + current_vidx;
+            fp[3 * fidx + 2] = face.mIndices[2] + current_vidx;
+        }
         mesh_faces.push_back(faces);
 
         if (assimp_mesh->HasTextureCoords(0)) {
@@ -597,7 +594,8 @@ bool ReadTriangleMeshUsingASSIMP(
                 *up++ = assimp_mesh->mTextureCoords[0][i].y;
             }
             // Index vertex UVs by the face array to get per-triangle UVs.
-            mesh_uvs.push_back(vertex_uvs.IndexGet({faces}));
+            mesh_uvs.push_back(vertex_uvs.IndexGet(
+                    {faces - static_cast<int64_t>(current_vidx)}));
             count_mesh_with_uvs++;
         }
 

--- a/cpp/open3d/t/io/file_format/FileASSIMP.cpp
+++ b/cpp/open3d/t/io/file_format/FileASSIMP.cpp
@@ -14,7 +14,10 @@
 #include <assimp/Exporter.hpp>
 #include <assimp/Importer.hpp>
 #include <assimp/ProgressHandler.hpp>
+#include <cmath>
+#include <cstring>
 #include <filesystem>
+#include <functional>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -25,7 +28,9 @@
 #include "open3d/core/TensorFunction.h"
 #include "open3d/t/io/ImageIO.h"
 #include "open3d/t/io/TriangleMeshIO.h"
+#include "open3d/utility/Helper.h"
 #include "open3d/utility/Logging.h"
+#include "open3d/utility/ProgressBar.h"
 
 namespace open3d {
 namespace t {
@@ -184,6 +189,7 @@ struct ExportFormat {
 
 ExportFormat ResolveExportFormat(const std::string& ext, bool write_ascii) {
     //                             assimp_id          embed  mat    pbr
+    // glb / gltf: encoding follows the file extension, not write_ascii.
     if (ext == "glb") return {"glb2", true, true, true};
     if (ext == "gltf") return {"gltf2", false, true, true};
     if (ext == "obj") return {"obj", false, true, false};
@@ -192,6 +198,43 @@ ExportFormat ResolveExportFormat(const std::string& ext, bool write_ascii) {
         return {write_ascii ? "stl" : "stlb", false, false, false};
     utility::LogError("Unsupported ASSIMP export extension: {}", ext);
 }
+
+// Log when write_ascii does not match the encoding implied by the extension.
+void WarnIfWriteAsciiMismatch(const std::string& ext, bool write_ascii) {
+    if (ext == "glb" && write_ascii) {
+        utility::LogInfo(".glb export is binary; write_ascii=true is ignored.");
+    }
+    // STL: write_ascii selects ASSIMP "stl" (ASCII) vs "stlb" (binary); both
+    // use a .stl filename — no message when the flag matches
+    // ResolveExportFormat.
+    if ((ext == "obj" || ext == "gltf") && !write_ascii) {
+        utility::LogInfo(
+                ".{} export is text-based; write_ascii=false is ignored.", ext);
+    }
+    if (ext == "fbx" && write_ascii) {
+        utility::LogInfo(
+                "ASSIMP FBX export is binary; write_ascii=true is ignored.");
+    }
+}
+
+// ASSIMP import/export progress (same contract as legacy ReadModelUsingAssimp).
+class AssimpProgressHandler : public Assimp::ProgressHandler {
+public:
+    explicit AssimpProgressHandler(std::function<bool(double)> update_progress)
+        : update_progress_(std::move(update_progress)) {}
+
+    bool Update(float percentage = -1.f) override {
+        if (!update_progress_) {
+            return true;
+        }
+        const double pct =
+                100.0 * static_cast<double>(std::max(0.f, percentage));
+        return update_progress_(pct);
+    }
+
+private:
+    std::function<bool(double)> update_progress_;
+};
 
 // Register a texture URI (embedded "*N" or a relative sidecar filename) in
 // one material texture slot.
@@ -231,7 +274,12 @@ std::string EmbedTexturePNG(aiScene* scene,
                             int idx,
                             const geometry::Image& img) {
     std::vector<uint8_t> buf;
-    WriteImageToPNGInMemory(buf, img, 6);
+    if (!WriteImageToPNGInMemory(buf, img, 6) || buf.empty()) {
+        utility::LogWarning(
+                "Could not encode texture to PNG for embedding (slot {}).",
+                idx);
+        return "";
+    }
 
     auto* tex = scene->mTextures[idx];
     const std::string uri = std::string("*") + std::to_string(idx);
@@ -469,6 +517,11 @@ bool ReadTriangleMeshUsingASSIMP(
         const open3d::io::ReadTriangleMeshOptions& params /*={}*/) {
     Assimp::Importer importer;
 
+    if (params.update_progress) {
+        importer.SetProgressHandler(
+                new AssimpProgressHandler(params.update_progress));
+    }
+
     unsigned int post_process_flags = kPostProcessFlags_compulsory;
     if (params.enable_post_processing) {
         post_process_flags = kPostProcessFlags_fast;
@@ -682,7 +735,14 @@ bool WriteTriangleMeshUsingASSIMP(const std::string& filename,
     std::string ext = filepath.extension().string();
     if (!ext.empty()) ext = ext.substr(1);  // strip leading '.'
     std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+    WarnIfWriteAsciiMismatch(ext, write_ascii);
     const ExportFormat fmt = ResolveExportFormat(ext, write_ascii);
+
+    if (compressed) {
+        utility::LogWarning(
+                "The compressed flag is not used for ASSIMP export (.{}).",
+                ext);
+    }
 
     if (!fmt.supports_materials) {
         if (write_triangle_uvs && mesh.HasTriangleAttr("texture_uvs"))
@@ -691,11 +751,6 @@ bool WriteTriangleMeshUsingASSIMP(const std::string& filename,
             utility::LogWarning("{} does not support vertex colors.", ext);
         if (mesh.HasMaterial())
             utility::LogWarning("{} does not support materials.", ext);
-    }
-    if (write_ascii && (ext == "glb" || ext == "gltf")) {
-        utility::LogWarning(
-                "TriangleMesh cannot be saved in ASCII format as .{}.", ext);
-        return false;
     }
 
     // Convert per-triangle UVs to per-vertex UVs (ASSIMP requirement).
@@ -706,6 +761,17 @@ bool WriteTriangleMeshUsingASSIMP(const std::string& filename,
                     : mesh;
 
     Assimp::Exporter exporter;
+    if (print_progress) {
+        const std::string progress_info = std::string("Writing ") +
+                                          utility::ToUpper(ext) +
+                                          " file: " + filename;
+        auto pbar = utility::ProgressBar(100, progress_info, true);
+        exporter.SetProgressHandler(
+                new AssimpProgressHandler([pbar](double pct) mutable -> bool {
+                    pbar.SetCurrentCount(size_t(pct));
+                    return true;
+                }));
+    }
     auto ai_scene = std::unique_ptr<aiScene>(new aiScene);
 
     // ----- Geometry -----
@@ -715,7 +781,7 @@ bool WriteTriangleMeshUsingASSIMP(const std::string& filename,
     ai_mesh->mName.Set("Object1");
     ai_mesh->mPrimitiveTypes = aiPrimitiveType_TRIANGLE;
 
-    auto vertices = w_mesh.GetVertexPositions().Contiguous();
+    auto vertices = w_mesh.GetVertexPositions().To(core::Float32).Contiguous();
     // ASSIMP face indices must be unsigned int; get a contiguous buffer.
     auto indices =
             w_mesh.GetTriangleIndices().To(core::Dtype::UInt32).Contiguous();
@@ -723,7 +789,7 @@ bool WriteTriangleMeshUsingASSIMP(const std::string& filename,
     ai_mesh->mNumFaces = static_cast<unsigned int>(indices.GetShape(0));
 
     ai_mesh->mVertices = new aiVector3D[ai_mesh->mNumVertices];
-    std::memcpy(&ai_mesh->mVertices->x, vertices.GetDataPtr(),
+    std::memcpy(&ai_mesh->mVertices->x, vertices.GetDataPtr<float>(),
                 sizeof(float) * ai_mesh->mNumVertices * 3);
 
     // Build aiFace array. ASSIMP's aiFace destructor calls delete[] on
@@ -739,35 +805,42 @@ bool WriteTriangleMeshUsingASSIMP(const std::string& filename,
     }
 
     if (write_vertex_normals && w_mesh.HasVertexNormals()) {
-        auto normals = w_mesh.GetVertexNormals().Contiguous();
+        auto normals = w_mesh.GetVertexNormals().To(core::Float32).Contiguous();
         ai_mesh->mNormals = new aiVector3D[ai_mesh->mNumVertices];
-        std::memcpy(&ai_mesh->mNormals->x, normals.GetDataPtr(),
+        std::memcpy(&ai_mesh->mNormals->x, normals.GetDataPtr<float>(),
                     sizeof(float) * ai_mesh->mNumVertices * 3);
     }
 
     if (fmt.supports_materials && write_vertex_colors &&
         w_mesh.HasVertexColors()) {
-        auto colors = w_mesh.GetVertexColors().Contiguous();
+        auto colors = w_mesh.GetVertexColors().To(core::Float32).Contiguous();
         ai_mesh->mColors[0] = new aiColor4D[ai_mesh->mNumVertices];
         if (colors.GetShape(1) == 4) {
-            std::memcpy(&ai_mesh->mColors[0][0].r, colors.GetDataPtr(),
+            std::memcpy(&ai_mesh->mColors[0][0].r, colors.GetDataPtr<float>(),
                         sizeof(float) * ai_mesh->mNumVertices * 4);
         } else {
-            auto* cp = colors.GetDataPtr<float>();
+            const auto* cp = colors.GetDataPtr<float>();
             for (unsigned int i = 0; i < ai_mesh->mNumVertices; ++i) {
-                ai_mesh->mColors[0][i] = {*cp++, *cp++, *cp++, 1.f};
+                const float r = cp[i * 3 + 0];
+                const float g = cp[i * 3 + 1];
+                const float b = cp[i * 3 + 2];
+                ai_mesh->mColors[0][i] = aiColor4D(r, g, b, 1.f);
             }
         }
     }
 
     if (fmt.supports_materials && write_triangle_uvs &&
         w_mesh.HasVertexAttr("texture_uvs")) {
-        auto vuv = w_mesh.GetVertexAttr("texture_uvs").Contiguous();
+        auto vuv = w_mesh.GetVertexAttr("texture_uvs")
+                           .To(core::Float32)
+                           .Contiguous();
         ai_mesh->mNumUVComponents[0] = 2;
         ai_mesh->mTextureCoords[0] = new aiVector3D[ai_mesh->mNumVertices];
-        auto* up = vuv.GetDataPtr<float>();
+        const auto* up = vuv.GetDataPtr<float>();
         for (unsigned int i = 0; i < ai_mesh->mNumVertices; ++i) {
-            ai_mesh->mTextureCoords[0][i] = {*up++, *up++, 0.f};
+            const float u = up[i * 2 + 0];
+            const float v = up[i * 2 + 1];
+            ai_mesh->mTextureCoords[0][i] = aiVector3D(u, v, 0.f);
         }
     }
     ai_scene->mMeshes[0] = ai_mesh;
@@ -841,6 +914,12 @@ bool WriteTriangleMeshUsingASSIMP(const std::string& filename,
             for (int i = 0; i < n; ++i) {
                 const std::string uri =
                         EmbedTexturePNG(ai_scene.get(), i, textures[i].img);
+                if (uri.empty()) {
+                    utility::LogWarning(
+                            "Skipping embedded texture '{}' (encode failed).",
+                            textures[i].name);
+                    continue;
+                }
                 for (auto tt : textures[i].ai_types) {
                     SetMaterialTextureURI(ai_mat, tt, uri);
                 }

--- a/cpp/open3d/t/io/file_format/FileJPG.cpp
+++ b/cpp/open3d/t/io/file_format/FileJPG.cpp
@@ -192,7 +192,7 @@ bool WriteImageToJPG(const std::string &filename,
         return true;
     } catch (const std::runtime_error &err) {
         fclose(file_out);
-        utility::LogWarning(err.what());
+        utility::LogWarning("libjpeg error: {}", err.what());
         return false;
     }
 }

--- a/cpp/open3d/t/io/file_format/FileJPG.cpp
+++ b/cpp/open3d/t/io/file_format/FileJPG.cpp
@@ -26,10 +26,9 @@ namespace {
 void jpeg_error_throw(j_common_ptr p_cinfo) {
     if (p_cinfo->is_decompressor)
         jpeg_destroy_decompress(
-                reinterpret_cast<jpeg_decompress_struct *>(p_cinfo));
+                reinterpret_cast<jpeg_decompress_struct*>(p_cinfo));
     else
-        jpeg_destroy_compress(
-                reinterpret_cast<jpeg_compress_struct *>(p_cinfo));
+        jpeg_destroy_compress(reinterpret_cast<jpeg_compress_struct*>(p_cinfo));
     char buffer[JMSG_LENGTH_MAX];
     (*p_cinfo->err->format_message)(p_cinfo, buffer);
     throw std::runtime_error(buffer);
@@ -39,8 +38,8 @@ void jpeg_error_throw(j_common_ptr p_cinfo) {
 
 // Decompress a JPEG after the source has already been set on cinfo.
 // Shared by the file-based and in-memory readers.
-static bool DecompressJPG(struct jpeg_decompress_struct &cinfo,
-                          geometry::Image &image) {
+static bool DecompressJPG(struct jpeg_decompress_struct& cinfo,
+                          geometry::Image& image) {
     jpeg_read_header(&cinfo, TRUE);
 
     // We only support two channel types: gray, and RGB.
@@ -71,7 +70,7 @@ static bool DecompressJPG(struct jpeg_decompress_struct &cinfo,
     const int row_stride = cinfo.output_width * cinfo.output_components;
     JSAMPARRAY buffer = (*cinfo.mem->alloc_sarray)((j_common_ptr)&cinfo,
                                                    JPOOL_IMAGE, row_stride, 1);
-    uint8_t *pdata = static_cast<uint8_t *>(image.GetDataPtr());
+    uint8_t* pdata = static_cast<uint8_t*>(image.GetDataPtr());
 
     while (cinfo.output_scanline < cinfo.output_height) {
         jpeg_read_scanlines(&cinfo, buffer, 1);
@@ -84,10 +83,10 @@ static bool DecompressJPG(struct jpeg_decompress_struct &cinfo,
     return true;
 }
 
-bool ReadImageFromJPG(const std::string &filename, geometry::Image &image) {
+bool ReadImageFromJPG(const std::string& filename, geometry::Image& image) {
     struct jpeg_decompress_struct cinfo;
     struct jpeg_error_mgr jerr;
-    FILE *file_in;
+    FILE* file_in;
 
     if ((file_in = utility::filesystem::FOpen(filename, "rb")) == NULL) {
         utility::LogWarning("Read JPG failed: unable to open file: {}",
@@ -103,7 +102,7 @@ bool ReadImageFromJPG(const std::string &filename, geometry::Image &image) {
         bool ok = DecompressJPG(cinfo, image);
         fclose(file_in);
         return ok;
-    } catch (const std::runtime_error &err) {
+    } catch (const std::runtime_error& err) {
         fclose(file_in);
         image.Clear();
         utility::LogWarning("libjpeg error: {}", err.what());
@@ -111,9 +110,15 @@ bool ReadImageFromJPG(const std::string &filename, geometry::Image &image) {
     }
 }
 
-bool ReadImageFromJPGInMemory(const uint8_t *data,
+bool ReadImageFromJPGInMemory(const uint8_t* data,
                               size_t size,
-                              geometry::Image &image) {
+                              geometry::Image& image) {
+    if (data == nullptr || size == 0) {
+        utility::LogWarning(
+                "ReadImageFromJPGInMemory failed: null or empty buffer.");
+        image.Clear();
+        return false;
+    }
     struct jpeg_decompress_struct cinfo;
     struct jpeg_error_mgr jerr;
     try {
@@ -121,18 +126,18 @@ bool ReadImageFromJPGInMemory(const uint8_t *data,
         jerr.error_exit = jpeg_error_throw;
         jpeg_create_decompress(&cinfo);
         // jpeg_mem_src accepts non-const data pointer (libjpeg API)
-        jpeg_mem_src(&cinfo, const_cast<uint8_t *>(data),
+        jpeg_mem_src(&cinfo, const_cast<uint8_t*>(data),
                      static_cast<unsigned long>(size));
         return DecompressJPG(cinfo, image);
-    } catch (const std::runtime_error &err) {
+    } catch (const std::runtime_error& err) {
         image.Clear();
         utility::LogWarning("libjpeg error: {}", err.what());
         return false;
     }
 }
 
-bool WriteImageToJPG(const std::string &filename,
-                     const geometry::Image &image,
+bool WriteImageToJPG(const std::string& filename,
+                     const geometry::Image& image,
                      int quality /* = kOpen3DImageIODefaultQuality*/) {
     if (image.IsEmpty()) {
         utility::LogWarning("Write JPG failed: image has no data.");
@@ -154,7 +159,7 @@ bool WriteImageToJPG(const std::string &filename,
 
     struct jpeg_compress_struct cinfo;
     struct jpeg_error_mgr jerr;
-    FILE *file_out;
+    FILE* file_out;
     JSAMPROW row_pointer[1];
 
     if ((file_out = utility::filesystem::FOpen(filename, "wb")) == NULL) {
@@ -177,7 +182,7 @@ bool WriteImageToJPG(const std::string &filename,
         jpeg_set_quality(&cinfo, quality, TRUE);
         jpeg_start_compress(&cinfo, TRUE);
         int row_stride = image.GetCols() * image.GetChannels();
-        const uint8_t *pdata = static_cast<const uint8_t *>(image.GetDataPtr());
+        const uint8_t* pdata = static_cast<const uint8_t*>(image.GetDataPtr());
         std::vector<uint8_t> buffer(row_stride);
         while (cinfo.next_scanline < cinfo.image_height) {
             core::MemoryManager::MemcpyToHost(
@@ -190,7 +195,7 @@ bool WriteImageToJPG(const std::string &filename,
         fclose(file_out);
         jpeg_destroy_compress(&cinfo);
         return true;
-    } catch (const std::runtime_error &err) {
+    } catch (const std::runtime_error& err) {
         fclose(file_out);
         utility::LogWarning("libjpeg error: {}", err.what());
         return false;

--- a/cpp/open3d/t/io/file_format/FileJPG.cpp
+++ b/cpp/open3d/t/io/file_format/FileJPG.cpp
@@ -37,11 +37,57 @@ void jpeg_error_throw(j_common_ptr p_cinfo) {
 
 }  // namespace
 
+// Decompress a JPEG after the source has already been set on cinfo.
+// Shared by the file-based and in-memory readers.
+static bool DecompressJPG(struct jpeg_decompress_struct &cinfo,
+                          geometry::Image &image) {
+    jpeg_read_header(&cinfo, TRUE);
+
+    // We only support two channel types: gray, and RGB.
+    int num_of_channels = 3;
+    switch (cinfo.jpeg_color_space) {
+        case JCS_RGB:
+        case JCS_YCbCr:
+            cinfo.out_color_space = JCS_RGB;
+            cinfo.out_color_components = 3;
+            num_of_channels = 3;
+            break;
+        case JCS_GRAYSCALE:
+            cinfo.jpeg_color_space = JCS_GRAYSCALE;
+            cinfo.out_color_components = 1;
+            num_of_channels = 1;
+            break;
+        default:
+            utility::LogWarning("Read JPG failed: color space not supported.");
+            jpeg_destroy_decompress(&cinfo);
+            image.Clear();
+            return false;
+    }
+    jpeg_start_decompress(&cinfo);
+    image.Clear();
+    image.Reset(cinfo.output_height, cinfo.output_width, num_of_channels,
+                core::UInt8, image.GetDevice());
+
+    const int row_stride = cinfo.output_width * cinfo.output_components;
+    JSAMPARRAY buffer = (*cinfo.mem->alloc_sarray)((j_common_ptr)&cinfo,
+                                                   JPOOL_IMAGE, row_stride, 1);
+    uint8_t *pdata = static_cast<uint8_t *>(image.GetDataPtr());
+
+    while (cinfo.output_scanline < cinfo.output_height) {
+        jpeg_read_scanlines(&cinfo, buffer, 1);
+        core::MemoryManager::MemcpyFromHost(pdata, image.GetDevice(), buffer[0],
+                                            row_stride * 1);
+        pdata += row_stride;
+    }
+    jpeg_finish_decompress(&cinfo);
+    jpeg_destroy_decompress(&cinfo);
+    return true;
+}
+
 bool ReadImageFromJPG(const std::string &filename, geometry::Image &image) {
     struct jpeg_decompress_struct cinfo;
     struct jpeg_error_mgr jerr;
     FILE *file_in;
-    JSAMPARRAY buffer;
 
     if ((file_in = utility::filesystem::FOpen(filename, "rb")) == NULL) {
         utility::LogWarning("Read JPG failed: unable to open file: {}",
@@ -49,60 +95,36 @@ bool ReadImageFromJPG(const std::string &filename, geometry::Image &image) {
         image.Clear();
         return false;
     }
-
     try {
         cinfo.err = jpeg_std_error(&jerr);
         jerr.error_exit = jpeg_error_throw;
         jpeg_create_decompress(&cinfo);
         jpeg_stdio_src(&cinfo, file_in);
-        jpeg_read_header(&cinfo, TRUE);
-
-        // We only support two channel types: gray, and RGB.
-        int num_of_channels = 3;
-        switch (cinfo.jpeg_color_space) {
-            case JCS_RGB:
-            case JCS_YCbCr:
-                cinfo.out_color_space = JCS_RGB;
-                cinfo.out_color_components = 3;
-                num_of_channels = 3;
-                break;
-            case JCS_GRAYSCALE:
-                cinfo.jpeg_color_space = JCS_GRAYSCALE;
-                cinfo.out_color_components = 1;
-                num_of_channels = 1;
-                break;
-            case JCS_CMYK:
-            case JCS_YCCK:
-            default:
-                utility::LogWarning(
-                        "Read JPG failed: color space not supported.");
-                jpeg_destroy_decompress(&cinfo);
-                fclose(file_in);
-                image.Clear();
-                return false;
-        }
-        jpeg_start_decompress(&cinfo);
-        image.Clear();
-        image.Reset(cinfo.output_height, cinfo.output_width, num_of_channels,
-                    core::UInt8, image.GetDevice());
-
-        int row_stride = cinfo.output_width * cinfo.output_components;
-        buffer = (*cinfo.mem->alloc_sarray)((j_common_ptr)&cinfo, JPOOL_IMAGE,
-                                            row_stride, 1);
-        uint8_t *pdata = static_cast<uint8_t *>(image.GetDataPtr());
-
-        while (cinfo.output_scanline < cinfo.output_height) {
-            jpeg_read_scanlines(&cinfo, buffer, 1);
-            core::MemoryManager::MemcpyFromHost(pdata, image.GetDevice(),
-                                                buffer[0], row_stride * 1);
-            pdata += row_stride;
-        }
-        jpeg_finish_decompress(&cinfo);
-        jpeg_destroy_decompress(&cinfo);
+        bool ok = DecompressJPG(cinfo, image);
         fclose(file_in);
-        return true;
+        return ok;
     } catch (const std::runtime_error &err) {
         fclose(file_in);
+        image.Clear();
+        utility::LogWarning("libjpeg error: {}", err.what());
+        return false;
+    }
+}
+
+bool ReadImageFromJPGInMemory(const uint8_t *data,
+                              size_t size,
+                              geometry::Image &image) {
+    struct jpeg_decompress_struct cinfo;
+    struct jpeg_error_mgr jerr;
+    try {
+        cinfo.err = jpeg_std_error(&jerr);
+        jerr.error_exit = jpeg_error_throw;
+        jpeg_create_decompress(&cinfo);
+        // jpeg_mem_src accepts non-const data pointer (libjpeg API)
+        jpeg_mem_src(&cinfo, const_cast<uint8_t *>(data),
+                     static_cast<unsigned long>(size));
+        return DecompressJPG(cinfo, image);
+    } catch (const std::runtime_error &err) {
         image.Clear();
         utility::LogWarning("libjpeg error: {}", err.what());
         return false;

--- a/cpp/open3d/t/io/file_format/FilePNG.cpp
+++ b/cpp/open3d/t/io/file_format/FilePNG.cpp
@@ -21,7 +21,7 @@ namespace {
 
 // libpng fills pngimage.message with text that already includes "libpng error:
 // ".
-void LogLibPNGError(const png_image &pngimage, const char *fallback) {
+void LogLibPNGError(const png_image& pngimage, const char* fallback) {
     if (pngimage.message[0] != '\0') {
         utility::LogWarning("{}", pngimage.message);
     } else {
@@ -31,9 +31,9 @@ void LogLibPNGError(const png_image &pngimage, const char *fallback) {
 
 }  // namespace
 
-static void SetPNGImageFromImage(const geometry::Image &image,
+static void SetPNGImageFromImage(const geometry::Image& image,
                                  int quality,
-                                 png_image &pngimage) {
+                                 png_image& pngimage) {
     pngimage.width = image.GetCols();
     pngimage.height = image.GetRows();
     pngimage.format = pngimage.flags = 0;
@@ -53,9 +53,9 @@ static void SetPNGImageFromImage(const geometry::Image &image,
 }
 
 // Shared setup for a png_image struct from a decoded format descriptor.
-static bool FinishReadPNG(png_image &pngimage,
-                          geometry::Image &image,
-                          const char *source_label) {
+static bool FinishReadPNG(png_image& pngimage,
+                          geometry::Image& image,
+                          const char* source_label) {
     if (pngimage.format & PNG_FORMAT_FLAG_COLORMAP) {
         pngimage.format &= ~PNG_FORMAT_FLAG_COLORMAP;
     }
@@ -79,7 +79,7 @@ static bool FinishReadPNG(png_image &pngimage,
     return true;
 }
 
-bool ReadImageFromPNG(const std::string &filename, geometry::Image &image) {
+bool ReadImageFromPNG(const std::string& filename, geometry::Image& image) {
     png_image pngimage;
     memset(&pngimage, 0, sizeof(pngimage));
     pngimage.version = PNG_IMAGE_VERSION;
@@ -91,9 +91,15 @@ bool ReadImageFromPNG(const std::string &filename, geometry::Image &image) {
     return FinishReadPNG(pngimage, image, filename.c_str());
 }
 
-bool ReadImageFromPNGInMemory(const uint8_t *data,
+bool ReadImageFromPNGInMemory(const uint8_t* data,
                               size_t size,
-                              geometry::Image &image) {
+                              geometry::Image& image) {
+    if (data == nullptr || size == 0) {
+        utility::LogWarning(
+                "ReadImageFromPNGInMemory failed: null or empty buffer.");
+        image.Clear();
+        return false;
+    }
     png_image pngimage;
     memset(&pngimage, 0, sizeof(pngimage));
     pngimage.version = PNG_IMAGE_VERSION;
@@ -106,8 +112,8 @@ bool ReadImageFromPNGInMemory(const uint8_t *data,
     return FinishReadPNG(pngimage, image, "<memory>");
 }
 
-bool WriteImageToPNG(const std::string &filename,
-                     const geometry::Image &image,
+bool WriteImageToPNG(const std::string& filename,
+                     const geometry::Image& image,
                      int quality) {
     if (image.IsEmpty()) {
         utility::LogWarning("Write PNG failed: image has no data.");
@@ -142,8 +148,8 @@ bool WriteImageToPNG(const std::string &filename,
     return true;
 }
 
-bool WriteImageToPNGInMemory(std::vector<uint8_t> &buffer,
-                             const t::geometry::Image &image,
+bool WriteImageToPNGInMemory(std::vector<uint8_t>& buffer,
+                             const t::geometry::Image& image,
                              int quality) {
     if (image.IsEmpty()) {
         utility::LogWarning("Write PNG failed: image has no data.");

--- a/cpp/open3d/t/io/file_format/FilePNG.cpp
+++ b/cpp/open3d/t/io/file_format/FilePNG.cpp
@@ -7,6 +7,8 @@
 
 #include <png.h>
 
+#include <string>
+
 #include "open3d/core/Dtype.h"
 #include "open3d/t/io/ImageIO.h"
 #include "open3d/utility/Logging.h"
@@ -14,6 +16,20 @@
 namespace open3d {
 namespace t {
 namespace io {
+
+namespace {
+
+// libpng fills pngimage.message with text that already includes "libpng error:
+// ".
+void LogLibPNGError(const png_image &pngimage, const char *fallback) {
+    if (pngimage.message[0] != '\0') {
+        utility::LogWarning("{}", pngimage.message);
+    } else {
+        utility::LogWarning("PNG error: {}.", fallback);
+    }
+}
+
+}  // namespace
 
 static void SetPNGImageFromImage(const geometry::Image &image,
                                  int quality,
@@ -54,8 +70,9 @@ static bool FinishReadPNG(png_image &pngimage,
     }
     if (png_image_finish_read(&pngimage, NULL, image.GetDataPtr(), 0, NULL) ==
         0) {
-        utility::LogWarning("Read PNG failed from {}: {}", source_label,
-                            pngimage.message);
+        const std::string fallback =
+                std::string("Read PNG failed from ") + source_label;
+        LogLibPNGError(pngimage, fallback.c_str());
         image.Clear();
         return false;
     }
@@ -67,7 +84,7 @@ bool ReadImageFromPNG(const std::string &filename, geometry::Image &image) {
     memset(&pngimage, 0, sizeof(pngimage));
     pngimage.version = PNG_IMAGE_VERSION;
     if (png_image_begin_read_from_file(&pngimage, filename.c_str()) == 0) {
-        utility::LogWarning("Read PNG failed: unable to parse header.");
+        LogLibPNGError(pngimage, "Read PNG failed: unable to parse header");
         image.Clear();
         return false;
     }
@@ -81,8 +98,8 @@ bool ReadImageFromPNGInMemory(const uint8_t *data,
     memset(&pngimage, 0, sizeof(pngimage));
     pngimage.version = PNG_IMAGE_VERSION;
     if (png_image_begin_read_from_memory(&pngimage, data, size) == 0) {
-        utility::LogWarning(
-                "Read PNG from memory failed: unable to parse header.");
+        LogLibPNGError(pngimage,
+                       "Read PNG from memory failed: unable to parse header");
         image.Clear();
         return false;
     }
@@ -117,8 +134,9 @@ bool WriteImageToPNG(const std::string &filename,
     SetPNGImageFromImage(image, quality, pngimage);
     if (png_image_write_to_file(&pngimage, filename.c_str(), 0,
                                 image.GetDataPtr(), 0, NULL) == 0) {
-        utility::LogWarning("Write PNG failed: unable to write file: {}",
-                            filename);
+        const std::string fallback =
+                std::string("unable to write file: ") + filename;
+        LogLibPNGError(pngimage, fallback.c_str());
         return false;
     }
     return true;
@@ -154,15 +172,17 @@ bool WriteImageToPNGInMemory(std::vector<uint8_t> &buffer,
     size_t mem_bytes = 0;
     if (png_image_write_to_memory(&pngimage, nullptr, &mem_bytes, 0,
                                   image.GetDataPtr(), 0, nullptr) == 0) {
-        utility::LogWarning(
-                "Could not compute bytes needed for encoding to PNG in "
-                "memory.");
+        LogLibPNGError(
+                pngimage,
+                "Write PNG failed: could not compute in-memory buffer size");
         return false;
     }
     buffer.resize(mem_bytes);
     if (png_image_write_to_memory(&pngimage, &buffer[0], &mem_bytes, 0,
                                   image.GetDataPtr(), 0, nullptr) == 0) {
-        utility::LogWarning("Unable to encode to PNG in memory.");
+        LogLibPNGError(pngimage,
+                       "Write PNG failed: unable to encode to memory");
+        buffer.clear();
         return false;
     }
     return true;

--- a/cpp/open3d/t/io/file_format/FilePNG.cpp
+++ b/cpp/open3d/t/io/file_format/FilePNG.cpp
@@ -36,18 +36,10 @@ static void SetPNGImageFromImage(const geometry::Image &image,
     }
 }
 
-bool ReadImageFromPNG(const std::string &filename, geometry::Image &image) {
-    png_image pngimage;
-    memset(&pngimage, 0, sizeof(pngimage));
-    pngimage.version = PNG_IMAGE_VERSION;
-    if (png_image_begin_read_from_file(&pngimage, filename.c_str()) == 0) {
-        utility::LogWarning("Read PNG failed: unable to parse header.");
-        image.Clear();
-        return false;
-    }
-
-    // Clear colormap flag if necessary to ensure libpng expands the color
-    // indexed pixels to full color
+// Shared setup for a png_image struct from a decoded format descriptor.
+static bool FinishReadPNG(png_image &pngimage,
+                          geometry::Image &image,
+                          const char *source_label) {
     if (pngimage.format & PNG_FORMAT_FLAG_COLORMAP) {
         pngimage.format &= ~PNG_FORMAT_FLAG_COLORMAP;
     }
@@ -60,16 +52,41 @@ bool ReadImageFromPNG(const std::string &filename, geometry::Image &image) {
                     PNG_IMAGE_SAMPLE_CHANNELS(pngimage.format), core::UInt8,
                     image.GetDevice());
     }
-
     if (png_image_finish_read(&pngimage, NULL, image.GetDataPtr(), 0, NULL) ==
         0) {
-        utility::LogWarning("Read PNG failed: unable to read file: {}",
-                            filename);
-        utility::LogWarning("PNG error: {}", pngimage.message);
+        utility::LogWarning("Read PNG failed from {}: {}", source_label,
+                            pngimage.message);
         image.Clear();
         return false;
     }
     return true;
+}
+
+bool ReadImageFromPNG(const std::string &filename, geometry::Image &image) {
+    png_image pngimage;
+    memset(&pngimage, 0, sizeof(pngimage));
+    pngimage.version = PNG_IMAGE_VERSION;
+    if (png_image_begin_read_from_file(&pngimage, filename.c_str()) == 0) {
+        utility::LogWarning("Read PNG failed: unable to parse header.");
+        image.Clear();
+        return false;
+    }
+    return FinishReadPNG(pngimage, image, filename.c_str());
+}
+
+bool ReadImageFromPNGInMemory(const uint8_t *data,
+                              size_t size,
+                              geometry::Image &image) {
+    png_image pngimage;
+    memset(&pngimage, 0, sizeof(pngimage));
+    pngimage.version = PNG_IMAGE_VERSION;
+    if (png_image_begin_read_from_memory(&pngimage, data, size) == 0) {
+        utility::LogWarning(
+                "Read PNG from memory failed: unable to parse header.");
+        image.Clear();
+        return false;
+    }
+    return FinishReadPNG(pngimage, image, "<memory>");
 }
 
 bool WriteImageToPNG(const std::string &filename,

--- a/cpp/pybind/t/io/class_io.cpp
+++ b/cpp/pybind/t/io/class_io.cpp
@@ -199,8 +199,8 @@ Supported formats:
 - ``npz`` -- Open3D NPZ format (full round-trip including materials and
   texture maps).
 - ``obj``, ``stl``, ``off``, ``gltf``, ``glb``, ``fbx`` -- via ASSIMP
-  (geometry + vertex normals/colors + UV coordinates + single PBR material
-  with scalar properties and texture maps).
+  (geometry; optional vertex normals/colors, UVs, and material/PBR data
+  depending on format, e.g. STL is geometry-only).
 
 The following example reads a triangle mesh with the .ply extension::
 

--- a/cpp/pybind/t/io/class_io.cpp
+++ b/cpp/pybind/t/io/class_io.cpp
@@ -189,34 +189,46 @@ linear scales directly.)",
             },
             "Function to read TriangleMesh from file", "filename"_a,
             "enable_post_processing"_a = false, "print_progress"_a = false,
-            R"doc(The general entrance for reading a TriangleMesh from a file.
-The function calls read functions based on the extension name of filename.
-Supported formats are `obj, ply, stl, off, gltf, glb, fbx`.
+            R"doc(Read a TriangleMesh from a file.
+
+The format is inferred from the file extension.
+
+Supported formats:
+
+- ``ply`` -- native Open3D reader (geometry + colors/normals).
+- ``npz`` -- Open3D NPZ format (full round-trip including materials and
+  texture maps).
+- ``obj``, ``stl``, ``off``, ``gltf``, ``glb``, ``fbx`` -- via ASSIMP
+  (geometry + vertex normals/colors + UV coordinates + single PBR material
+  with scalar properties and texture maps).
 
 The following example reads a triangle mesh with the .ply extension::
+
     import open3d as o3d
     mesh = o3d.t.io.read_triangle_mesh('mesh.ply')
 
 Args:
     filename (str): Path to the mesh file.
-    enable_post_processing (bool): If True enables post-processing.
-        Post-processing will
+    enable_post_processing (bool): If True enables post-processing for
+        ASSIMP-read formats. Post-processing will
+
           - triangulate meshes with polygonal faces
           - remove redundant materials
           - pretransform vertices
           - generate face normals if needed
 
-        For more information see ASSIMPs documentation on the flags
-        `aiProcessPreset_TargetRealtime_Fast, aiProcess_RemoveRedundantMaterials,
-        aiProcess_OptimizeMeshes, aiProcess_PreTransformVertices`.
+        For more information see ASSIMP's documentation on the flags
+        ``aiProcessPreset_TargetRealtime_Fast``,
+        ``aiProcess_RemoveRedundantMaterials``,
+        ``aiProcess_OptimizeMeshes``, ``aiProcess_PreTransformVertices``.
 
-        Note that identical vertices will always be joined regardless of whether
-        post-processing is enabled or not, which changes the number of vertices
-        in the mesh.
+        Note that identical vertices will always be joined regardless of
+        whether post-processing is enabled or not, which changes the number
+        of vertices in the mesh. The ``ply`` format is not affected by
+        post-processing.
 
-        The `ply`-format is not affected by the post-processing.
-
-    print_progress (bool): If True print the reading progress to the terminal.
+    print_progress (bool): If True print the reading progress to the
+        terminal.
 
 Returns:
     Returns the mesh object. On failure an empty mesh is returned.
@@ -237,7 +249,60 @@ Returns:
             "Function to write TriangleMesh to file", "filename"_a, "mesh"_a,
             "write_ascii"_a = false, "compressed"_a = false,
             "write_vertex_normals"_a = true, "write_vertex_colors"_a = true,
-            "write_triangle_uvs"_a = true, "print_progress"_a = false);
+            "write_triangle_uvs"_a = true, "print_progress"_a = false,
+            R"doc(Write a TriangleMesh to a file.
+
+The format is inferred from the file extension.
+
+Supported formats and material/texture export:
+
+- ``npz`` -- full round-trip (geometry + material + all texture maps).
+- ``glb``  -- via ASSIMP; full PBR single material with embedded textures.
+- ``gltf`` -- via ASSIMP; full PBR single material with external textures.
+- ``obj``  -- via ASSIMP; single material exported; texture maps written as
+  external PNG sidecars (``<stem>_albedo.png``, ``<stem>_normal.png``,
+  ``<stem>_roughness.png``, ``<stem>_metallic.png``,
+  ``<stem>_ambient_occlusion.png``, ``<stem>_ao_rough_metal.png``).
+- ``fbx``  -- via ASSIMP; best-effort geometry export; texture maps may not
+  be reliably written by the ASSIMP FBX exporter.
+- ``stl``  -- via ASSIMP; geometry only (positions, faces, normals);
+  materials, UV coordinates, and vertex colors are not supported by STL.
+- ``ply``, ``off`` -- via legacy Open3D writer; geometry + colors/normals
+  only; materials and UV coordinates are not exported.
+
+Only a single material per mesh is supported. Multiple materials,
+``triangle_material_ids``, per-triangle normals, and animation are not
+supported.
+
+Example: write an OBJ with a textured material::
+
+    import open3d as o3d
+    import numpy as np
+
+    mesh = o3d.t.geometry.TriangleMesh.create_box()
+    mesh.material.set_default_properties()
+    albedo = o3d.t.geometry.Image(
+        np.random.randint(0, 256, (256, 256, 3), dtype=np.uint8))
+    mesh.material.texture_maps['albedo'] = albedo
+    o3d.t.io.write_triangle_mesh('/tmp/box.obj', mesh)
+
+Args:
+    filename (str): Path to the output file.
+    mesh (open3d.t.geometry.TriangleMesh): The mesh to write.
+    write_ascii (bool): If True, write in ASCII format where supported.
+        Not supported for glb or gltf.
+    compressed (bool): Reserved; not used by current writers.
+    write_vertex_normals (bool): If True, write vertex normals when present.
+    write_vertex_colors (bool): If True, write vertex colors when present
+        (not supported by STL).
+    write_triangle_uvs (bool): If True, write UV coordinates and associated
+        texture maps (not supported by STL or ply/off).
+    print_progress (bool): If True print the writing progress to the
+        terminal.
+
+Returns:
+    True on success, False on failure.
+)doc");
     docstring::FunctionDocInject(m_io, "write_triangle_mesh",
                                  map_shared_argument_docstrings);
 

--- a/cpp/tests/t/io/TriangleMeshIO.cpp
+++ b/cpp/tests/t/io/TriangleMeshIO.cpp
@@ -65,7 +65,8 @@ TEST(TriangleMeshIO, ReadWriteTriangleMeshOBJ) {
 
     const std::string filename =
             utility::filesystem::GetTempDirectoryPath() + "/cube.obj";
-    EXPECT_TRUE(t::io::WriteTriangleMesh(filename, cube_mesh));
+    EXPECT_TRUE(t::io::WriteTriangleMesh(filename, cube_mesh,
+                                         /*write_ascii=*/true));
     t::geometry::TriangleMesh mesh_read;
     EXPECT_TRUE(t::io::ReadTriangleMesh(filename, mesh_read));
 
@@ -77,15 +78,15 @@ TEST(TriangleMeshIO, ReadWriteTriangleMeshOBJ) {
 }
 
 // OBJ round-trip with PBR material.  The OBJ/MTL format has no PBR material
-// properties, so roughness/metallic maps are skipped on export (a warning is
-// logged).  Only albedo (map_Kd) is written to the MTL and read back.
+// properties, so roughness/metallic maps are skipped on export.  Only albedo
+// (map_Kd) is written to the MTL and read back.
 TEST(TriangleMeshIO, ReadWriteTriangleMeshOBJMaterial) {
     t::geometry::TriangleMesh mesh = MakeTexturedBoxPBR();
 
     const std::string tmp =
             utility::filesystem::GetTempDirectoryPath() + "/obj_material";
     const std::string filename = tmp + ".obj";
-    EXPECT_TRUE(t::io::WriteTriangleMesh(filename, mesh));
+    EXPECT_TRUE(t::io::WriteTriangleMesh(filename, mesh, /*write_ascii=*/true));
 
     // Albedo sidecar PNG must be written and referenced by the MTL.
     EXPECT_TRUE(utility::filesystem::FileExists(tmp + "_albedo.png"));
@@ -227,7 +228,8 @@ TEST(TriangleMeshIO, TriangleMeshLegecyCompatibility) {
     std::string file_name_tensor = tmp_path + "/test_mesh_tensor.obj";
     std::string file_name_legacy = tmp_path + "/test_mesh_legacy.obj";
 
-    EXPECT_TRUE(t::io::WriteTriangleMesh(file_name_tensor, mesh_tensor));
+    EXPECT_TRUE(t::io::WriteTriangleMesh(file_name_tensor, mesh_tensor,
+                                         /*write_ascii=*/true));
     EXPECT_TRUE(io::WriteTriangleMesh(file_name_legacy, mesh_legacy));
     EXPECT_TRUE(t::io::ReadTriangleMesh(file_name_tensor, mesh_tensor_read));
     EXPECT_TRUE(io::ReadTriangleMesh(file_name_legacy, mesh_legacy_read));

--- a/cpp/tests/t/io/TriangleMeshIO.cpp
+++ b/cpp/tests/t/io/TriangleMeshIO.cpp
@@ -7,14 +7,37 @@
 
 #include "open3d/t/io/TriangleMeshIO.h"
 
+#include "open3d/core/Tensor.h"
 #include "open3d/data/Dataset.h"
 #include "open3d/io/TriangleMeshIO.h"
+#include "open3d/t/geometry/Image.h"
 #include "open3d/t/geometry/TriangleMesh.h"
 #include "open3d/utility/FileSystem.h"
 #include "tests/Tests.h"
 
 namespace open3d {
 namespace tests {
+
+namespace {
+
+// Unit box with 2×2 albedo, roughness, and metallic maps and per-triangle UVs.
+// Used by all material round-trip tests.
+t::geometry::TriangleMesh MakeTexturedBoxPBR() {
+    auto mesh = t::geometry::TriangleMesh::CreateBox();
+    const int64_t n = mesh.GetTriangleIndices().GetLength();
+    mesh.SetTriangleAttr("texture_uvs",
+                         core::Tensor::Zeros({n, 3, 2}, core::Float32));
+    mesh.GetMaterial().SetDefaultProperties();
+    mesh.GetMaterial().SetAlbedoMap(t::geometry::Image(
+            core::Tensor::Ones({2, 2, 3}, core::UInt8) * 200));
+    mesh.GetMaterial().SetRoughnessMap(t::geometry::Image(
+            core::Tensor::Ones({2, 2, 1}, core::UInt8) * 180));
+    mesh.GetMaterial().SetMetallicMap(t::geometry::Image(
+            core::Tensor::Ones({2, 2, 1}, core::UInt8) * 64));
+    return mesh;
+}
+
+}  // namespace
 
 TEST(TriangleMeshIO, CreateMeshFromFile) {
     data::KnotMesh knot_data;
@@ -43,32 +66,135 @@ TEST(TriangleMeshIO, ReadWriteTriangleMeshOBJ) {
     const std::string filename =
             utility::filesystem::GetTempDirectoryPath() + "/cube.obj";
     EXPECT_TRUE(t::io::WriteTriangleMesh(filename, cube_mesh));
-    t::geometry::TriangleMesh mesh, mesh_read;
-    EXPECT_TRUE(t::io::ReadTriangleMesh(filename, mesh));
+    t::geometry::TriangleMesh mesh_read;
+    EXPECT_TRUE(t::io::ReadTriangleMesh(filename, mesh_read));
 
-    core::Tensor vertices = core::Tensor::Init<float>({{0.0, 1.0, 0.0},
-                                                       {1.0, 1.0, 1.0},
-                                                       {1.0, 1.0, 0.0},
-                                                       {0.0, 1.0, 1.0},
-                                                       {0.0, 0.0, 0.0},
-                                                       {0.0, 0.0, 1.0},
-                                                       {1.0, 0.0, 0.0},
-                                                       {1.0, 0.0, 1.0}});
-    EXPECT_TRUE(mesh.GetVertexPositions().AllClose(vertices));
+    // Vertex and triangle counts must be preserved.
+    EXPECT_EQ(mesh_read.GetVertexPositions().GetLength(),
+              cube_mesh.GetVertexPositions().GetLength());
+    EXPECT_EQ(mesh_read.GetTriangleIndices().GetLength(),
+              cube_mesh.GetTriangleIndices().GetLength());
+}
 
-    core::Tensor triangles = core::Tensor::Init<int64_t>({{0, 1, 2},
-                                                          {0, 3, 1},
-                                                          {4, 5, 0},
-                                                          {5, 3, 0},
-                                                          {4, 6, 5},
-                                                          {6, 7, 5},
-                                                          {6, 2, 1},
-                                                          {6, 1, 7},
-                                                          {5, 7, 1},
-                                                          {5, 1, 3},
-                                                          {4, 0, 6},
-                                                          {6, 0, 2}});
-    EXPECT_TRUE(mesh.GetTriangleIndices().AllClose(triangles));
+// OBJ round-trip with PBR material.  The OBJ/MTL format has no PBR material
+// properties, so roughness/metallic maps are skipped on export (a warning is
+// logged).  Only albedo (map_Kd) is written to the MTL and read back.
+TEST(TriangleMeshIO, ReadWriteTriangleMeshOBJMaterial) {
+    t::geometry::TriangleMesh mesh = MakeTexturedBoxPBR();
+
+    const std::string tmp =
+            utility::filesystem::GetTempDirectoryPath() + "/obj_material";
+    const std::string filename = tmp + ".obj";
+    EXPECT_TRUE(t::io::WriteTriangleMesh(filename, mesh));
+
+    // Albedo sidecar PNG must be written and referenced by the MTL.
+    EXPECT_TRUE(utility::filesystem::FileExists(tmp + "_albedo.png"));
+
+    t::geometry::TriangleMesh mesh_read;
+    EXPECT_TRUE(t::io::ReadTriangleMesh(filename, mesh_read));
+
+    EXPECT_EQ(mesh_read.GetVertexPositions().GetLength(),
+              mesh.GetVertexPositions().GetLength());
+    EXPECT_EQ(mesh_read.GetTriangleIndices().GetLength(),
+              mesh.GetTriangleIndices().GetLength());
+    // Per-triangle UVs round-trip via ASSIMP's per-vertex UV export.
+    EXPECT_TRUE(mesh_read.HasTriangleAttr("texture_uvs"));
+    EXPECT_TRUE(mesh_read.GetMaterial().IsValid());
+    EXPECT_TRUE(mesh_read.GetMaterial().HasAlbedoMap());
+    EXPECT_EQ(mesh_read.GetMaterial().GetAlbedoMap().GetRows(), 2);
+    EXPECT_EQ(mesh_read.GetMaterial().GetAlbedoMap().GetCols(), 2);
+}
+
+// GLB round-trip with PBR material: textures are embedded (no sidecar files).
+// The ao_rough_metal map (G=roughness, B=metallic) is written to ASSIMP 6's
+// aiTextureType_DIFFUSE_ROUGHNESS slot, which the glTF2 exporter maps to
+// metallicRoughnessTexture.  On read-back ASSIMP 6 stores it in the dedicated
+// aiTextureType_GLTF_METALLIC_ROUGHNESS slot, which our reader loads as
+// ao_rough_metal.  A combined map is set directly here to isolate this path
+// from CombineRoughnessMetallic.
+TEST(TriangleMeshIO, ReadWriteTriangleMeshGLBMaterial) {
+    auto mesh = t::geometry::TriangleMesh::CreateBox();
+    const int64_t n = mesh.GetTriangleIndices().GetLength();
+    mesh.SetTriangleAttr("texture_uvs",
+                         core::Tensor::Zeros({n, 3, 2}, core::Float32));
+    mesh.GetMaterial().SetDefaultProperties();
+    mesh.GetMaterial().SetAlbedoMap(t::geometry::Image(
+            core::Tensor::Ones({2, 2, 3}, core::UInt8) * 200));
+    mesh.GetMaterial().SetAORoughnessMetalMap(t::geometry::Image(
+            core::Tensor::Ones({2, 2, 4}, core::UInt8) * 128));
+
+    const std::string filename =
+            utility::filesystem::GetTempDirectoryPath() + "/glb_material.glb";
+    EXPECT_TRUE(t::io::WriteTriangleMesh(filename, mesh));
+
+    t::geometry::TriangleMesh mesh_read;
+    EXPECT_TRUE(t::io::ReadTriangleMesh(filename, mesh_read));
+
+    EXPECT_EQ(mesh_read.GetVertexPositions().GetLength(),
+              mesh.GetVertexPositions().GetLength());
+    EXPECT_EQ(mesh_read.GetTriangleIndices().GetLength(),
+              mesh.GetTriangleIndices().GetLength());
+    EXPECT_TRUE(mesh_read.GetMaterial().HasAlbedoMap());
+    EXPECT_EQ(mesh_read.GetMaterial().GetAlbedoMap().GetRows(), 2);
+    EXPECT_EQ(mesh_read.GetMaterial().GetAlbedoMap().GetCols(), 2);
+    EXPECT_TRUE(mesh_read.GetMaterial().HasAORoughnessMetalMap());
+    EXPECT_EQ(mesh_read.GetMaterial().GetAORoughnessMetalMap().GetRows(), 2);
+    EXPECT_EQ(mesh_read.GetMaterial().GetAORoughnessMetalMap().GetCols(), 2);
+}
+
+// FBX round-trip with PBR material: geometry and albedo sidecar are verified;
+// full material fidelity is best-effort for the ASSIMP FBX exporter.
+TEST(TriangleMeshIO, ReadWriteTriangleMeshFBXMaterial) {
+    t::geometry::TriangleMesh mesh = MakeTexturedBoxPBR();
+
+    const std::string tmp =
+            utility::filesystem::GetTempDirectoryPath() + "/fbx_material";
+    const std::string filename = tmp + ".fbx";
+    EXPECT_TRUE(t::io::WriteTriangleMesh(filename, mesh));
+
+    // Sidecar textures must be written even for FBX.
+    EXPECT_TRUE(utility::filesystem::FileExists(tmp + "_albedo.png"));
+
+    t::geometry::TriangleMesh mesh_read;
+    EXPECT_TRUE(t::io::ReadTriangleMesh(filename, mesh_read));
+    EXPECT_EQ(mesh_read.GetTriangleIndices().GetLength(),
+              mesh.GetTriangleIndices().GetLength());
+    EXPECT_EQ(mesh_read.GetVertexPositions().GetLength(),
+              mesh.GetVertexPositions().GetLength());
+}
+
+// STL round-trip: triangle count only.  STL stores 3 vertices per face (no
+// shared-vertex support), so after ASSIMP's JoinIdenticalVertices pass the
+// vertex count differs from the original (e.g. 24 for a box, not 8).
+TEST(TriangleMeshIO, ReadWriteTriangleMeshSTL) {
+    t::geometry::TriangleMesh mesh = t::geometry::TriangleMesh::CreateBox();
+
+    const std::string filename =
+            utility::filesystem::GetTempDirectoryPath() + "/box.stl";
+    EXPECT_TRUE(t::io::WriteTriangleMesh(filename, mesh));
+
+    t::geometry::TriangleMesh mesh_read;
+    EXPECT_TRUE(t::io::ReadTriangleMesh(filename, mesh_read));
+
+    EXPECT_EQ(mesh_read.GetTriangleIndices().GetLength(),
+              mesh.GetTriangleIndices().GetLength());
+}
+
+// FBX round-trip: geometry counts only (ASSIMP FBX exporter is best-effort).
+TEST(TriangleMeshIO, ReadWriteTriangleMeshFBX) {
+    t::geometry::TriangleMesh mesh = t::geometry::TriangleMesh::CreateBox();
+
+    const std::string filename =
+            utility::filesystem::GetTempDirectoryPath() + "/box.fbx";
+    EXPECT_TRUE(t::io::WriteTriangleMesh(filename, mesh));
+
+    t::geometry::TriangleMesh mesh_read;
+    EXPECT_TRUE(t::io::ReadTriangleMesh(filename, mesh_read));
+
+    EXPECT_EQ(mesh_read.GetTriangleIndices().GetLength(),
+              mesh.GetTriangleIndices().GetLength());
+    EXPECT_EQ(mesh_read.GetVertexPositions().GetLength(),
+              mesh.GetVertexPositions().GetLength());
 }
 
 TEST(TriangleMeshIO, ReadWriteTriangleMeshNPZ) {
@@ -85,8 +211,6 @@ TEST(TriangleMeshIO, ReadWriteTriangleMeshNPZ) {
             mesh.GetTriangleIndices().AllClose(cube_mesh.GetTriangleIndices()));
 }
 
-// TODO: Add tests for triangle_uvs, materials, triangle_material_ids and
-// textures once these are supported.
 TEST(TriangleMeshIO, TriangleMeshLegecyCompatibility) {
     t::geometry::TriangleMesh mesh_tensor, mesh_tensor_read;
     geometry::TriangleMesh mesh_legacy, mesh_legacy_read;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [x] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [x] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [x] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [ ] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

### Tensor mesh IO: 

- Materials on export: OBJ, FBX, STL, GLB/glTF via ASSIMP; scalar PBR fields and texture maps (albedo, normal, AO, roughness/metallic where the format allows).
- Textures: GLB embeds PNGs; OBJ/FBX write sidecar PNGs next to the mesh; albedo can map to both diffuse and base-color ASSIMP slots without double-embedding.
- OBJ/MTL: No PBR roughness/metallic in the format — those maps are skipped on export with a warning; only albedo (and UVs where supported).
- GLB: Combined ao_rough_metal uses ASSIMP 6’s DIFFUSE_ROUGHNESS on write; read path uses GLTF_METALLIC_ROUGHNESS when present.
- Multi-material warning: Only when mesh faces reference more than one distinct material index (not merely mNumMaterials > 1).
- UVs: MakeVertexUVsUnique always produces vertex texture_uvs for export; read stores per-triangle texture_uvs from ASSIMP vertex UVs.
- Partial geometry: Warnings when normals/colors/UVs exist on only some sub-meshes and are dropped.

### Tensor image I/O

- In-memory decode: ReadImageFromMemory, PNG/JPG in-memory readers for embedded textures (no legacy geometry::Image / CreateImageFromMemory in tensor mesh I/O).

### Tests & Docs

- C++ tests OBJ/GLB/FBX material round-trips
- Python docs
- TriangleMeshIO.h: Updated format support notes (single material, STL geometry-only, OBJ PBR limits).
