### PR TITLE
[ROCm] Port the core GPU tensor stack to HIP (USE_HIP)

### DIFF
--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -485,7 +485,19 @@ include(ProcessorCount)
 ProcessorCount(NPROC)
 
 # CUDAToolkit (required at this point for subsequent checks and targets)
-if(BUILD_CUDA_MODULE)
+if(BUILD_CUDA_MODULE AND USE_HIP)
+    # ROCm/HIP: link only hip::host (the runtime). Do NOT link hip::device or
+    # roc::rocthrust: their INTERFACE_COMPILE_OPTIONS carry "-x hip
+    # --offload-arch" which propagate to every language of a consuming target,
+    # so g++ chokes on the host .cpp in the same OBJECT lib.
+    # rocThrust/hipCUB/rocPRIM are header-only on
+    # the HIP compiler's default include path, so a LANGUAGE-HIP .cu finds them
+    # with no link target.
+    find_package(hip REQUIRED)
+    find_package(hipblas REQUIRED)
+    find_package(hipsolver REQUIRED)
+    find_package(hipsparse REQUIRED)
+elseif(BUILD_CUDA_MODULE)
     find_package(CUDAToolkit REQUIRED)
 endif()
 
@@ -1789,7 +1801,26 @@ else(OPEN3D_USE_ONEAPI_PACKAGES)
 endif(OPEN3D_USE_ONEAPI_PACKAGES)
 
 # cuBLAS
-if(BUILD_CUDA_MODULE)
+if(BUILD_CUDA_MODULE AND USE_HIP)
+    # Build the 3rdparty_cublas INTERFACE target from the ROCm math libs. The
+    # LinalgHeadersCUDA.h compat shim aliases the cublas*/cusolver* spellings to
+    # the hipblas*/hipsolver* symbols these targets provide. hipsparse stands in
+    # for cusparse; hipblaslt is folded into hipblas on ROCm so no separate
+    # target is needed.
+    add_library(3rdparty_cublas INTERFACE)
+    target_link_libraries(3rdparty_cublas INTERFACE
+        roc::hipblas
+        roc::hipsolver
+        roc::hipsparse
+        hip::host
+    )
+    if(NOT BUILD_SHARED_LIBS)
+        install(TARGETS 3rdparty_cublas EXPORT Open3DTargets)
+        list(APPEND Open3D_3RDPARTY_EXTERNAL_MODULES "hip" "hipblas" "hipsolver" "hipsparse")
+    endif()
+    add_library(Open3D::3rdparty_cublas ALIAS 3rdparty_cublas)
+    list(APPEND Open3D_3RDPARTY_PRIVATE_TARGETS_FROM_SYSTEM Open3D::3rdparty_cublas)
+elseif(BUILD_CUDA_MODULE)
     if(WIN32)
         # Nvidia does not provide static libraries for Windows. We don't release
         # pip wheels for Windows with CUDA support at the moment. For the pip
@@ -1853,7 +1884,11 @@ if(BUILD_CUDA_MODULE)
 endif()
 
 # NPP
-if (BUILD_CUDA_MODULE)
+# NVIDIA Performance Primitives has no ROCm equivalent, so the GPU image-filter
+# ops that dispatch to NPP (NPPImage.*) are guarded out of the HIP build and
+# Image.cpp reports them unsupported on ROCm (the CPU/IPP image path is
+# unaffected). See notes.md for the scoped-out image ops.
+if (BUILD_CUDA_MODULE AND NOT USE_HIP)
     # NPP library list: https://docs.nvidia.com/cuda/npp/index.html
     if(WIN32)
         open3d_find_package_3rdparty_library(3rdparty_cuda_npp

--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -1887,7 +1887,7 @@ endif()
 # NVIDIA Performance Primitives has no ROCm equivalent, so the GPU image-filter
 # ops that dispatch to NPP (NPPImage.*) are guarded out of the HIP build and
 # Image.cpp reports them unsupported on ROCm (the CPU/IPP image path is
-# unaffected). See notes.md for the scoped-out image ops.
+# unaffected). See the AMD GPU support section of docs/compilation.rst.
 if (BUILD_CUDA_MODULE AND NOT USE_HIP)
     # NPP library list: https://docs.nvidia.com/cuda/npp/index.html
     if(WIN32)

--- a/3rdparty/libpng/libpng.cmake
+++ b/3rdparty/libpng/libpng.cmake
@@ -1,6 +1,9 @@
 include(ExternalProject)
 
-if(MSVC)
+# libpng's CMake emits libpng16_static on Windows regardless of compiler
+# frontend, so gate the imported name on WIN32 (not MSVC) -- an all-clang
+# Windows toolchain has CMake's MSVC set to FALSE.
+if(WIN32)
     set(LIBPNG_LIB_NAME libpng16_static)
 else()
     set(LIBPNG_LIB_NAME png16)

--- a/3rdparty/stdgpu/stdgpu.cmake
+++ b/3rdparty/stdgpu/stdgpu.cmake
@@ -6,6 +6,60 @@ include(ExternalProject)
 
 find_package(Git QUIET REQUIRED)
 
+if(USE_HIP)
+    # stdgpu's pinned commit ships an experimental HIP backend
+    # (STDGPU_BACKEND_HIP). Build it with hipcc/clang: the device headers are
+    # marked LANGUAGE HIP by stdgpu itself, and the host impl/*.cpp reach the
+    # HIP backend headers (rocPRIM, clang-only builtins) so the CXX compiler
+    # must also be clang. stdgpu's bundled cmake/hip/Findthrust.cmake locates
+    # rocThrust and exposes thrust::thrust, so no Findthrust shim is needed (the
+    # broken bundled Findthrust in the older stdgpu 1.3.0 release is fixed at
+    # this pinned commit).
+    ExternalProject_Add(
+        ext_stdgpu
+        PREFIX stdgpu
+        URL https://github.com/stotko/stdgpu/archive/d7c07d056a654454c3f2d7cf928e6cec6e0ce28e.tar.gz
+        URL_HASH SHA256=85b38dc3807ac24b5afe8d06a674dbff8e66579dfd67cbb33189783b0a84a0aa
+        DOWNLOAD_DIR "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/stdgpu"
+        UPDATE_COMMAND ""
+        # The pinned commit's HIP backend dir is missing determine_thrust_paths
+        # .cmake (only the CUDA backend ships it), but src/stdgpu/CMakeLists.txt
+        # unconditionally installs it -> the install step fails. Open3D consumes
+        # stdgpu by include-dir + lib (not find_package(stdgpu)), so the file is
+        # never used; copy the CUDA one into the hip dir so install succeeds.
+        PATCH_COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            <SOURCE_DIR>/cmake/cuda/determine_thrust_paths.cmake
+            <SOURCE_DIR>/cmake/hip/determine_thrust_paths.cmake
+        CMAKE_ARGS
+            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+            -DSTDGPU_BACKEND=STDGPU_BACKEND_HIP
+            -DSTDGPU_BUILD_SHARED_LIBS=OFF
+            -DSTDGPU_BUILD_EXAMPLES=OFF
+            -DSTDGPU_BUILD_TESTS=OFF
+            -DSTDGPU_BUILD_BENCHMARKS=OFF
+            -DSTDGPU_ENABLE_CONTRACT_CHECKS=OFF
+            -DSTDGPU_COMPILE_WARNING_AS_ERROR=OFF
+            -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+            ${ExternalProject_CMAKE_ARGS_hidden}
+            # These must come AFTER the hidden args, which set CMAKE_CXX_COMPILER
+            # to the host g++: stdgpu's HIP backend reaches rocPRIM (clang-only
+            # builtins) from its host impl/*.cpp, so CXX must be hipcc/clang too.
+            -DCMAKE_CXX_COMPILER=${CMAKE_HIP_COMPILER}
+            -DCMAKE_HIP_COMPILER=${CMAKE_HIP_COMPILER}
+            -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
+        CMAKE_CACHE_ARGS
+            -DCMAKE_HIP_ARCHITECTURES:STRING=${CMAKE_HIP_ARCHITECTURES}
+        BUILD_BYPRODUCTS
+            <INSTALL_DIR>/lib/${CMAKE_STATIC_LIBRARY_PREFIX}stdgpu${CMAKE_STATIC_LIBRARY_SUFFIX}
+    )
+
+    ExternalProject_Get_Property(ext_stdgpu INSTALL_DIR)
+    set(STDGPU_INCLUDE_DIRS ${INSTALL_DIR}/include/) # "/" is critical.
+    set(STDGPU_LIB_DIR ${INSTALL_DIR}/lib)
+    set(STDGPU_LIBRARIES stdgpu)
+    return()
+endif()
+
 # In CUDA 13.0+, Thrust moved from include/thrust/ to include/cccl/thrust/
 # Set the appropriate include directory based on CUDA version
 if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "13.0")

--- a/3rdparty/zlib/zlib.cmake
+++ b/3rdparty/zlib/zlib.cmake
@@ -1,6 +1,10 @@
 include(ExternalProject)
 
-if(MSVC)
+# The static lib basename follows the target platform (zlib's CMake emits
+# zlibstatic on Windows), not the compiler frontend -- gate on WIN32 so an
+# all-clang Windows toolchain (where CMake's MSVC is FALSE) still imports the
+# right name.
+if(WIN32)
     set(lib_name zlibstatic)
 else()
     set(lib_name z)
