### PR TITLE
Fix Open3D import crash when pybind stub directories exist (#7481)

### DIFF
--- a/python/open3d/__init__.py
+++ b/python/open3d/__init__.py
@@ -35,7 +35,11 @@ if _build_config["BUILD_CUDA_MODULE"]:
     # Load CPU pybind dll gracefully without introducing new python variable.
     # Do this before loading the CUDA pybind dll to correctly resolve symbols
     try:  # StopIteration if cpu version not available
-        CDLL(str(next((Path(__file__).parent / "cpu").glob("pybind*"))))
+        
+        CDLL(str(next(
+            p for p in (Path(__file__).parent / "cpu").glob("pybind*")
+            if p.is_file()
+        )))
     except StopIteration:
         warnings.warn(
             "Open3D was built with CUDA support, but Open3D CPU Python "
@@ -60,8 +64,10 @@ if _build_config["BUILD_CUDA_MODULE"]:
 
         # Check CUDA availability without importing CUDA pybind symbols to
         # prevent "symbol already registered" errors if first import fails.
-        _pybind_cuda = CDLL(
-            str(next((Path(__file__).parent / "cuda").glob("pybind*"))))
+        _pybind_cuda = CDLL(str(next(
+                p for p in (Path(__file__).parent / "cuda").glob("pybind*")
+                if p.is_file()
+            )))
         if _pybind_cuda.open3d_core_cuda_device_count() > 0:
             from open3d.cuda.pybind import (
                 core,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Type
Fixes #7481

Related issue:
https://github.com/isl-org/Open3D/issues/7481
<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [x] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [ ] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [ ] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [ ] This PR changes Open3D behavior or adds new functionality.
    -   [ ] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [ ] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [ ] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [ ] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->
## Problem

When generating Python stubs using `pybind11-stubgen`, a `pybind/` directory is created inside the Open3D package (e.g. `open3d/cpu/pybind/` or `open3d/cuda/pybind/`).

The current implementation in `open3d/__init__.py` locates the compiled Python extension using:

    CDLL(str(next(Path(...).glob("pybind*"))))

However, `glob("pybind*")` may return both:
- a directory (`pybind/`)
- a compiled shared library (`pybind*.so`, `pybind*.dll`, etc.)

Because `next()` does not filter by type, the directory may be selected first.

This leads to a runtime crash when ctypes attempts to load a directory:

    OSError: ... pybind: Is a directory


## Root Cause

- `Path.glob("pybind*")` matches both files and directories
- No filtering is applied before passing the result to `CDLL`
- Directory entries can be returned before the actual shared library depending on filesystem ordering


## Fix

Filter glob results to ensure only valid shared library files are used:

```python
p for p in Path(...).glob("pybind*") if p.is_file()

## Testing

Reproduced the issue described in #7481 by simulating the directory layout
created by `pybind11-stubgen`.

Created:

cpu/
├── pybind/      (directory)
└── pybind.so    (shared library)

Test script:

```python
from pathlib import Path

paths = list(Path("cpu").glob("pybind*"))
print("ALL MATCHES:", paths)

filtered = [p for p in paths if p.is_file()]
print("FILES ONLY:", filtered)

selected = next(
    p for p in Path("cpu").glob("pybind*")
    if p.is_file()
)
print("SELECTED FILE:", selected)