@@ -32,7 +36,7 @@ ExternalProject_Add(
 ExternalProject_Get_Property(ext_zlib INSTALL_DIR)
 set(ZLIB_INCLUDE_DIRS ${INSTALL_DIR}/include/) # "/" is critical.
 set(ZLIB_LIB_DIR ${INSTALL_DIR}/lib)
-if(MSVC)
+if(WIN32)
     set(ZLIB_LIBRARIES ${lib_name}$<$<CONFIG:Debug>:d>)
 else()
     set(ZLIB_LIBRARIES ${lib_name})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 -   Add `CorrespondenceCheckerBasedOnSourceRotation` to constrain global orientation priors in RANSAC registration (PR #7461)
+-   Add an AMD GPU (ROCm/HIP) build for the core tensor module (`open3d.core`, `open3d.t`), enabled with `-DUSE_HIP=ON` (PR #7509)
 -   Use glfwGetMonitorWorkarea for accurate screen size in GetScreenSize, remove unusable_height estimation hack, and subtract window-decoration extents before clamping auto-sized windows (PR #7469)
 -   Upgrade stdgpu third-party library to commit d7c07d0.
 -   Fix performance for non-contiguous NumPy array conversion in pybind vector converters. This change removes restrictive `py::array::c_style` flags and adds a runtime contiguity check, improving Pandas-to-Open3D conversion speed by up to ~50×. (issue #5250)(PR #7343).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,12 +40,26 @@ option(BUILD_UNIT_TESTS           "Build Open3D unit tests"                  OFF
 option(BUILD_BENCHMARKS           "Build the micro benchmarks"               OFF)
 option(BUILD_PYTHON_MODULE        "Build the python module"                  ON )
 option(BUILD_CUDA_MODULE          "Build the CUDA module"                    OFF)
+option(USE_HIP                    "Build the GPU module with HIP for AMD"    OFF)
 option(BUILD_WITH_CUDA_STATIC     "Build with static CUDA libraries"         ON )
 option(BUILD_COMMON_CUDA_ARCHS    "Build for common CUDA GPUs (for release)" OFF)
 if (WIN32)   # Causes CUDA runtime error on Windows (See issue #6555)
     option(ENABLE_CACHED_CUDA_MANAGER "Enable cached CUDA memory manager"    OFF)
 else()
     option(ENABLE_CACHED_CUDA_MANAGER "Enable cached CUDA memory manager"    ON )
+endif()
+
+# USE_HIP drives the GPU module through HIP (AMD ROCm) instead of CUDA. The GPU
+# code paths are keyed on BUILD_CUDA_MODULE throughout the tree (both in CMake
+# and via #if defined(BUILD_CUDA_MODULE) host guards), so HIP reuses that switch
+# and only swaps the compiler/language and the math libraries. The .cu sources
+# stay in CUDA spelling and are retagged LANGUAGE HIP (see
+# Open3DSetGlobalProperties.cmake); a single compat header
+# (cpp/open3d/core/hip/CUDAToHIP.h) is force-included on the HIP TUs.
+if(USE_HIP)
+    set(BUILD_CUDA_MODULE ON CACHE BOOL "Build the CUDA module" FORCE)
+    set(BUILD_WITH_CUDA_STATIC OFF CACHE BOOL "Build with static CUDA libraries" FORCE)
+    set(BUILD_COMMON_CUDA_ARCHS OFF CACHE BOOL "Build for common CUDA GPUs" FORCE)
 endif()
 if(NOT LINUX_AARCH64 AND NOT APPLE_AARCH64)
     option(BUILD_ISPC_MODULE      "Build the ISPC module"                    ON )
@@ -405,7 +419,19 @@ endmacro()
 cmake_language(EVAL CODE "cmake_language(DEFER CALL open3d_patch_findthreads_module_)")
 
 # Build CUDA module by default if CUDA is available
-if(BUILD_CUDA_MODULE)
+if(BUILD_CUDA_MODULE AND USE_HIP)
+    # AMD ROCm/HIP path. Mirror the CUDA enable but for the HIP language.
+    # enable_language(HIP) would auto-detect the host GPU architecture (via
+    # rocm_agent_enumerator) when CMAKE_HIP_ARCHITECTURES is unset; we pin
+    # gfx90a as a deterministic default instead. Pass -DCMAKE_HIP_ARCHITECTURES
+    # to build for another target.
+    if(NOT DEFINED CMAKE_HIP_ARCHITECTURES OR CMAKE_HIP_ARCHITECTURES STREQUAL "")
+        set(CMAKE_HIP_ARCHITECTURES "gfx90a")
+    endif()
+    enable_language(HIP)
+    set(CMAKE_HIP_STANDARD 17)
+    message(STATUS "Building with HIP for AMD architectures: ${CMAKE_HIP_ARCHITECTURES}")
+elseif(BUILD_CUDA_MODULE)
     if(MSVC)
         # Handle/suppress nvcc unsupported compiler error for MSVC>=1940 with CUDA 11.7 to 12.4:
         # (https://forums.developer.nvidia.com/t/problems-with-latest-vs2022-update/294150/12)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,13 +421,10 @@ cmake_language(EVAL CODE "cmake_language(DEFER CALL open3d_patch_findthreads_mod
 # Build CUDA module by default if CUDA is available
 if(BUILD_CUDA_MODULE AND USE_HIP)
     # AMD ROCm/HIP path. Mirror the CUDA enable but for the HIP language.
-    # enable_language(HIP) would auto-detect the host GPU architecture (via
-    # rocm_agent_enumerator) when CMAKE_HIP_ARCHITECTURES is unset; we pin
-    # gfx90a as a deterministic default instead. Pass -DCMAKE_HIP_ARCHITECTURES
-    # to build for another target.
-    if(NOT DEFINED CMAKE_HIP_ARCHITECTURES OR CMAKE_HIP_ARCHITECTURES STREQUAL "")
-        set(CMAKE_HIP_ARCHITECTURES "gfx90a")
-    endif()
+    # enable_language(HIP) honors an explicit -DCMAKE_HIP_ARCHITECTURES, otherwise
+    # auto-detects the host GPU(s) (via rocm_agent_enumerator) and fails with a
+    # fatal error if none is found -- so a build host with no AMD GPU must set the
+    # arch explicitly rather than getting a silently-wrong default.
     enable_language(HIP)
     set(CMAKE_HIP_STANDARD 17)
     message(STATUS "Building with HIP for AMD architectures: ${CMAKE_HIP_ARCHITECTURES}")

--- a/cmake/Open3DSetGlobalProperties.cmake
+++ b/cmake/Open3DSetGlobalProperties.cmake
@@ -93,6 +93,29 @@ function(open3d_set_global_properties target)
         if (ENABLE_CACHED_CUDA_MANAGER)
             target_compile_definitions(${target} PRIVATE ENABLE_CACHED_CUDA_MANAGER)
         endif()
+        if (USE_HIP)
+            target_compile_definitions(${target} PRIVATE USE_HIP)
+            # Host .cpp across the tree include CUDAUtils.h -> <cuda.h>. Put the
+            # hip_compat shim dir + cpp root + the ROCm include dir on EVERY
+            # target (not just the .cu-bearing GPU libs) so those CUDA-spelled
+            # includes resolve to the HIP runtime under the host compiler too.
+            target_include_directories(${target} PRIVATE
+                "${PROJECT_SOURCE_DIR}/cpp/open3d/core/hip/hip_compat"
+                "${PROJECT_SOURCE_DIR}/cpp")
+            # rocThrust's compiler.h auto-detects the backend from __CUDACC__
+            # / __HIPCC__; without an explicit override it can pin to the wrong
+            # backend. THRUST_DEVICE_SYSTEM_HIP == 5 (thrust/detail/config/
+            # device_system.h); pin it directly so auto-detect is bypassed.
+            # __CUDACC__ is deliberately NOT defined (CUDAToHIP.h explains why;
+            # the device guards are extended to ||__HIPCC__ at each site).
+            # Applies to .cu TUs and host .cpp alike.
+            target_compile_definitions(${target} PRIVATE
+                THRUST_DEVICE_SYSTEM=5)
+            find_package(hip QUIET)
+            if (TARGET hip::host)
+                target_link_libraries(${target} PRIVATE hip::host)
+            endif()
+        endif()
     endif()
     if (BUILD_ISPC_MODULE)
         target_compile_definitions(${target} PRIVATE BUILD_ISPC_MODULE)
@@ -205,10 +228,51 @@ function(open3d_set_global_properties target)
             BUILD_RPATH "@loader_path;@loader_path/../;@loader_path/../lib/:@loader_path/../../../../")
     elseif(UNIX)
         # INSTALL_RPATH for C++ binaries.
-        set_target_properties(${target} PROPERTIES 
+        set_target_properties(${target} PROPERTIES
             INSTALL_RPATH "$ORIGIN;$ORIGIN/../;$ORIGIN/../lib/;$ORIGIN/../../../../"
         # BUILD_RPATH for Python wheel libs and app.
             BUILD_RPATH "$ORIGIN;$ORIGIN/../;$ORIGIN/../lib/;$ORIGIN/../../../../")
     endif()
 
+    # HIP: retag this target's .cu sources to the HIP language so they compile
+    # with hipcc/clang, force-include the CUDA->HIP compat header on them, and
+    # add the toolkit-include shim dir (hip_compat) so the CUDA-spelled
+    # <cuda.h>/<cuda_runtime.h>/<cub/cub.cuh> includes resolve to HIP. Every GPU
+    # library calls open3d_set_global_properties after its target_sources, so
+    # the .cu sources are present here; the CUDA build never enters this branch.
+    if (USE_HIP)
+        open3d_set_hip_properties(${target})
+    endif()
+
+endfunction()
+
+
+# open3d_set_hip_properties(target)
+#
+# Mark a target's CUDA-spelled .cu sources LANGUAGE HIP and wire up the compat
+# layer (force-include + shim include dir). No-op for targets with no .cu.
+function(open3d_set_hip_properties target)
+    get_target_property(target_sources_list ${target} SOURCES)
+    if (NOT target_sources_list)
+        return()
+    endif()
+    set(hip_sources)
+    foreach(src ${target_sources_list})
+        if (src MATCHES "\\.cu$")
+            list(APPEND hip_sources ${src})
+        endif()
+    endforeach()
+    if (NOT hip_sources)
+        return()
+    endif()
+    set_source_files_properties(${hip_sources} TARGET_DIRECTORY ${target}
+                                PROPERTIES LANGUAGE HIP)
+    set_target_properties(${target} PROPERTIES
+        HIP_ARCHITECTURES "${CMAKE_HIP_ARCHITECTURES}")
+    # The hip_compat shim dir + cpp root are already on the include path for
+    # every target (open3d_set_global_properties). Force-include the compat
+    # header on the HIP TUs so its aliases precede any use regardless of each
+    # file's include order.
+    target_compile_options(${target} PRIVATE
+        "$<$<COMPILE_LANGUAGE:HIP>:SHELL:-include ${PROJECT_SOURCE_DIR}/cpp/open3d/core/hip/CUDAToHIP.h>")
 endfunction()

--- a/cmake/Open3DShowAndAbortOnWarning.cmake
+++ b/cmake/Open3DShowAndAbortOnWarning.cmake
@@ -66,4 +66,22 @@ function(open3d_show_and_abort_on_warning target)
         $<$<COMPILE_LANGUAGE:CUDA>:SHELL:${CUDA_FLAGS}>
         $<$<COMPILE_LANGUAGE:ISPC>:--werror>
     )
+    if (USE_HIP)
+        # HIP's <hip/hip_runtime.h> marks the runtime API nodiscard where CUDA's
+        # does not, so host .cpp including it via the compat shim trip
+        # -Werror=unused-result under -Wall (the CUDA build suppresses the same
+        # nodiscard, NVCC warning 2809). Relax just that warning; do not blanket
+        # -Wno-error. The HIP device TUs get no -Werror here at all.
+        target_compile_options(${target} PRIVATE
+            $<$<COMPILE_LANGUAGE:CXX>:-Wno-error=unused-result>
+            $<$<COMPILE_LANGUAGE:HIP>:-Wno-unused-result>)
+        # MinimumOBB/OBE.cpp: gcc 13 emits a false -Wmaybe-uninitialized on
+        # Eigen's SIMD stores into best_R/best_radii, which ARE initialized to
+        # Identity()/Zero() at declaration -- a known gcc+Eigen false positive,
+        # not a real bug and not HIP-specific. Relax just that warning.
+        if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+            target_compile_options(${target} PRIVATE
+                $<$<COMPILE_LANGUAGE:CXX>:-Wno-error=maybe-uninitialized>)
+        endif()
+    endif()
 endfunction()

--- a/cmake/Open3DShowAndAbortOnWarning.cmake
+++ b/cmake/Open3DShowAndAbortOnWarning.cmake
@@ -83,5 +83,13 @@ function(open3d_show_and_abort_on_warning target)
             target_compile_options(${target} PRIVATE
                 $<$<COMPILE_LANGUAGE:CXX>:-Wno-error=maybe-uninitialized>)
         endif()
+        # On Windows USE_HIP forces an all-clang toolchain, so the host .cpp are
+        # clang-compiled. clang reports the ignored nodiscard hipError_t under
+        # -Wunused-value (gcc spells it -Wunused-result, relaxed above); demote
+        # that one too. Host-only, clang-only: the Linux gcc build is unchanged.
+        if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+            target_compile_options(${target} PRIVATE
+                $<$<COMPILE_LANGUAGE:CXX>:-Wno-error=unused-value>)
+        endif()
     endif()
 endfunction()

--- a/cpp/open3d/core/CUDAUtils.cpp
+++ b/cpp/open3d/core/CUDAUtils.cpp
@@ -260,8 +260,10 @@ CUDAState::CUDAState() {
                     p2p_enabled_[src_id][tar_id] = true;
                     cudaError_t err = cudaDeviceEnablePeerAccess(tar_id, 0);
                     if (err == cudaErrorPeerAccessAlreadyEnabled) {
-                        // Ignore error since P2P is already enabled.
-                        cudaGetLastError();
+                        // Ignore error since P2P is already enabled. Cast to
+                        // void: HIP marks hipGetLastError nodiscard (CUDA does
+                        // not), which trips -Werror.
+                        static_cast<void>(cudaGetLastError());
                     } else {
                         OPEN3D_CUDA_CHECK(err);
                     }

--- a/cpp/open3d/core/CUDAUtils.h
+++ b/cpp/open3d/core/CUDAUtils.h
@@ -28,9 +28,17 @@
 #define OPEN3D_FORCE_INLINE __forceinline__
 #define OPEN3D_HOST_DEVICE __host__ __device__
 #define OPEN3D_DEVICE __device__
+#if defined(USE_HIP)
+// __nv_is_extended_host_device_lambda_closure_type is an nvcc-only intrinsic;
+// clang/hipcc has no equivalent. The assertion is only a compile-time sanity
+// check that the kernel lambda is __host__ __device__, so make it a no-op on
+// HIP (HIP's extended lambdas need no such annotation check).
+#define OPEN3D_ASSERT_HOST_DEVICE_LAMBDA(type)
+#else
 #define OPEN3D_ASSERT_HOST_DEVICE_LAMBDA(type)                            \
     static_assert(__nv_is_extended_host_device_lambda_closure_type(type), \
                   #type " must be a __host__ __device__ lambda")
+#endif
 #define OPEN3D_CUDA_CHECK(err) \
     open3d::core::__OPEN3D_CUDA_CHECK(err, __FILE__, __LINE__)
 #define OPEN3D_GET_LAST_CUDA_ERROR(message) \

--- a/cpp/open3d/core/ParallelFor.h
+++ b/cpp/open3d/core/ParallelFor.h
@@ -16,7 +16,7 @@
 #include "open3d/utility/Parallel.h"
 #include "open3d/utility/Preprocessor.h"
 
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 #include <cuda.h>
 #include <cuda_runtime.h>
 
@@ -26,7 +26,7 @@
 namespace open3d {
 namespace core {
 
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 
 static constexpr int64_t OPEN3D_PARFOR_BLOCK = 128;
 static constexpr int64_t OPEN3D_PARFOR_THREAD = 4;
@@ -106,7 +106,7 @@ void ParallelForCPU_(const Device& device, int64_t n, const func_t& func) {
 /// ParallelForSYCL instead.
 template <typename func_t>
 void ParallelFor(const Device& device, int64_t n, const func_t& func) {
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
     ParallelForCUDA_(device, n, func);
 #else
     ParallelForCPU_(device, n, func);
@@ -166,7 +166,7 @@ void ParallelFor(const Device& device,
                  const vec_func_t& vec_func) {
 #ifdef BUILD_ISPC_MODULE
 
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
     ParallelForCUDA_(device, n, func);
 #else
     int num_threads = utility::EstimateMaxThreads();
@@ -179,7 +179,7 @@ void ParallelFor(const Device& device,
 
 #else
 
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
     ParallelForCUDA_(device, n, func);
 #else
     ParallelForCPU_(device, n, func);

--- a/cpp/open3d/core/hashmap/CUDA/SlabMacros.h
+++ b/cpp/open3d/core/hashmap/CUDA/SlabMacros.h
@@ -63,8 +63,19 @@ static constexpr uint32_t kBlockMaskBits = 10;
 static constexpr uint32_t kSlabMaskBits = 5;
 
 // Masks & flags
+// The SlabHash backend is the NON-default warp-cooperative hashmap (the default
+// is StdGPU). Its 32-lane lane-election logic (tid>>5, lane masks, __ffs of a
+// ballot) is NOT wave64-correct and a correct wave64 rewrite is deferred; here
+// the lane masks are only widened to 64 bits so the *_sync intrinsics, which on
+// HIP static_assert sizeof(mask)==8, compile. SlabHash-backend tests are
+// skipped on this port (see notes.md).
+#if defined(USE_HIP)
+static constexpr unsigned long long kSyncLanesMask = 0xFFFFFFFFFFFFFFFFull;
+static constexpr unsigned long long kNodePtrLanesMask = 0x7FFFFFFFull;
+#else
 static constexpr uint32_t kSyncLanesMask = 0xFFFFFFFF;
 static constexpr uint32_t kNodePtrLanesMask = 0x7FFFFFFF;
+#endif
 static constexpr uint32_t kNextSlabPtrLaneId = 31;
 
 static constexpr uint32_t kHeadSlabAddr = 0xFFFFFFFE;

--- a/cpp/open3d/core/hashmap/CUDA/SlabMacros.h
+++ b/cpp/open3d/core/hashmap/CUDA/SlabMacros.h
@@ -68,7 +68,7 @@ static constexpr uint32_t kSlabMaskBits = 5;
 // ballot) is NOT wave64-correct and a correct wave64 rewrite is deferred; here
 // the lane masks are only widened to 64 bits so the *_sync intrinsics, which on
 // HIP static_assert sizeof(mask)==8, compile. SlabHash-backend tests are
-// skipped on this port (see notes.md).
+// skipped on this port.
 #if defined(USE_HIP)
 static constexpr unsigned long long kSyncLanesMask = 0xFFFFFFFFFFFFFFFFull;
 static constexpr unsigned long long kNodePtrLanesMask = 0x7FFFFFFFull;

--- a/cpp/open3d/core/hashmap/Dispatch.h
+++ b/cpp/open3d/core/hashmap/Dispatch.h
@@ -59,7 +59,7 @@
         }                                                                     \
     }()
 
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 // Reinterpret hash maps' void* value arrays as CUDA primitive types arrays, to
 // avoid slow memcpy or byte-by-byte copy in kernels.
 // Not used in the CPU version since memcpy is relatively fast on CPU.

--- a/cpp/open3d/core/hip/CUDAToHIP.h
+++ b/cpp/open3d/core/hip/CUDAToHIP.h
@@ -1,0 +1,130 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// Copyright (c) 2018-2024 www.open3d.org
+// SPDX-License-Identifier: MIT
+// ----------------------------------------------------------------------------
+
+// CUDA-to-HIP compatibility shim for the ROCm/HIP build (USE_HIP=ON).
+//
+// This is the single file that knows about HIP. It is force-included on every
+// HIP translation unit (cmake/Open3DSetGlobalProperties.cmake adds it via the
+// HIP language -include flag) so the CUDA-spelled core sources compile under
+// hipcc unchanged. On the NVIDIA build this header is never referenced and the
+// CUDA path is byte-for-byte unaffected.
+//
+// libc host declarations must win over HIP's __device__ memcpy/memset
+// overloads, so pull them in before <hip/hip_runtime.h>.
+
+#pragma once
+
+#if defined(USE_HIP)
+
+#include <cstdlib>
+#include <cstring>
+
+#include <hip/hip_runtime.h>
+
+// Open3D gates device-vs-host code throughout core/t on __CUDACC__ (device
+// decorations, kernel launch, host fallbacks). We do NOT fake __CUDACC__ for
+// HIP: rocThrust's HIP backend disables its for_each/copy specializations when
+// __CUDACC__ is set (it reads __CUDACC__ as "use the CUDA backend", which
+// contradicts THRUST_DEVICE_SYSTEM=HIP and dumps every thrust call into the
+// "unimplemented for this system" generic fallback). Instead the Open3D device
+// guards are extended to also accept __HIPCC__ at each site. Provide
+// OPEN3D_DEVICE_CODE as the device-vs-host
+// discriminator: __CUDA_ARCH__ on CUDA, __HIP_DEVICE_COMPILE__ on HIP.
+#if defined(__HIP_DEVICE_COMPILE__) && __HIP_DEVICE_COMPILE__
+#define OPEN3D_DEVICE_CODE 1
+#else
+#define OPEN3D_DEVICE_CODE 0
+#endif
+// Eigen would take its CUDA path (<math_constants.h>, absent on ROCm) under a
+// CUDA compiler; EIGEN_NO_CUDA keeps it on its native HIP path. Harmless when
+// no device TU includes Eigen.
+#if !defined(EIGEN_NO_CUDA)
+#define EIGEN_NO_CUDA
+#endif
+
+// hipCUB lives under the hipcub:: namespace and <hipcub/...> headers; the core
+// sources spell it cub::/<cub/cub.cuh>. The forwarding header hip_compat/cub
+// remaps the include; this remaps the namespace token.
+#define cub hipcub
+
+// Full-wavefront lane mask for the *_sync warp primitives. HIP's
+// __shfl_*_sync / __ballot_sync / __any_sync take a 64-bit mask and
+// static_assert sizeof(mask)==8, so the upstream 0xffffffff (32-bit) literal
+// does not compile. ~0ull is the all-lanes mask on both wave32 and wave64.
+#define OPEN3D_FULL_WARP_MASK (~0ull)
+
+// HIP declares __ffs(int) and __ffs(unsigned int) but no 64-bit overload, so
+// __ffs(__ballot_sync(...)) -- whose ballot result is unsigned long long on a
+// 64-lane wavefront (SlabHash work-queue loop) -- is AMBIGUOUS (the ull arg
+// converts to int and unsigned equally). Add the exact 64-bit overload as
+// __host__ __device__ so it resolves in both passes; __ffsll is device-only,
+// so fall back to __builtin_ffsll on the host pass.
+__host__ __device__ __forceinline__ int __ffs(unsigned long long x) {
+#if defined(__HIP_DEVICE_COMPILE__) && __HIP_DEVICE_COMPILE__
+    return __ffsll(x);
+#else
+    return __builtin_ffsll(static_cast<long long>(x));
+#endif
+}
+
+// CUDA runtime symbols used by the core GPU sources, mapped to their HIP
+// equivalents. Only the symbols the build actually references are listed.
+#define CUDA_VERSION 9000  // gate the >=9000 *_sync paths in the FAISS sources
+
+#define cudaError_t hipError_t
+#define cudaError hipError
+#define cudaSuccess hipSuccess
+#define cudaErrorNotReady hipErrorNotReady
+#define cudaErrorPeerAccessAlreadyEnabled hipErrorPeerAccessAlreadyEnabled
+#define cudaGetErrorString hipGetErrorString
+#define cudaGetLastError hipGetLastError
+
+#define cudaStream_t hipStream_t
+#define cudaStreamCreate hipStreamCreate
+#define cudaStreamDestroy hipStreamDestroy
+#define cudaStreamQuery hipStreamQuery
+#define cudaStreamGetFlags hipStreamGetFlags
+
+#define cudaMalloc hipMalloc
+#define cudaFree hipFree
+#define cudaMallocHost hipHostMalloc
+#define cudaMallocManaged hipMallocManaged
+#define cudaMallocAsync hipMallocAsync
+#define cudaFreeAsync hipFreeAsync
+#define cudaMemset hipMemset
+#define cudaMemsetAsync hipMemsetAsync
+#define cudaMemcpy hipMemcpy
+#define cudaMemcpyAsync hipMemcpyAsync
+#define cudaMemcpyPeerAsync hipMemcpyPeerAsync
+#define cudaMemcpyKind hipMemcpyKind
+#define cudaMemcpyHostToDevice hipMemcpyHostToDevice
+#define cudaMemcpyDeviceToHost hipMemcpyDeviceToHost
+#define cudaMemcpyDeviceToDevice hipMemcpyDeviceToDevice
+#define cudaMemGetInfo hipMemGetInfo
+
+#define cudaSetDevice hipSetDevice
+#define cudaGetDevice hipGetDevice
+#define cudaGetDeviceCount hipGetDeviceCount
+#define cudaGetDeviceProperties hipGetDeviceProperties
+#define cudaDeviceProp hipDeviceProp_t
+#define cudaDeviceSynchronize hipDeviceSynchronize
+#define cudaDeviceGetAttribute hipDeviceGetAttribute
+#define cudaDeviceCanAccessPeer hipDeviceCanAccessPeer
+#define cudaDeviceEnablePeerAccess hipDeviceEnablePeerAccess
+#define cudaDriverGetVersion hipDriverGetVersion
+#define cudaRuntimeGetVersion hipRuntimeGetVersion
+
+#define cudaDevAttrWarpSize hipDeviceAttributeWarpSize
+#define cudaDevAttrTextureAlignment hipDeviceAttributeTextureAlignment
+#define cudaDevAttrMemoryPoolsSupported hipDeviceAttributeMemoryPoolsSupported
+#define cudaDevAttrComputeCapabilityMajor hipDeviceAttributeComputeCapabilityMajor
+#define cudaDevAttrComputeCapabilityMinor hipDeviceAttributeComputeCapabilityMinor
+
+#define cudaPointerAttributes hipPointerAttribute_t
+#define cudaPointerGetAttributes hipPointerGetAttributes
+
+#endif  // USE_HIP

--- a/cpp/open3d/core/hip/hip_compat/cub/cub.cuh
+++ b/cpp/open3d/core/hip/hip_compat/cub/cub.cuh
@@ -1,0 +1,6 @@
+// CUB include shim for the HIP build: route <cub/cub.cuh> to hipCUB. The
+// compat header additionally aliases the cub:: namespace token to hipcub::.
+// On the NVIDIA build this dir is not on the include path, so the real CUB is
+// used unchanged.
+#pragma once
+#include <hipcub/hipcub.hpp>

--- a/cpp/open3d/core/hip/hip_compat/cuda.h
+++ b/cpp/open3d/core/hip/hip_compat/cuda.h
@@ -1,0 +1,4 @@
+// CUDA-toolkit include shim for the HIP build. On the NVIDIA build this dir is
+// not on the include path, so the real <cuda.h> is used unchanged.
+#pragma once
+#include "open3d/core/hip/CUDAToHIP.h"

--- a/cpp/open3d/core/hip/hip_compat/cuda_runtime.h
+++ b/cpp/open3d/core/hip/hip_compat/cuda_runtime.h
@@ -1,0 +1,3 @@
+// CUDA-toolkit include shim for the HIP build. See cuda.h in this dir.
+#pragma once
+#include "open3d/core/hip/CUDAToHIP.h"

--- a/cpp/open3d/core/hip/hip_compat/cuda_runtime_api.h
+++ b/cpp/open3d/core/hip/hip_compat/cuda_runtime_api.h
@@ -1,0 +1,3 @@
+// CUDA-toolkit include shim for the HIP build. See cuda.h in this dir.
+#pragma once
+#include "open3d/core/hip/CUDAToHIP.h"

--- a/cpp/open3d/core/kernel/ReductionCUDA.cu
+++ b/cpp/open3d/core/kernel/ReductionCUDA.cu
@@ -56,11 +56,24 @@ constexpr uint32_t CUDA_THREADS_PER_BLOCK_FALLBACK = 256;
                       (OPEN3D_MIN_BLOCKS_PER_SM((max_threads_per_block),       \
                                                 (min_blocks_per_sm))))
 
+// The full-warp mask: HIP's __shfl_down_sync takes a 64-bit mask and
+// static_asserts sizeof(mask)==8, so a 32-bit default does not compile there.
+// This reduction tree is wave-size-aware (it shuffles with width=warpSize, 64
+// on gfx9xx), so the mask must cover the whole wavefront.
+#if defined(USE_HIP)
+using open3d_warp_mask_t = unsigned long long;
+#define OPEN3D_REDUCE_FULL_WARP_MASK (~0ull)
+#else
+using open3d_warp_mask_t = unsigned int;
+#define OPEN3D_REDUCE_FULL_WARP_MASK 0xffffffffu
+#endif
+
 template <typename T>
-OPEN3D_DEVICE __forceinline__ T WARP_SHFL_DOWN(T value,
-                                               unsigned int delta,
-                                               int width = warpSize,
-                                               unsigned int mask = 0xffffffff) {
+OPEN3D_DEVICE __forceinline__ T
+WARP_SHFL_DOWN(T value,
+               unsigned int delta,
+               int width = warpSize,
+               open3d_warp_mask_t mask = OPEN3D_REDUCE_FULL_WARP_MASK) {
 #if CUDA_VERSION >= 9000
     return __shfl_down_sync(mask, value, delta, width);
 #else

--- a/cpp/open3d/core/linalg/LinalgHeadersCUDA.h
+++ b/cpp/open3d/core/linalg/LinalgHeadersCUDA.h
@@ -13,9 +13,76 @@
 #pragma once
 
 #ifdef BUILD_CUDA_MODULE
+
+#if defined(USE_HIP)
+// hipBLAS / hipSOLVER expose a near-1:1 typed-Dense API for the cuBLAS /
+// cuSOLVER calls the linalg sources use; alias the CUDA spellings to the HIP
+// ones so the host .cpp wrappers compile unchanged. The cuSOLVER status enum
+// is wider than hipSOLVER's, so the orphan cases below are guarded out.
+#include <hipblas/hipblas.h>
+#include <hipsolver/hipsolver.h>
+
+#define cublasStatus_t hipblasStatus_t
+#define cublasHandle_t hipblasHandle_t
+#define cublasOperation_t hipblasOperation_t
+#define cublasFillMode_t hipblasFillMode_t
+#define cublasDiagType_t hipblasDiagType_t
+#define cublasSideMode_t hipblasSideMode_t
+#define cublasCreate hipblasCreate
+#define cublasDestroy hipblasDestroy
+#define cublasSgemm hipblasSgemm
+#define cublasDgemm hipblasDgemm
+#define cublasStrsm hipblasStrsm
+#define cublasDtrsm hipblasDtrsm
+#define CUBLAS_OP_N HIPBLAS_OP_N
+#define CUBLAS_OP_T HIPBLAS_OP_T
+#define CUBLAS_SIDE_LEFT HIPBLAS_SIDE_LEFT
+#define CUBLAS_FILL_MODE_UPPER HIPBLAS_FILL_MODE_UPPER
+#define CUBLAS_DIAG_NON_UNIT HIPBLAS_DIAG_NON_UNIT
+#define CUBLAS_STATUS_SUCCESS HIPBLAS_STATUS_SUCCESS
+#define CUBLAS_STATUS_NOT_SUPPORTED HIPBLAS_STATUS_NOT_SUPPORTED
+
+#define cusolverStatus_t hipsolverStatus_t
+#define cusolverDnHandle_t hipsolverDnHandle_t
+#define cusolverDnCreate hipsolverDnCreate
+#define cusolverDnDestroy hipsolverDnDestroy
+#define cusolverDnSgetrf hipsolverDnSgetrf
+#define cusolverDnDgetrf hipsolverDnDgetrf
+#define cusolverDnSgetrf_bufferSize hipsolverDnSgetrf_bufferSize
+#define cusolverDnDgetrf_bufferSize hipsolverDnDgetrf_bufferSize
+#define cusolverDnSgetrs hipsolverDnSgetrs
+#define cusolverDnDgetrs hipsolverDnDgetrs
+#define cusolverDnSgesvd hipsolverDnSgesvd
+#define cusolverDnDgesvd hipsolverDnDgesvd
+#define cusolverDnSgesvd_bufferSize hipsolverDnSgesvd_bufferSize
+#define cusolverDnDgesvd_bufferSize hipsolverDnDgesvd_bufferSize
+#define cusolverDnSgeqrf hipsolverDnSgeqrf
+#define cusolverDnDgeqrf hipsolverDnDgeqrf
+#define cusolverDnSgeqrf_bufferSize hipsolverDnSgeqrf_bufferSize
+#define cusolverDnDgeqrf_bufferSize hipsolverDnDgeqrf_bufferSize
+#define cusolverDnSormqr hipsolverDnSormqr
+#define cusolverDnDormqr hipsolverDnDormqr
+#define cusolverDnSormqr_bufferSize hipsolverDnSormqr_bufferSize
+#define cusolverDnDormqr_bufferSize hipsolverDnDormqr_bufferSize
+
+#define CUSOLVER_STATUS_SUCCESS HIPSOLVER_STATUS_SUCCESS
+#define CUSOLVER_STATUS_NOT_INITIALIZED HIPSOLVER_STATUS_NOT_INITIALIZED
+#define CUSOLVER_STATUS_ALLOC_FAILED HIPSOLVER_STATUS_ALLOC_FAILED
+#define CUSOLVER_STATUS_INVALID_VALUE HIPSOLVER_STATUS_INVALID_VALUE
+#define CUSOLVER_STATUS_ARCH_MISMATCH HIPSOLVER_STATUS_ARCH_MISMATCH
+#define CUSOLVER_STATUS_MAPPING_ERROR HIPSOLVER_STATUS_MAPPING_ERROR
+#define CUSOLVER_STATUS_EXECUTION_FAILED HIPSOLVER_STATUS_EXECUTION_FAILED
+#define CUSOLVER_STATUS_INTERNAL_ERROR HIPSOLVER_STATUS_INTERNAL_ERROR
+#define CUSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED \
+    HIPSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED
+#define CUSOLVER_STATUS_NOT_SUPPORTED HIPSOLVER_STATUS_NOT_SUPPORTED
+#define CUSOLVER_STATUS_ZERO_PIVOT HIPSOLVER_STATUS_ZERO_PIVOT
+#else
 #include <cublas_v2.h>
 #include <cusolverDn.h>
 #include <cusolver_common.h>
+#endif
+
 #include <fmt/core.h>
 #include <fmt/format.h>
 
@@ -61,6 +128,8 @@ struct formatter<cusolverStatus_t> {
             case CUSOLVER_STATUS_ZERO_PIVOT:
                 text = "CUSOLVER_STATUS_ZERO_PIVOT";
                 break;
+#if !defined(USE_HIP)
+            // hipSOLVER's status enum does not define these codes.
             case CUSOLVER_STATUS_INVALID_LICENSE:
                 text = "CUSOLVER_STATUS_INVALID_LICENSE";
                 break;
@@ -104,6 +173,7 @@ struct formatter<cusolverStatus_t> {
             case CUSOLVER_STATUS_INVALID_WORKSPACE:
                 text = "CUSOLVER_STATUS_INVALID_WORKSPACE";
                 break;
+#endif  // !USE_HIP
             default:
                 text = "CUSOLVER_STATUS_UNKNOWN";
                 break;

--- a/cpp/open3d/core/linalg/kernel/SVD3x3.h
+++ b/cpp/open3d/core/linalg/kernel/SVD3x3.h
@@ -29,7 +29,7 @@
 #include "open3d/core/CUDAUtils.h"
 #include "open3d/t/geometry/kernel/GeometryMacros.h"
 
-#if defined(BUILD_CUDA_MODULE) && defined(__CUDACC__)
+#if defined(BUILD_CUDA_MODULE) && (defined(__CUDACC__) || defined(__HIPCC__))
 #include <cuda.h>
 #endif
 
@@ -43,13 +43,13 @@
 #define gtiny_number 1.e-20
 #define gfour_gamma_squared 5.8284273147583007813
 
-#ifndef __CUDACC__
+#if !defined(__CUDACC__) && !defined(__HIPCC__)
 using std::abs;
 using std::max;
 using std::sqrt;
 #endif
 
-#if defined(BUILD_CUDA_MODULE) && defined(__CUDACC__)
+#if defined(BUILD_CUDA_MODULE) && (defined(__CUDACC__) || defined(__HIPCC__))
 #define __fadd_rn(x, y) __fadd_rn(x, y)
 #define __fsub_rn(x, y) __fsub_rn(x, y)
 #define __frsqrt_rn(x) __frsqrt_rn(x)

--- a/cpp/open3d/core/nns/NeighborSearchCommon.h
+++ b/cpp/open3d/core/nns/NeighborSearchCommon.h
@@ -18,7 +18,7 @@ namespace nns {
 /// Supported metrics
 enum Metric { L1, L2, Linf };
 
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 #define HOST_DEVICE __host__ __device__
 #else
 #define HOST_DEVICE

--- a/cpp/open3d/core/nns/kernel/DeviceDefs.cuh
+++ b/cpp/open3d/core/nns/kernel/DeviceDefs.cuh
@@ -41,12 +41,25 @@ namespace core {
 #error "CUDA >= 8.0 is required"
 #endif
 
-// We validate this against the actual architecture in device initialization
+// This FAISS-derived warp-select treats a "warp" as a 32-lane bitonic-sort
+// group: the queue layout, the shfl_xor butterfly (width=kWarpSize), the
+// per-thread/warp-queue register counts, and the smallest instantiated queue
+// (NumWarpQ==32, see BlockSelectFloat*.cu) are all built around 32 lanes. On a
+// 64-lane CDNA wavefront we therefore run the algorithm as two independent
+// 32-lane groups: kWarpSize stays 32, every
+// shfl uses width=32 so exchanges stay within a group, and getLaneId() returns
+// the 0..31 lane *within* the group (PtxUtils.cuh). This is correct on wave32
+// (gfx11xx) and wave64 (gfx9xx) alike; do NOT raise it to 64 -- that collapses
+// the NumWarpQ<64 queues (kNumWarpQRegisters = NumWarpQ / kWarpSize == 0).
 constexpr int kWarpSize = 32;
 
-// This is a memory barrier for intra-warp writes to shared memory.
+// This is a memory barrier for intra-warp writes to shared memory. The select
+// kernels are warp-convergent (no warp-granularity divergence), so a
+// full-wavefront barrier is safe and covers both 32-lane groups on wave64.
 __forceinline__ __device__ void warpFence() {
-#if CUDA_VERSION >= 9000
+#if defined(USE_HIP)
+    __syncthreads();
+#elif CUDA_VERSION >= 9000
     __syncwarp();
 #else
     // For the time being, assume synchronicity.

--- a/cpp/open3d/core/nns/kernel/PtxUtils.cuh
+++ b/cpp/open3d/core/nns/kernel/PtxUtils.cuh
@@ -36,6 +36,69 @@
 namespace open3d {
 namespace core {
 
+#if defined(USE_HIP)
+
+// HIP has no inline PTX; provide the same helpers with HIP/clang builtins.
+// getLaneId() returns the lane within the 32-lane bitonic group (0..31), so on
+// a 64-lane wavefront the two halves each behave as a 32-lane NVIDIA warp (see
+// DeviceDefs.cuh). These select kernels launch 1-D blocks, so the in-group
+// lane is threadIdx.x & 31.
+#define GET_BITFIELD_U32(OUT, VAL, POS, LEN) \
+    OUT = ((VAL) >> (POS)) & ((1u << (LEN)) - 1u)
+
+#define GET_BITFIELD_U64(OUT, VAL, POS, LEN) \
+    OUT = ((VAL) >> (POS)) & ((1ull << (LEN)) - 1ull)
+
+__device__ __forceinline__ unsigned int getBitfield(unsigned int val,
+                                                     int pos,
+                                                     int len) {
+    return (val >> pos) & ((1u << len) - 1u);
+}
+
+__device__ __forceinline__ uint64_t getBitfield(uint64_t val, int pos, int len) {
+    return (val >> pos) & ((1ull << len) - 1ull);
+}
+
+__device__ __forceinline__ unsigned int setBitfield(unsigned int val,
+                                                     unsigned int toInsert,
+                                                     int pos,
+                                                     int len) {
+    unsigned int mask = ((1u << len) - 1u) << pos;
+    return (val & ~mask) | ((toInsert << pos) & mask);
+}
+
+__device__ __forceinline__ int getLaneId() {
+    return static_cast<int>(threadIdx.x & 31u);
+}
+
+__device__ __forceinline__ unsigned getLaneMaskLt() {
+    unsigned lane = threadIdx.x & 31u;
+    return (1u << lane) - 1u;
+}
+
+__device__ __forceinline__ unsigned getLaneMaskLe() {
+    unsigned lane = threadIdx.x & 31u;
+    return (lane >= 31u) ? 0xffffffffu : ((1u << (lane + 1u)) - 1u);
+}
+
+__device__ __forceinline__ unsigned getLaneMaskGt() {
+    return ~getLaneMaskLe();
+}
+
+__device__ __forceinline__ unsigned getLaneMaskGe() {
+    return ~getLaneMaskLt();
+}
+
+__device__ __forceinline__ void namedBarrierWait(int name, int numThreads) {
+    __syncthreads();
+}
+
+__device__ __forceinline__ void namedBarrierArrived(int name, int numThreads) {
+    __syncthreads();
+}
+
+#else
+
 // defines to simplify the SASS assembly structure file/line in the profiler
 #define GET_BITFIELD_U32(OUT, VAL, POS, LEN) \
     asm("bfe.u32 %0, %1, %2, %3;" : "=r"(OUT) : "r"(VAL), "r"(POS), "r"(LEN));
@@ -110,6 +173,8 @@ __device__ __forceinline__ void namedBarrierArrived(int name, int numThreads) {
                  : "r"(name), "r"(numThreads)
                  : "memory");
 }
+
+#endif  // USE_HIP
 
 }  // namespace core
 }  // namespace open3d

--- a/cpp/open3d/core/nns/kernel/Select.cuh
+++ b/cpp/open3d/core/nns/kernel/Select.cuh
@@ -158,7 +158,7 @@ struct BlockSelect {
         bool needSort = (numVals == NumThreadQ);
 
 #if CUDA_VERSION >= 9000
-        needSort = __any_sync(0xffffffff, needSort);
+        needSort = __any_sync(OPEN3D_FULL_WARP_MASK, needSort);
 #else
         needSort = __any(needSort);
 #endif
@@ -422,7 +422,7 @@ struct WarpSelect {
         bool needSort = (numVals == NumThreadQ);
 
 #if CUDA_VERSION >= 9000
-        needSort = __any_sync(0xffffffff, needSort);
+        needSort = __any_sync(OPEN3D_FULL_WARP_MASK, needSort);
 #else
         needSort = __any(needSort);
 #endif

--- a/cpp/open3d/core/nns/kernel/WarpShuffle.cuh
+++ b/cpp/open3d/core/nns/kernel/WarpShuffle.cuh
@@ -33,13 +33,20 @@
 
 #include <cuda.h>
 
+// Full-warp lane mask for the *_sync shuffles. HIP requires a 64-bit mask
+// (sizeof(mask)==8 static_assert), so the compat header provides ~0ull; on
+// CUDA the mask is the 32-bit all-lanes value.
+#ifndef OPEN3D_FULL_WARP_MASK
+#define OPEN3D_FULL_WARP_MASK 0xffffffffu
+#endif
+
 namespace open3d {
 namespace core {
 
 // defines to simplify the SASS assembly structure file/line in the profiler
 #if CUDA_VERSION >= 9000
 #define SHFL_SYNC(VAL, SRC_LANE, WIDTH) \
-    __shfl_sync(0xffffffff, VAL, SRC_LANE, WIDTH)
+    __shfl_sync(OPEN3D_FULL_WARP_MASK, VAL, SRC_LANE, WIDTH)
 #else
 #define SHFL_SYNC(VAL, SRC_LANE, WIDTH) __shfl(VAL, SRC_LANE, WIDTH)
 #endif
@@ -47,7 +54,7 @@ namespace core {
 template <typename T>
 inline __device__ T shfl(const T val, int srcLane, int width = kWarpSize) {
 #if CUDA_VERSION >= 9000
-    return __shfl_sync(0xffffffff, val, srcLane, width);
+    return __shfl_sync(OPEN3D_FULL_WARP_MASK, val, srcLane, width);
 #else
     return __shfl(val, srcLane, width);
 #endif
@@ -67,7 +74,7 @@ inline __device__ T shfl_up(const T val,
                             unsigned int delta,
                             int width = kWarpSize) {
 #if CUDA_VERSION >= 9000
-    return __shfl_up_sync(0xffffffff, val, delta, width);
+    return __shfl_up_sync(OPEN3D_FULL_WARP_MASK, val, delta, width);
 #else
     return __shfl_up(val, delta, width);
 #endif
@@ -89,7 +96,7 @@ inline __device__ T shfl_down(const T val,
                               unsigned int delta,
                               int width = kWarpSize) {
 #if CUDA_VERSION >= 9000
-    return __shfl_down_sync(0xffffffff, val, delta, width);
+    return __shfl_down_sync(OPEN3D_FULL_WARP_MASK, val, delta, width);
 #else
     return __shfl_down(val, delta, width);
 #endif
@@ -108,7 +115,7 @@ inline __device__ T* shfl_down(T* const val,
 template <typename T>
 inline __device__ T shfl_xor(const T val, int laneMask, int width = kWarpSize) {
 #if CUDA_VERSION >= 9000
-    return __shfl_xor_sync(0xffffffff, val, laneMask, width);
+    return __shfl_xor_sync(OPEN3D_FULL_WARP_MASK, val, laneMask, width);
 #else
     return __shfl_xor(val, laneMask, width);
 #endif

--- a/cpp/open3d/t/geometry/kernel/GeometryMacros.h
+++ b/cpp/open3d/t/geometry/kernel/GeometryMacros.h
@@ -11,8 +11,10 @@
 
 #include "open3d/core/CUDAUtils.h"
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 
+// HIP (gfx90a) provides a native double atomicAdd, so the Pascal-era CAS
+// fallback below is CUDA-only (guard on __CUDA_ARCH__, undefined on HIP).
 #if defined(__CUDA_ARCH__)
 #if __CUDA_ARCH__ < 600
 __device__ double atomicAdd(double *address, double val) {
@@ -54,7 +56,7 @@ OPEN3D_HOST_DEVICE scalar_t Square(const scalar_t &x) {
 }  // namespace open3d
 
 // https://stackoverflow.com/a/51549250
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 __device__ inline float atomicMinf(float *addr, float value) {
     float old;
     old = (value >= 0) ? __int_as_float(

--- a/cpp/open3d/t/geometry/kernel/ImageImpl.h
+++ b/cpp/open3d/t/geometry/kernel/ImageImpl.h
@@ -20,12 +20,12 @@ namespace geometry {
 namespace kernel {
 namespace image {
 
-#ifndef __CUDACC__
+#if !defined(__CUDACC__) && !defined(__HIPCC__)
 using std::isinf;
 using std::isnan;
 #endif
 
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void ToCUDA
 #else
 void ToCPU
@@ -82,7 +82,7 @@ void ToCPU
 #undef LINEAR_SATURATE
 }
 
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void ClipTransformCUDA
 #else
 void ClipTransformCPU
@@ -118,7 +118,7 @@ void ClipTransformCPU
 
 // Reimplementation of the reference:
 // https://github.com/mp3guy/ICPCUDA/blob/master/Cuda/pyrdown.cu#L41
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void PyrDownDepthCUDA
 #else
 void PyrDownDepthCPU
@@ -143,7 +143,7 @@ void PyrDownDepthCPU
     const int gkernel_size_2 = gkernel_size / 2;
     const float gweights[3] = {0.375f, 0.25f, 0.0625f};
 
-#ifndef __CUDACC__
+#if !defined(__CUDACC__) && !defined(__HIPCC__)
     using std::abs;
     using std::max;
     using std::min;
@@ -191,7 +191,7 @@ void PyrDownDepthCPU
             });
 }
 
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void CreateVertexMapCUDA
 #else
 void CreateVertexMapCPU
@@ -209,7 +209,7 @@ void CreateVertexMapCPU
     int64_t cols = src.GetShape(1);
     int64_t n = rows * cols;
 
-#ifndef __CUDACC__
+#if !defined(__CUDACC__) && !defined(__HIPCC__)
     using std::isinf;
     using std::isnan;
 #endif
@@ -238,7 +238,7 @@ void CreateVertexMapCPU
                 }
             });
 }
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void CreateNormalMapCUDA
 #else
 void CreateNormalMapCPU
@@ -303,7 +303,7 @@ void CreateNormalMapCPU
             });
 }
 
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void ColorizeDepthCUDA
 #else
 void ColorizeDepthCPU

--- a/cpp/open3d/t/geometry/kernel/NPPImage.cpp
+++ b/cpp/open3d/t/geometry/kernel/NPPImage.cpp
@@ -12,8 +12,8 @@
 // NVIDIA Performance Primitives has no ROCm equivalent. On the HIP build the
 // GPU image-filter ops are an explicitly-unsupported path: these stubs satisfy
 // the link from Image.cpp's CUDA branch and report the limitation at runtime.
-// The CPU (IPP) image path and every other GPU kernel are unaffected. Image
-// filter GPU tests are scoped out of this port (see notes.md).
+// The CPU (IPP) image path and every other GPU kernel are unaffected. See the
+// AMD GPU support section of docs/compilation.rst for the unsupported ops.
 
 #include "open3d/core/Tensor.h"
 #include "open3d/t/geometry/Image.h"

--- a/cpp/open3d/t/geometry/kernel/NPPImage.cpp
+++ b/cpp/open3d/t/geometry/kernel/NPPImage.cpp
@@ -7,6 +7,68 @@
 
 #include "open3d/t/geometry/kernel/NPPImage.h"
 
+#if defined(USE_HIP)
+
+// NVIDIA Performance Primitives has no ROCm equivalent. On the HIP build the
+// GPU image-filter ops are an explicitly-unsupported path: these stubs satisfy
+// the link from Image.cpp's CUDA branch and report the limitation at runtime.
+// The CPU (IPP) image path and every other GPU kernel are unaffected. Image
+// filter GPU tests are scoped out of this port (see notes.md).
+
+#include "open3d/core/Tensor.h"
+#include "open3d/t/geometry/Image.h"
+#include "open3d/utility/Logging.h"
+
+namespace open3d {
+namespace t {
+namespace geometry {
+namespace npp {
+
+static void NppUnsupportedOnHIP() {
+    utility::LogError(
+            "GPU image filtering (NPP) is not supported on ROCm/HIP; use the "
+            "CPU device for this operation.");
+}
+
+void RGBToGray(const core::Tensor &, core::Tensor &) { NppUnsupportedOnHIP(); }
+
+void Dilate(const core::Tensor &, core::Tensor &, int) {
+    NppUnsupportedOnHIP();
+}
+
+void Resize(const core::Tensor &,
+            core::Tensor &,
+            t::geometry::Image::InterpType) {
+    NppUnsupportedOnHIP();
+}
+
+void Filter(const core::Tensor &, core::Tensor &, const core::Tensor &) {
+    NppUnsupportedOnHIP();
+}
+
+void FilterBilateral(const core::Tensor &,
+                     core::Tensor &,
+                     int,
+                     float,
+                     float) {
+    NppUnsupportedOnHIP();
+}
+
+void FilterGaussian(const core::Tensor &, core::Tensor &, int, float) {
+    NppUnsupportedOnHIP();
+}
+
+void FilterSobel(const core::Tensor &, core::Tensor &, core::Tensor &, int) {
+    NppUnsupportedOnHIP();
+}
+
+}  // namespace npp
+}  // namespace geometry
+}  // namespace t
+}  // namespace open3d
+
+#else  // !USE_HIP
+
 #include <npp.h>
 
 #include "open3d/core/CUDAUtils.h"
@@ -484,3 +546,5 @@ void FilterSobel(const core::Tensor &src_im,
 }  // namespace geometry
 }  // namespace t
 }  // namespace open3d
+
+#endif  // USE_HIP

--- a/cpp/open3d/t/geometry/kernel/PointCloudImpl.h
+++ b/cpp/open3d/t/geometry/kernel/PointCloudImpl.h
@@ -30,14 +30,14 @@ namespace geometry {
 namespace kernel {
 namespace pointcloud {
 
-#ifndef __CUDACC__
+#if !defined(__CUDACC__) && !defined(__HIPCC__)
 using std::abs;
 using std::max;
 using std::min;
 using std::sqrt;
 #endif
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void UnprojectCUDA
 #else
 void UnprojectCPU
@@ -76,7 +76,7 @@ void UnprojectCPU
     }
 
     // Counter
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
     core::Tensor count(std::vector<int>{0}, {}, core::Int32, depth.GetDevice());
     int* count_ptr = count.GetDataPtr<int>();
 #else
@@ -118,13 +118,13 @@ void UnprojectCPU
                     }
                 });
     });
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
     int total_pts_count = count.Item<int>();
 #else
     int total_pts_count = (*count_ptr).load();
 #endif
 
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
     core::cuda::Synchronize();
 #endif
     points = points.Slice(0, 0, total_pts_count);
@@ -134,7 +134,7 @@ void UnprojectCPU
     }
 }
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void GetPointMaskWithinAABBCUDA
 #else
 void GetPointMaskWithinAABBCPU
@@ -168,7 +168,7 @@ void GetPointMaskWithinAABBCPU
     });
 }
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void GetPointMaskWithinOBBCUDA
 #else
 void GetPointMaskWithinOBBCPU
@@ -212,7 +212,7 @@ void GetPointMaskWithinOBBCPU
     });
 }
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void NormalizeNormalsCUDA
 #else
 void NormalizeNormalsCPU
@@ -243,7 +243,7 @@ void NormalizeNormalsCPU
     });
 }
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void OrientNormalsToAlignWithDirectionCUDA
 #else
 void OrientNormalsToAlignWithDirectionCPU
@@ -277,7 +277,7 @@ void OrientNormalsToAlignWithDirectionCPU
     });
 }
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void OrientNormalsTowardsCameraLocationCUDA
 #else
 void OrientNormalsTowardsCameraLocationCPU
@@ -412,7 +412,7 @@ OPEN3D_HOST_DEVICE bool IsBoundaryPoints(const scalar_t* angles,
     return max_diff > angle_threshold * M_PI / 180.0 ? true : false;
 }
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void ComputeBoundaryPointsCUDA
 #else
 void ComputeBoundaryPointsCPU
@@ -553,7 +553,7 @@ OPEN3D_HOST_DEVICE void EstimatePointWiseRobustNormalizedCovarianceKernel(
     covariance_ptr[7] = covariance_ptr[5];
 }
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void EstimateCovariancesUsingHybridSearchCUDA
 #else
 void EstimateCovariancesUsingHybridSearchCPU
@@ -603,7 +603,7 @@ void EstimateCovariancesUsingHybridSearchCPU
     core::cuda::Synchronize(points.GetDevice());
 }
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void EstimateCovariancesUsingRadiusSearchCUDA
 #else
 void EstimateCovariancesUsingRadiusSearchCPU
@@ -652,7 +652,7 @@ void EstimateCovariancesUsingRadiusSearchCPU
     core::cuda::Synchronize(points.GetDevice());
 }
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void EstimateCovariancesUsingKNNSearchCUDA
 #else
 void EstimateCovariancesUsingKNNSearchCPU
@@ -970,7 +970,7 @@ OPEN3D_HOST_DEVICE void EstimatePointWiseNormalsWithFastEigen3x3(
     }
 }
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void EstimateNormalsFromCovariancesCUDA
 #else
 void EstimateNormalsFromCovariancesCPU
@@ -1124,7 +1124,7 @@ OPEN3D_HOST_DEVICE void EstimatePointWiseColorGradientKernel(
     }
 }
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void EstimateColorGradientsUsingHybridSearchCUDA
 #else
 void EstimateColorGradientsUsingHybridSearchCPU
@@ -1176,7 +1176,7 @@ void EstimateColorGradientsUsingHybridSearchCPU
     core::cuda::Synchronize(points.GetDevice());
 }
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void EstimateColorGradientsUsingKNNSearchCUDA
 #else
 void EstimateColorGradientsUsingKNNSearchCPU
@@ -1231,7 +1231,7 @@ void EstimateColorGradientsUsingKNNSearchCPU
     core::cuda::Synchronize(points.GetDevice());
 }
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void EstimateColorGradientsUsingRadiusSearchCUDA
 #else
 void EstimateColorGradientsUsingRadiusSearchCPU

--- a/cpp/open3d/t/geometry/kernel/TransformImpl.h
+++ b/cpp/open3d/t/geometry/kernel/TransformImpl.h
@@ -87,7 +87,7 @@ OPEN3D_HOST_DEVICE OPEN3D_FORCE_INLINE void RotateNormalsKernel(
     normals_ptr[2] = x[2];
 }
 
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void TransformPointsCUDA
 #else
 void TransformPointsCPU
@@ -107,7 +107,7 @@ void TransformPointsCPU
     });
 }
 
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void TransformNormalsCUDA
 #else
 void TransformNormalsCPU
@@ -127,7 +127,7 @@ void TransformNormalsCPU
     });
 }
 
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void RotatePointsCUDA
 #else
 void RotatePointsCPU
@@ -149,7 +149,7 @@ void RotatePointsCPU
     });
 }
 
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void RotateNormalsCUDA
 #else
 void RotateNormalsCPU

--- a/cpp/open3d/t/geometry/kernel/TriangleMeshImpl.h
+++ b/cpp/open3d/t/geometry/kernel/TriangleMeshImpl.h
@@ -21,11 +21,11 @@ namespace geometry {
 namespace kernel {
 namespace trianglemesh {
 
-#ifndef __CUDACC__
+#if !defined(__CUDACC__) && !defined(__HIPCC__)
 using std::isnan;
 #endif
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void NormalizeNormalsCUDA
 #else
 void NormalizeNormalsCPU
@@ -62,7 +62,7 @@ void NormalizeNormalsCPU
     });
 }
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void ComputeTriangleNormalsCUDA
 #else
 void ComputeTriangleNormalsCPU
@@ -107,7 +107,7 @@ void ComputeTriangleNormalsCPU
     });
 }
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void ComputeTriangleAreasCUDA
 #else
 void ComputeTriangleAreasCPU

--- a/cpp/open3d/t/geometry/kernel/VoxelBlockGridImpl.h
+++ b/cpp/open3d/t/geometry/kernel/VoxelBlockGridImpl.h
@@ -30,7 +30,7 @@ namespace voxel_grid {
 using index_t = int;
 using ArrayIndexer = TArrayIndexer<index_t>;
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void GetVoxelCoordinatesAndFlattenedIndicesCUDA
 #else
 void GetVoxelCoordinatesAndFlattenedIndicesCPU
@@ -141,7 +141,7 @@ template <typename input_depth_t,
           typename tsdf_t,
           typename weight_t,
           typename color_t>
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void IntegrateCUDA
 #else
 void IntegrateCPU
@@ -288,12 +288,12 @@ void IntegrateCPU
         *weight_ptr = weight + 1;
     });
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
     core::cuda::Synchronize();
 #endif
 }
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void EstimateRangeCUDA
 #else
 void EstimateRangeCPU
@@ -337,7 +337,7 @@ void EstimateRangeCPU
     NDArrayIndexer frag_buffer_indexer(fragment_buffer, 1);
     NDArrayIndexer block_keys_indexer(block_keys, 1);
     TransformIndexer w2c_transform_indexer(intrinsics, extrinsics);
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
     core::Tensor count(std::vector<int>{0}, {1}, core::Int32,
                        block_keys.GetDevice());
     int* count_ptr = count.GetDataPtr<int>();
@@ -346,7 +346,7 @@ void EstimateRangeCPU
     std::atomic<int>* count_ptr = &count_atomic;
 #endif
 
-#ifndef __CUDACC__
+#if !defined(__CUDACC__) && !defined(__HIPCC__)
     using std::max;
     using std::min;
 #endif
@@ -434,7 +434,7 @@ void EstimateRangeCPU
                     }
                 }
             });
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
     int needed_frag_count = count[0].Item<int>();
 #else
     int needed_frag_count = (*count_ptr).load();
@@ -486,7 +486,7 @@ void EstimateRangeCPU
                 float z_min = frag_ptr[0];
                 float z_max = frag_ptr[1];
                 float* range_ptr = range_map_indexer.GetDataPtr<float>(u, v);
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
                 atomicMinf(&(range_ptr[0]), z_min);
                 atomicMaxf(&(range_ptr[1]), z_max);
 #else
@@ -498,7 +498,7 @@ void EstimateRangeCPU
 #endif
             });
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
     core::cuda::Synchronize();
 #endif
 
@@ -533,7 +533,7 @@ struct MiniVecCache {
 };
 
 template <typename tsdf_t, typename weight_t, typename color_t>
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void RayCastCUDA
 #else
 void RayCastCPU
@@ -559,7 +559,7 @@ void RayCastCPU
     using Eq = utility::MiniVecEq<index_t, 3>;
 
     auto device_hashmap = hashmap->GetDeviceHashBackend();
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
     auto cuda_hashmap =
             std::dynamic_pointer_cast<core::StdGPUHashBackend<Key, Hash, Eq>>(
                     device_hashmap);
@@ -675,7 +675,7 @@ void RayCastCPU
     index_t resolution2 = block_resolution * block_resolution;
     index_t resolution3 = resolution2 * block_resolution;
 
-#ifndef __CUDACC__
+#if !defined(__CUDACC__) && !defined(__HIPCC__)
     using std::max;
     using std::sqrt;
 #endif
@@ -781,7 +781,7 @@ void RayCastCPU
 
         if (mask_indexer.GetDataPtr()) {
             mask_ptr = mask_indexer.GetDataPtr<bool>(x, y);
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 #pragma unroll
 #endif
             for (int i = 0; i < 8; ++i) {
@@ -790,7 +790,7 @@ void RayCastCPU
         }
         if (index_indexer.GetDataPtr()) {
             index_ptr = index_indexer.GetDataPtr<int64_t>(x, y);
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 #pragma unroll
 #endif
             for (int i = 0; i < 8; ++i) {
@@ -799,7 +799,7 @@ void RayCastCPU
         }
         if (interp_ratio_indexer.GetDataPtr()) {
             interp_ratio_ptr = interp_ratio_indexer.GetDataPtr<float>(x, y);
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 #pragma unroll
 #endif
             for (int i = 0; i < 8; ++i) {
@@ -809,7 +809,7 @@ void RayCastCPU
         if (interp_ratio_dx_indexer.GetDataPtr()) {
             interp_ratio_dx_ptr =
                     interp_ratio_dx_indexer.GetDataPtr<float>(x, y);
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 #pragma unroll
 #endif
             for (int i = 0; i < 8; ++i) {
@@ -819,7 +819,7 @@ void RayCastCPU
         if (interp_ratio_dy_indexer.GetDataPtr()) {
             interp_ratio_dy_ptr =
                     interp_ratio_dy_indexer.GetDataPtr<float>(x, y);
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 #pragma unroll
 #endif
             for (int i = 0; i < 8; ++i) {
@@ -829,7 +829,7 @@ void RayCastCPU
         if (interp_ratio_dz_indexer.GetDataPtr()) {
             interp_ratio_dz_ptr =
                     interp_ratio_dz_indexer.GetDataPtr<float>(x, y);
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 #pragma unroll
 #endif
             for (int i = 0; i < 8; ++i) {
@@ -1026,13 +1026,13 @@ void RayCastCPU
         }  // surface-found
     });
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
     core::cuda::Synchronize();
 #endif
 }
 
 template <typename tsdf_t, typename weight_t, typename color_t>
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void ExtractPointCloudCUDA
 #else
 void ExtractPointCloudCPU
@@ -1085,7 +1085,7 @@ void ExtractPointCloudCPU
     index_t n = n_blocks * resolution3;
 
     // Output
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
     core::Tensor count(std::vector<index_t>{0}, {1}, core::Int32,
                        block_keys.GetDevice());
     index_t* count_ptr = count.GetDataPtr<index_t>();
@@ -1139,7 +1139,7 @@ void ExtractPointCloudCPU
             }
         });
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
         valid_size = count[0].Item<index_t>();
         count[0] = 0;
 #else
@@ -1274,7 +1274,7 @@ void ExtractPointCloudCPU
         }
     });
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
     index_t total_count = count.Item<index_t>();
 #else
     index_t total_count = (*count_ptr).load();
@@ -1283,13 +1283,13 @@ void ExtractPointCloudCPU
     utility::LogDebug("{} vertices extracted", total_count);
     valid_size = total_count;
 
-#if defined(BUILD_CUDA_MODULE) && defined(__CUDACC__)
+#if defined(BUILD_CUDA_MODULE) && (defined(__CUDACC__) || defined(__HIPCC__))
     core::cuda::Synchronize();
 #endif
 }
 
 template <typename tsdf_t, typename weight_t, typename color_t>
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void ExtractTriangleMeshCUDA
 #else
 void ExtractTriangleMeshCPU
@@ -1434,7 +1434,7 @@ void ExtractTriangleMeshCPU
     });
 
     // Pass 1: determine valid number of vertices (if not preset)
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
     core::Tensor count(std::vector<index_t>{0}, {}, core::Int32, device);
 
     index_t* count_ptr = count.GetDataPtr<index_t>();
@@ -1473,7 +1473,7 @@ void ExtractTriangleMeshCPU
             }
         });
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
         vertex_count = count.Item<index_t>();
 #else
         vertex_count = (*count_ptr).load();
@@ -1495,7 +1495,7 @@ void ExtractTriangleMeshCPU
     ArrayIndexer block_keys_indexer(block_keys, 1);
     ArrayIndexer vertex_indexer(vertices, 1);
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
     count = core::Tensor(std::vector<index_t>{0}, {}, core::Int32, device);
     count_ptr = count.GetDataPtr<index_t>();
 #else
@@ -1620,7 +1620,7 @@ void ExtractTriangleMeshCPU
     triangles = core::Tensor({triangle_count, 3}, core::Int32, device);
     ArrayIndexer triangle_indexer(triangles, 1);
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
     count = core::Tensor(std::vector<index_t>{0}, {}, core::Int32, device);
     count_ptr = count.GetDataPtr<index_t>();
 #else
@@ -1678,7 +1678,7 @@ void ExtractTriangleMeshCPU
         }
     });
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
     triangle_count = count.Item<index_t>();
 #else
     triangle_count = (*count_ptr).load();

--- a/cpp/open3d/t/pipelines/kernel/FeatureImpl.h
+++ b/cpp/open3d/t/pipelines/kernel/FeatureImpl.h
@@ -16,7 +16,7 @@ namespace t {
 namespace pipelines {
 namespace kernel {
 
-#ifndef __CUDACC__
+#if !defined(__CUDACC__) && !defined(__HIPCC__)
 using std::max;
 using std::min;
 #endif
@@ -104,7 +104,7 @@ OPEN3D_HOST_DEVICE void UpdateSPFHFeature(const scalar_t *feature,
     spfh[idx * 33 + h_index3 + 22] += hist_incr;
 }
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void ComputeFPFHFeatureCUDA
 #else
 void ComputeFPFHFeatureCPU

--- a/cpp/open3d/t/pipelines/kernel/FillInLinearSystemImpl.h
+++ b/cpp/open3d/t/pipelines/kernel/FillInLinearSystemImpl.h
@@ -13,7 +13,7 @@ namespace open3d {
 namespace t {
 namespace pipelines {
 namespace kernel {
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void FillInRigidAlignmentTermCUDA
 #else
 void FillInRigidAlignmentTermCPU
@@ -76,7 +76,7 @@ void FillInRigidAlignmentTermCPU
                 }
 
         // Not optimized; Switch to reduction if necessary.
-#if defined(BUILD_CUDA_MODULE) && defined(__CUDACC__)
+#if defined(BUILD_CUDA_MODULE) && (defined(__CUDACC__) || defined(__HIPCC__))
                 for (int i_local = 0; i_local < 12; ++i_local) {
                     for (int j_local = 0; j_local < 12; ++j_local) {
                         atomicAdd(&AtA_local_ptr[i_local * 12 + j_local],
@@ -127,7 +127,7 @@ void FillInRigidAlignmentTermCPU
     Atb.IndexSet({indices}, Atb_sub + Atb_local.View({12, 1}));
 }
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void FillInSLACAlignmentTermCUDA
 #else
 void FillInSLACAlignmentTermCPU
@@ -247,7 +247,7 @@ void FillInSLACAlignmentTermCPU
                 }
 
         // Not optimized; Switch to reduction if necessary.
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
                 for (int ki = 0; ki < 60; ++ki) {
                     for (int kj = 0; kj < 60; ++kj) {
                         float AtA_ij = J[ki] * J[kj];
@@ -274,7 +274,7 @@ void FillInSLACAlignmentTermCPU
             });
 }
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 void FillInSLACRegularizerTermCUDA
 #else
 void FillInSLACRegularizerTermCPU
@@ -413,7 +413,7 @@ void FillInSLACRegularizerTermCPU
                         int offset_idx_i = 3 * idx_i + 6 * n_frags;
                         int offset_idx_k = 3 * idx_k + 6 * n_frags;
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
                         // Update residual
                         atomicAdd(residual_ptr,
                                   weight * (local_r[0] * local_r[0] +

--- a/cpp/open3d/t/pipelines/kernel/RGBDOdometryJacobianImpl.h
+++ b/cpp/open3d/t/pipelines/kernel/RGBDOdometryJacobianImpl.h
@@ -20,7 +20,7 @@ namespace odometry {
 using t::geometry::kernel::NDArrayIndexer;
 using t::geometry::kernel::TransformIndexer;
 
-#ifndef __CUDACC__
+#if !defined(__CUDACC__) && !defined(__HIPCC__)
 using std::abs;
 using std::isnan;
 using std::max;

--- a/cpp/open3d/t/pipelines/kernel/RegistrationImpl.h
+++ b/cpp/open3d/t/pipelines/kernel/RegistrationImpl.h
@@ -17,7 +17,7 @@
 #include "open3d/t/pipelines/kernel/TransformationConverter.h"
 #include "open3d/t/pipelines/registration/RobustKernel.h"
 
-#ifndef __CUDACC__
+#if !defined(__CUDACC__) && !defined(__HIPCC__)
 using std::abs;
 #endif
 
@@ -187,7 +187,7 @@ OPEN3D_HOST_DEVICE inline bool GetJacobianPointToPlane(
     return true;
 }
 
-template bool GetJacobianPointToPlane(int64_t workload_idx,
+template OPEN3D_HOST_DEVICE bool GetJacobianPointToPlane(int64_t workload_idx,
                                       const float *source_points_ptr,
                                       const float *target_points_ptr,
                                       const float *target_normals_ptr,
@@ -195,7 +195,7 @@ template bool GetJacobianPointToPlane(int64_t workload_idx,
                                       float *J_ij,
                                       float &r);
 
-template bool GetJacobianPointToPlane(int64_t workload_idx,
+template OPEN3D_HOST_DEVICE bool GetJacobianPointToPlane(int64_t workload_idx,
                                       const double *source_points_ptr,
                                       const double *target_points_ptr,
                                       const double *target_normals_ptr,
@@ -285,7 +285,7 @@ OPEN3D_HOST_DEVICE inline bool GetJacobianColoredICP(
     return true;
 }
 
-template bool GetJacobianColoredICP(const int64_t workload_idx,
+template OPEN3D_HOST_DEVICE bool GetJacobianColoredICP(const int64_t workload_idx,
                                     const float *source_points_ptr,
                                     const float *source_colors_ptr,
                                     const float *target_points_ptr,
@@ -300,7 +300,7 @@ template bool GetJacobianColoredICP(const int64_t workload_idx,
                                     float &r_G,
                                     float &r_I);
 
-template bool GetJacobianColoredICP(const int64_t workload_idx,
+template OPEN3D_HOST_DEVICE bool GetJacobianColoredICP(const int64_t workload_idx,
                                     const double *source_points_ptr,
                                     const double *source_colors_ptr,
                                     const double *target_points_ptr,
@@ -333,13 +333,13 @@ OPEN3D_HOST_DEVICE inline void PreComputeForDopplerICP(
     core::linalg::kernel::matmul3x3_3x1(R_S_to_V, v_s_in_V, v_s_in_S);
 }
 
-template void PreComputeForDopplerICP(const float *R_S_to_V,
+template OPEN3D_HOST_DEVICE void PreComputeForDopplerICP(const float *R_S_to_V,
                                       const float *r_v_to_s_in_V,
                                       const float *w_v_in_V,
                                       const float *v_v_in_V,
                                       float *v_s_in_S);
 
-template void PreComputeForDopplerICP(const double *R_S_to_V,
+template OPEN3D_HOST_DEVICE void PreComputeForDopplerICP(const double *R_S_to_V,
                                       const double *r_v_to_s_in_V,
                                       const double *w_v_in_V,
                                       const double *v_v_in_V,
@@ -435,7 +435,7 @@ OPEN3D_HOST_DEVICE inline bool GetJacobianDopplerICP(
     return true;
 }
 
-template bool GetJacobianDopplerICP(const int64_t workload_idx,
+template OPEN3D_HOST_DEVICE bool GetJacobianDopplerICP(const int64_t workload_idx,
                                     const float *source_points_ptr,
                                     const float *source_dopplers_ptr,
                                     const float *source_directions_ptr,
@@ -455,7 +455,7 @@ template bool GetJacobianDopplerICP(const int64_t workload_idx,
                                     float &r_G,
                                     float &r_D);
 
-template bool GetJacobianDopplerICP(const int64_t workload_idx,
+template OPEN3D_HOST_DEVICE bool GetJacobianDopplerICP(const int64_t workload_idx,
                                     const double *source_points_ptr,
                                     const double *source_dopplers_ptr,
                                     const double *source_directions_ptr,
@@ -507,14 +507,14 @@ OPEN3D_HOST_DEVICE inline bool GetInformationJacobians(
     return true;
 }
 
-template bool GetInformationJacobians(int64_t workload_idx,
+template OPEN3D_HOST_DEVICE bool GetInformationJacobians(int64_t workload_idx,
                                       const float *target_points_ptr,
                                       const int64_t *correspondence_indices,
                                       float *jacobian_x,
                                       float *jacobian_y,
                                       float *jacobian_z);
 
-template bool GetInformationJacobians(int64_t workload_idx,
+template OPEN3D_HOST_DEVICE bool GetInformationJacobians(int64_t workload_idx,
                                       const double *target_points_ptr,
                                       const int64_t *correspondence_indices,
                                       double *jacobian_x,

--- a/cpp/open3d/t/pipelines/registration/RobustKernelImpl.h
+++ b/cpp/open3d/t/pipelines/registration/RobustKernelImpl.h
@@ -13,7 +13,7 @@
 #include "open3d/t/geometry/kernel/GeometryMacros.h"
 #include "open3d/t/pipelines/registration/RobustKernel.h"
 
-#ifndef __CUDACC__
+#if !defined(__CUDACC__) && !defined(__HIPCC__)
 using std::abs;
 using std::exp;
 using std::max;

--- a/cpp/open3d/utility/CPUInfo.cpp
+++ b/cpp/open3d/utility/CPUInfo.cpp
@@ -83,16 +83,18 @@ static int PhysicalConcurrency() {
 #elif _WIN32
         // Ref: https://stackoverflow.com/a/44247223/1255535.
         DWORD length = 0;
-        const BOOL result_first = GetLogicalProcessorInformationEx(
-                RelationProcessorCore, nullptr, &length);
+        [[maybe_unused]] const BOOL result_first =
+                GetLogicalProcessorInformationEx(RelationProcessorCore, nullptr,
+                                                 &length);
         assert(GetLastError() == ERROR_INSUFFICIENT_BUFFER);
 
         std::unique_ptr<uint8_t[]> buffer(new uint8_t[length]);
         const PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX info =
                 reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(
                         buffer.get());
-        const BOOL result_second = GetLogicalProcessorInformationEx(
-                RelationProcessorCore, info, &length);
+        [[maybe_unused]] const BOOL result_second =
+                GetLogicalProcessorInformationEx(RelationProcessorCore, info,
+                                                 &length);
         assert(result_second != FALSE);
 
         int nb_physical_cores = 0;

--- a/cpp/open3d/utility/MiniVec.h
+++ b/cpp/open3d/utility/MiniVec.h
@@ -9,7 +9,11 @@
 
 #include <cmath>
 
-#ifdef __CUDACC__
+// hipcc defines __HIPCC__ (not __CUDACC__), so include it or these methods
+// become host-only and device kernels (RegistrationCUDA.cu et al.) fail to
+// call MiniVec's ctor/operator[]. Same __CUDACC__-vs-__HIPCC__ device/host
+// guard issue handled at the other device-decorated sites in this port.
+#if defined(__CUDACC__) || defined(__HIPCC__)
 #define FN_SPECIFIERS inline __host__ __device__
 #else
 #define FN_SPECIFIERS inline

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -52,7 +52,9 @@ endif()
 open3d_show_and_abort_on_warning(tests)
 open3d_set_global_properties(tests)
 # On Windows, running tests from the build folder needs tbb.dll to be in the same folder.
-if (WIN32)
+# With USE_SYSTEM_TBB the bundled `tbb` target does not exist (TBB::tbb is imported
+# from the system/vcpkg tree); its DLL is supplied on PATH at run time instead.
+if (WIN32 AND TARGET tbb)
   add_custom_command(
       TARGET tests
       POST_BUILD

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -66,7 +66,12 @@ if (BUILD_AZURE_KINECT)
     target_include_directories(tests SYSTEM PRIVATE ${K4A_INCLUDE_DIR})
 endif()
 
-if (BUILD_CUDA_MODULE)
+if (BUILD_CUDA_MODULE AND USE_HIP)
+    # HIP: link the HIP runtime (hip::host) for the few tests that touch the
+    # CUDA-spelled runtime API. hip::host carries no -x hip propagation.
+    find_package(hip REQUIRED)
+    target_link_libraries(tests PRIVATE hip::host)
+elseif (BUILD_CUDA_MODULE)
     # We still need to explicitly link against CUDA libraries.
     # Consider removing dependencies of CUDA headers in the future.
     find_package(CUDAToolkit REQUIRED)

--- a/cpp/tests/core/HashMap.cpp
+++ b/cpp/tests/core/HashMap.cpp
@@ -62,7 +62,7 @@ TEST_P(HashMapPermuteDevices, SimpleInit) {
 #ifndef USE_HIP
         // The Slab (warp-cooperative) backend's 32-lane lane election is not
         // wave64-correct on ROCm/CDNA and is out of scope for this port; only
-        // the default StdGPU backend is validated here. See notes.md.
+        // the default StdGPU backend is validated here.
         backends.push_back(core::HashBackendType::Slab);
 #endif
         backends.push_back(core::HashBackendType::StdGPU);
@@ -97,7 +97,7 @@ TEST_P(HashMapPermuteDevices, Find) {
 #ifndef USE_HIP
         // The Slab (warp-cooperative) backend's 32-lane lane election is not
         // wave64-correct on ROCm/CDNA and is out of scope for this port; only
-        // the default StdGPU backend is validated here. See notes.md.
+        // the default StdGPU backend is validated here.
         backends.push_back(core::HashBackendType::Slab);
 #endif
         backends.push_back(core::HashBackendType::StdGPU);
@@ -146,7 +146,7 @@ TEST_P(HashMapPermuteDevices, Insert) {
 #ifndef USE_HIP
         // The Slab (warp-cooperative) backend's 32-lane lane election is not
         // wave64-correct on ROCm/CDNA and is out of scope for this port; only
-        // the default StdGPU backend is validated here. See notes.md.
+        // the default StdGPU backend is validated here.
         backends.push_back(core::HashBackendType::Slab);
 #endif
         backends.push_back(core::HashBackendType::StdGPU);
@@ -204,7 +204,7 @@ TEST_P(HashMapPermuteDevices, Erase) {
 #ifndef USE_HIP
         // The Slab (warp-cooperative) backend's 32-lane lane election is not
         // wave64-correct on ROCm/CDNA and is out of scope for this port; only
-        // the default StdGPU backend is validated here. See notes.md.
+        // the default StdGPU backend is validated here.
         backends.push_back(core::HashBackendType::Slab);
 #endif
         backends.push_back(core::HashBackendType::StdGPU);
@@ -272,7 +272,7 @@ TEST_P(HashMapPermuteDevices, Reserve) {
 #ifndef USE_HIP
         // The Slab (warp-cooperative) backend's 32-lane lane election is not
         // wave64-correct on ROCm/CDNA and is out of scope for this port; only
-        // the default StdGPU backend is validated here. See notes.md.
+        // the default StdGPU backend is validated here.
         backends.push_back(core::HashBackendType::Slab);
 #endif
         backends.push_back(core::HashBackendType::StdGPU);
@@ -331,7 +331,7 @@ TEST_P(HashMapPermuteDevices, Clear) {
 #ifndef USE_HIP
         // The Slab (warp-cooperative) backend's 32-lane lane election is not
         // wave64-correct on ROCm/CDNA and is out of scope for this port; only
-        // the default StdGPU backend is validated here. See notes.md.
+        // the default StdGPU backend is validated here.
         backends.push_back(core::HashBackendType::Slab);
 #endif
         backends.push_back(core::HashBackendType::StdGPU);
@@ -414,7 +414,7 @@ TEST_P(HashMapPermuteDevices, InsertComplexKeys) {
 #ifndef USE_HIP
         // The Slab (warp-cooperative) backend's 32-lane lane election is not
         // wave64-correct on ROCm/CDNA and is out of scope for this port; only
-        // the default StdGPU backend is validated here. See notes.md.
+        // the default StdGPU backend is validated here.
         backends.push_back(core::HashBackendType::Slab);
 #endif
         backends.push_back(core::HashBackendType::StdGPU);
@@ -478,7 +478,7 @@ TEST_P(HashMapPermuteDevices, MultivalueInsertion) {
 #ifndef USE_HIP
         // The Slab (warp-cooperative) backend's 32-lane lane election is not
         // wave64-correct on ROCm/CDNA and is out of scope for this port; only
-        // the default StdGPU backend is validated here. See notes.md.
+        // the default StdGPU backend is validated here.
         backends.push_back(core::HashBackendType::Slab);
 #endif
         backends.push_back(core::HashBackendType::StdGPU);
@@ -556,7 +556,7 @@ TEST_P(HashMapPermuteDevices, HashSet) {
 #ifndef USE_HIP
         // The Slab (warp-cooperative) backend's 32-lane lane election is not
         // wave64-correct on ROCm/CDNA and is out of scope for this port; only
-        // the default StdGPU backend is validated here. See notes.md.
+        // the default StdGPU backend is validated here.
         backends.push_back(core::HashBackendType::Slab);
 #endif
         backends.push_back(core::HashBackendType::StdGPU);

--- a/cpp/tests/core/HashMap.cpp
+++ b/cpp/tests/core/HashMap.cpp
@@ -59,7 +59,12 @@ TEST_P(HashMapPermuteDevices, SimpleInit) {
 
     std::vector<core::HashBackendType> backends;
     if (device.IsCUDA()) {
+#ifndef USE_HIP
+        // The Slab (warp-cooperative) backend's 32-lane lane election is not
+        // wave64-correct on ROCm/CDNA and is out of scope for this port; only
+        // the default StdGPU backend is validated here. See notes.md.
         backends.push_back(core::HashBackendType::Slab);
+#endif
         backends.push_back(core::HashBackendType::StdGPU);
     } else {
         backends.push_back(core::HashBackendType::TBB);
@@ -89,7 +94,12 @@ TEST_P(HashMapPermuteDevices, Find) {
     core::Device device = GetParam();
     std::vector<core::HashBackendType> backends;
     if (device.IsCUDA()) {
+#ifndef USE_HIP
+        // The Slab (warp-cooperative) backend's 32-lane lane election is not
+        // wave64-correct on ROCm/CDNA and is out of scope for this port; only
+        // the default StdGPU backend is validated here. See notes.md.
         backends.push_back(core::HashBackendType::Slab);
+#endif
         backends.push_back(core::HashBackendType::StdGPU);
     } else {
         backends.push_back(core::HashBackendType::TBB);
@@ -133,7 +143,12 @@ TEST_P(HashMapPermuteDevices, Insert) {
     core::Device device = GetParam();
     std::vector<core::HashBackendType> backends;
     if (device.IsCUDA()) {
+#ifndef USE_HIP
+        // The Slab (warp-cooperative) backend's 32-lane lane election is not
+        // wave64-correct on ROCm/CDNA and is out of scope for this port; only
+        // the default StdGPU backend is validated here. See notes.md.
         backends.push_back(core::HashBackendType::Slab);
+#endif
         backends.push_back(core::HashBackendType::StdGPU);
     } else {
         backends.push_back(core::HashBackendType::TBB);
@@ -186,7 +201,12 @@ TEST_P(HashMapPermuteDevices, Erase) {
     core::Device device = GetParam();
     std::vector<core::HashBackendType> backends;
     if (device.IsCUDA()) {
+#ifndef USE_HIP
+        // The Slab (warp-cooperative) backend's 32-lane lane election is not
+        // wave64-correct on ROCm/CDNA and is out of scope for this port; only
+        // the default StdGPU backend is validated here. See notes.md.
         backends.push_back(core::HashBackendType::Slab);
+#endif
         backends.push_back(core::HashBackendType::StdGPU);
     } else {
         backends.push_back(core::HashBackendType::TBB);
@@ -249,7 +269,12 @@ TEST_P(HashMapPermuteDevices, Reserve) {
     core::Device device = GetParam();
     std::vector<core::HashBackendType> backends;
     if (device.IsCUDA()) {
+#ifndef USE_HIP
+        // The Slab (warp-cooperative) backend's 32-lane lane election is not
+        // wave64-correct on ROCm/CDNA and is out of scope for this port; only
+        // the default StdGPU backend is validated here. See notes.md.
         backends.push_back(core::HashBackendType::Slab);
+#endif
         backends.push_back(core::HashBackendType::StdGPU);
     } else {
         backends.push_back(core::HashBackendType::TBB);
@@ -303,7 +328,12 @@ TEST_P(HashMapPermuteDevices, Clear) {
     core::Device device = GetParam();
     std::vector<core::HashBackendType> backends;
     if (device.IsCUDA()) {
+#ifndef USE_HIP
+        // The Slab (warp-cooperative) backend's 32-lane lane election is not
+        // wave64-correct on ROCm/CDNA and is out of scope for this port; only
+        // the default StdGPU backend is validated here. See notes.md.
         backends.push_back(core::HashBackendType::Slab);
+#endif
         backends.push_back(core::HashBackendType::StdGPU);
     } else {
         backends.push_back(core::HashBackendType::TBB);
@@ -381,7 +411,12 @@ TEST_P(HashMapPermuteDevices, InsertComplexKeys) {
     core::Device device = GetParam();
     std::vector<core::HashBackendType> backends;
     if (device.IsCUDA()) {
+#ifndef USE_HIP
+        // The Slab (warp-cooperative) backend's 32-lane lane election is not
+        // wave64-correct on ROCm/CDNA and is out of scope for this port; only
+        // the default StdGPU backend is validated here. See notes.md.
         backends.push_back(core::HashBackendType::Slab);
+#endif
         backends.push_back(core::HashBackendType::StdGPU);
     } else {
         backends.push_back(core::HashBackendType::TBB);
@@ -440,7 +475,12 @@ TEST_P(HashMapPermuteDevices, MultivalueInsertion) {
     core::Device device = GetParam();
     std::vector<core::HashBackendType> backends;
     if (device.IsCUDA()) {
+#ifndef USE_HIP
+        // The Slab (warp-cooperative) backend's 32-lane lane election is not
+        // wave64-correct on ROCm/CDNA and is out of scope for this port; only
+        // the default StdGPU backend is validated here. See notes.md.
         backends.push_back(core::HashBackendType::Slab);
+#endif
         backends.push_back(core::HashBackendType::StdGPU);
     } else {
         backends.push_back(core::HashBackendType::TBB);
@@ -513,7 +553,12 @@ TEST_P(HashMapPermuteDevices, HashSet) {
     core::Device device = GetParam();
     std::vector<core::HashBackendType> backends;
     if (device.IsCUDA()) {
+#ifndef USE_HIP
+        // The Slab (warp-cooperative) backend's 32-lane lane election is not
+        // wave64-correct on ROCm/CDNA and is out of scope for this port; only
+        // the default StdGPU backend is validated here. See notes.md.
         backends.push_back(core::HashBackendType::Slab);
+#endif
         backends.push_back(core::HashBackendType::StdGPU);
     } else {
         backends.push_back(core::HashBackendType::TBB);

--- a/cpp/tests/t/geometry/VoxelBlockGrid.cpp
+++ b/cpp/tests/t/geometry/VoxelBlockGrid.cpp
@@ -64,7 +64,7 @@ static std::vector<core::HashBackendType> EnumerateBackends(
 #ifdef USE_HIP
         // The Slab (warp-cooperative) backend's 32-lane lane election is not
         // wave64-correct on ROCm/CDNA and is out of scope for this port; only
-        // the default StdGPU backend is validated here. See notes.md.
+        // the default StdGPU backend is validated here.
         include_slab = false;
 #endif
         if (include_slab) {

--- a/cpp/tests/t/geometry/VoxelBlockGrid.cpp
+++ b/cpp/tests/t/geometry/VoxelBlockGrid.cpp
@@ -61,6 +61,12 @@ static std::vector<core::HashBackendType> EnumerateBackends(
         const core::Device &device, bool include_slab = true) {
     std::vector<core::HashBackendType> backends;
     if (device.IsCUDA()) {
+#ifdef USE_HIP
+        // The Slab (warp-cooperative) backend's 32-lane lane election is not
+        // wave64-correct on ROCm/CDNA and is out of scope for this port; only
+        // the default StdGPU backend is validated here. See notes.md.
+        include_slab = false;
+#endif
         if (include_slab) {
             backends.push_back(core::HashBackendType::Slab);
         }

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -327,6 +327,40 @@ for all supported ML frameworks and bundling the high level Open3D-ML code.
     by following the `official
     documentation. <https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html>`_
 
+AMD GPU support (ROCm/HIP)
+``````````````````````````
+
+Open3D's core tensor module (``open3d.core`` and ``open3d.t``) can be built for
+AMD GPUs with `ROCm <https://rocm.docs.amd.com/>`_, using HIP as the device
+language. Enable it by configuring with ``-DUSE_HIP=ON``; this reuses the
+``BUILD_CUDA_MODULE`` code paths but selects the HIP toolchain instead of CUDA,
+and links the ROCm math libraries (hipBLAS/hipSOLVER/hipSPARSE). A working ROCm
+installation (providing ``hipcc``/``amdclang++`` and the hip* libraries, by
+default under ``/opt/rocm``) is required.
+
+.. code-block:: bash
+
+    # In the build directory
+    cmake -DUSE_HIP=ON \
+          -DCMAKE_HIP_COMPILER=/opt/rocm/llvm/bin/clang++ \
+          -DCMAKE_PREFIX_PATH=/opt/rocm \
+          ..
+    cmake --build . -j$(nproc)
+
+Without ``-DCMAKE_HIP_ARCHITECTURES`` the build targets ``gfx90a`` by default.
+Pass it to build for a different AMD GPU, or for several at once, e.g.
+``-DCMAKE_HIP_ARCHITECTURES=gfx1100`` or
+``-DCMAKE_HIP_ARCHITECTURES="gfx90a;gfx1100"``. ``rocminfo`` prints the
+architecture of the installed GPU.
+
+.. note::
+    ROCm support targets Linux and covers the core tensor and ``open3d.t``
+    GPU code paths. A few CUDA-only features are not yet available on ROCm and
+    are handled gracefully rather than failing the build: the NPP-based GPU
+    image filters (the CPU image path is used instead), the non-default SlabHash
+    hashmap backend (the default StdGPU backend is used), and the ML ops
+    (``BUILD_PYTORCH_OPS``/``BUILD_TENSORFLOW_OPS``, which remain CUDA-only).
+
 WebRTC remote visualization
 ```````````````````````````
 

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -347,19 +347,22 @@ default under ``/opt/rocm``) is required.
           ..
     cmake --build . -j$(nproc)
 
-Without ``-DCMAKE_HIP_ARCHITECTURES`` the build targets ``gfx90a`` by default.
-Pass it to build for a different AMD GPU, or for several at once, e.g.
+Without ``-DCMAKE_HIP_ARCHITECTURES`` the HIP toolchain auto-detects the AMD
+GPUs installed on the build host (via ``rocm_agent_enumerator``); a host with
+no AMD GPU must pass the architecture explicitly. Set it to build for a
+specific GPU, or for several at once, e.g.
 ``-DCMAKE_HIP_ARCHITECTURES=gfx1100`` or
 ``-DCMAKE_HIP_ARCHITECTURES="gfx90a;gfx1100"``. ``rocminfo`` prints the
 architecture of the installed GPU.
 
 .. note::
     ROCm support targets Linux and covers the core tensor and ``open3d.t``
-    GPU code paths. A few CUDA-only features are not yet available on ROCm and
-    are handled gracefully rather than failing the build: the NPP-based GPU
-    image filters (the CPU image path is used instead), the non-default SlabHash
-    hashmap backend (the default StdGPU backend is used), and the ML ops
-    (``BUILD_PYTORCH_OPS``/``BUILD_TENSORFLOW_OPS``, which remain CUDA-only).
+    GPU code paths. A few CUDA-only features are not yet available on ROCm but
+    do not fail the build: the NPP-based GPU image filters report the operation
+    as unsupported at runtime (run them on the CPU device instead), the
+    non-default SlabHash hashmap backend is unused (the default StdGPU backend
+    is selected), and the ML ops (``BUILD_PYTORCH_OPS``/``BUILD_TENSORFLOW_OPS``)
+    remain CUDA-only.
 
 WebRTC remote visualization
 ```````````````````````````


### PR DESCRIPTION
This adds an AMD GPU (ROCm/HIP) build for Open3D's core GPU "tensor" subsystem (cpp/open3d/core, cpp/open3d/t), so the GPU code paths run on AMD in addition to NVIDIA. It is enabled with -DUSE_HIP=ON and validated on Linux AMD GPUs (gfx90a CDNA2 and gfx1100 RDNA3) and on Windows (gfx1201 RDNA4) under the all-clang ROCm toolchain. Building with ROCm is documented in docs/compilation.rst.

The approach keeps the existing CUDA sources in their CUDA spelling: only the .cu translation units take the HIP toolchain, the host C++ is untouched, and the NVIDIA build is byte-for-byte unchanged. USE_HIP=ON reuses the existing BUILD_CUDA_MODULE switch (which already gates the GPU code throughout the tree) and only swaps the language to HIP, the math libraries to hipBLAS/hipSOLVER/hipSPARSE, and retags the .cu sources LANGUAGE HIP. A single compat header (cpp/open3d/core/hip/CUDAToHIP.h), force-included on the HIP translation units, aliases the CUDA-spelled runtime symbols to their HIP equivalents; forwarding shims under hip_compat/ redirect the <cuda.h>/<cuda_runtime.h>/<cub/cub.cuh> includes so no include line is edited.

To review, start with CMakeLists.txt (the USE_HIP enable) and cmake/Open3DSetGlobalProperties.cmake (the .cu LANGUAGE HIP retag, force-include, and THRUST_DEVICE_SYSTEM=HIP), then the compat header, then find_dependencies.cmake (the HIP math-lib targets and the stdgpu HIP backend), then the device/host-guard source fixes, and finally the two test files (cpp/tests/core/HashMap.cpp, cpp/tests/t/geometry/VoxelBlockGrid.cpp) which gate the non-default Slab hashmap backend out under USE_HIP.

Key fixes for the AMD architecture:
- FAISS warp-select (core/nns/kernel): kept kWarpSize=32 and run each 64-lane wavefront as two independent 32-lane bitonic groups (the smallest instantiated warp queue is 32, so kWarpSize=64 would collapse it); replaced the inline-PTX PtxUtils with clang builtins; widened the __shfl_*_sync / __any_sync masks to 64-bit. KNN / FixedRadius / Hybrid GPU results match the CPU reference.
- Extended the __CUDACC__/__CUDA_ARCH__ device-vs-host guards across the kernel headers to also accept __HIPCC__/__HIP_DEVICE_COMPILE__, rather than faking __CUDACC__ globally (which would force rocThrust to its CUDA backend); same for MiniVec's FN_SPECIFIERS and the explicit-instantiation attributes in RegistrationImpl.h. __CUDACC__ is deliberately not defined, and THRUST_DEVICE_SYSTEM is pinned to the HIP backend rather than relying on auto-detect.
- Library swaps in LinalgHeadersCUDA.h (cublas/cusolver -> hipblas/hipsolver typed Dn API), guarding the cuSOLVER-only status enum cases.
- stdgpu's HIP backend (the default hashmap) is built via ExternalProject with hipcc as CXX plus a missing-install-file patch. The StdGPU hashmap is wave64-correct as-is: its concurrent duplicate-key dedup elects exactly one winner per key across all 64 lanes (confirmed by repeating the dedup-heavy HashMap tests), so no stdgpu source change is needed.

The hashmap unit tests loop over both GPU backends (Slab and StdGPU). The Slab backend (warp-cooperative, a tid>>5 / __ffs-ballot 32-lane election) is wave64-incorrect on a 64-lane architecture and is out of scope here, so HashMap.cpp and the VoxelBlockGrid test's EnumerateBackends helper exercise only the StdGPU backend under USE_HIP. With Slab excluded, the full HashMap suite and the VoxelBlockGrid TSDF suite (which uses the StdGPU hashmap internally) pass on GPU.

Out of scope for this change (guarded, not regressed): the NPP-based GPU image filters (no ROCm equivalent; the CPU/IPP path is unaffected and the GPU ops report unsupported), the non-default SlabHash backend's wave64 correctness (made to compile only; its tests are excluded under USE_HIP as above), and the CUTLASS-based ML conv ops (ML modules off).

On Windows, USE_HIP forces an all-clang toolchain (enable_language(HIP) does not allow a clang-HIP plus MSVC-host mix), so CMake's MSVC variable is false. A few places keyed Windows behavior on if(MSVC) or assumed an MSVC environment, which kept the ROCm port from building under clang on Windows; these are now gated on WIN32 or the Clang compiler id, leaving the Linux and NVIDIA builds byte-for-byte unchanged: the bundled zlib/libpng imported library names follow WIN32 (they build as zlibstatic / libpng16_static regardless of the frontend), the ignored-nodiscard hipError_t that clang reports under -Wunused-value is demoted to a warning (gcc's -Wunused-result was already relaxed), two assert-only Windows BOOLs in CPUInfo are marked [[maybe_unused]], and the test tbb.dll copy is guarded on the bundled tbb target so USE_SYSTEM_TBB works. Open3D's bundled host third-party that does not build under clang on Windows (TBB, libjpeg-turbo, curl, openssl, embree, zeromq) is supplied through the existing USE_SYSTEM_* options, and the standard Windows defines (_USE_MATH_DEFINES, WIN32) are passed in the build invocation.

This work was done with the assistance of Claude (an AI assistant by Anthropic), which did the CUDA-to-HIP analysis, the compat layer, the build-system changes, and the validation.

## Test Plan

Validated on a Linux AMD GPU (Instinct MI250X, one gfx90a GCD, ROCm 7.2.1; the PermuteDevices CPU parameterization is the per-test reference) and on gfx1100 (RDNA3).

    cmake -S . -B build -DUSE_HIP=ON -DCMAKE_HIP_COMPILER=/opt/rocm/llvm/bin/clang++ -DCMAKE_PREFIX_PATH=/opt/rocm \
      -DBUILD_PYTORCH_OPS=OFF -DBUILD_TENSORFLOW_OPS=OFF -DBUILD_GUI=OFF \
      -DBUILD_WEBRTC=OFF -DBUILD_EXAMPLES=OFF -DBUILD_BENCHMARKS=OFF \
      -DBUILD_PYTHON_MODULE=OFF -DBUILD_UNIT_TESTS=ON -DBUILD_ISPC_MODULE=OFF \
      -DWITH_IPP=OFF -DCMAKE_BUILD_TYPE=Release -DDEVELOPER_BUILD=ON
    cmake --build build -j16 --target tests
    HIP_VISIBLE_DEVICES=3 ./build/bin/tests \
      --gtest_filter='*Tensor*:*Reduction*:*MemoryManager*:*NearestNeighbor*:*Knn*:*FixedRadius*:*Registration*:*Feature*'
    HIP_VISIBLE_DEVICES=3 ./build/bin/tests --gtest_filter='*HashMap*:*VoxelBlockGrid*'
    HIP_VISIBLE_DEVICES=3 ./build/bin/tests --gtest_repeat=30 --gtest_break_on_failure \
      --gtest_filter='*HashMapPermuteDevices.Reserve*:*HashMapPermuteDevices.InsertComplexKeys*:*HashMapPermuteDevices.MultivalueInsertion*:*HashMapPermuteDevices.HashSet*'

Results: Tensor + Reduction + MemoryManager 421/421; NearestNeighborSearch / Knn / FixedRadius / Hybrid; HashMap 20/20 (the four dedup tests stable over 30 repeats); VoxelBlockGrid 14/14 (TSDF integrate / ray casting / IO, stable over 5 repeats); ICP Registration and FPFH Feature all pass.

Also built and run on Windows (Radeon RX 9070 XT, gfx1201 RDNA4) with the all-clang ROCm toolchain, the bundled host third-party supplied via vcpkg, and a dynamic CRT (-DSTATIC_WINDOWS_RUNTIME=OFF):

    cmake -G Ninja -S . -B build -DUSE_HIP=ON -DCMAKE_HIP_ARCHITECTURES=gfx1201 \
      -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_HIP_COMPILER=clang++ \
      -DSTATIC_WINDOWS_RUNTIME=OFF \
      -DCMAKE_C_FLAGS="-D_USE_MATH_DEFINES" \
      -DCMAKE_CXX_FLAGS="-DNOMINMAX -DWIN32_LEAN_AND_MEAN -D_USE_MATH_DEFINES -DWIN32" \
      -DCMAKE_HIP_FLAGS="-DNOMINMAX -DWIN32_LEAN_AND_MEAN -D_USE_MATH_DEFINES -DWIN32" \
      -DUSE_SYSTEM_TBB=ON -DUSE_SYSTEM_JPEG=ON -DUSE_SYSTEM_CURL=ON -DUSE_SYSTEM_OPENSSL=ON \
      -DUSE_SYSTEM_EMBREE=ON -DUSE_SYSTEM_ZEROMQ=ON \
      -DBUILD_GUI=OFF -DBUILD_WEBRTC=OFF -DBUILD_EXAMPLES=OFF -DBUILD_BENCHMARKS=OFF \
      -DBUILD_PYTHON_MODULE=OFF -DBUILD_UNIT_TESTS=ON -DBUILD_ISPC_MODULE=OFF \
      -DWITH_IPP=OFF -DCMAKE_BUILD_TYPE=Release -DDEVELOPER_BUILD=ON
    cmake --build build --target tests
    build\bin\tests.exe --gtest_filter='*Tensor*:*Reduction*:*MemoryManager*:*HashMap*:*VoxelBlockGrid*:*NearestNeighbor*:*Knn*:*FixedRadius*:*Registration*:*Feature*'

The architecture-sensitive GPU paths all pass on RDNA4: the FAISS warp-select (NearestNeighbor / Knn / FixedRadius), the StdGPU hashmap (HashMap 20/20), and the TSDF VoxelBlockGrid (14/14). A small number of linear-algebra GPU tests (which call rocSOLVER getrf) are affected by a known ROCm code-object-loading issue on the multi-architecture toolchain build used here; it is not specific to Open3D and is unrelated to this change.
