### PR TITLE
Adding Minimum Bounding Sphere functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Main
+-   Add Minimum Bounding Sphere support, including exact (Welzl) and approximate (Ritter) methods. Supports PointCloud, TriangleMesh, and LineSet. (PR #7511)
 -   Use glfwGetMonitorWorkarea for accurate screen size in GetScreenSize, remove unusable_height estimation hack, and subtract window-decoration extents before clamping auto-sized windows (PR #7469)
 -   Upgrade stdgpu third-party library to commit d7c07d0.
 -   Fix performance for non-contiguous NumPy array conversion in pybind vector converters. This change removes restrictive `py::array::c_style` flags and adds a runtime contiguity check, improving Pandas-to-Open3D conversion speed by up to ~50×. (issue #5250)(PR #7343).

--- a/cpp/open3d/geometry/BoundingVolume.cpp
+++ b/cpp/open3d/geometry/BoundingVolume.cpp
@@ -234,9 +234,18 @@ std::vector<size_t> BoundingSphere::GetPointIndicesWithinBoundingSphere(
 }
 
 BoundingSphere BoundingSphere::CreateFromPoints(
-        const std::vector<Eigen::Vector3d>& points, bool robust) {
-    return t::geometry::kernel::bounding_sphere::ComputeMinimumBSWelzl(points,
-    robust);
+        const std::vector<Eigen::Vector3d>& points,
+        bool exact,
+        bool robust) {
+    
+    if (exact) {
+        return t::geometry::kernel::bounding_sphere::ComputeMinimumBSWelzl(
+            points, robust);
+    } else {
+        return t::geometry::kernel::bounding_sphere::ComputeApproximateBSRitter(
+            points);
+    }
+
 
 }
 

--- a/cpp/open3d/geometry/BoundingVolume.cpp
+++ b/cpp/open3d/geometry/BoundingVolume.cpp
@@ -117,19 +117,20 @@ OrientedBoundingEllipsoid OrientedBoundingEllipsoid::CreateFromPoints(
                                                                         robust);
 }
 
-std::vector<size_t> OrientedBoundingEllipsoid::GetPointIndicesWithinBoundingEllipsoid(
+std::vector<size_t>
+OrientedBoundingEllipsoid::GetPointIndicesWithinBoundingEllipsoid(
         const std::vector<Eigen::Vector3d>& points) const {
     std::vector<size_t> indices;
     for (size_t idx = 0; idx < points.size(); idx++) {
         // Transform point to ellipsoid's local frame
         Eigen::Vector3d p_centered = points[idx] - center_;
         Eigen::Vector3d p_local = R_.transpose() * p_centered;
-        
+
         // Normalize by radii
         Eigen::Vector3d p_normalized(p_local(0) / radii_(0),
-                                      p_local(1) / radii_(1),
-                                      p_local(2) / radii_(2));
-        
+                                     p_local(1) / radii_(1),
+                                     p_local(2) / radii_(2));
+
         // Check if norm squared is <= 1
         if (p_normalized.squaredNorm() <= 1.0) {
             indices.push_back(idx);
@@ -161,16 +162,15 @@ AxisAlignedBoundingBox BoundingSphere::GetAxisAlignedBoundingBox() const {
     return AxisAlignedBoundingBox::CreateFromPoints(GetSpherePoints());
 }
 
-OrientedBoundingBox BoundingSphere::GetOrientedBoundingBox(
-        bool) const {
+OrientedBoundingBox BoundingSphere::GetOrientedBoundingBox(bool) const {
     return OrientedBoundingBox::CreateFromAxisAlignedBoundingBox(
-        GetAxisAlignedBoundingBox());
+            GetAxisAlignedBoundingBox());
 }
 
 OrientedBoundingBox BoundingSphere::GetMinimalOrientedBoundingBox(
         bool robust) const {
     return OrientedBoundingBox::CreateFromAxisAlignedBoundingBox(
-        GetAxisAlignedBoundingBox());
+            GetAxisAlignedBoundingBox());
 }
 
 BoundingSphere& BoundingSphere::Transform(
@@ -234,19 +234,14 @@ std::vector<size_t> BoundingSphere::GetPointIndicesWithinBoundingSphere(
 }
 
 BoundingSphere BoundingSphere::CreateFromPoints(
-        const std::vector<Eigen::Vector3d>& points,
-        bool exact,
-        bool robust) {
-    
+        const std::vector<Eigen::Vector3d>& points, bool exact, bool robust) {
     if (exact) {
         return t::geometry::kernel::bounding_sphere::ComputeMinimumBSWelzl(
-            points, robust);
+                points, robust);
     } else {
         return t::geometry::kernel::bounding_sphere::ComputeApproximateBSRitter(
-            points);
+                points);
     }
-
-
 }
 
 OrientedBoundingBox& OrientedBoundingBox::Clear() {

--- a/cpp/open3d/geometry/BoundingVolume.cpp
+++ b/cpp/open3d/geometry/BoundingVolume.cpp
@@ -225,8 +225,9 @@ std::vector<Eigen::Vector3d> BoundingSphere::GetSpherePoints() const {
 // }
 
 BoundingSphere BoundingSphere::CreateFromPoints(
-        const std::vector<Eigen::Vector3d>& points) {
-    return t::geometry::kernel::bounding_sphere::ComputeMinimumBSWelzl(points);
+        const std::vector<Eigen::Vector3d>& points, bool robust) {
+    return t::geometry::kernel::bounding_sphere::ComputeMinimumBSWelzl(points,
+    robust);
 
 }
 

--- a/cpp/open3d/geometry/BoundingVolume.cpp
+++ b/cpp/open3d/geometry/BoundingVolume.cpp
@@ -14,6 +14,7 @@
 #include "open3d/geometry/PointCloud.h"
 #include "open3d/geometry/Qhull.h"
 #include "open3d/geometry/TriangleMesh.h"
+#include "open3d/t/geometry/kernel/MinimumBS.h"
 #include "open3d/t/geometry/kernel/MinimumOBB.h"
 #include "open3d/t/geometry/kernel/MinimumOBE.h"
 #include "open3d/utility/Logging.h"
@@ -114,6 +115,119 @@ OrientedBoundingEllipsoid OrientedBoundingEllipsoid::CreateFromPoints(
         const std::vector<Eigen::Vector3d>& points, bool robust) {
     return t::geometry::kernel::minimum_obe::ComputeMinimumOBEKhachiyan(points,
                                                                         robust);
+}
+
+// checked
+BoundingSphere& BoundingSphere::Clear() {
+    center_.setZero();
+    radius_ = 0;
+    color_.setOnes();
+    return *this;
+}
+
+// checked
+bool BoundingSphere::IsEmpty() const { return Volume() <= 0; }
+
+// checked
+Eigen::Vector3d BoundingSphere::GetMinBound() const {
+    return center_ - Eigen::Vector3d(radius_, radius_, radius_);
+}
+
+// checked
+Eigen::Vector3d BoundingSphere::GetMaxBound() const {
+    return center_ + Eigen::Vector3d(radius_, radius_, radius_);
+}
+
+// checked
+Eigen::Vector3d BoundingSphere::GetCenter() const { return center_; }
+
+// checked
+AxisAlignedBoundingBox BoundingSphere::GetAxisAlignedBoundingBox() const {
+    return AxisAlignedBoundingBox::CreateFromPoints(GetSpherePoints());
+}
+
+OrientedBoundingBox BoundingSphere::GetOrientedBoundingBox(
+        bool) const {
+    return OrientedBoundingBox::CreateFromAxisAlignedBoundingBox(
+        GetAxisAlignedBoundingBox());
+}
+
+OrientedBoundingBox BoundingSphere::GetMinimalOrientedBoundingBox(
+        bool robust) const {
+    return OrientedBoundingBox::CreateFromAxisAlignedBoundingBox(
+        GetAxisAlignedBoundingBox());
+}
+
+// checked
+BoundingSphere& BoundingSphere::Transform(
+        const Eigen::Matrix4d& transformation) {
+    utility::LogError(
+            "A general transform of a BoundingSphere is not "
+            "implemented. "
+            "Call Translate, Scale, and Rotate.");
+    return *this;
+}
+
+// checked
+BoundingSphere& BoundingSphere::Translate(const Eigen::Vector3d& translation,
+                                          bool relative) {
+    if (relative) {
+        center_ += translation;
+    } else {
+        center_ = translation;
+    }
+    return *this;
+}
+
+// checked
+BoundingSphere& BoundingSphere::Scale(const double scale,
+                                      const Eigen::Vector3d& center) {
+    radius_ *= scale;
+    center_ = scale * (center_ - center) + center;
+    return *this;
+}
+
+// checked
+BoundingSphere& BoundingSphere::Rotate(const Eigen::Matrix3d& R,
+                                       const Eigen::Vector3d& center) {
+    center_ = R * (center_ - center) + center;
+    return *this;
+}
+
+// checked
+double BoundingSphere::Volume() const {
+    return 4.0 * M_PI * radius_ * radius_ * radius_ / 3.0;
+}
+
+// checked
+std::vector<Eigen::Vector3d> BoundingSphere::GetSpherePoints() const {
+    std::vector<Eigen::Vector3d> points(6);
+    points[0] = center_ + Eigen::Vector3d(radius_, 0, 0);
+    points[1] = center_ - Eigen::Vector3d(radius_, 0, 0);
+    points[2] = center_ + Eigen::Vector3d(0, radius_, 0);
+    points[3] = center_ - Eigen::Vector3d(0, radius_, 0);
+    points[4] = center_ + Eigen::Vector3d(0, 0, radius_);
+    points[5] = center_ - Eigen::Vector3d(0, 0, radius_);
+    return points;
+}
+
+// std::vector<size_t> BoundingSphere::GetPointIndicesWithinBoundingSphere(
+//         const std::vector<Eigen::Vector3d>& points) const {
+//     std::vector<size_t> indices;
+//     double radius_sq = radius_ * radius_;
+//     for (size_t idx = 0; idx < points.size(); idx++) {
+//         Eigen::Vector3d diff = points[idx] - center_;
+//         if (diff.squaredNorm() <= radius_sq) {
+//             indices.push_back(idx);
+//         }
+//     }
+//     return indices;
+// }
+
+BoundingSphere BoundingSphere::CreateFromPoints(
+        const std::vector<Eigen::Vector3d>& points) {
+    return t::geometry::kernel::bounding_sphere::ComputeMinimumBSWelzl(points);
+
 }
 
 OrientedBoundingBox& OrientedBoundingBox::Clear() {

--- a/cpp/open3d/geometry/BoundingVolume.cpp
+++ b/cpp/open3d/geometry/BoundingVolume.cpp
@@ -138,7 +138,6 @@ std::vector<size_t> OrientedBoundingEllipsoid::GetPointIndicesWithinBoundingElli
     return indices;
 }
 
-// checked
 BoundingSphere& BoundingSphere::Clear() {
     center_.setZero();
     radius_ = 0;
@@ -146,23 +145,18 @@ BoundingSphere& BoundingSphere::Clear() {
     return *this;
 }
 
-// checked
 bool BoundingSphere::IsEmpty() const { return Volume() <= 0; }
 
-// checked
 Eigen::Vector3d BoundingSphere::GetMinBound() const {
     return center_ - Eigen::Vector3d(radius_, radius_, radius_);
 }
 
-// checked
 Eigen::Vector3d BoundingSphere::GetMaxBound() const {
     return center_ + Eigen::Vector3d(radius_, radius_, radius_);
 }
 
-// checked
 Eigen::Vector3d BoundingSphere::GetCenter() const { return center_; }
 
-// checked
 AxisAlignedBoundingBox BoundingSphere::GetAxisAlignedBoundingBox() const {
     return AxisAlignedBoundingBox::CreateFromPoints(GetSpherePoints());
 }
@@ -179,7 +173,6 @@ OrientedBoundingBox BoundingSphere::GetMinimalOrientedBoundingBox(
         GetAxisAlignedBoundingBox());
 }
 
-// checked
 BoundingSphere& BoundingSphere::Transform(
         const Eigen::Matrix4d& transformation) {
     utility::LogError(
@@ -189,7 +182,6 @@ BoundingSphere& BoundingSphere::Transform(
     return *this;
 }
 
-// checked
 BoundingSphere& BoundingSphere::Translate(const Eigen::Vector3d& translation,
                                           bool relative) {
     if (relative) {
@@ -200,7 +192,6 @@ BoundingSphere& BoundingSphere::Translate(const Eigen::Vector3d& translation,
     return *this;
 }
 
-// checked
 BoundingSphere& BoundingSphere::Scale(const double scale,
                                       const Eigen::Vector3d& center) {
     radius_ *= scale;
@@ -208,19 +199,16 @@ BoundingSphere& BoundingSphere::Scale(const double scale,
     return *this;
 }
 
-// checked
 BoundingSphere& BoundingSphere::Rotate(const Eigen::Matrix3d& R,
                                        const Eigen::Vector3d& center) {
     center_ = R * (center_ - center) + center;
     return *this;
 }
 
-// checked
 double BoundingSphere::Volume() const {
     return 4.0 * M_PI * radius_ * radius_ * radius_ / 3.0;
 }
 
-// checked
 std::vector<Eigen::Vector3d> BoundingSphere::GetSpherePoints() const {
     std::vector<Eigen::Vector3d> points(6);
     points[0] = center_ + Eigen::Vector3d(radius_, 0, 0);

--- a/cpp/open3d/geometry/BoundingVolume.cpp
+++ b/cpp/open3d/geometry/BoundingVolume.cpp
@@ -117,6 +117,27 @@ OrientedBoundingEllipsoid OrientedBoundingEllipsoid::CreateFromPoints(
                                                                         robust);
 }
 
+std::vector<size_t> OrientedBoundingEllipsoid::GetPointIndicesWithinBoundingEllipsoid(
+        const std::vector<Eigen::Vector3d>& points) const {
+    std::vector<size_t> indices;
+    for (size_t idx = 0; idx < points.size(); idx++) {
+        // Transform point to ellipsoid's local frame
+        Eigen::Vector3d p_centered = points[idx] - center_;
+        Eigen::Vector3d p_local = R_.transpose() * p_centered;
+        
+        // Normalize by radii
+        Eigen::Vector3d p_normalized(p_local(0) / radii_(0),
+                                      p_local(1) / radii_(1),
+                                      p_local(2) / radii_(2));
+        
+        // Check if norm squared is <= 1
+        if (p_normalized.squaredNorm() <= 1.0) {
+            indices.push_back(idx);
+        }
+    }
+    return indices;
+}
+
 // checked
 BoundingSphere& BoundingSphere::Clear() {
     center_.setZero();
@@ -211,18 +232,18 @@ std::vector<Eigen::Vector3d> BoundingSphere::GetSpherePoints() const {
     return points;
 }
 
-// std::vector<size_t> BoundingSphere::GetPointIndicesWithinBoundingSphere(
-//         const std::vector<Eigen::Vector3d>& points) const {
-//     std::vector<size_t> indices;
-//     double radius_sq = radius_ * radius_;
-//     for (size_t idx = 0; idx < points.size(); idx++) {
-//         Eigen::Vector3d diff = points[idx] - center_;
-//         if (diff.squaredNorm() <= radius_sq) {
-//             indices.push_back(idx);
-//         }
-//     }
-//     return indices;
-// }
+std::vector<size_t> BoundingSphere::GetPointIndicesWithinBoundingSphere(
+        const std::vector<Eigen::Vector3d>& points) const {
+    std::vector<size_t> indices;
+    double radius_sq = radius_ * radius_;
+    for (size_t idx = 0; idx < points.size(); idx++) {
+        Eigen::Vector3d diff = points[idx] - center_;
+        if (diff.squaredNorm() <= radius_sq) {
+            indices.push_back(idx);
+        }
+    }
+    return indices;
+}
 
 BoundingSphere BoundingSphere::CreateFromPoints(
         const std::vector<Eigen::Vector3d>& points, bool robust) {

--- a/cpp/open3d/geometry/BoundingVolume.h
+++ b/cpp/open3d/geometry/BoundingVolume.h
@@ -129,6 +129,85 @@ public:
     Eigen::Vector3d color_;
 };
 
+/// \class BoundingSphere
+///
+/// \brief A bounding sphere defined by a center point and a radius.
+///
+/// The bounding sphere is the smallest sphere that encloses a set of points.
+class BoundingSphere : public Geometry3D {
+public:
+    /// \brief Default constructor.
+    ///
+    /// Creates an empty Bounding Sphere.
+    BoundingSphere()
+        : Geometry3D(Geometry::GeometryType::BoundingSphere),
+          center_(0, 0, 0),
+          radius_(0),
+          color_(1, 1, 1) {}
+
+    /// \brief Parameterized constructor.
+    ///
+    /// \param center Specifies the center position of the bounding sphere.
+    /// \param radius The radius of the bounding sphere.
+    BoundingSphere(const Eigen::Vector3d& center, double radius)
+        : Geometry3D(Geometry::GeometryType::BoundingSphere),
+          center_(center),
+          radius_(radius),
+          color_(1, 1, 1) {}
+    ~BoundingSphere() override {}
+
+public:
+    BoundingSphere& Clear() override;
+    bool IsEmpty() const override;
+    virtual Eigen::Vector3d GetMinBound() const override;
+    virtual Eigen::Vector3d GetMaxBound() const override;
+    virtual Eigen::Vector3d GetCenter() const override;
+
+    /// Creates an axis-aligned bounding box around the sphere.
+    virtual AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
+    /// Returns an oriented bounding box around the sphere.
+    /// internally calls GetAxisAlignedBoundingBox() since the oriented 
+    /// bounding box of a sphere is the same as its axis-aligned bounding box.
+    virtual OrientedBoundingBox GetOrientedBoundingBox(
+            bool robust) const override;
+    /// Returns an oriented bounding box around the sphere.
+    /// internally calls GetAxisAlignedBoundingBox() since the minimum oriented 
+    /// bounding box of a sphere is the same as its axis-aligned bounding box.
+    virtual OrientedBoundingBox GetMinimalOrientedBoundingBox(
+            bool robust) const override;
+
+    virtual BoundingSphere& Transform(const Eigen::Matrix4d& transformation) override;
+    virtual BoundingSphere& Translate(const Eigen::Vector3d& translation,
+                                      bool relative = true) override;
+    virtual BoundingSphere& Scale(const double scale,
+                                  const Eigen::Vector3d& center) override;
+    virtual BoundingSphere& Rotate(const Eigen::Matrix3d& R,
+                                   const Eigen::Vector3d& center) override;
+
+    /// Returns the volume of the bounding sphere.
+    double Volume() const;
+
+    /// Returns six critical points on the surface of the bounding sphere.
+    std::vector<Eigen::Vector3d> GetSpherePoints() const;
+
+    /// Return indices to points that are within the bounding sphere.
+    std::vector<size_t> GetPointIndicesWithinBoundingSphere(
+            const std::vector<Eigen::Vector3d>& points) const;
+
+    /// Creates a bounding sphere using Welzl's algorithm.
+    /// \param points The input points
+    static BoundingSphere CreateFromPoints(
+            const std::vector<Eigen::Vector3d>& points);
+
+public:
+    /// The center point of the bounding sphere.
+    Eigen::Vector3d center_;
+    /// The radius of the bounding sphere.
+    double radius_;
+    /// The color of the bounding sphere in RGB.
+    Eigen::Vector3d color_;
+};
+
 /// \class OrientedBoundingBox
 ///
 /// \brief A bounding box oriented along an arbitrary frame of reference.

--- a/cpp/open3d/geometry/BoundingVolume.h
+++ b/cpp/open3d/geometry/BoundingVolume.h
@@ -200,7 +200,9 @@ public:
     ///               in degenerate cases but introduces noise to the points
     ///               coordinates.
     static BoundingSphere CreateFromPoints(
-            const std::vector<Eigen::Vector3d>& points, bool robust);
+            const std::vector<Eigen::Vector3d>& points,
+            bool exact = true,
+            bool robust = false);
 
 public:
     /// The center point of the bounding sphere.

--- a/cpp/open3d/geometry/BoundingVolume.h
+++ b/cpp/open3d/geometry/BoundingVolume.h
@@ -166,17 +166,18 @@ public:
     /// Creates an axis-aligned bounding box around the sphere.
     virtual AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
     /// Returns an oriented bounding box around the sphere.
-    /// internally calls GetAxisAlignedBoundingBox() since the oriented 
+    /// internally calls GetAxisAlignedBoundingBox() since the oriented
     /// bounding box of a sphere is the same as its axis-aligned bounding box.
     virtual OrientedBoundingBox GetOrientedBoundingBox(
             bool robust) const override;
     /// Returns an oriented bounding box around the sphere.
-    /// internally calls GetAxisAlignedBoundingBox() since the minimum oriented 
+    /// internally calls GetAxisAlignedBoundingBox() since the minimum oriented
     /// bounding box of a sphere is the same as its axis-aligned bounding box.
     virtual OrientedBoundingBox GetMinimalOrientedBoundingBox(
             bool robust) const override;
 
-    virtual BoundingSphere& Transform(const Eigen::Matrix4d& transformation) override;
+    virtual BoundingSphere& Transform(
+            const Eigen::Matrix4d& transformation) override;
     virtual BoundingSphere& Translate(const Eigen::Vector3d& translation,
                                       bool relative = true) override;
     virtual BoundingSphere& Scale(const double scale,

--- a/cpp/open3d/geometry/BoundingVolume.h
+++ b/cpp/open3d/geometry/BoundingVolume.h
@@ -196,8 +196,11 @@ public:
 
     /// Creates a bounding sphere using Welzl's algorithm.
     /// \param points The input points
+    /// \param robust If set to true uses a more robust method which works
+    ///               in degenerate cases but introduces noise to the points
+    ///               coordinates.
     static BoundingSphere CreateFromPoints(
-            const std::vector<Eigen::Vector3d>& points);
+            const std::vector<Eigen::Vector3d>& points, bool robust);
 
 public:
     /// The center point of the bounding sphere.

--- a/cpp/open3d/geometry/Geometry.h
+++ b/cpp/open3d/geometry/Geometry.h
@@ -49,6 +49,8 @@ public:
         AxisAlignedBoundingBox = 12,
         /// OrientedBoundingEllipsoid
         OrientedBoundingEllipsoid = 13,
+        /// BoundingSphere
+        BoundingSphere = 14,
     };
 
 public:

--- a/cpp/open3d/geometry/Geometry3D.h
+++ b/cpp/open3d/geometry/Geometry3D.h
@@ -20,6 +20,7 @@ namespace geometry {
 class AxisAlignedBoundingBox;
 class OrientedBoundingBox;
 class OrientedBoundingEllipsoid;
+class BoundingSphere;
 
 /// \class Geometry3D
 ///
@@ -65,6 +66,14 @@ public:
     ///               in degenerate cases but introduces noise to the points
     ///               coordinates.
     virtual OrientedBoundingBox GetMinimalOrientedBoundingBox(
+            bool robust = false) const = 0;
+
+    /// Creates a bounding sphere around the points of the object.
+    /// Further details in BoundingSphere::CreateFromPoints()
+    /// \param robust If set to true uses a more robust method which works
+    ///               in degenerate cases but introduces noise to the points
+    ///               coordinates.
+    virtual BoundingSphere GetBoundingSphere(
             bool robust = false) const = 0;
 
     /// \brief Apply transformation (4x4 matrix) to the geometry coordinates.

--- a/cpp/open3d/geometry/Geometry3D.h
+++ b/cpp/open3d/geometry/Geometry3D.h
@@ -68,14 +68,6 @@ public:
     virtual OrientedBoundingBox GetMinimalOrientedBoundingBox(
             bool robust = false) const = 0;
 
-    /// Creates a bounding sphere around the points of the object.
-    /// Further details in BoundingSphere::CreateFromPoints()
-    /// \param robust If set to true uses a more robust method which works
-    ///               in degenerate cases but introduces noise to the points
-    ///               coordinates.
-    virtual BoundingSphere GetBoundingSphere(
-            bool robust = false) const = 0;
-
     /// \brief Apply transformation (4x4 matrix) to the geometry coordinates.
     virtual Geometry3D& Transform(const Eigen::Matrix4d& transformation) = 0;
 

--- a/cpp/open3d/geometry/LineSet.h
+++ b/cpp/open3d/geometry/LineSet.h
@@ -20,6 +20,7 @@ class PointCloud;
 class OrientedBoundingEllipsoid;
 class OrientedBoundingBox;
 class AxisAlignedBoundingBox;
+class BoundingSphere;
 class TriangleMesh;
 class TetraMesh;
 
@@ -140,6 +141,11 @@ public:
     /// \param ellipsoid The input bounding ellipsoid.
     static std::shared_ptr<LineSet> CreateFromOrientedBoundingEllipsoid(
             const OrientedBoundingEllipsoid &ellipsoid);
+
+    /// \brief Factory function to create a LineSet from a BoundingSphere.
+    /// \param sphere The input bounding sphere.
+    static std::shared_ptr<LineSet> CreateFromBoundingSphere(
+            const BoundingSphere &sphere);
 
     /// Factory function to create a LineSet from edges of a triangle mesh.
     ///

--- a/cpp/open3d/geometry/LineSetFactory.cpp
+++ b/cpp/open3d/geometry/LineSetFactory.cpp
@@ -76,10 +76,10 @@ std::shared_ptr<LineSet> LineSet::CreateFromOrientedBoundingEllipsoid(
 
 std::shared_ptr<LineSet> LineSet::CreateFromBoundingSphere(
         const BoundingSphere& sphere) {
-    std::shared_ptr<TriangleMesh> ebs =
+    std::shared_ptr<TriangleMesh> bs =
             geometry::TriangleMesh::CreateSphere(sphere.radius_);
-    ebs->Translate(sphere.center_);
-    auto line_set = CreateFromTriangleMesh(*ebs);
+    bs->Translate(sphere.center_);
+    auto line_set = CreateFromTriangleMesh(*bs);
     line_set->PaintUniformColor(sphere.color_);
     return line_set;
 }

--- a/cpp/open3d/geometry/LineSetFactory.cpp
+++ b/cpp/open3d/geometry/LineSetFactory.cpp
@@ -74,6 +74,16 @@ std::shared_ptr<LineSet> LineSet::CreateFromOrientedBoundingEllipsoid(
     return line_set;
 }
 
+std::shared_ptr<LineSet> LineSet::CreateFromBoundingSphere(
+        const BoundingSphere& sphere) {
+    std::shared_ptr<TriangleMesh> ebs =
+            geometry::TriangleMesh::CreateSphere(sphere.radius_);
+    ebs->Translate(sphere.center_);
+    auto line_set = CreateFromTriangleMesh(*ebs);
+    line_set->PaintUniformColor(sphere.color_);
+    return line_set;
+}
+
 std::shared_ptr<LineSet> LineSet::CreateFromOrientedBoundingBox(
         const OrientedBoundingBox& box) {
     auto line_set = std::make_shared<LineSet>();

--- a/cpp/open3d/geometry/MeshBase.cpp
+++ b/cpp/open3d/geometry/MeshBase.cpp
@@ -59,6 +59,11 @@ OrientedBoundingEllipsoid MeshBase::GetOrientedBoundingEllipsoid(
     return OrientedBoundingEllipsoid::CreateFromPoints(vertices_, robust);
 }
 
+BoundingSphere MeshBase::GetBoundingSphere(
+        bool robust) const {
+    return BoundingSphere::CreateFromPoints(vertices_, robust);
+}
+
 MeshBase &MeshBase::Transform(const Eigen::Matrix4d &transformation) {
     TransformPoints(transformation, vertices_);
     TransformNormals(transformation, vertex_normals_);

--- a/cpp/open3d/geometry/MeshBase.cpp
+++ b/cpp/open3d/geometry/MeshBase.cpp
@@ -60,8 +60,8 @@ OrientedBoundingEllipsoid MeshBase::GetOrientedBoundingEllipsoid(
 }
 
 BoundingSphere MeshBase::GetBoundingSphere(
-        bool robust) const {
-    return BoundingSphere::CreateFromPoints(vertices_, robust);
+        bool exact, bool robust) const {
+    return BoundingSphere::CreateFromPoints(vertices_, exact, robust);
 }
 
 MeshBase &MeshBase::Transform(const Eigen::Matrix4d &transformation) {

--- a/cpp/open3d/geometry/MeshBase.cpp
+++ b/cpp/open3d/geometry/MeshBase.cpp
@@ -59,8 +59,7 @@ OrientedBoundingEllipsoid MeshBase::GetOrientedBoundingEllipsoid(
     return OrientedBoundingEllipsoid::CreateFromPoints(vertices_, robust);
 }
 
-BoundingSphere MeshBase::GetBoundingSphere(
-        bool exact, bool robust) const {
+BoundingSphere MeshBase::GetBoundingSphere(bool exact, bool robust) const {
     return BoundingSphere::CreateFromPoints(vertices_, exact, robust);
 }
 

--- a/cpp/open3d/geometry/MeshBase.h
+++ b/cpp/open3d/geometry/MeshBase.h
@@ -23,6 +23,7 @@ namespace geometry {
 class PointCloud;
 class TriangleMesh;
 class OrientedBoundingEllipsoid;
+class BoundingSphere;
 
 /// \class MeshBase
 ///
@@ -95,6 +96,14 @@ public:
     ///               in degenerate cases but introduces noise to the points
     ///               coordinates.
     virtual OrientedBoundingEllipsoid GetOrientedBoundingEllipsoid(
+            bool robust = false) const;
+
+    /// Creates a bounding sphere around the points of the object.
+    /// Further details in BoundingSphere::CreateFromPoints()
+    /// \param robust If set to true uses a more robust method which works
+    ///               in degenerate cases but introduces noise to the points
+    ///               coordinates.
+    virtual BoundingSphere GetBoundingSphere(
             bool robust = false) const;
 
     virtual MeshBase &Transform(const Eigen::Matrix4d &transformation) override;

--- a/cpp/open3d/geometry/MeshBase.h
+++ b/cpp/open3d/geometry/MeshBase.h
@@ -105,9 +105,8 @@ public:
     ///      If set to true uses a more robust method which works
     ///      in degenerate cases but introduces noise to the points
     ///      coordinates.
-    virtual BoundingSphere GetBoundingSphere(
-            bool exact = true,
-            bool robust = false) const;
+    virtual BoundingSphere GetBoundingSphere(bool exact = true,
+                                             bool robust = false) const;
 
     virtual MeshBase &Transform(const Eigen::Matrix4d &transformation) override;
     virtual MeshBase &Translate(const Eigen::Vector3d &translation,

--- a/cpp/open3d/geometry/MeshBase.h
+++ b/cpp/open3d/geometry/MeshBase.h
@@ -100,10 +100,13 @@ public:
 
     /// Creates a bounding sphere around the points of the object.
     /// Further details in BoundingSphere::CreateFromPoints()
-    /// \param robust If set to true uses a more robust method which works
-    ///               in degenerate cases but introduces noise to the points
-    ///               coordinates.
+    /// \param exact If set to true uses the exact method.
+    /// \param robust Used only if exact is true.
+    ///      If set to true uses a more robust method which works
+    ///      in degenerate cases but introduces noise to the points
+    ///      coordinates.
     virtual BoundingSphere GetBoundingSphere(
+            bool exact = true,
             bool robust = false) const;
 
     virtual MeshBase &Transform(const Eigen::Matrix4d &transformation) override;

--- a/cpp/open3d/geometry/PointCloud.cpp
+++ b/cpp/open3d/geometry/PointCloud.cpp
@@ -62,8 +62,8 @@ OrientedBoundingEllipsoid PointCloud::GetOrientedBoundingEllipsoid(
     return OrientedBoundingEllipsoid::CreateFromPoints(points_, robust);
 }
 
-BoundingSphere PointCloud::GetBoundingSphere(bool robust) const {
-    return BoundingSphere::CreateFromPoints(points_, robust);
+BoundingSphere PointCloud::GetBoundingSphere(bool exact, bool robust) const {
+    return BoundingSphere::CreateFromPoints(points_, exact, robust);
 }
 
 PointCloud &PointCloud::Transform(const Eigen::Matrix4d &transformation) {

--- a/cpp/open3d/geometry/PointCloud.cpp
+++ b/cpp/open3d/geometry/PointCloud.cpp
@@ -62,6 +62,10 @@ OrientedBoundingEllipsoid PointCloud::GetOrientedBoundingEllipsoid(
     return OrientedBoundingEllipsoid::CreateFromPoints(points_, robust);
 }
 
+BoundingSphere PointCloud::GetBoundingSphere(bool robust) const {
+    return BoundingSphere::CreateFromPoints(points_, robust);
+}
+
 PointCloud &PointCloud::Transform(const Eigen::Matrix4d &transformation) {
     TransformPoints(transformation, points_);
     TransformNormals(transformation, normals_);

--- a/cpp/open3d/geometry/PointCloud.h
+++ b/cpp/open3d/geometry/PointCloud.h
@@ -58,6 +58,7 @@ public:
     OrientedBoundingEllipsoid GetOrientedBoundingEllipsoid(
             bool robust = false) const;
     BoundingSphere GetBoundingSphere(
+            bool exact = true,
             bool robust = false) const;
     PointCloud &Transform(const Eigen::Matrix4d &transformation) override;
     PointCloud &Translate(const Eigen::Vector3d &translation,

--- a/cpp/open3d/geometry/PointCloud.h
+++ b/cpp/open3d/geometry/PointCloud.h
@@ -57,9 +57,8 @@ public:
             bool robust = false) const override;
     OrientedBoundingEllipsoid GetOrientedBoundingEllipsoid(
             bool robust = false) const;
-    BoundingSphere GetBoundingSphere(
-            bool exact = true,
-            bool robust = false) const;
+    BoundingSphere GetBoundingSphere(bool exact = true,
+                                     bool robust = false) const;
     PointCloud &Transform(const Eigen::Matrix4d &transformation) override;
     PointCloud &Translate(const Eigen::Vector3d &translation,
                           bool relative = true) override;

--- a/cpp/open3d/geometry/PointCloud.h
+++ b/cpp/open3d/geometry/PointCloud.h
@@ -57,6 +57,8 @@ public:
             bool robust = false) const override;
     OrientedBoundingEllipsoid GetOrientedBoundingEllipsoid(
             bool robust = false) const;
+    BoundingSphere GetBoundingSphere(
+            bool robust = false) const;
     PointCloud &Transform(const Eigen::Matrix4d &transformation) override;
     PointCloud &Translate(const Eigen::Vector3d &translation,
                           bool relative = true) override;

--- a/cpp/open3d/geometry/TriangleMesh.h
+++ b/cpp/open3d/geometry/TriangleMesh.h
@@ -602,13 +602,11 @@ public:
             bool create_uv_map = false);
     
     /// Factory function to create solid mesh from a BoundingSphere.
-    /// \param ebs BoundingSphere object to create a mesh of
-    /// \param scale scale factor along radius of the BoundingSphere
+    /// \param bs BoundingSphere object to create a mesh of
     /// \param resolution defines the resolution of the sphere.
     /// \param create_uv_map add default UV map to the mesh.
     static std::shared_ptr<TriangleMesh> CreateFromBoundingSphere(
-            const BoundingSphere &ebs,
-            double scale = 1.0,
+            const BoundingSphere &bs,
             int resolution = 20,
             bool create_uv_map = false);
 

--- a/cpp/open3d/geometry/TriangleMesh.h
+++ b/cpp/open3d/geometry/TriangleMesh.h
@@ -600,7 +600,7 @@ public:
             const Eigen::Vector3d &scale = Eigen::Vector3d::Ones(),
             int resolution = 20,
             bool create_uv_map = false);
-    
+
     /// Factory function to create solid mesh from a BoundingSphere.
     /// \param bs BoundingSphere object to create a mesh of
     /// \param resolution defines the resolution of the sphere.

--- a/cpp/open3d/geometry/TriangleMesh.h
+++ b/cpp/open3d/geometry/TriangleMesh.h
@@ -600,6 +600,17 @@ public:
             const Eigen::Vector3d &scale = Eigen::Vector3d::Ones(),
             int resolution = 20,
             bool create_uv_map = false);
+    
+    /// Factory function to create solid mesh from a BoundingSphere.
+    /// \param ebs BoundingSphere object to create a mesh of
+    /// \param scale scale factor along radius of the BoundingSphere
+    /// \param resolution defines the resolution of the sphere.
+    /// \param create_uv_map add default UV map to the mesh.
+    static std::shared_ptr<TriangleMesh> CreateFromBoundingSphere(
+            const BoundingSphere &ebs,
+            double scale = 1.0,
+            int resolution = 20,
+            bool create_uv_map = false);
 
     /// Factory function to create a box mesh (TriangleMeshFactory.cpp)
     /// The left bottom corner on the front will be placed at (0, 0, 0).

--- a/cpp/open3d/geometry/TriangleMeshFactory.cpp
+++ b/cpp/open3d/geometry/TriangleMeshFactory.cpp
@@ -166,6 +166,21 @@ std::shared_ptr<TriangleMesh> TriangleMesh::CreateFromOrientedBoundingEllipsoid(
     return mesh;
 }
 
+std::shared_ptr<TriangleMesh> TriangleMesh::CreateFromBoundingSphere(
+        const BoundingSphere &ebs,
+        double scale /*= 1.0*/,        
+        int resolution /* = 20 */,
+        bool create_uv_map /*= false*/) {
+
+    auto mesh = CreateSphere(ebs.radius_ * scale, resolution,
+                                create_uv_map);
+    Eigen::Matrix4d t = Eigen::Matrix4d::Identity();
+    t.block<3, 1>(0, 3) = ebs.center_;
+    mesh->Transform(t);
+    mesh->PaintUniformColor(ebs.color_);
+    return mesh;
+}
+
 std::shared_ptr<TriangleMesh> TriangleMesh::CreateBox(
         double width /* = 1.0*/,
         double height /* = 1.0*/,

--- a/cpp/open3d/geometry/TriangleMeshFactory.cpp
+++ b/cpp/open3d/geometry/TriangleMeshFactory.cpp
@@ -167,17 +167,14 @@ std::shared_ptr<TriangleMesh> TriangleMesh::CreateFromOrientedBoundingEllipsoid(
 }
 
 std::shared_ptr<TriangleMesh> TriangleMesh::CreateFromBoundingSphere(
-        const BoundingSphere &ebs,
-        double scale /*= 1.0*/,        
+        const BoundingSphere &bs,
         int resolution /* = 20 */,
         bool create_uv_map /*= false*/) {
 
-    auto mesh = CreateSphere(ebs.radius_ * scale, resolution,
+    auto mesh = CreateSphere(bs.radius_, resolution,
                                 create_uv_map);
-    Eigen::Matrix4d t = Eigen::Matrix4d::Identity();
-    t.block<3, 1>(0, 3) = ebs.center_;
-    mesh->Transform(t);
-    mesh->PaintUniformColor(ebs.color_);
+    mesh->Translate(bs.center_);
+    mesh->PaintUniformColor(bs.color_);
     return mesh;
 }
 

--- a/cpp/open3d/geometry/TriangleMeshFactory.cpp
+++ b/cpp/open3d/geometry/TriangleMeshFactory.cpp
@@ -170,9 +170,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::CreateFromBoundingSphere(
         const BoundingSphere &bs,
         int resolution /* = 20 */,
         bool create_uv_map /*= false*/) {
-
-    auto mesh = CreateSphere(bs.radius_, resolution,
-                                create_uv_map);
+    auto mesh = CreateSphere(bs.radius_, resolution, create_uv_map);
     mesh->Translate(bs.center_);
     mesh->PaintUniformColor(bs.color_);
     return mesh;

--- a/cpp/open3d/t/geometry/BoundingVolume.cpp
+++ b/cpp/open3d/t/geometry/BoundingVolume.cpp
@@ -9,6 +9,7 @@
 
 #include "open3d/core/EigenConverter.h"
 #include "open3d/core/TensorFunction.h"
+#include "open3d/t/geometry/kernel/MinimumBS.h"
 #include "open3d/t/geometry/kernel/MinimumOBB.h"
 #include "open3d/t/geometry/kernel/MinimumOBE.h"
 #include "open3d/t/geometry/kernel/PointCloud.h"
@@ -904,6 +905,301 @@ OrientedBoundingEllipsoid OrientedBoundingEllipsoid::CreateFromPoints(
         utility::LogError("Input point set has less than 4 points.");
     }
     return kernel::minimum_obe::ComputeMinimumOBEKhachiyan(points, robust);
+}
+
+// checked
+BoundingSphere::BoundingSphere(const core::Device &device)
+    : Geometry(Geometry::GeometryType::BoundingSphere, 3),
+      device_(device),
+      dtype_(core::Float32),
+      center_(core::Tensor::Zeros({3}, dtype_, device)),
+      radius_(core::Tensor::Zeros({1}, dtype_, device)),
+      color_(core::Tensor::Ones({3}, dtype_, device)) {}
+
+// checked
+BoundingSphere::BoundingSphere(const core::Tensor &center,
+                               const core::Tensor &radius)
+    : BoundingSphere([&]() {
+          core::AssertTensorDevice(center, radius.GetDevice());
+          core::AssertTensorDtype(center, radius.GetDtype());
+          core::AssertTensorDtypes(radius, {core::Float32, core::Float64});
+          core::AssertTensorShape(center, {3});
+          core::AssertTensorShape(radius, {1});
+          return center.GetDevice();
+      }()) {
+    device_ = center.GetDevice();
+    dtype_ = center.GetDtype();
+
+    center_ = center;
+    radius_ = radius;
+    color_ = core::Tensor::Ones({3}, dtype_, device_);
+
+    // Check if the bounding sphere is valid.
+    // allow degenerate zero-radius sphere, but not negative radius
+    if (radius.To(core::Float64).Item<double>() < 0) {
+        utility::LogError(
+                "Invalid bounding sphere. Please make sure the radius is "
+                "non-negative.");
+    }
+}
+
+// checked
+BoundingSphere BoundingSphere::To(
+    const core::Device &device, const core::Dtype &dtype, bool copy) const {
+    if (!copy && GetDevice() == device && GetDtype() == dtype) {
+        return *this;
+    }
+    BoundingSphere sphere(
+        center_.To(device, dtype, /*copy=*/true),
+        radius_.To(device, dtype, /*copy=*/true));
+    sphere.SetColor(color_.To(device, dtype, /*copy=*/true));
+    return sphere;
+}
+
+// checked
+BoundingSphere &BoundingSphere::Clear() {
+    center_ = core::Tensor::Zeros({3}, GetDtype(), GetDevice());
+    radius_ = core::Tensor::Zeros({1}, GetDtype(), GetDevice());
+    color_ = core::Tensor::Ones({3}, GetDtype(), GetDevice());
+    return *this;
+}
+
+// checked
+void BoundingSphere::SetCenter(const core::Tensor &center) {
+    core::AssertTensorDevice(center, GetDevice());
+    core::AssertTensorShape(center, {3});
+    core::AssertTensorDtypes(center, {core::Float32, core::Float64});
+
+    center_ = center.To(GetDtype());
+}
+
+// checked
+void BoundingSphere::SetRadius(const core::Tensor &radius) {
+    core::AssertTensorDevice(radius, GetDevice());
+    core::AssertTensorShape(radius, {1});
+    core::AssertTensorDtypes(radius, {core::Float32, core::Float64});
+
+    // allow degenerate zero-radius sphere, but not negative radius
+    if (radius.To(core::Float64).Item<double>() < 0) {
+        utility::LogError(
+                "Invalid bounding sphere. Please make sure the radius is "
+                "non-negative.");
+    }
+
+    radius_ = radius.To(GetDtype());
+}
+
+// checked
+void BoundingSphere::SetColor(const core::Tensor &color) {
+    core::AssertTensorDevice(color, GetDevice());
+    core::AssertTensorShape(color, {3});
+
+    if (color.Max({0}).To(core::Float64).Item<double>() > 1.0 ||
+        color.Min({0}).To(core::Float64).Item<double>() < 0.0) {
+        utility::LogError(
+                "The color must be in the range [0, 1], but found in range "
+                "[{}, {}].",
+                color.Min({0}).To(core::Float64).Item<double>(),
+                color.Max({0}).To(core::Float64).Item<double>());
+    }
+
+    color_ = color.To(GetDtype());
+}
+
+// checked
+core::Tensor BoundingSphere::GetMinBound() const {
+    return GetCenter() - GetRadius().Reshape({});
+}
+
+// checked
+core::Tensor BoundingSphere::GetMaxBound() const {
+    return GetCenter() + GetRadius().Reshape({});
+}
+
+// checked
+double BoundingSphere::Volume() const {
+    double r = radius_.Item<double>();
+    return 4.0 * M_PI * r * r * r / 3.0;
+}
+
+// checked
+core::Tensor BoundingSphere::GetSpherePoints() const {
+    double r = radius_.Item<double>();
+    std::vector<core::Tensor> points;
+
+    // Six critical points along the principal axes
+    points.push_back(GetCenter() + core::Tensor(std::vector<double>{r, 0.0, 0.0},
+                                                 {3}, GetDtype(), GetDevice()));
+    points.push_back(GetCenter() + core::Tensor(std::vector<double>{-r, 0.0, 0.0},
+                                                 {3}, GetDtype(), GetDevice()));
+    points.push_back(GetCenter() + core::Tensor(std::vector<double>{0.0, r, 0.0},
+                                                 {3}, GetDtype(), GetDevice()));
+    points.push_back(GetCenter() + core::Tensor(std::vector<double>{0.0, -r, 0.0},
+                                                 {3}, GetDtype(), GetDevice()));
+    points.push_back(GetCenter() + core::Tensor(std::vector<double>{0.0, 0.0, r},
+                                                 {3}, GetDtype(), GetDevice()));
+    points.push_back(GetCenter() + core::Tensor(std::vector<double>{0.0, 0.0, -r},
+                                                 {3}, GetDtype(), GetDevice()));
+
+    return core::Concatenate(points).Reshape({6, 3});
+}
+
+// checked
+BoundingSphere &BoundingSphere::Translate(const core::Tensor &translation,
+                                          bool relative) {
+    core::AssertTensorDevice(translation, GetDevice());
+    core::AssertTensorShape(translation, {3});
+    core::AssertTensorDtypes(translation, {core::Float32, core::Float64});
+
+    const core::Tensor translation_d = translation.To(GetDtype());
+    if (relative) {
+        center_ += translation_d;
+    } else {
+        center_ = translation_d;
+    }
+    return *this;
+}
+
+BoundingSphere &BoundingSphere::Rotate(
+        const core::Tensor &rotation,
+        const std::optional<core::Tensor> &center) {
+
+    core::AssertTensorDevice(rotation, GetDevice());
+    core::AssertTensorShape(rotation, {3, 3});
+    core::AssertTensorDtypes(rotation, {core::Float32, core::Float64});
+
+    if (!rotation.T().AllClose(rotation.Inverse(), 1e-5, 1e-5)) {
+        utility::LogWarning(
+                "Invalid rotation matrix. Please make sure the rotation "
+                "matrix is orthogonal.");
+        return *this;
+    }
+
+    if (center.has_value()) {
+        core::AssertTensorDevice(center.value(), GetDevice());
+        core::AssertTensorShape(center.value(), {3});
+        core::AssertTensorDtypes(center.value(),
+                                 {core::Float32, core::Float64});
+
+        const core::Tensor rotation_d = rotation.To(GetDtype());
+        core::Tensor center_d = center.value().To(GetDtype());
+
+        center_ = rotation_d.Matmul(center_ - center_d).Flatten() + center_d;
+    }
+
+    return *this;
+}
+
+// checked
+BoundingSphere &BoundingSphere::Scale(double scale,
+                                      const std::optional<core::Tensor> &center) {
+    radius_ *= scale;
+    if (center.has_value()) {
+        core::Tensor center_d = center.value();
+        core::AssertTensorDevice(center_d, GetDevice());
+        core::AssertTensorShape(center_d, {3});
+        core::AssertTensorDtypes(center_d, {core::Float32, core::Float64});
+
+        center_d = center_d.To(GetDtype());
+        center_ = scale * (center_ - center_d) + center_d;
+    }
+    return *this;
+}
+
+// checked
+core::Tensor BoundingSphere::GetPointIndicesWithinBoundingSphere(
+        const core::Tensor &points) const {
+    core::AssertTensorDevice(points, GetDevice());
+    core::AssertTensorShape(points, {std::nullopt, 3});
+    core::AssertTensorDtypes(points, {core::Float32, core::Float64});
+
+    // Calculate squared distance from center
+    core::Tensor diff = points - GetCenter();
+    core::Tensor dist_squared = (diff * diff).Sum({1});
+
+    // Get squared radius
+    core::Tensor radius_d = GetRadius().To(points.GetDtype());
+    core::Tensor radius_squared = radius_d * radius_d;
+
+    // Check if distance squared is <= radius squared
+    core::Tensor mask = dist_squared.Le(radius_squared.Reshape({}));
+
+    return mask.NonZero().Flatten();
+}
+
+// checked
+std::string BoundingSphere::ToString() const {
+    return fmt::format("BoundingSphere[center: {}, radius: {}, {}, {}]",
+                       GetCenter().ToString(false), GetRadius().ToString(false),
+                       GetDtype().ToString(), GetDevice().ToString());
+}
+
+// checked
+open3d::geometry::BoundingSphere BoundingSphere::ToLegacy() const {
+    open3d::geometry::BoundingSphere legacy_sphere;
+
+    legacy_sphere.center_ =
+            core::eigen_converter::TensorToEigenVector3dVector(
+                    GetCenter().Reshape({1, 3}))[0];
+    legacy_sphere.radius_ = GetRadius().To(core::Float64).Item<double>();
+    legacy_sphere.color_ =
+            core::eigen_converter::TensorToEigenVector3dVector(
+                    GetColor().Reshape({1, 3}))[0];
+    return legacy_sphere;
+}
+
+// checked
+AxisAlignedBoundingBox BoundingSphere::GetAxisAlignedBoundingBox()
+        const {
+    return AxisAlignedBoundingBox::CreateFromPoints(GetSpherePoints());
+}
+
+OrientedBoundingBox BoundingSphere::GetOrientedBoundingBox(
+        bool robust) const {
+    return OrientedBoundingBox::CreateFromAxisAlignedBoundingBox(
+            GetAxisAlignedBoundingBox());
+}
+
+OrientedBoundingBox BoundingSphere::GetMinimalOrientedBoundingBox(
+        bool robust) const {
+    return OrientedBoundingBox::CreateFromAxisAlignedBoundingBox(
+            GetAxisAlignedBoundingBox());
+}
+
+// checked
+BoundingSphere BoundingSphere::FromLegacy(
+    const open3d::geometry::BoundingSphere &sphere,
+    const core::Dtype &dtype,
+    const core::Device &device) {
+    if (dtype != core::Float32 && dtype != core::Float64) {
+        utility::LogError(
+                "Got data-type {}, but the supported data-type of the bounding "
+                "sphere are Float32 and Float64.",
+                dtype.ToString());
+    }
+
+    BoundingSphere t_sphere(
+            core::eigen_converter::EigenMatrixToTensor(sphere.center_)
+                    .Flatten()
+                    .To(device, dtype),
+            core::Tensor(std::vector<double>{sphere.radius_}, {1}, dtype,
+                         device));
+
+    t_sphere.SetColor(
+            core::eigen_converter::EigenMatrixToTensor(sphere.color_)
+                    .Flatten()
+                    .To(device, dtype));
+    return t_sphere;
+}
+
+// checked
+BoundingSphere BoundingSphere::CreateFromPoints(const core::Tensor &points) {
+    core::AssertTensorShape(points, {std::nullopt, 3});
+    core::AssertTensorDtypes(points, {core::Float32, core::Float64});
+    if (points.GetShape(0) < 1) {
+        utility::LogError("Input point set must have at least 1 point.");
+    }
+    return kernel::bounding_sphere::ComputeMinimumBSWelzl(points);
 }
 
 }  // namespace geometry

--- a/cpp/open3d/t/geometry/BoundingVolume.cpp
+++ b/cpp/open3d/t/geometry/BoundingVolume.cpp
@@ -1175,7 +1175,7 @@ BoundingSphere BoundingSphere::FromLegacy(
 
 BoundingSphere BoundingSphere::CreateFromPoints(
     const core::Tensor &points,
-    MethodBoundingSphereCreate method, 
+    bool exact,
     bool robust) {
     core::AssertTensorShape(points, {std::nullopt, 3});
     core::AssertTensorDtypes(points, {core::Float32, core::Float64});
@@ -1183,17 +1183,12 @@ BoundingSphere BoundingSphere::CreateFromPoints(
         utility::LogError("Input point set must have at least 1 point.");
     }
 
-    switch (method) {
-        case MethodBoundingSphereCreate::EXACT:
-            return kernel::bounding_sphere::ComputeMinimumBSWelzl(points, 
-                                                                  robust);
-        case MethodBoundingSphereCreate::APPROX:
-            return kernel::bounding_sphere::ComputeApproximateBSRitter(points);  
+    if (exact) {
+        return kernel::bounding_sphere::ComputeMinimumBSWelzl(points, robust);
+    } else {
+        return kernel::bounding_sphere::ComputeApproximateBSRitter(points);
     }
-    utility::LogError(
-        "Invalid method for computing bounding sphere. Supported methods are "
-        "EXACT and APPROXIMATE.");
-    return BoundingSphere();
+
 }
 
 }  // namespace geometry

--- a/cpp/open3d/t/geometry/BoundingVolume.cpp
+++ b/cpp/open3d/t/geometry/BoundingVolume.cpp
@@ -1193,13 +1193,15 @@ BoundingSphere BoundingSphere::FromLegacy(
 }
 
 // checked
-BoundingSphere BoundingSphere::CreateFromPoints(const core::Tensor &points) {
+BoundingSphere BoundingSphere::CreateFromPoints(
+    const core::Tensor &points, 
+    bool robust) {
     core::AssertTensorShape(points, {std::nullopt, 3});
     core::AssertTensorDtypes(points, {core::Float32, core::Float64});
     if (points.GetShape(0) < 1) {
         utility::LogError("Input point set must have at least 1 point.");
     }
-    return kernel::bounding_sphere::ComputeMinimumBSWelzl(points);
+    return kernel::bounding_sphere::ComputeMinimumBSWelzl(points, robust);
 }
 
 }  // namespace geometry

--- a/cpp/open3d/t/geometry/BoundingVolume.cpp
+++ b/cpp/open3d/t/geometry/BoundingVolume.cpp
@@ -941,14 +941,14 @@ BoundingSphere::BoundingSphere(const core::Tensor &center,
     }
 }
 
-BoundingSphere BoundingSphere::To(
-    const core::Device &device, const core::Dtype &dtype, bool copy) const {
+BoundingSphere BoundingSphere::To(const core::Device &device,
+                                  const core::Dtype &dtype,
+                                  bool copy) const {
     if (!copy && GetDevice() == device && GetDtype() == dtype) {
         return *this;
     }
-    BoundingSphere sphere(
-        center_.To(device, dtype, /*copy=*/true),
-        radius_.To(device, dtype, /*copy=*/true));
+    BoundingSphere sphere(center_.To(device, dtype, /*copy=*/true),
+                          radius_.To(device, dtype, /*copy=*/true));
     sphere.SetColor(color_.To(device, dtype, /*copy=*/true));
     return sphere;
 }
@@ -1014,14 +1014,14 @@ double BoundingSphere::Volume() const {
 
 core::Tensor BoundingSphere::GetSpherePoints() const {
     // Unit axis directions
-    core::Tensor offsets = core::Tensor::Init<float>(
-            {{ 1.f,  0.f,  0.f},
-             {-1.f,  0.f,  0.f},
-             { 0.f,  1.f,  0.f},
-             { 0.f, -1.f,  0.f},
-             { 0.f,  0.f,  1.f},
-             { 0.f,  0.f, -1.f}},
-            GetDevice()).To(GetDtype());
+    core::Tensor offsets = core::Tensor::Init<float>({{1.f, 0.f, 0.f},
+                                                      {-1.f, 0.f, 0.f},
+                                                      {0.f, 1.f, 0.f},
+                                                      {0.f, -1.f, 0.f},
+                                                      {0.f, 0.f, 1.f},
+                                                      {0.f, 0.f, -1.f}},
+                                                     GetDevice())
+                                   .To(GetDtype());
 
     // Shape: {6,3}
     // offsets * radius broadcasts scalar radius to all entries
@@ -1049,7 +1049,6 @@ BoundingSphere &BoundingSphere::Translate(const core::Tensor &translation,
 BoundingSphere &BoundingSphere::Rotate(
         const core::Tensor &rotation,
         const std::optional<core::Tensor> &center) {
-
     core::AssertTensorDevice(rotation, GetDevice());
     core::AssertTensorShape(rotation, {3, 3});
     core::AssertTensorDtypes(rotation, {core::Float32, core::Float64});
@@ -1076,9 +1075,8 @@ BoundingSphere &BoundingSphere::Rotate(
     return *this;
 }
 
-
-BoundingSphere &BoundingSphere::Scale(double scale,
-                                      const std::optional<core::Tensor> &center) {
+BoundingSphere &BoundingSphere::Scale(
+        double scale, const std::optional<core::Tensor> &center) {
     radius_ *= scale;
     if (center.has_value()) {
         core::Tensor center_d = center.value();
@@ -1121,23 +1119,19 @@ std::string BoundingSphere::ToString() const {
 open3d::geometry::BoundingSphere BoundingSphere::ToLegacy() const {
     open3d::geometry::BoundingSphere legacy_sphere;
 
-    legacy_sphere.center_ =
-            core::eigen_converter::TensorToEigenVector3dVector(
-                    GetCenter().Reshape({1, 3}))[0];
+    legacy_sphere.center_ = core::eigen_converter::TensorToEigenVector3dVector(
+            GetCenter().Reshape({1, 3}))[0];
     legacy_sphere.radius_ = GetRadius().To(core::Float64).Item<double>();
-    legacy_sphere.color_ =
-            core::eigen_converter::TensorToEigenVector3dVector(
-                    GetColor().Reshape({1, 3}))[0];
+    legacy_sphere.color_ = core::eigen_converter::TensorToEigenVector3dVector(
+            GetColor().Reshape({1, 3}))[0];
     return legacy_sphere;
 }
 
-AxisAlignedBoundingBox BoundingSphere::GetAxisAlignedBoundingBox()
-        const {
+AxisAlignedBoundingBox BoundingSphere::GetAxisAlignedBoundingBox() const {
     return AxisAlignedBoundingBox::CreateFromPoints(GetSpherePoints());
 }
 
-OrientedBoundingBox BoundingSphere::GetOrientedBoundingBox(
-        bool robust) const {
+OrientedBoundingBox BoundingSphere::GetOrientedBoundingBox(bool robust) const {
     return OrientedBoundingBox::CreateFromAxisAlignedBoundingBox(
             GetAxisAlignedBoundingBox());
 }
@@ -1149,9 +1143,9 @@ OrientedBoundingBox BoundingSphere::GetMinimalOrientedBoundingBox(
 }
 
 BoundingSphere BoundingSphere::FromLegacy(
-    const open3d::geometry::BoundingSphere &sphere,
-    const core::Dtype &dtype,
-    const core::Device &device) {
+        const open3d::geometry::BoundingSphere &sphere,
+        const core::Dtype &dtype,
+        const core::Device &device) {
     if (dtype != core::Float32 && dtype != core::Float64) {
         utility::LogError(
                 "Got data-type {}, but the supported data-type of the bounding "
@@ -1163,20 +1157,19 @@ BoundingSphere BoundingSphere::FromLegacy(
             core::eigen_converter::EigenMatrixToTensor(sphere.center_)
                     .Flatten()
                     .To(device, dtype),
-            core::Tensor(std::vector<double>{sphere.radius_}, {1}, 
-                core::Float64, device).To(device, dtype));
-
-    t_sphere.SetColor(
-            core::eigen_converter::EigenMatrixToTensor(sphere.color_)
-                    .Flatten()
+            core::Tensor(std::vector<double>{sphere.radius_}, {1},
+                         core::Float64, device)
                     .To(device, dtype));
+
+    t_sphere.SetColor(core::eigen_converter::EigenMatrixToTensor(sphere.color_)
+                              .Flatten()
+                              .To(device, dtype));
     return t_sphere;
 }
 
-BoundingSphere BoundingSphere::CreateFromPoints(
-    const core::Tensor &points,
-    bool exact,
-    bool robust) {
+BoundingSphere BoundingSphere::CreateFromPoints(const core::Tensor &points,
+                                                bool exact,
+                                                bool robust) {
     core::AssertTensorShape(points, {std::nullopt, 3});
     core::AssertTensorDtypes(points, {core::Float32, core::Float64});
     if (points.GetShape(0) < 1) {
@@ -1188,7 +1181,6 @@ BoundingSphere BoundingSphere::CreateFromPoints(
     } else {
         return kernel::bounding_sphere::ComputeApproximateBSRitter(points);
     }
-
 }
 
 }  // namespace geometry

--- a/cpp/open3d/t/geometry/BoundingVolume.cpp
+++ b/cpp/open3d/t/geometry/BoundingVolume.cpp
@@ -907,7 +907,6 @@ OrientedBoundingEllipsoid OrientedBoundingEllipsoid::CreateFromPoints(
     return kernel::minimum_obe::ComputeMinimumOBEKhachiyan(points, robust);
 }
 
-// checked
 BoundingSphere::BoundingSphere(const core::Device &device)
     : Geometry(Geometry::GeometryType::BoundingSphere, 3),
       device_(device),
@@ -916,7 +915,6 @@ BoundingSphere::BoundingSphere(const core::Device &device)
       radius_(core::Tensor::Zeros({1}, dtype_, device)),
       color_(core::Tensor::Ones({3}, dtype_, device)) {}
 
-// checked
 BoundingSphere::BoundingSphere(const core::Tensor &center,
                                const core::Tensor &radius)
     : BoundingSphere([&]() {
@@ -943,7 +941,6 @@ BoundingSphere::BoundingSphere(const core::Tensor &center,
     }
 }
 
-// checked
 BoundingSphere BoundingSphere::To(
     const core::Device &device, const core::Dtype &dtype, bool copy) const {
     if (!copy && GetDevice() == device && GetDtype() == dtype) {
@@ -956,7 +953,6 @@ BoundingSphere BoundingSphere::To(
     return sphere;
 }
 
-// checked
 BoundingSphere &BoundingSphere::Clear() {
     center_ = core::Tensor::Zeros({3}, GetDtype(), GetDevice());
     radius_ = core::Tensor::Zeros({1}, GetDtype(), GetDevice());
@@ -964,7 +960,6 @@ BoundingSphere &BoundingSphere::Clear() {
     return *this;
 }
 
-// checked
 void BoundingSphere::SetCenter(const core::Tensor &center) {
     core::AssertTensorDevice(center, GetDevice());
     core::AssertTensorShape(center, {3});
@@ -973,7 +968,6 @@ void BoundingSphere::SetCenter(const core::Tensor &center) {
     center_ = center.To(GetDtype());
 }
 
-// checked
 void BoundingSphere::SetRadius(const core::Tensor &radius) {
     core::AssertTensorDevice(radius, GetDevice());
     core::AssertTensorShape(radius, {1});
@@ -989,7 +983,6 @@ void BoundingSphere::SetRadius(const core::Tensor &radius) {
     radius_ = radius.To(GetDtype());
 }
 
-// checked
 void BoundingSphere::SetColor(const core::Tensor &color) {
     core::AssertTensorDevice(color, GetDevice());
     core::AssertTensorShape(color, {3});
@@ -1006,45 +999,38 @@ void BoundingSphere::SetColor(const core::Tensor &color) {
     color_ = color.To(GetDtype());
 }
 
-// checked
 core::Tensor BoundingSphere::GetMinBound() const {
     return GetCenter() - GetRadius().Reshape({});
 }
 
-// checked
 core::Tensor BoundingSphere::GetMaxBound() const {
     return GetCenter() + GetRadius().Reshape({});
 }
 
-// checked
 double BoundingSphere::Volume() const {
-    double r = radius_.Item<double>();
+    double r = radius_.To(core::Float64).Item<double>();
     return 4.0 * M_PI * r * r * r / 3.0;
 }
 
-// checked
 core::Tensor BoundingSphere::GetSpherePoints() const {
-    double r = radius_.Item<double>();
-    std::vector<core::Tensor> points;
+    // Unit axis directions
+    core::Tensor offsets = core::Tensor::Init<float>(
+            {{ 1.f,  0.f,  0.f},
+             {-1.f,  0.f,  0.f},
+             { 0.f,  1.f,  0.f},
+             { 0.f, -1.f,  0.f},
+             { 0.f,  0.f,  1.f},
+             { 0.f,  0.f, -1.f}},
+            GetDevice()).To(GetDtype());
 
-    // Six critical points along the principal axes
-    points.push_back(GetCenter() + core::Tensor(std::vector<double>{r, 0.0, 0.0},
-                                                 {3}, GetDtype(), GetDevice()));
-    points.push_back(GetCenter() + core::Tensor(std::vector<double>{-r, 0.0, 0.0},
-                                                 {3}, GetDtype(), GetDevice()));
-    points.push_back(GetCenter() + core::Tensor(std::vector<double>{0.0, r, 0.0},
-                                                 {3}, GetDtype(), GetDevice()));
-    points.push_back(GetCenter() + core::Tensor(std::vector<double>{0.0, -r, 0.0},
-                                                 {3}, GetDtype(), GetDevice()));
-    points.push_back(GetCenter() + core::Tensor(std::vector<double>{0.0, 0.0, r},
-                                                 {3}, GetDtype(), GetDevice()));
-    points.push_back(GetCenter() + core::Tensor(std::vector<double>{0.0, 0.0, -r},
-                                                 {3}, GetDtype(), GetDevice()));
+    // Shape: {6,3}
+    // offsets * radius broadcasts scalar radius to all entries
+    core::Tensor scaled_offsets = offsets * GetRadius();
 
-    return core::Concatenate(points).Reshape({6, 3});
+    // Center reshape allows broadcasting across rows
+    return GetCenter().Reshape({1, 3}) + scaled_offsets;
 }
 
-// checked
 BoundingSphere &BoundingSphere::Translate(const core::Tensor &translation,
                                           bool relative) {
     core::AssertTensorDevice(translation, GetDevice());
@@ -1090,7 +1076,7 @@ BoundingSphere &BoundingSphere::Rotate(
     return *this;
 }
 
-// checked
+
 BoundingSphere &BoundingSphere::Scale(double scale,
                                       const std::optional<core::Tensor> &center) {
     radius_ *= scale;
@@ -1106,7 +1092,6 @@ BoundingSphere &BoundingSphere::Scale(double scale,
     return *this;
 }
 
-// checked
 core::Tensor BoundingSphere::GetPointIndicesWithinBoundingSphere(
         const core::Tensor &points) const {
     core::AssertTensorDevice(points, GetDevice());
@@ -1127,14 +1112,12 @@ core::Tensor BoundingSphere::GetPointIndicesWithinBoundingSphere(
     return mask.NonZero().Flatten();
 }
 
-// checked
 std::string BoundingSphere::ToString() const {
     return fmt::format("BoundingSphere[center: {}, radius: {}, {}, {}]",
                        GetCenter().ToString(false), GetRadius().ToString(false),
                        GetDtype().ToString(), GetDevice().ToString());
 }
 
-// checked
 open3d::geometry::BoundingSphere BoundingSphere::ToLegacy() const {
     open3d::geometry::BoundingSphere legacy_sphere;
 
@@ -1148,7 +1131,6 @@ open3d::geometry::BoundingSphere BoundingSphere::ToLegacy() const {
     return legacy_sphere;
 }
 
-// checked
 AxisAlignedBoundingBox BoundingSphere::GetAxisAlignedBoundingBox()
         const {
     return AxisAlignedBoundingBox::CreateFromPoints(GetSpherePoints());
@@ -1166,7 +1148,6 @@ OrientedBoundingBox BoundingSphere::GetMinimalOrientedBoundingBox(
             GetAxisAlignedBoundingBox());
 }
 
-// checked
 BoundingSphere BoundingSphere::FromLegacy(
     const open3d::geometry::BoundingSphere &sphere,
     const core::Dtype &dtype,
@@ -1192,7 +1173,7 @@ BoundingSphere BoundingSphere::FromLegacy(
     return t_sphere;
 }
 
-// checked
+
 BoundingSphere BoundingSphere::CreateFromPoints(
     const core::Tensor &points, 
     bool robust) {

--- a/cpp/open3d/t/geometry/BoundingVolume.cpp
+++ b/cpp/open3d/t/geometry/BoundingVolume.cpp
@@ -1182,8 +1182,8 @@ BoundingSphere BoundingSphere::FromLegacy(
             core::eigen_converter::EigenMatrixToTensor(sphere.center_)
                     .Flatten()
                     .To(device, dtype),
-            core::Tensor(std::vector<double>{sphere.radius_}, {1}, dtype,
-                         device));
+            core::Tensor(std::vector<double>{sphere.radius_}, {1}, 
+                core::Float64, device).To(device, dtype));
 
     t_sphere.SetColor(
             core::eigen_converter::EigenMatrixToTensor(sphere.color_)

--- a/cpp/open3d/t/geometry/BoundingVolume.cpp
+++ b/cpp/open3d/t/geometry/BoundingVolume.cpp
@@ -1173,16 +1173,27 @@ BoundingSphere BoundingSphere::FromLegacy(
     return t_sphere;
 }
 
-
 BoundingSphere BoundingSphere::CreateFromPoints(
-    const core::Tensor &points, 
+    const core::Tensor &points,
+    MethodBoundingSphereCreate method, 
     bool robust) {
     core::AssertTensorShape(points, {std::nullopt, 3});
     core::AssertTensorDtypes(points, {core::Float32, core::Float64});
     if (points.GetShape(0) < 1) {
         utility::LogError("Input point set must have at least 1 point.");
     }
-    return kernel::bounding_sphere::ComputeMinimumBSWelzl(points, robust);
+
+    switch (method) {
+        case MethodBoundingSphereCreate::EXACT:
+            return kernel::bounding_sphere::ComputeMinimumBSWelzl(points, 
+                                                                  robust);
+        case MethodBoundingSphereCreate::APPROX:
+            return kernel::bounding_sphere::ComputeApproximateBSRitter(points);  
+    }
+    utility::LogError(
+        "Invalid method for computing bounding sphere. Supported methods are "
+        "EXACT and APPROXIMATE.");
+    return BoundingSphere();
 }
 
 }  // namespace geometry

--- a/cpp/open3d/t/geometry/BoundingVolume.h
+++ b/cpp/open3d/t/geometry/BoundingVolume.h
@@ -823,7 +823,6 @@ public:
     BoundingSphere &Translate(const core::Tensor &translation,
                               bool relative = true);
 
-
     /// \brief Rotate the sphere by the given rotation matrix. If
     /// the rotation matrix is not orthogonal, the rotation will not be applied.
     /// The rotation center will be the sphere center if it is not specified.
@@ -871,12 +870,12 @@ public:
     AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const;
 
     /// Returns an oriented bounding box around the sphere.
-    /// Internally calls GetAxisAlignedBoundingBox() since the oriented 
+    /// Internally calls GetAxisAlignedBoundingBox() since the oriented
     /// bounding box of a sphere is the same as its axis-aligned bounding box.
     OrientedBoundingBox GetOrientedBoundingBox(bool robust = false) const;
 
     /// Returns an oriented bounding box around the sphere.
-    /// Internally calls GetAxisAlignedBoundingBox() since the oriented 
+    /// Internally calls GetAxisAlignedBoundingBox() since the oriented
     /// bounding box of a sphere is the same as its axis-aligned bounding box.
     OrientedBoundingBox GetMinimalOrientedBoundingBox(
             bool robust = false) const;
@@ -888,27 +887,27 @@ public:
     /// The default is float32.
     /// \param device The device of the sphere. The default is CPU:0.
     static BoundingSphere FromLegacy(
-        const open3d::geometry::BoundingSphere &sphere,
+            const open3d::geometry::BoundingSphere &sphere,
             const core::Dtype &dtype = core::Float32,
             const core::Device &device = core::Device("CPU:0"));
 
     /// Creates the minimum bounding sphere.
     /// \param points A list of points with data type of float32 or float64 (N x
     /// 3 tensor, where N must be larger than 0).
-    /// \param exact If true, computes the exact minimum bounding sphere 
+    /// \param exact If true, computes the exact minimum bounding sphere
     ///     using Welzl's algorithm.
     ///     This algorithm is recursive and has an expected time
     ///     complexity of O(n).
-    ///     If false, computes a fast approximate minimum bounding sphere 
+    ///     If false, computes a fast approximate minimum bounding sphere
     ///     using Ritter's algorithm.
     ///     The sphere can be 5% bigger than the exact minimum bounding sphere.
-    /// \param robust Used only if exact is set to true. 
+    /// \param robust Used only if exact is set to true.
     ///     If set to true uses a more robust method which works in
-    ///     degenerate cases but introduces noise to the points coordinates.    
+    ///     degenerate cases but introduces noise to the points coordinates.
     /// \return BoundingSphere with same data type and device as input points.
     static BoundingSphere CreateFromPoints(const core::Tensor &points,
-        bool exact = true, 
-        bool robust = false);
+                                           bool exact = true,
+                                           bool robust = false);
 
 protected:
     core::Device device_ = core::Device("CPU:0");

--- a/cpp/open3d/t/geometry/BoundingVolume.h
+++ b/cpp/open3d/t/geometry/BoundingVolume.h
@@ -892,21 +892,22 @@ public:
             const core::Dtype &dtype = core::Float32,
             const core::Device &device = core::Device("CPU:0"));
 
-    /// Creates the minimum bounding sphere using Welzl's algorithm.
+    /// Creates the minimum bounding sphere.
     /// \param points A list of points with data type of float32 or float64 (N x
     /// 3 tensor, where N must be larger than 0).
-    /// \param method This is one of \c EXACT and \c APPROX in the
-    /// open3d::t::geometry::MethodBoundingSphereCreate namespace.
-    ///     \li \c EXACT computes the exact minimum bounding sphere using Welzl's
-    ///     algorithm. This algorithm is recursive and has an expected time
+    /// \param exact If true, computes the exact minimum bounding sphere 
+    ///     using Welzl's algorithm.
+    ///     This algorithm is recursive and has an expected time
     ///     complexity of O(n).
-    ///     \li \c APPROX computes an approximate minimum bounding sphere using 
-    ///     Ritter's approximation algorithm.
-    /// \param robust If set to true uses a more robust method which works in
-    /// degenerate cases but introduces noise to the points coordinates.    
+    ///     If false, computes a fast approximate minimum bounding sphere 
+    ///     using Ritter's algorithm.
+    ///     The sphere can be 5% bigger than the exact minimum bounding sphere.
+    /// \param robust Used only if exact is set to true. 
+    ///     If set to true uses a more robust method which works in
+    ///     degenerate cases but introduces noise to the points coordinates.    
     /// \return BoundingSphere with same data type and device as input points.
     static BoundingSphere CreateFromPoints(const core::Tensor &points,
-        MethodBoundingSphereCreate method = MethodBoundingSphereCreate::EXACT, 
+        bool exact = true, 
         bool robust = false);
 
 protected:

--- a/cpp/open3d/t/geometry/BoundingVolume.h
+++ b/cpp/open3d/t/geometry/BoundingVolume.h
@@ -895,11 +895,19 @@ public:
     /// Creates the minimum bounding sphere using Welzl's algorithm.
     /// \param points A list of points with data type of float32 or float64 (N x
     /// 3 tensor, where N must be larger than 0).
+    /// \param method This is one of \c EXACT and \c APPROX in the
+    /// open3d::t::geometry::MethodBoundingSphereCreate namespace.
+    ///     \li \c EXACT computes the exact minimum bounding sphere using Welzl's
+    ///     algorithm. This algorithm is recursive and has an expected time
+    ///     complexity of O(n).
+    ///     \li \c APPROX computes an approximate minimum bounding sphere using 
+    ///     Ritter's approximation algorithm.
     /// \param robust If set to true uses a more robust method which works in
     /// degenerate cases but introduces noise to the points coordinates.    
     /// \return BoundingSphere with same data type and device as input points.
-    static BoundingSphere CreateFromPoints(const core::Tensor &points, 
-        bool robust);
+    static BoundingSphere CreateFromPoints(const core::Tensor &points,
+        MethodBoundingSphereCreate method = MethodBoundingSphereCreate::EXACT, 
+        bool robust = false);
 
 protected:
     core::Device device_ = core::Device("CPU:0");

--- a/cpp/open3d/t/geometry/BoundingVolume.h
+++ b/cpp/open3d/t/geometry/BoundingVolume.h
@@ -893,8 +893,11 @@ public:
     /// Creates the minimum bounding sphere using Welzl's algorithm.
     /// \param points A list of points with data type of float32 or float64 (N x
     /// 3 tensor, where N must be larger than 0).
+    /// \param robust If set to true uses a more robust method which works in
+    /// degenerate cases but introduces noise to the points coordinates.    
     /// \return BoundingSphere with same data type and device as input points.
-    static BoundingSphere CreateFromPoints(const core::Tensor &points);
+    static BoundingSphere CreateFromPoints(const core::Tensor &points, 
+        bool robust);
 
 protected:
     core::Device device_ = core::Device("CPU:0");

--- a/cpp/open3d/t/geometry/BoundingVolume.h
+++ b/cpp/open3d/t/geometry/BoundingVolume.h
@@ -718,6 +718,192 @@ protected:
     core::Tensor color_;
 };
 
+/// \class BoundingSphere
+/// \brief A bounding sphere defined by a center point and a radius.
+///
+/// - (center, radius): The bounding sphere is defined by its center position
+/// and radius.
+///     - Usage
+///         - BoundingSphere::GetCenter()
+///         - BoundingSphere::SetCenter(const core::Tensor &center)
+///         - BoundingSphere::GetRadius()
+///         - BoundingSphere::SetRadius(const core::Tensor &radius)
+///     - Value tensor of center must have shape {3,}.
+///     - Value tensor of radius must have shape {1,}.
+///     - Value tensor must have the same data type and device.
+///     - Value tensor can only be float32 (default) or float64.
+///     - The device of the tensor determines the device of the sphere.
+///
+/// - color: Color of the bounding sphere.
+///     - Usage
+///         - BoundingSphere::GetColor()
+///         - BoundingSphere::SetColor(const core::Tensor &color)
+///     - Value tensor must have shape {3,}.
+///     - Value tensor can only be float32 (default) or float64.
+///     - Value tensor can only be range [0.0, 1.0].
+class BoundingSphere : public Geometry, public DrawableGeometry {
+public:
+    /// \brief Construct an empty BoundingSphere on the provided device.
+    BoundingSphere(const core::Device &device = core::Device("CPU:0"));
+
+    /// \brief Construct a BoundingSphere from center and radius.
+    ///
+    /// The BoundingSphere will be created on the device of the given tensors,
+    /// which must be on the same device and have the same data type.
+    /// \param center Center of the bounding sphere. Tensor of shape {3,}, and
+    /// type float32 or float64.
+    /// \param radius Radius of the bounding sphere. Tensor of shape {1,}, and
+    /// type float32 or float64.
+    BoundingSphere(const core::Tensor &center, const core::Tensor &radius);
+
+    virtual ~BoundingSphere() override {}
+
+    /// \brief Returns the device attribute of this BoundingSphere.
+    core::Device GetDevice() const override { return device_; }
+
+    /// \brief Returns the data type attribute of this BoundingSphere.
+    core::Dtype GetDtype() const { return dtype_; }
+
+    /// Transfer the BoundingSphere to a specified device.
+    /// \param device The targeted device to convert to.
+    /// \param copy If true, a new BoundingSphere is always created; if false,
+    /// the copy is avoided when the original BoundingSphere is already on the
+    /// targeted device.
+    BoundingSphere To(const core::Device &device,
+                      const core::Dtype &dtype,
+                      bool copy = false) const;
+
+    /// Returns copy of the BoundingSphere on the same device.
+    BoundingSphere Clone() const { return To(GetDevice(), /*copy=*/true); }
+
+    BoundingSphere &Clear() override;
+
+    bool IsEmpty() const override { return Volume() == 0; }
+
+    /// \brief Set the center of the sphere.
+    /// If the data type of the given tensor differs from the data type of the
+    /// sphere, an exception will be thrown.
+    ///
+    /// \param center Tensor with {3,} shape, and type float32 or float64.
+    void SetCenter(const core::Tensor &center);
+
+    /// \brief Set the radius of the sphere.
+    /// If the data type of the given tensor differs from the data type of the
+    /// sphere, an exception will be thrown.
+    ///
+    /// \param radius Tensor with {1,} shape, and type float32 or float64.
+    void SetRadius(const core::Tensor &radius);
+
+    /// \brief Set the color of the sphere.
+    ///
+    /// \param color Tensor with {3,} shape, and type float32 or float64,
+    /// with values in range [0.0, 1.0].
+    void SetColor(const core::Tensor &color);
+
+public:
+    core::Tensor GetMinBound() const;
+
+    core::Tensor GetMaxBound() const;
+
+    core::Tensor GetColor() const { return color_; }
+
+    core::Tensor GetCenter() const { return center_; }
+
+    core::Tensor GetRadius() const { return radius_; }
+
+    /// \brief Translate the bounding sphere by the given translation.
+    /// If relative is true, the translation is added to the center of the
+    /// sphere. If false, the center will be assigned to the translation.
+    ///
+    /// \param translation Translation tensor of shape {3,}, type float32 or
+    /// float64, device same as the sphere.
+    /// \param relative Whether to perform relative translation.
+    BoundingSphere &Translate(const core::Tensor &translation,
+                              bool relative = true);
+
+
+    /// \brief Rotate the sphere by the given rotation matrix. If
+    /// the rotation matrix is not orthogonal, the rotation will not be applied.
+    /// The rotation center will be the sphere center if it is not specified.
+    ///
+    /// \param rotation Rotation matrix of shape {3, 3}, type float32 or
+    /// float64, device same as the sphere.
+    /// \param center Center of the rotation, default is null, which means use
+    /// center of the sphere as rotation center.
+    BoundingSphere &Rotate(
+            const core::Tensor &rotation,
+            const std::optional<core::Tensor> &center = std::nullopt);
+
+    /// \brief Scale the bounding sphere.
+    /// The scaling center will be the sphere center if it is not specified.
+    ///
+    /// \param scale The scale parameter.
+    /// \param center Center used for the scaling operation. Tensor of shape
+    /// {3,}, type float32 or float64, device same as the sphere.
+    BoundingSphere &Scale(
+            double scale,
+            const std::optional<core::Tensor> &center = std::nullopt);
+
+    /// Returns the volume of the bounding sphere.
+    double Volume() const;
+
+    /// \brief Returns six critical points on the surface of the bounding
+    /// sphere along the principal axes.
+    ///
+    /// The Return tensor has shape {6, 3} and data type same as the sphere.
+    core::Tensor GetSpherePoints() const;
+
+    /// \brief Indices to points that are within the bounding sphere.
+    ///
+    /// \param points Tensor with {N, 3} shape, and type float32 or float64.
+    core::Tensor GetPointIndicesWithinBoundingSphere(
+            const core::Tensor &points) const;
+
+    /// Text description.
+    std::string ToString() const;
+
+    /// Convert to a legacy Open3D bounding sphere.
+    open3d::geometry::BoundingSphere ToLegacy() const;
+
+    /// Convert to an axis-aligned box.
+    AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const;
+
+    /// Returns an oriented bounding box around the sphere.
+    /// Internally calls GetAxisAlignedBoundingBox() since the oriented 
+    /// bounding box of a sphere is the same as its axis-aligned bounding box.
+    OrientedBoundingBox GetOrientedBoundingBox(bool robust = false) const;
+
+    /// Returns an oriented bounding box around the sphere.
+    /// Internally calls GetAxisAlignedBoundingBox() since the oriented 
+    /// bounding box of a sphere is the same as its axis-aligned bounding box.
+    OrientedBoundingBox GetMinimalOrientedBoundingBox(
+            bool robust = false) const;
+
+    /// Create a BoundingSphere from a legacy Open3D bounding sphere.
+    /// (If legacy support is needed in the future)
+    ///
+    /// \param dtype The data type of the sphere for center, radius and color.
+    /// The default is float32.
+    /// \param device The device of the sphere. The default is CPU:0.
+    static BoundingSphere FromLegacy(
+        const open3d::geometry::BoundingSphere &sphere,
+            const core::Dtype &dtype = core::Float32,
+            const core::Device &device = core::Device("CPU:0"));
+
+    /// Creates the minimum bounding sphere using Welzl's algorithm.
+    /// \param points A list of points with data type of float32 or float64 (N x
+    /// 3 tensor, where N must be larger than 0).
+    /// \return BoundingSphere with same data type and device as input points.
+    static BoundingSphere CreateFromPoints(const core::Tensor &points);
+
+protected:
+    core::Device device_ = core::Device("CPU:0");
+    core::Dtype dtype_ = core::Float32;
+    core::Tensor center_;
+    core::Tensor radius_;
+    core::Tensor color_;
+};
+
 }  // namespace geometry
 }  // namespace t
 }  // namespace open3d

--- a/cpp/open3d/t/geometry/BoundingVolume.h
+++ b/cpp/open3d/t/geometry/BoundingVolume.h
@@ -774,7 +774,9 @@ public:
                       bool copy = false) const;
 
     /// Returns copy of the BoundingSphere on the same device.
-    BoundingSphere Clone() const { return To(GetDevice(), /*copy=*/true); }
+    BoundingSphere Clone() const {
+        return To(GetDevice(), GetDtype(), /*copy=*/true);
+    }
 
     BoundingSphere &Clear() override;
 

--- a/cpp/open3d/t/geometry/Geometry.h
+++ b/cpp/open3d/t/geometry/Geometry.h
@@ -54,6 +54,8 @@ public:
         AxisAlignedBoundingBox = 12,
         /// OrientedBoundingEllipsoid
         OrientedBoundingEllipsoid = 13,
+        /// BoundingSphere
+        BoundingSphere = 14,
     };
 
 public:

--- a/cpp/open3d/t/geometry/Geometry.h
+++ b/cpp/open3d/t/geometry/Geometry.h
@@ -125,12 +125,6 @@ enum class MethodOBBCreate {
     MINIMAL_JYLANKI  ///< Minimal OBB by Jylanki
 };
 
-
-enum class MethodBoundingSphereCreate {
-    EXACT,          ///< Exact bounding sphere using Welzl's algorithm
-    APPROX     ///< Approximate bounding sphere using Ritter's algorithm
-};
-
 }  // namespace geometry
 }  // namespace t
 }  // namespace open3d

--- a/cpp/open3d/t/geometry/Geometry.h
+++ b/cpp/open3d/t/geometry/Geometry.h
@@ -125,6 +125,12 @@ enum class MethodOBBCreate {
     MINIMAL_JYLANKI  ///< Minimal OBB by Jylanki
 };
 
+
+enum class MethodBoundingSphereCreate {
+    EXACT,          ///< Exact bounding sphere using Welzl's algorithm
+    APPROX     ///< Approximate bounding sphere using Ritter's algorithm
+};
+
 }  // namespace geometry
 }  // namespace t
 }  // namespace open3d

--- a/cpp/open3d/t/geometry/LineSet.cpp
+++ b/cpp/open3d/t/geometry/LineSet.cpp
@@ -235,6 +235,33 @@ LineSet LineSet::CreateFromOrientedBoundingEllipsoid(
     return FromLegacy(*legacy_lineset, float_dtype, int_dtype, device);
 }
 
+// TODO: This makes a round trip through the legacy API, since we don't have a
+// tensor t::LineSet::CreateFromTriangleMesh(). This needs tensor row hash set
+// support for de-deuplicating the edges of the triangle mesh.
+LineSet LineSet::CreateFromBoundingSphere(
+        const BoundingSphere &sphere,
+        double scale,
+        int resolution,
+        core::Dtype float_dtype,
+        core::Dtype int_dtype,
+        const core::Device &device) {
+    // Build a solid sphere mesh then extract its wireframe edges.
+    TriangleMesh mesh = TriangleMesh::CreateFromBoundingSphere(
+            sphere,
+            scale,
+            resolution,
+            float_dtype,
+            int_dtype,
+            device);
+    auto legacy_mesh = mesh.ToLegacy();
+    auto legacy_lineset =
+            open3d::geometry::LineSet::CreateFromTriangleMesh(legacy_mesh);
+    legacy_lineset->PaintUniformColor(legacy_mesh.vertex_colors_.empty()
+                                              ? Eigen::Vector3d::Ones()
+                                              : legacy_mesh.vertex_colors_[0]);
+    return FromLegacy(*legacy_lineset, float_dtype, int_dtype, device);
+}
+
 LineSet &LineSet::PaintUniformColor(const core::Tensor &color) {
     core::AssertTensorShape(color, {3});
     core::Tensor clipped_color = color.To(GetDevice());

--- a/cpp/open3d/t/geometry/LineSet.cpp
+++ b/cpp/open3d/t/geometry/LineSet.cpp
@@ -240,7 +240,6 @@ LineSet LineSet::CreateFromOrientedBoundingEllipsoid(
 // support for de-deuplicating the edges of the triangle mesh.
 LineSet LineSet::CreateFromBoundingSphere(
         const BoundingSphere &sphere,
-        double scale,
         int resolution,
         core::Dtype float_dtype,
         core::Dtype int_dtype,
@@ -248,7 +247,6 @@ LineSet LineSet::CreateFromBoundingSphere(
     // Build a solid sphere mesh then extract its wireframe edges.
     TriangleMesh mesh = TriangleMesh::CreateFromBoundingSphere(
             sphere,
-            scale,
             resolution,
             float_dtype,
             int_dtype,

--- a/cpp/open3d/t/geometry/LineSet.cpp
+++ b/cpp/open3d/t/geometry/LineSet.cpp
@@ -238,19 +238,14 @@ LineSet LineSet::CreateFromOrientedBoundingEllipsoid(
 // TODO: This makes a round trip through the legacy API, since we don't have a
 // tensor t::LineSet::CreateFromTriangleMesh(). This needs tensor row hash set
 // support for de-deuplicating the edges of the triangle mesh.
-LineSet LineSet::CreateFromBoundingSphere(
-        const BoundingSphere &sphere,
-        int resolution,
-        core::Dtype float_dtype,
-        core::Dtype int_dtype,
-        const core::Device &device) {
+LineSet LineSet::CreateFromBoundingSphere(const BoundingSphere &sphere,
+                                          int resolution,
+                                          core::Dtype float_dtype,
+                                          core::Dtype int_dtype,
+                                          const core::Device &device) {
     // Build a solid sphere mesh then extract its wireframe edges.
     TriangleMesh mesh = TriangleMesh::CreateFromBoundingSphere(
-            sphere,
-            resolution,
-            float_dtype,
-            int_dtype,
-            device);
+            sphere, resolution, float_dtype, int_dtype, device);
     auto legacy_mesh = mesh.ToLegacy();
     auto legacy_lineset =
             open3d::geometry::LineSet::CreateFromTriangleMesh(legacy_mesh);

--- a/cpp/open3d/t/geometry/LineSet.h
+++ b/cpp/open3d/t/geometry/LineSet.h
@@ -382,6 +382,23 @@ public:
             core::Dtype int_dtype = core::Int64,
             const core::Device &device = core::Device("CPU:0"));
 
+    /// Create a wireframe LineSet representing the surface of a
+    /// BoundingSphere.
+    /// \param sphere The bounding sphere.
+    /// \param scale Scale factor applied to radius before
+    /// constructing the mesh.
+    /// \param resolution Resolution of the generated sphere wireframe.
+    /// \param float_dtype The data type for point attributes.
+    /// \param int_dtype The data type for line indices.
+    /// \param device The device for the returned line set.
+    static LineSet CreateFromBoundingSphere(
+            const BoundingSphere &sphere,
+            double scale = 1.0,
+            int resolution = 20,
+            core::Dtype float_dtype = core::Float32,
+            core::Dtype int_dtype = core::Int64,
+            const core::Device &device = core::Device("CPU:0"));
+
     /// Sweeps the line set rotationally about an axis.
     /// \param angle The rotation angle in degree.
     /// \param axis The rotation axis.

--- a/cpp/open3d/t/geometry/LineSet.h
+++ b/cpp/open3d/t/geometry/LineSet.h
@@ -385,15 +385,12 @@ public:
     /// Create a wireframe LineSet representing the surface of a
     /// BoundingSphere.
     /// \param sphere The bounding sphere.
-    /// \param scale Scale factor applied to radius before
-    /// constructing the mesh.
     /// \param resolution Resolution of the generated sphere wireframe.
     /// \param float_dtype The data type for point attributes.
     /// \param int_dtype The data type for line indices.
     /// \param device The device for the returned line set.
     static LineSet CreateFromBoundingSphere(
             const BoundingSphere &sphere,
-            double scale = 1.0,
             int resolution = 20,
             core::Dtype float_dtype = core::Float32,
             core::Dtype int_dtype = core::Int64,

--- a/cpp/open3d/t/geometry/PointCloud.cpp
+++ b/cpp/open3d/t/geometry/PointCloud.cpp
@@ -1507,10 +1507,10 @@ OrientedBoundingEllipsoid PointCloud::GetOrientedBoundingEllipsoid(
 }
 
 BoundingSphere PointCloud::GetBoundingSphere(
-                                MethodBoundingSphereCreate method,
+                                bool exact,
                                 bool robust) const {
     return BoundingSphere::CreateFromPoints(GetPointPositions(),
-                                            method, 
+                                            exact,
                                             robust);
 }
 

--- a/cpp/open3d/t/geometry/PointCloud.cpp
+++ b/cpp/open3d/t/geometry/PointCloud.cpp
@@ -1506,12 +1506,8 @@ OrientedBoundingEllipsoid PointCloud::GetOrientedBoundingEllipsoid(
                                                        robust);
 }
 
-BoundingSphere PointCloud::GetBoundingSphere(
-                                bool exact,
-                                bool robust) const {
-    return BoundingSphere::CreateFromPoints(GetPointPositions(),
-                                            exact,
-                                            robust);
+BoundingSphere PointCloud::GetBoundingSphere(bool exact, bool robust) const {
+    return BoundingSphere::CreateFromPoints(GetPointPositions(), exact, robust);
 }
 
 LineSet PointCloud::ExtrudeRotation(double angle,

--- a/cpp/open3d/t/geometry/PointCloud.cpp
+++ b/cpp/open3d/t/geometry/PointCloud.cpp
@@ -1506,8 +1506,12 @@ OrientedBoundingEllipsoid PointCloud::GetOrientedBoundingEllipsoid(
                                                        robust);
 }
 
-BoundingSphere PointCloud::GetBoundingSphere(bool robust) const {
-    return BoundingSphere::CreateFromPoints(GetPointPositions(), robust);
+BoundingSphere PointCloud::GetBoundingSphere(
+                                MethodBoundingSphereCreate method,
+                                bool robust) const {
+    return BoundingSphere::CreateFromPoints(GetPointPositions(),
+                                            method, 
+                                            robust);
 }
 
 LineSet PointCloud::ExtrudeRotation(double angle,

--- a/cpp/open3d/t/geometry/PointCloud.cpp
+++ b/cpp/open3d/t/geometry/PointCloud.cpp
@@ -1506,6 +1506,10 @@ OrientedBoundingEllipsoid PointCloud::GetOrientedBoundingEllipsoid(
                                                        robust);
 }
 
+BoundingSphere PointCloud::GetBoundingSphere(bool robust) const {
+    return BoundingSphere::CreateFromPoints(GetPointPositions(), robust);
+}
+
 LineSet PointCloud::ExtrudeRotation(double angle,
                                     const core::Tensor& axis,
                                     int resolution,

--- a/cpp/open3d/t/geometry/PointCloud.h
+++ b/cpp/open3d/t/geometry/PointCloud.h
@@ -683,7 +683,7 @@ public:
 
     /// Create a bounding sphere from attribute "positions".
     BoundingSphere GetBoundingSphere(
-        MethodBoundingSphereCreate method = MethodBoundingSphereCreate::EXACT,
+        bool exact = true,
         bool robust = false) const;
 
     /// \brief Function to crop pointcloud into output pointcloud.

--- a/cpp/open3d/t/geometry/PointCloud.h
+++ b/cpp/open3d/t/geometry/PointCloud.h
@@ -682,9 +682,8 @@ public:
             bool robust = false) const;
 
     /// Create a bounding sphere from attribute "positions".
-    BoundingSphere GetBoundingSphere(
-        bool exact = true,
-        bool robust = false) const;
+    BoundingSphere GetBoundingSphere(bool exact = true,
+                                     bool robust = false) const;
 
     /// \brief Function to crop pointcloud into output pointcloud.
     ///

--- a/cpp/open3d/t/geometry/PointCloud.h
+++ b/cpp/open3d/t/geometry/PointCloud.h
@@ -682,7 +682,9 @@ public:
             bool robust = false) const;
 
     /// Create a bounding sphere from attribute "positions".
-    BoundingSphere GetBoundingSphere(bool robust = false) const;
+    BoundingSphere GetBoundingSphere(
+        MethodBoundingSphereCreate method = MethodBoundingSphereCreate::EXACT,
+        bool robust = false) const;
 
     /// \brief Function to crop pointcloud into output pointcloud.
     ///

--- a/cpp/open3d/t/geometry/PointCloud.h
+++ b/cpp/open3d/t/geometry/PointCloud.h
@@ -681,6 +681,9 @@ public:
     OrientedBoundingEllipsoid GetOrientedBoundingEllipsoid(
             bool robust = false) const;
 
+    /// Create a bounding sphere from attribute "positions".
+    BoundingSphere GetBoundingSphere(bool robust = false) const;
+
     /// \brief Function to crop pointcloud into output pointcloud.
     ///
     /// \param aabb AxisAlignedBoundingBox to crop points.

--- a/cpp/open3d/t/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/t/geometry/TriangleMesh.cpp
@@ -803,7 +803,6 @@ BoundingSphere TriangleMesh::GetBoundingSphere(
 
 TriangleMesh TriangleMesh::CreateFromBoundingSphere(
         const BoundingSphere &sphere,
-        double scale = 1.0,
         int resolution,
         core::Dtype float_dtype,
         core::Dtype int_dtype,
@@ -813,7 +812,7 @@ TriangleMesh TriangleMesh::CreateFromBoundingSphere(
             sphere.GetRadius().To(core::Float64).Item<double>();
 
     TriangleMesh mesh = CreateSphere(
-        radius * scale, 
+        radius, 
         resolution,
         float_dtype,
         int_dtype,

--- a/cpp/open3d/t/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/t/geometry/TriangleMesh.cpp
@@ -795,11 +795,8 @@ TriangleMesh TriangleMesh::CreateFromOrientedBoundingEllipsoid(
     return mesh;
 }
 
-BoundingSphere TriangleMesh::GetBoundingSphere(
-        bool exact,
-        bool robust) const {
-    return BoundingSphere::CreateFromPoints(GetVertexPositions(),
-                                            exact,
+BoundingSphere TriangleMesh::GetBoundingSphere(bool exact, bool robust) const {
+    return BoundingSphere::CreateFromPoints(GetVertexPositions(), exact,
                                             robust);
 }
 
@@ -810,15 +807,10 @@ TriangleMesh TriangleMesh::CreateFromBoundingSphere(
         core::Dtype int_dtype,
         const core::Device &device) {
     // Extract radii scaled by the per-axis scale factors.
-    double radius =
-            sphere.GetRadius().To(core::Float64).Item<double>();
+    double radius = sphere.GetRadius().To(core::Float64).Item<double>();
 
-    TriangleMesh mesh = CreateSphere(
-        radius, 
-        resolution,
-        float_dtype,
-        int_dtype,
-        device);
+    TriangleMesh mesh =
+            CreateSphere(radius, resolution, float_dtype, int_dtype, device);
     // Apply the sphere translation.
     core::Tensor center = sphere.GetCenter().To(device, float_dtype);
     mesh.Translate(center);

--- a/cpp/open3d/t/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/t/geometry/TriangleMesh.cpp
@@ -795,6 +795,40 @@ TriangleMesh TriangleMesh::CreateFromOrientedBoundingEllipsoid(
     return mesh;
 }
 
+BoundingSphere TriangleMesh::GetBoundingSphere(
+        bool robust) const {
+    return BoundingSphere::CreateFromPoints(GetVertexPositions(),
+                                                       robust);
+}
+
+TriangleMesh TriangleMesh::CreateFromBoundingSphere(
+        const BoundingSphere &sphere,
+        double scale = 1.0,
+        int resolution,
+        core::Dtype float_dtype,
+        core::Dtype int_dtype,
+        const core::Device &device) {
+    // Extract radii scaled by the per-axis scale factors.
+    double radius =
+            sphere.GetRadius().To(core::Float64).Item<double>();
+
+    TriangleMesh mesh = CreateSphere(
+        radius * scale, 
+        resolution,
+        float_dtype,
+        int_dtype,
+        device);
+    // Apply the sphere translation.
+    core::Tensor center = sphere.GetCenter().To(device, float_dtype);
+    mesh.Translate(center);
+    // Copy color from the ellipsoid to all vertices.
+    core::Tensor color = sphere.GetColor().To(device, float_dtype);
+    int64_t num_vertices = mesh.GetVertexPositions().GetLength();
+    mesh.SetVertexColors(
+            color.Reshape({1, 3}).Expand({num_vertices, 3}).Contiguous());
+    return mesh;
+}
+
 TriangleMesh TriangleMesh::FillHoles(double hole_size) const {
     using namespace vtkutils;
     // do not include triangle attributes because they will not be preserved by

--- a/cpp/open3d/t/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/t/geometry/TriangleMesh.cpp
@@ -796,10 +796,10 @@ TriangleMesh TriangleMesh::CreateFromOrientedBoundingEllipsoid(
 }
 
 BoundingSphere TriangleMesh::GetBoundingSphere(
-        MethodBoundingSphereCreate method,
+        bool exact,
         bool robust) const {
     return BoundingSphere::CreateFromPoints(GetVertexPositions(),
-                                            method,
+                                            exact,
                                             robust);
 }
 

--- a/cpp/open3d/t/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/t/geometry/TriangleMesh.cpp
@@ -821,7 +821,7 @@ TriangleMesh TriangleMesh::CreateFromBoundingSphere(
     // Apply the sphere translation.
     core::Tensor center = sphere.GetCenter().To(device, float_dtype);
     mesh.Translate(center);
-    // Copy color from the ellipsoid to all vertices.
+    // Copy color from the sphere to all vertices.
     core::Tensor color = sphere.GetColor().To(device, float_dtype);
     int64_t num_vertices = mesh.GetVertexPositions().GetLength();
     mesh.SetVertexColors(

--- a/cpp/open3d/t/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/t/geometry/TriangleMesh.cpp
@@ -796,9 +796,11 @@ TriangleMesh TriangleMesh::CreateFromOrientedBoundingEllipsoid(
 }
 
 BoundingSphere TriangleMesh::GetBoundingSphere(
+        MethodBoundingSphereCreate method,
         bool robust) const {
     return BoundingSphere::CreateFromPoints(GetVertexPositions(),
-                                                       robust);
+                                            method,
+                                            robust);
 }
 
 TriangleMesh TriangleMesh::CreateFromBoundingSphere(

--- a/cpp/open3d/t/geometry/TriangleMesh.h
+++ b/cpp/open3d/t/geometry/TriangleMesh.h
@@ -664,7 +664,6 @@ public:
     /// \param device The device for the returned mesh.
     static TriangleMesh CreateFromBoundingSphere(
             const BoundingSphere &sphere,
-            double scale = 1.0,
             int resolution = 20,
             core::Dtype float_dtype = core::Float32,
             core::Dtype int_dtype = core::Int64,

--- a/cpp/open3d/t/geometry/TriangleMesh.h
+++ b/cpp/open3d/t/geometry/TriangleMesh.h
@@ -653,6 +653,23 @@ public:
             core::Dtype int_dtype = core::Int64,
             const core::Device &device = core::Device("CPU:0"));
 
+    /// Create a solid TriangleMesh representing the surface of a
+    /// BoundingSphere.
+    /// \param sphere The bounding sphere.
+    /// \param scale Scale factor applied to radius before
+    /// constructing the mesh.
+    /// \param resolution Resolution of the generated ellipsoid surface mesh.
+    /// \param float_dtype The data type for vertex attributes.
+    /// \param int_dtype The data type for triangle indices.
+    /// \param device The device for the returned mesh.
+    static TriangleMesh CreateFromBoundingSphere(
+            const BoundingSphere &sphere,
+            double scale = 1.0,
+            int resolution = 20,
+            core::Dtype float_dtype = core::Float32,
+            core::Dtype int_dtype = core::Int64,
+            const core::Device &device = core::Device("CPU:0"));
+
 public:
     /// Clear all data in the trianglemesh.
     TriangleMesh &Clear() override {
@@ -878,6 +895,10 @@ public:
 
     /// Create an oriented bounding ellipsoid from vertex attribute "positions".
     OrientedBoundingEllipsoid GetOrientedBoundingEllipsoid(
+            bool robust = false) const;
+
+    /// Create an oriented bounding ellipsoid from vertex attribute "positions".
+    BoundingSphere GetBoundingSphere(
             bool robust = false) const;
 
     /// Fill holes by triangulating boundary edges.

--- a/cpp/open3d/t/geometry/TriangleMesh.h
+++ b/cpp/open3d/t/geometry/TriangleMesh.h
@@ -894,9 +894,10 @@ public:
     OrientedBoundingEllipsoid GetOrientedBoundingEllipsoid(
             bool robust = false) const;
 
-    /// Create an oriented bounding ellipsoid from vertex attribute "positions".
+    /// Create an oriented bounding sphere from vertex attribute "positions".
     BoundingSphere GetBoundingSphere(
-            bool robust = false) const;
+        MethodBoundingSphereCreate method = MethodBoundingSphereCreate::EXACT,
+        bool robust = false) const;
 
     /// Fill holes by triangulating boundary edges.
     ///

--- a/cpp/open3d/t/geometry/TriangleMesh.h
+++ b/cpp/open3d/t/geometry/TriangleMesh.h
@@ -895,9 +895,8 @@ public:
             bool robust = false) const;
 
     /// Create a bounding sphere from vertex attribute "positions".
-    BoundingSphere GetBoundingSphere(
-        bool exact = true,
-        bool robust = false) const;
+    BoundingSphere GetBoundingSphere(bool exact = true,
+                                     bool robust = false) const;
 
     /// Fill holes by triangulating boundary edges.
     ///

--- a/cpp/open3d/t/geometry/TriangleMesh.h
+++ b/cpp/open3d/t/geometry/TriangleMesh.h
@@ -656,9 +656,7 @@ public:
     /// Create a solid TriangleMesh representing the surface of a
     /// BoundingSphere.
     /// \param sphere The bounding sphere.
-    /// \param scale Scale factor applied to radius before
-    /// constructing the mesh.
-    /// \param resolution Resolution of the generated ellipsoid surface mesh.
+    /// \param resolution Resolution of the generated sphere surface mesh.
     /// \param float_dtype The data type for vertex attributes.
     /// \param int_dtype The data type for triangle indices.
     /// \param device The device for the returned mesh.

--- a/cpp/open3d/t/geometry/TriangleMesh.h
+++ b/cpp/open3d/t/geometry/TriangleMesh.h
@@ -894,9 +894,9 @@ public:
     OrientedBoundingEllipsoid GetOrientedBoundingEllipsoid(
             bool robust = false) const;
 
-    /// Create an oriented bounding sphere from vertex attribute "positions".
+    /// Create a bounding sphere from vertex attribute "positions".
     BoundingSphere GetBoundingSphere(
-        MethodBoundingSphereCreate method = MethodBoundingSphereCreate::EXACT,
+        bool exact = true,
         bool robust = false) const;
 
     /// Fill holes by triangulating boundary edges.

--- a/cpp/open3d/t/geometry/kernel/CMakeLists.txt
+++ b/cpp/open3d/t/geometry/kernel/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(tgeometry_kernel PRIVATE
     Metrics.cpp
     MinimumOBB.cpp
     MinimumOBE.cpp
+    MinimumBS.cpp
     TriangleMesh.cpp
     TriangleMeshCPU.cpp
     Transform.cpp

--- a/cpp/open3d/t/geometry/kernel/MinimumBS.cpp
+++ b/cpp/open3d/t/geometry/kernel/MinimumBS.cpp
@@ -1,15 +1,17 @@
 // ----------------------------------------------------------------------------
 // -                        Open3D: www.open3d.org                            -
 // ----------------------------------------------------------------------------
-// Copyright (c) 2018-2024 www.open3d.org
-// SPDX-License-Identifier: MIT
-// ----------------------------------------------------------------------------
 
 #include "open3d/t/geometry/kernel/MinimumBS.h"
 
+#include <Eigen/Dense>
+
 #include <algorithm>
+#include <array>
 #include <cmath>
+#include <limits>
 #include <random>
+#include <vector>
 
 #include "open3d/core/EigenConverter.h"
 #include "open3d/core/TensorCheck.h"
@@ -24,27 +26,65 @@ namespace geometry {
 namespace kernel {
 namespace bounding_sphere {
 
+// ============================================================================
+// MINIMUM BOUNDING SPHERE COMPUTATION
+// ============================================================================
+// Algorithm: Welzl's linear-time randomized algorithm for the smallest
+// enclosing sphere. Handles full-rank (3D) and lower-dimensional (coplanar,
+// collinear) point sets through projection and lifting.
+//
+// Key features:
+// - O(n) expected time complexity with linear space usage
+// - Robust handling of degenerate (coplanar/collinear) point sets
+// - Analytic circumsphere formulas for small boundary sets (2-4 points)
+// - Single global shuffle for deterministic recursion
+// ============================================================================
+
 namespace {
 
-// Helper struct using Eigen datatypes on the stack for sphere computation
+// Tolerance for rank detection and geometric degeneracy tests
+// Machine epsilon is ~1e-16 for float64, so 1e-12 is safely above noise
+constexpr double kEps = 1e-12;
+constexpr double kRankTol = 1e-9;
+
+// ----------------------------------------------------------------------------
+// Helper sphere type
+// ----------------------------------------------------------------------------
+
+// Minimal sphere representation: center, radius, and boundary points.
+// The boundary_ vector stores the 1-4 points that define the sphere's
+// minimal enclosing property (i.e., at least 2 boundary points on the
+// sphere surface for valid small-dimension enclosing spheres).
 struct EigenSphere {
     EigenSphere()
-        : center_(Eigen::Vector3d::Zero()), radius_(0.0), boundary_() {}
+        : center_(Eigen::Vector3d::Zero()),
+          radius_(0.0),
+          boundary_() {}
 
     EigenSphere(const Eigen::Vector3d& c, double r)
-        : center_(c), radius_(r), boundary_() {}
+        : center_(c),
+          radius_(r),
+          boundary_() {}
 
-    EigenSphere(const Eigen::Vector3d& c, double r,
+    EigenSphere(const Eigen::Vector3d& c,
+                double r,
                 const std::vector<Eigen::Vector3d>& b)
-        : center_(c), radius_(r), boundary_(b) {}
+        : center_(c),
+          radius_(r),
+          boundary_(b) {}
 
-    bool IsInside(const Eigen::Vector3d& point, double eps = 1e-9) const {
-        double dist = (point - center_).norm();
-        return dist <= radius_ + eps;
+    // Check if point is inside or on the sphere surface (within tolerance eps).
+    // Uses squared-norm to avoid expensive sqrt operations.
+    bool IsInside(const Eigen::Vector3d& point,
+                  double eps = kEps) const {
+        return (point - center_).squaredNorm() <=
+               (radius_ + eps) * (radius_ + eps);
     }
 
+    // Compute sphere volume: (4/3) * π * r³
     double Volume() const {
-        return 4.0 * M_PI * radius_ * radius_ * radius_ / 3.0;
+        return (4.0 / 3.0) * std::acos(-1.0) *
+               radius_ * radius_ * radius_;
     }
 
     Eigen::Vector3d center_;
@@ -52,38 +92,170 @@ struct EigenSphere {
     std::vector<Eigen::Vector3d> boundary_;
 };
 
-// Compute circumsphere of 2 points
-EigenSphere ComputeCircumsphere2(const Eigen::Vector3d& p1,
-                                  const Eigen::Vector3d& p2) {
-    Eigen::Vector3d center = (p1 + p2) / 2.0;
-    double radius = (p2 - p1).norm() / 2.0;
-    return EigenSphere(center, radius, std::vector<Eigen::Vector3d>{p1, p2});
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+// Verify that all points are contained within (or on) the sphere.
+// Used as a sanity check for circumsphere solvers and fallback selection.
+bool ContainsAll(const EigenSphere& sphere,
+                 const std::vector<Eigen::Vector3d>& pts,
+                 double eps = kEps) {
+    for (const auto& p : pts) {
+        if (!sphere.IsInside(p, eps)) {
+            return false;
+        }
+    }
+    return true;
 }
 
-// Compute circumsphere of 3 points
-EigenSphere ComputeCircumsphere3(const Eigen::Vector3d& p1,
-                                  const Eigen::Vector3d& p2,
-                                  const Eigen::Vector3d& p3) {
-    // Vectors from p1 to p2 and p1 to p3
-    Eigen::Vector3d v1 = p2 - p1;
-    Eigen::Vector3d v2 = p3 - p1;
+static std::pair<Eigen::VectorXd, double> FitCircumsphereND(
+        const Eigen::MatrixXd &points);
 
-    // Compute the circumcenter
-    // Using the formula for circumcenter of a triangle
-    double a = v1.squaredNorm();
-    double b = v2.squaredNorm();
-    double c = v1.dot(v2);
+static EigenSphere ComputeCircumsphere2(
+        const Eigen::Vector3d& p1,
+        const Eigen::Vector3d& p2);
 
-    double denom = 2.0 * (a * b - c * c);
+static EigenSphere ComputeCircumsphere3(
+        const Eigen::Vector3d& p1,
+        const Eigen::Vector3d& p2,
+        const Eigen::Vector3d& p3);
 
-    // Degenerate case: collinear points
-    if (std::abs(denom) < 1e-12) {
-        // Fall back to computing minimum sphere from 2 points
-        Eigen::Vector3d p_far;
-        double max_dist = 0.0;
-        double d12 = (p2 - p1).norm();
-        double d13 = (p3 - p1).norm();
-        double d23 = (p3 - p2).norm();
+static EigenSphere ComputeCircumsphere4(
+        const Eigen::Vector3d& p1,
+        const Eigen::Vector3d& p2,
+        const Eigen::Vector3d& p3,
+        const Eigen::Vector3d& p4);
+
+static int ComputeIntrinsicRank(
+        const Eigen::MatrixXd &mat,
+        double tol = kRankTol);
+
+static const std::array<std::array<int, 3>, 4> kSubTriangles = {{
+    {0, 1, 2},
+    {0, 1, 3},
+    {0, 2, 3},
+    {1, 2, 3}
+}};
+
+static const std::array<std::array<int, 2>, 6> kSubPairs = {{
+    {0, 1},
+    {0, 2},
+    {0, 3},
+    {1, 2},
+    {1, 3},
+    {2, 3}
+}};
+
+static EigenSphere ComputeBestLowerDimensionalSphere(
+        const std::vector<Eigen::Vector3d>& pts) {
+    EigenSphere best;
+    best.radius_ = std::numeric_limits<double>::infinity();
+
+    for (const auto& c : kSubTriangles) {
+        EigenSphere s = ComputeCircumsphere3(
+                pts[c[0]],
+                pts[c[1]],
+                pts[c[2]]);
+        if (ContainsAll(s, pts, 1e-9) && s.radius_ < best.radius_) {
+            best = s;
+        }
+    }
+
+    if (best.radius_ < std::numeric_limits<double>::infinity()) {
+        return best;
+    }
+
+    for (const auto& c : kSubPairs) {
+        EigenSphere s = ComputeCircumsphere2(
+                pts[c[0]],
+                pts[c[1]]);
+        if (ContainsAll(s, pts, 1e-9) && s.radius_ < best.radius_) {
+            best = s;
+        }
+    }
+
+    if (best.radius_ < std::numeric_limits<double>::infinity()) {
+        return best;
+    }
+
+    EigenSphere fallback = ComputeCircumsphere2(pts[0], pts[1]);
+    for (const auto& c : kSubPairs) {
+        EigenSphere s = ComputeCircumsphere2(
+                pts[c[0]],
+                pts[c[1]]);
+        if (s.radius_ > fallback.radius_) {
+            fallback = s;
+        }
+    }
+    return fallback;
+}
+
+static std::pair<Eigen::VectorXd, double> WelzlNDRecursive(
+        std::vector<Eigen::VectorXd> &points,
+        std::vector<Eigen::VectorXd> boundary,
+        size_t n,
+        double eps);
+
+static int ComputeIntrinsicRank(
+        const Eigen::VectorXd &svals,
+        double tol = kRankTol) {
+    int rank = 0;
+    for (int i = 0; i < static_cast<int>(svals.size()); ++i) {
+        if (svals(i) > tol) {
+            ++rank;
+        }
+    }
+    return rank;
+}
+
+static int ComputeIntrinsicRank(
+        const Eigen::MatrixXd &mat,
+        double tol) {
+    Eigen::JacobiSVD<Eigen::MatrixXd> svd(
+            mat, Eigen::ComputeThinU | Eigen::ComputeThinV);
+    return ComputeIntrinsicRank(svd.singularValues(), tol);
+}
+
+// ----------------------------------------------------------------------------
+// 2-point sphere
+// ----------------------------------------------------------------------------
+
+EigenSphere ComputeCircumsphere2(
+        const Eigen::Vector3d& p1,
+        const Eigen::Vector3d& p2) {
+
+    Eigen::Vector3d center = 0.5 * (p1 + p2);
+    double radius = 0.5 * (p2 - p1).norm();
+
+    return EigenSphere(center, radius, {p1, p2});
+}
+
+// ----------------------------------------------------------------------------
+// 3-point sphere
+// Robust against collinear points
+// ----------------------------------------------------------------------------
+
+EigenSphere ComputeCircumsphere3(
+        const Eigen::Vector3d& p1,
+        const Eigen::Vector3d& p2,
+        const Eigen::Vector3d& p3) {
+
+    Eigen::Vector3d a = p2 - p1;
+    Eigen::Vector3d b = p3 - p1;
+
+    Eigen::Vector3d n = a.cross(b);
+    double n2 = n.squaredNorm();
+
+    // ------------------------------------------------------------------------
+    // Collinear fallback
+    // ------------------------------------------------------------------------
+
+    if (n2 < kEps) {
+
+        double d12 = (p2 - p1).squaredNorm();
+        double d13 = (p3 - p1).squaredNorm();
+        double d23 = (p3 - p2).squaredNorm();
 
         if (d12 >= d13 && d12 >= d23) {
             return ComputeCircumsphere2(p1, p2);
@@ -94,228 +266,467 @@ EigenSphere ComputeCircumsphere3(const Eigen::Vector3d& p1,
         }
     }
 
-    double s = (b - c) / denom;
-    double t = (a - c) / denom;
+    // ------------------------------------------------------------------------
+    // Analytic circumcenter for 3 points in 3D.
+    // ------------------------------------------------------------------------
 
-    Eigen::Vector3d center = p1 + s * v1 + t * v2;
+    double a2 = a.squaredNorm();
+    double b2 = b.squaredNorm();
+    Eigen::Vector3d center = p1 + ((b * a2 - a * b2).cross(n)) / (2.0 * n2);
     double radius = (center - p1).norm();
 
-    return EigenSphere(center, radius, std::vector<Eigen::Vector3d>{p1, p2, p3});
+    return EigenSphere(center, radius, {p1, p2, p3});
 }
 
-// Compute circumsphere of 4 points (minimal sphere through 4 points)
-EigenSphere ComputeCircumsphere4(const Eigen::Vector3d& p1,
-                                  const Eigen::Vector3d& p2,
-                                  const Eigen::Vector3d& p3,
-                                  const Eigen::Vector3d& p4) {
-    // Solve the linear system to find the circumcenter
-    // |p1.x p1.y p1.z 1| |x|   |p1.x^2 + p1.y^2 + p1.z^2|
-    // |p2.x p2.y p2.z 1| |y| = |p2.x^2 + p2.y^2 + p2.z^2|
-    // |p3.x p3.y p3.z 1| |z|   |p3.x^2 + p3.y^2 + p3.z^2|
-    // |p4.x p4.y p4.z 1| |r|   |p4.x^2 + p4.y^2 + p4.z^2|
+// ----------------------------------------------------------------------------
+// 4-point sphere
+// Robust against coplanar tetrahedra
+// ----------------------------------------------------------------------------
 
-    Eigen::Matrix4d A;
-    Eigen::Vector4d b;
+EigenSphere ComputeCircumsphere4(
+        const Eigen::Vector3d& p1,
+        const Eigen::Vector3d& p2,
+        const Eigen::Vector3d& p3,
+        const Eigen::Vector3d& p4) {
 
-    A.row(0) << p1.x(), p1.y(), p1.z(), 1.0;
-    A.row(1) << p2.x(), p2.y(), p2.z(), 1.0;
-    A.row(2) << p3.x(), p3.y(), p3.z(), 1.0;
-    A.row(3) << p4.x(), p4.y(), p4.z(), 1.0;
+    Eigen::Matrix3d M;
+    M.row(0) = p2 - p1;
+    M.row(1) = p3 - p1;
+    M.row(2) = p4 - p1;
 
-    b(0) = p1.squaredNorm();
-    b(1) = p2.squaredNorm();
-    b(2) = p3.squaredNorm();
-    b(3) = p4.squaredNorm();
-
-    // Solve Ax = b
-    Eigen::Vector4d x = A.colPivHouseholderQr().solve(b);
-
-    Eigen::Vector3d center(x(0) / 2.0, x(1) / 2.0, x(2) / 2.0);
-    double radius_sq = center.squaredNorm() - x(3) / 2.0;
-    double radius = std::max(0.0, std::sqrt(radius_sq));
-    return EigenSphere(center, radius,
-                       std::vector<Eigen::Vector3d>{p1, p2, p3, p4});
-}
-
-// Recursive implementation of Welzl's algorithm
-EigenSphere WelzlRecursive(
-        std::vector<Eigen::Vector3d>& points,
-        std::vector<Eigen::Vector3d> boundary,
-        size_t n) {
-    // Base cases
-    if (n == 0 || boundary.size() == 4) {
-        if (boundary.empty()) {
-            return EigenSphere(Eigen::Vector3d::Zero(), 0.0, boundary);
-        } else if (boundary.size() == 1) {
-            return EigenSphere(boundary[0], 0.0, boundary);
-        } else if (boundary.size() == 2) {
-            return ComputeCircumsphere2(boundary[0], boundary[1]);
-        } else if (boundary.size() == 3) {
-            return ComputeCircumsphere3(boundary[0], boundary[1], boundary[2]);
-        } else {  // boundary.size() == 4
-            return ComputeCircumsphere4(boundary[0], boundary[1], boundary[2],
-                                       boundary[3]);
-        }
+    const int rank = ComputeIntrinsicRank(Eigen::MatrixXd(M));
+    std::vector<Eigen::Vector3d> pts = {p1, p2, p3, p4};
+    if (rank < 3) {
+        return ComputeBestLowerDimensionalSphere(pts);
     }
 
-    // Pick a random point
-    static std::random_device rd;
-    static std::mt19937 gen(rd());
-    std::uniform_int_distribution<> dis(0, n - 1);
-    size_t idx = dis(gen);
+    // ------------------------------------------------------------------------
+    // Proper tetrahedral circumsphere
+    // ------------------------------------------------------------------------
 
-    Eigen::Vector3d p = points[idx];
+    Eigen::Matrix3d A;
+    A.row(0) = 2.0 * (p2 - p1);
+    A.row(1) = 2.0 * (p3 - p1);
+    A.row(2) = 2.0 * (p4 - p1);
 
-    // Swap the selected point to the end and reduce n
-    std::swap(points[idx], points[n - 1]);
+    Eigen::Vector3d b;
+    b(0) = p2.squaredNorm() - p1.squaredNorm();
+    b(1) = p3.squaredNorm() - p1.squaredNorm();
+    b(2) = p4.squaredNorm() - p1.squaredNorm();
 
-    // Recursively compute the minimum sphere for n-1 points
-    EigenSphere sphere = WelzlRecursive(points, boundary, n - 1);
-
-    // If p is inside the sphere, we're done
-    if (sphere.IsInside(p)) {
-        // Swap back
-        std::swap(points[idx], points[n - 1]);
-        return sphere;
+    Eigen::FullPivLU<Eigen::Matrix3d> lu(A);
+    if (lu.rank() < 3) {
+        return ComputeBestLowerDimensionalSphere(pts);
     }
 
-    // Otherwise, p must be on the boundary
-    boundary.push_back(p);
-    sphere = WelzlRecursive(points, boundary, n - 1);
+    Eigen::Vector3d center = A.jacobiSvd(
+        Eigen::ComputeFullU | Eigen::ComputeFullV).solve(b);
+    double radius = (center - p1).norm();
 
-    // Swap back
-    std::swap(points[idx], points[n - 1]);
+    EigenSphere sphere(center, radius, pts);
+    if (!ContainsAll(sphere, pts, 1e-9)) {
+        return ComputeBestLowerDimensionalSphere(pts);
+    }
 
     return sphere;
 }
 
-// Iterative (non-recursive) implementation of Welzl's algorithm.
-// Uses a randomized shuffle and nested loops to enforce the boundary
-// (points on the sphere) up to size 4.
-EigenSphere WelzlIterative(std::vector<Eigen::Vector3d>& points, size_t n) {
-    if (n == 0) return EigenSphere(Eigen::Vector3d::Zero(), 0.0);
+// ----------------------------------------------------------------------------
+// Boundary sphere
+// ----------------------------------------------------------------------------
 
-    // Random shuffle the first n points for randomized algorithm
+EigenSphere SphereFromBoundary(
+        const std::vector<Eigen::Vector3d>& boundary) {
+
+    switch (boundary.size()) {
+
+        case 0:
+            return EigenSphere(
+                    Eigen::Vector3d::Zero(),
+                    0.0,
+                    boundary);
+
+        case 1:
+            return EigenSphere(
+                    boundary[0],
+                    0.0,
+                    boundary);
+
+        case 2:
+            return ComputeCircumsphere2(
+                    boundary[0],
+                    boundary[1]);
+
+        case 3:
+            return ComputeCircumsphere3(
+                    boundary[0],
+                    boundary[1],
+                    boundary[2]);
+
+        case 4:
+            return ComputeCircumsphere4(
+                    boundary[0],
+                    boundary[1],
+                    boundary[2],
+                    boundary[3]);
+
+        default:
+            utility::LogError(
+                    "Boundary size > 4 is invalid.");
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Recursive Welzl
+// IMPORTANT:
+// - shuffle once globally
+// - no per-recursion randomization
+// ----------------------------------------------------------------------------
+
+EigenSphere WelzlRecursive(
+        std::vector<Eigen::Vector3d>& points,
+        std::vector<Eigen::Vector3d> boundary,
+        size_t n) {
+
+    if (n == 0 || boundary.size() == 4) {
+        return SphereFromBoundary(boundary);
+    }
+
+    const Eigen::Vector3d p = points[n - 1];
+
+    EigenSphere sphere =
+            WelzlRecursive(
+                    points,
+                    boundary,
+                    n - 1);
+
+    if (sphere.IsInside(p)) {
+        return sphere;
+    }
+
+    boundary.push_back(p);
+
+    return WelzlRecursive(
+            points,
+            boundary,
+            n - 1);
+}
+
+// ----------------------------------------------------------------------------
+// Iterative Welzl
+// ----------------------------------------------------------------------------
+
+EigenSphere WelzlIterative(
+        std::vector<Eigen::Vector3d>& points,
+        size_t n) {
+
+    if (n == 0) {
+        return EigenSphere(
+                Eigen::Vector3d::Zero(),
+                0.0);
+    }
+
     static std::random_device rd;
     static std::mt19937 gen(rd());
-    std::shuffle(points.begin(), points.begin() + static_cast<std::ptrdiff_t>(n), gen);
 
-    EigenSphere sphere(Eigen::Vector3d::Zero(), -1.0);
+    std::shuffle(
+            points.begin(),
+            points.begin() +
+                static_cast<std::ptrdiff_t>(n),
+            gen);
 
-    auto make2 = [](const Eigen::Vector3d& a, const Eigen::Vector3d& b) {
-        return ComputeCircumsphere2(a, b);
-    };
-    auto make3 = [](const Eigen::Vector3d& a, const Eigen::Vector3d& b, const Eigen::Vector3d& c) {
-        return ComputeCircumsphere3(a, b, c);
-    };
-    auto make4 = [](const Eigen::Vector3d& a, const Eigen::Vector3d& b, const Eigen::Vector3d& c, const Eigen::Vector3d& d) {
-        return ComputeCircumsphere4(a, b, c, d);
-    };
+    EigenSphere sphere(
+            Eigen::Vector3d::Zero(),
+            -1.0);
 
     for (size_t i = 0; i < n; ++i) {
-        const Eigen::Vector3d& p_i = points[i];
 
-        if (sphere.radius_ >= 0 && sphere.IsInside(p_i)) continue;
+        const Eigen::Vector3d& pi = points[i];
 
-        // Sphere must include p_i. Start with trivial sphere at p_i and record boundary.
-        sphere = EigenSphere(p_i, 0.0, std::vector<Eigen::Vector3d>{p_i});
+        if (sphere.radius_ >= 0 &&
+            sphere.IsInside(pi)) {
+            continue;
+        }
+
+        sphere = EigenSphere(
+                pi,
+                0.0,
+                {pi});
 
         for (size_t j = 0; j < i; ++j) {
-            const Eigen::Vector3d& p_j = points[j];
-            if (sphere.IsInside(p_j)) continue;
 
-            // Sphere must include p_j and p_i
-            sphere = make2(p_j, p_i);
+            const Eigen::Vector3d& pj = points[j];
+
+            if (sphere.IsInside(pj)) {
+                continue;
+            }
+
+            sphere = ComputeCircumsphere2(pi, pj);
 
             for (size_t k = 0; k < j; ++k) {
-                const Eigen::Vector3d& p_k = points[k];
-                if (sphere.IsInside(p_k)) continue;
 
-                // Sphere must include p_k, p_j, p_i
-                sphere = make3(p_k, p_j, p_i);
+                const Eigen::Vector3d& pk = points[k];
+
+                if (sphere.IsInside(pk)) {
+                    continue;
+                }
+
+                sphere =
+                        ComputeCircumsphere3(
+                                pi,
+                                pj,
+                                pk);
 
                 for (size_t l = 0; l < k; ++l) {
-                    const Eigen::Vector3d& p_l = points[l];
-                    if (sphere.IsInside(p_l)) continue;
 
-                    // Sphere must include p_l, p_k, p_j, p_i
-                    sphere = make4(p_l, p_k, p_j, p_i);
+                    const Eigen::Vector3d& pl = points[l];
+
+                    if (sphere.IsInside(pl)) {
+                        continue;
+                    }
+
+                    sphere =
+                            ComputeCircumsphere4(
+                                    pi,
+                                    pj,
+                                    pk,
+                                    pl);
                 }
             }
         }
     }
 
-    // If we never set a sphere (shouldn't happen for n>0), fallback
-    if (sphere.radius_ < 0) return EigenSphere(points[0], 0.0, std::vector<Eigen::Vector3d>{points[0]});
-
     return sphere;
 }
+
+// ----------------------------------------------------------------------------
+// Generic N-D Welzl (small helper for projecting degenerate 3D sets)
+// Supports D = 1 or 2 (used when points lie in a lower-dimensional subspace).
+// ----------------------------------------------------------------------------
+
+// Fit circumsphere to <= D+1 points in R^D (D small: 1 or 2).
+static std::pair<Eigen::VectorXd, double> FitCircumsphereND(
+        const Eigen::MatrixXd &points) {
+    const int M = static_cast<int>(points.rows());
+    const int D = static_cast<int>(points.cols());
+
+    if (M == 0) {
+        return {Eigen::VectorXd::Constant(D, std::numeric_limits<double>::quiet_NaN()),
+                std::numeric_limits<double>::quiet_NaN()};
+    }
+    if (M == 1) {
+        return {points.row(0).transpose(), 0.0};
+    }
+
+    if (M == 2) {
+        Eigen::VectorXd c = 0.5 * (points.row(0).transpose() + points.row(1).transpose());
+        double r = (points.row(0).transpose() - c).norm();
+        return {c, r};
+    }
+
+    // General small linear solve: 2*(p_i - p_0) · c = |p_i|^2 - |p_0|^2
+    Eigen::MatrixXd V = points.block(1, 0, M - 1, D) -
+                       points.row(0).replicate(M - 1, 1);
+    Eigen::MatrixXd A = 2.0 * V;
+    Eigen::VectorXd b(M - 1);
+    for (int i = 1; i < M; ++i) {
+        b(i - 1) = points.row(i).squaredNorm() - points.row(0).squaredNorm();
+    }
+
+    Eigen::VectorXd center;
+    if (A.fullPivLu().rank() == D) {
+        center = A.colPivHouseholderQr().solve(b);
+    } else {
+        center = A.jacobiSvd(Eigen::ComputeThinU | Eigen::ComputeThinV).solve(b);
+    }
+
+    double radius = (points.row(0).transpose() - center).norm();
+    return {center, radius};
+}
+
+// Recursive ND Welzl (points passed as Eigen vectors)
+static std::pair<Eigen::VectorXd, double> WelzlNDRecursive(
+        std::vector<Eigen::VectorXd> &points,
+        std::vector<Eigen::VectorXd> boundary,
+        size_t n,
+        double eps = kEps) {
+
+    const int D = static_cast<int>(points[0].size());
+
+    if (n == 0 || boundary.size() == static_cast<size_t>(D + 1)) {
+        Eigen::MatrixXd B_mat(static_cast<int>(boundary.size()), D);
+        for (int i = 0; i < static_cast<int>(boundary.size()); ++i) {
+            B_mat.row(i) = boundary[i].transpose();
+        }
+        auto [c, r] = FitCircumsphereND(B_mat);
+        return {c, r};
+    }
+
+    Eigen::VectorXd p = points[n - 1];
+
+    auto [c, r] = WelzlNDRecursive(points, boundary, n - 1, eps);
+
+    if (std::isnan(r) == false && (p - c).squaredNorm() <= (r + eps) * (r + eps)) {
+        return {c, r};
+    }
+
+    boundary.push_back(p);
+    return WelzlNDRecursive(points, boundary, n - 1, eps);
+}
+
 
 }  // namespace
 
+// ----------------------------------------------------------------------------
+// Public API
+// ----------------------------------------------------------------------------
+
 open3d::geometry::BoundingSphere ComputeMinimumBSWelzl(
-        const std::vector<Eigen::Vector3d>& points, bool robust) {
+        const std::vector<Eigen::Vector3d>& points,
+        bool robust) {
+
     if (points.empty()) {
-        utility::LogError("Input point set is empty.");
-    }
-    if (static_cast<int>(points.size()) < 2) {
-        utility::LogError("Input point set has less than 2 points.");
+        utility::LogError(
+                "Input point set is empty.");
     }
 
-    // ------------------------------------------------------------
-    // 0) Compute the convex hull of the input point cloud using legacy API
-    // (Eigen types, CPU). This reduces the input size for Welzl's algorithm.
-    // ------------------------------------------------------------
+    if (static_cast<int>(points.size()) < 2) {
+        utility::LogError(
+                "Input point set has less than 2 points.");
+    }
+
+    // ------------------------------------------------------------------------
+    // Convex hull reduction
+    // ------------------------------------------------------------------------
+
     open3d::geometry::PointCloud pcd;
     pcd.points_ = points;
-    auto [hull_mesh, hull_indices] = pcd.ComputeConvexHull(/*robust=*/robust);
+
+    auto [hull_mesh, hull_indices] =
+            pcd.ComputeConvexHull(robust);
+
     if (hull_mesh->vertices_.empty()) {
-        utility::LogWarning("Failed to compute convex hull.");
+        utility::LogWarning(
+                "Failed to compute convex hull.");
+
         return open3d::geometry::BoundingSphere();
     }
 
-    // Get convex hull vertices
-    const auto& hull_v = hull_mesh->vertices_;
-    int num_vertices = static_cast<int>(hull_v.size());
+    std::vector<Eigen::Vector3d> pts =
+            hull_mesh->vertices_;
 
-    // Handle degenerate planar cases up front.
-    if (num_vertices < 4) {
-        utility::LogWarning("Convex hull is degenerate.");
-        return open3d::geometry::BoundingSphere();
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+
+    // ========================================================================
+    // DIMENSIONALITY DETECTION AND DUAL-PATH ROUTING
+    // ========================================================================
+    // This section mirrors the Python logic in intrinsic_dimension():
+    //   1. Center points at first point (affine origin)
+    //   2. Compute SVD to find singular values
+    //   3. Count non-zero singular values to determine rank
+    //   4. Route to 3D Welzl (full rank) or N-D Welzl + projection (lower rank)
+    //
+    // Why: Coplanar (rank 2) or collinear (rank 1) point sets are degenerate
+    // in 3D but well-defined in their intrinsic dimension. The projection
+    // approach solves the problem in the intrinsic subspace, then lifts the
+    // result back to 3D, ensuring numeric stability.
+    // ========================================================================
+
+    // --- Step 1: Convert to matrix format and center at first point ---
+    const int M = static_cast<int>(pts.size());
+    Eigen::MatrixXd Pmat(M, 3);
+    for (int i = 0; i < M; ++i) {
+        Pmat.row(i) = pts[i].transpose();
     }
 
-    // Make a copy for processing (Welzl modifies the array)
-    std::vector<Eigen::Vector3d> pts = hull_v;
-    std::vector<Eigen::Vector3d> boundary;
+    // Center by subtracting first point (affine subspace origin)
+    Eigen::RowVector3d offset = Pmat.row(0);
+    Eigen::MatrixXd centered = Pmat.rowwise() - offset;
 
-    // Run Welzl's algorithm on convex hull vertices
-    EigenSphere es = WelzlRecursive(pts, boundary, pts.size());
-    // EigenSphere es = WelzlIterative(pts, pts.size());
+    // --- Step 2: Compute intrinsic rank using a shared helper ---
+    // Matches Python's matrix_rank(centered, tol=1e-9).
+    Eigen::JacobiSVD<Eigen::MatrixXd> svd(
+            centered, Eigen::ComputeThinU | Eigen::ComputeThinV);
+    const int rank = ComputeIntrinsicRank(svd.singularValues());
 
-    open3d::geometry::BoundingSphere sphere(es.center_, es.radius_);
-    return sphere;
+    // --- Step 4: Route based on rank ---
+    if (rank < 3 && rank > 0) {
+        // LOWER-DIMENSIONAL PATH: Points lie in a rank-D subspace (D < 3)
+        // Strategy: Project to intrinsic subspace, solve there, lift back
+        
+        // Extract basis: top 'rank' right singular vectors (columns of V)
+        // These span the subspace containing the points
+        Eigen::MatrixXd V = svd.matrixV();           // 3x3, orthonormal columns
+        Eigen::MatrixXd basis = V.transpose().block(0, 0, rank, 3); // rank x 3
+
+        // Project centered points onto basis: X_sub = centered * basis^T
+        // Result: M x rank matrix of coordinates in intrinsic subspace
+        Eigen::MatrixXd X_sub = centered * basis.transpose();
+
+        // Convert to vector of column vectors for WelzlNDRecursive
+        std::vector<Eigen::VectorXd> Psub;
+        Psub.reserve(M);
+        for (int i = 0; i < M; ++i) {
+            Psub.push_back(X_sub.row(i).transpose());
+        }
+
+        // Shuffle for randomized algorithm
+        std::shuffle(Psub.begin(), Psub.end(), gen);
+
+        // Run Welzl algorithm in the intrinsic dimension
+        auto [c_sub, r_sub] = WelzlNDRecursive(Psub, {}, Psub.size());
+
+        // LIFT: Transform center from intrinsic coordinates back to 3D
+        // center_3d = offset + basis^T * c_sub
+        // (offset accounts for the translation in Step 1)
+        Eigen::Vector3d center_nd = offset.transpose();
+        if (rank > 0) {
+            center_nd += basis.transpose() * c_sub;
+        }
+
+        return open3d::geometry::BoundingSphere(center_nd, r_sub);
+    }
+
+    // FULL-RANK PATH: Points span all 3 dimensions
+    // Run standard 3D Welzl directly
+    std::shuffle(pts.begin(), pts.end(), gen);
+
+    EigenSphere es = WelzlRecursive(pts, {}, pts.size());
+
+    return open3d::geometry::BoundingSphere(es.center_, es.radius_);
 }
 
-BoundingSphere ComputeMinimumBSWelzl(const core::Tensor& points, bool robust) {
+BoundingSphere ComputeMinimumBSWelzl(
+        const core::Tensor& points,
+        bool robust) {
+
     core::AssertTensorShape(points, {std::nullopt, 3});
+
     core::AssertTensorDtypes(points, {core::Float32, core::Float64});
+
     if (points.GetShape(0) < 1) {
-        utility::LogError("Input point set must have at least 1 point.");
+        utility::LogError(
+                "Input point set must have at least 1 point.");
     }
 
-    // Convert tensor → Eigen (Float64, CPU)
     const std::vector<Eigen::Vector3d> eigen_points =
-            core::eigen_converter::TensorToEigenVector3dVector(
-                    points.To(core::Device("CPU:0"), core::Float64));
+            core::eigen_converter::
+                    TensorToEigenVector3dVector(
+                            points.To(
+                                    core::Device("CPU:0"),
+                                    core::Float64));
 
-    // Run Eigen-native core (returns result in Float64, CPU)
-    open3d::geometry::BoundingSphere legacy_mbs = ComputeMinimumBSWelzl(
-        eigen_points, robust);
+    open3d::geometry::BoundingSphere sphere =
+            ComputeMinimumBSWelzl(
+                    eigen_points,
+                    robust);
 
-    // Convert result back to the caller's dtype and device
-    return open3d::t::geometry::BoundingSphere::FromLegacy(legacy_mbs, 
-        points.GetDtype(), 
-        points.GetDevice());
+    return open3d::t::geometry::BoundingSphere::
+            FromLegacy(
+                    sphere,
+                    points.GetDtype(),
+                    points.GetDevice());
 }
 
 }  // namespace bounding_sphere

--- a/cpp/open3d/t/geometry/kernel/MinimumBS.cpp
+++ b/cpp/open3d/t/geometry/kernel/MinimumBS.cpp
@@ -1,11 +1,13 @@
 // ----------------------------------------------------------------------------
 // -                        Open3D: www.open3d.org                            -
 // ----------------------------------------------------------------------------
+// Copyright (c) 2018-2024 www.open3d.org
+// SPDX-License-Identifier: MIT
+// ----------------------------------------------------------------------------
 
 #include "open3d/t/geometry/kernel/MinimumBS.h"
 
 #include <Eigen/Dense>
-
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -151,34 +153,26 @@ constexpr double kRankTol = 1e-9;
 // sphere surface for valid small-dimension enclosing spheres).
 struct EigenSphere {
     EigenSphere()
-        : center_(Eigen::Vector3d::Zero()),
-          radius_(0.0),
-          boundary_() {}
+        : center_(Eigen::Vector3d::Zero()), radius_(0.0), boundary_() {}
 
     EigenSphere(const Eigen::Vector3d& c, double r)
-        : center_(c),
-          radius_(r),
-          boundary_() {}
+        : center_(c), radius_(r), boundary_() {}
 
     EigenSphere(const Eigen::Vector3d& c,
                 double r,
                 const std::vector<Eigen::Vector3d>& b)
-        : center_(c),
-          radius_(r),
-          boundary_(b) {}
+        : center_(c), radius_(r), boundary_(b) {}
 
     // Check if point is inside or on the sphere surface (within tolerance eps).
     // Uses squared-norm to avoid expensive sqrt operations.
-    bool IsInside(const Eigen::Vector3d& point,
-                  double eps = kEps) const {
+    bool IsInside(const Eigen::Vector3d& point, double eps = kEps) const {
         return (point - center_).squaredNorm() <=
                (radius_ + eps) * (radius_ + eps);
     }
 
     // Compute sphere volume: (4/3) * π * r³
     double Volume() const {
-        return (4.0 / 3.0) * std::acos(-1.0) *
-               radius_ * radius_ * radius_;
+        return (4.0 / 3.0) * std::acos(-1.0) * radius_ * radius_ * radius_;
     }
 
     Eigen::Vector3d center_;
@@ -204,42 +198,28 @@ bool ContainsAll(const EigenSphere& sphere,
 }
 
 static std::pair<Eigen::VectorXd, double> FitCircumsphereND(
-        const Eigen::MatrixXd &points);
+        const Eigen::MatrixXd& points);
 
-static EigenSphere ComputeCircumsphere2(
-        const Eigen::Vector3d& p1,
-        const Eigen::Vector3d& p2);
+static EigenSphere ComputeCircumsphere2(const Eigen::Vector3d& p1,
+                                        const Eigen::Vector3d& p2);
 
-static EigenSphere ComputeCircumsphere3(
-        const Eigen::Vector3d& p1,
-        const Eigen::Vector3d& p2,
-        const Eigen::Vector3d& p3);
+static EigenSphere ComputeCircumsphere3(const Eigen::Vector3d& p1,
+                                        const Eigen::Vector3d& p2,
+                                        const Eigen::Vector3d& p3);
 
-static EigenSphere ComputeCircumsphere4(
-        const Eigen::Vector3d& p1,
-        const Eigen::Vector3d& p2,
-        const Eigen::Vector3d& p3,
-        const Eigen::Vector3d& p4);
+static EigenSphere ComputeCircumsphere4(const Eigen::Vector3d& p1,
+                                        const Eigen::Vector3d& p2,
+                                        const Eigen::Vector3d& p3,
+                                        const Eigen::Vector3d& p4);
 
-static int ComputeIntrinsicRank(
-        const Eigen::MatrixXd &mat,
-        double tol = kRankTol);
+static int ComputeIntrinsicRank(const Eigen::MatrixXd& mat,
+                                double tol = kRankTol);
 
-static const std::array<std::array<int, 3>, 4> kSubTriangles = {{
-    {0, 1, 2},
-    {0, 1, 3},
-    {0, 2, 3},
-    {1, 2, 3}
-}};
+static const std::array<std::array<int, 3>, 4> kSubTriangles = {
+        {{0, 1, 2}, {0, 1, 3}, {0, 2, 3}, {1, 2, 3}}};
 
-static const std::array<std::array<int, 2>, 6> kSubPairs = {{
-    {0, 1},
-    {0, 2},
-    {0, 3},
-    {1, 2},
-    {1, 3},
-    {2, 3}
-}};
+static const std::array<std::array<int, 2>, 6> kSubPairs = {
+        {{0, 1}, {0, 2}, {0, 3}, {1, 2}, {1, 3}, {2, 3}}};
 
 static EigenSphere ComputeBestLowerDimensionalSphere(
         const std::vector<Eigen::Vector3d>& pts) {
@@ -247,10 +227,7 @@ static EigenSphere ComputeBestLowerDimensionalSphere(
     best.radius_ = std::numeric_limits<double>::infinity();
 
     for (const auto& c : kSubTriangles) {
-        EigenSphere s = ComputeCircumsphere3(
-                pts[c[0]],
-                pts[c[1]],
-                pts[c[2]]);
+        EigenSphere s = ComputeCircumsphere3(pts[c[0]], pts[c[1]], pts[c[2]]);
         if (ContainsAll(s, pts, 1e-9) && s.radius_ < best.radius_) {
             best = s;
         }
@@ -261,9 +238,7 @@ static EigenSphere ComputeBestLowerDimensionalSphere(
     }
 
     for (const auto& c : kSubPairs) {
-        EigenSphere s = ComputeCircumsphere2(
-                pts[c[0]],
-                pts[c[1]]);
+        EigenSphere s = ComputeCircumsphere2(pts[c[0]], pts[c[1]]);
         if (ContainsAll(s, pts, 1e-9) && s.radius_ < best.radius_) {
             best = s;
         }
@@ -275,9 +250,7 @@ static EigenSphere ComputeBestLowerDimensionalSphere(
 
     EigenSphere fallback = ComputeCircumsphere2(pts[0], pts[1]);
     for (const auto& c : kSubPairs) {
-        EigenSphere s = ComputeCircumsphere2(
-                pts[c[0]],
-                pts[c[1]]);
+        EigenSphere s = ComputeCircumsphere2(pts[c[0]], pts[c[1]]);
         if (s.radius_ > fallback.radius_) {
             fallback = s;
         }
@@ -286,14 +259,13 @@ static EigenSphere ComputeBestLowerDimensionalSphere(
 }
 
 static std::pair<Eigen::VectorXd, double> WelzlNDRecursive(
-        std::vector<Eigen::VectorXd> &points,
+        std::vector<Eigen::VectorXd>& points,
         std::vector<Eigen::VectorXd> boundary,
         size_t n,
         double eps);
 
-static int ComputeIntrinsicRank(
-        const Eigen::VectorXd &svals,
-        double tol = kRankTol) {
+static int ComputeIntrinsicRank(const Eigen::VectorXd& svals,
+                                double tol = kRankTol) {
     int rank = 0;
     for (int i = 0; i < static_cast<int>(svals.size()); ++i) {
         if (svals(i) > tol) {
@@ -303,9 +275,7 @@ static int ComputeIntrinsicRank(
     return rank;
 }
 
-static int ComputeIntrinsicRank(
-        const Eigen::MatrixXd &mat,
-        double tol) {
+static int ComputeIntrinsicRank(const Eigen::MatrixXd& mat, double tol) {
     Eigen::JacobiSVD<Eigen::MatrixXd> svd(
             mat, Eigen::ComputeThinU | Eigen::ComputeThinV);
     return ComputeIntrinsicRank(svd.singularValues(), tol);
@@ -315,10 +285,8 @@ static int ComputeIntrinsicRank(
 // 2-point sphere
 // ----------------------------------------------------------------------------
 
-EigenSphere ComputeCircumsphere2(
-        const Eigen::Vector3d& p1,
-        const Eigen::Vector3d& p2) {
-
+EigenSphere ComputeCircumsphere2(const Eigen::Vector3d& p1,
+                                 const Eigen::Vector3d& p2) {
     Eigen::Vector3d center = 0.5 * (p1 + p2);
     double radius = 0.5 * (p2 - p1).norm();
 
@@ -330,11 +298,9 @@ EigenSphere ComputeCircumsphere2(
 // Robust against collinear points
 // ----------------------------------------------------------------------------
 
-EigenSphere ComputeCircumsphere3(
-        const Eigen::Vector3d& p1,
-        const Eigen::Vector3d& p2,
-        const Eigen::Vector3d& p3) {
-
+EigenSphere ComputeCircumsphere3(const Eigen::Vector3d& p1,
+                                 const Eigen::Vector3d& p2,
+                                 const Eigen::Vector3d& p3) {
     Eigen::Vector3d a = p2 - p1;
     Eigen::Vector3d b = p3 - p1;
 
@@ -346,7 +312,6 @@ EigenSphere ComputeCircumsphere3(
     // ------------------------------------------------------------------------
 
     if (n2 < kEps) {
-
         double d12 = (p2 - p1).squaredNorm();
         double d13 = (p3 - p1).squaredNorm();
         double d23 = (p3 - p2).squaredNorm();
@@ -377,12 +342,10 @@ EigenSphere ComputeCircumsphere3(
 // Robust against coplanar tetrahedra
 // ----------------------------------------------------------------------------
 
-EigenSphere ComputeCircumsphere4(
-        const Eigen::Vector3d& p1,
-        const Eigen::Vector3d& p2,
-        const Eigen::Vector3d& p3,
-        const Eigen::Vector3d& p4) {
-
+EigenSphere ComputeCircumsphere4(const Eigen::Vector3d& p1,
+                                 const Eigen::Vector3d& p2,
+                                 const Eigen::Vector3d& p3,
+                                 const Eigen::Vector3d& p4) {
     Eigen::Matrix3d M;
     M.row(0) = p2 - p1;
     M.row(1) = p3 - p1;
@@ -408,10 +371,10 @@ EigenSphere ComputeCircumsphere4(
     b(1) = p3.squaredNorm() - p1.squaredNorm();
     b(2) = p4.squaredNorm() - p1.squaredNorm();
 
-    // Find the unique point in 3D that is equidistant from the 
+    // Find the unique point in 3D that is equidistant from the
     // four tetrahedron vertices -> center of the circumsphere.
-    Eigen::Vector3d center = A.jacobiSvd(
-        Eigen::ComputeFullU | Eigen::ComputeFullV).solve(b);
+    Eigen::Vector3d center =
+            A.jacobiSvd(Eigen::ComputeFullU | Eigen::ComputeFullV).solve(b);
     double radius = (center - p1).norm();
 
     EigenSphere sphere(center, radius, pts);
@@ -426,44 +389,26 @@ EigenSphere ComputeCircumsphere4(
 // Boundary sphere
 // ----------------------------------------------------------------------------
 
-EigenSphere SphereFromBoundary(
-        const std::vector<Eigen::Vector3d>& boundary) {
-
+EigenSphere SphereFromBoundary(const std::vector<Eigen::Vector3d>& boundary) {
     switch (boundary.size()) {
-
         case 0:
-            return EigenSphere(
-                    Eigen::Vector3d::Zero(),
-                    0.0,
-                    boundary);
+            return EigenSphere(Eigen::Vector3d::Zero(), 0.0, boundary);
 
         case 1:
-            return EigenSphere(
-                    boundary[0],
-                    0.0,
-                    boundary);
+            return EigenSphere(boundary[0], 0.0, boundary);
 
         case 2:
-            return ComputeCircumsphere2(
-                    boundary[0],
-                    boundary[1]);
+            return ComputeCircumsphere2(boundary[0], boundary[1]);
 
         case 3:
-            return ComputeCircumsphere3(
-                    boundary[0],
-                    boundary[1],
-                    boundary[2]);
+            return ComputeCircumsphere3(boundary[0], boundary[1], boundary[2]);
 
         case 4:
-            return ComputeCircumsphere4(
-                    boundary[0],
-                    boundary[1],
-                    boundary[2],
-                    boundary[3]);
+            return ComputeCircumsphere4(boundary[0], boundary[1], boundary[2],
+                                        boundary[3]);
 
         default:
-            utility::LogError(
-                    "Boundary size > 4 is invalid.");
+            utility::LogError("Boundary size > 4 is invalid.");
     }
 }
 
@@ -473,22 +418,16 @@ EigenSphere SphereFromBoundary(
 // - shuffle once globally
 // ----------------------------------------------------------------------------
 
-EigenSphere WelzlRecursive(
-        std::vector<Eigen::Vector3d>& points,
-        std::vector<Eigen::Vector3d> boundary,
-        size_t n) {
-
+EigenSphere WelzlRecursive(std::vector<Eigen::Vector3d>& points,
+                           std::vector<Eigen::Vector3d> boundary,
+                           size_t n) {
     if (n == 0 || boundary.size() == 4) {
         return SphereFromBoundary(boundary);
     }
 
     const Eigen::Vector3d p = points[n - 1];
 
-    EigenSphere sphere =
-            WelzlRecursive(
-                    points,
-                    boundary,
-                    n - 1);
+    EigenSphere sphere = WelzlRecursive(points, boundary, n - 1);
 
     if (sphere.IsInside(p)) {
         return sphere;
@@ -496,12 +435,8 @@ EigenSphere WelzlRecursive(
 
     boundary.push_back(p);
 
-    return WelzlRecursive(
-            points,
-            boundary,
-            n - 1);
+    return WelzlRecursive(points, boundary, n - 1);
 }
-
 
 // ----------------------------------------------------------------------------
 // Generic N-D Welzl (small helper for projecting degenerate 3D sets)
@@ -513,12 +448,13 @@ EigenSphere WelzlRecursive(
 // Typically exercised for D=1 or D=2 degenerate 3D point sets,
 // but mathematically valid for arbitrary small D.
 static std::pair<Eigen::VectorXd, double> FitCircumsphereND(
-        const Eigen::MatrixXd &points) {
+        const Eigen::MatrixXd& points) {
     const int M = static_cast<int>(points.rows());
     const int D = static_cast<int>(points.cols());
 
     if (M == 0) {
-        return {Eigen::VectorXd::Constant(D, std::numeric_limits<double>::quiet_NaN()),
+        return {Eigen::VectorXd::Constant(
+                        D, std::numeric_limits<double>::quiet_NaN()),
                 std::numeric_limits<double>::quiet_NaN()};
     }
     if (M == 1) {
@@ -526,14 +462,15 @@ static std::pair<Eigen::VectorXd, double> FitCircumsphereND(
     }
 
     if (M == 2) {
-        Eigen::VectorXd c = 0.5 * (points.row(0).transpose() + points.row(1).transpose());
+        Eigen::VectorXd c =
+                0.5 * (points.row(0).transpose() + points.row(1).transpose());
         double r = (points.row(0).transpose() - c).norm();
         return {c, r};
     }
 
     // General small linear solve: 2*(p_i - p_0) · c = |p_i|^2 - |p_0|^2
-    Eigen::MatrixXd V = points.block(1, 0, M - 1, D) -
-                       points.row(0).replicate(M - 1, 1);
+    Eigen::MatrixXd V =
+            points.block(1, 0, M - 1, D) - points.row(0).replicate(M - 1, 1);
     Eigen::MatrixXd A = 2.0 * V;
     Eigen::VectorXd b(M - 1);
     for (int i = 1; i < M; ++i) {
@@ -544,7 +481,8 @@ static std::pair<Eigen::VectorXd, double> FitCircumsphereND(
     if (A.fullPivLu().rank() == D) {
         center = A.colPivHouseholderQr().solve(b);
     } else {
-        center = A.jacobiSvd(Eigen::ComputeThinU | Eigen::ComputeThinV).solve(b);
+        center =
+                A.jacobiSvd(Eigen::ComputeThinU | Eigen::ComputeThinV).solve(b);
     }
 
     double radius = (points.row(0).transpose() - center).norm();
@@ -553,11 +491,10 @@ static std::pair<Eigen::VectorXd, double> FitCircumsphereND(
 
 // Recursive ND Welzl (points passed as Eigen vectors)
 static std::pair<Eigen::VectorXd, double> WelzlNDRecursive(
-        std::vector<Eigen::VectorXd> &points,
+        std::vector<Eigen::VectorXd>& points,
         std::vector<Eigen::VectorXd> boundary,
         size_t n,
         double eps = kEps) {
-
     const int D = static_cast<int>(points[0].size());
 
     if (n == 0 || boundary.size() == static_cast<size_t>(D + 1)) {
@@ -573,14 +510,14 @@ static std::pair<Eigen::VectorXd, double> WelzlNDRecursive(
 
     auto [c, r] = WelzlNDRecursive(points, boundary, n - 1, eps);
 
-    if (std::isnan(r) == false && (p - c).squaredNorm() <= (r + eps) * (r + eps)) {
+    if (std::isnan(r) == false &&
+        (p - c).squaredNorm() <= (r + eps) * (r + eps)) {
         return {c, r};
     }
 
     boundary.push_back(p);
     return WelzlNDRecursive(points, boundary, n - 1, eps);
 }
-
 
 }  // namespace
 
@@ -589,17 +526,13 @@ static std::pair<Eigen::VectorXd, double> WelzlNDRecursive(
 // ----------------------------------------------------------------------------
 
 open3d::geometry::BoundingSphere ComputeMinimumBSWelzl(
-        const std::vector<Eigen::Vector3d>& points,
-        bool robust) {
-
+        const std::vector<Eigen::Vector3d>& points, bool robust) {
     if (points.empty()) {
-        utility::LogError(
-                "Input point set is empty.");
+        utility::LogError("Input point set is empty.");
     }
 
     if (static_cast<int>(points.size()) < 2) {
-        utility::LogError(
-                "Input point set has less than 2 points.");
+        utility::LogError("Input point set has less than 2 points.");
     }
 
     // ------------------------------------------------------------------------
@@ -609,18 +542,15 @@ open3d::geometry::BoundingSphere ComputeMinimumBSWelzl(
     open3d::geometry::PointCloud pcd;
     pcd.points_ = points;
 
-    auto [hull_mesh, hull_indices] =
-            pcd.ComputeConvexHull(robust);
+    auto [hull_mesh, hull_indices] = pcd.ComputeConvexHull(robust);
 
     if (hull_mesh->vertices_.empty()) {
-        utility::LogWarning(
-                "Failed to compute convex hull.");
+        utility::LogWarning("Failed to compute convex hull.");
 
         return open3d::geometry::BoundingSphere();
     }
 
-    std::vector<Eigen::Vector3d> pts =
-            hull_mesh->vertices_;
+    std::vector<Eigen::Vector3d> pts = hull_mesh->vertices_;
 
     static std::random_device rd;
     static std::mt19937 gen(rd());
@@ -659,11 +589,11 @@ open3d::geometry::BoundingSphere ComputeMinimumBSWelzl(
     if (rank < 3 && rank > 0) {
         // LOWER-DIMENSIONAL PATH: Points lie in a rank-D subspace (D < 3)
         // Strategy: Project to intrinsic subspace, solve there, lift back
-        
+
         // Extract basis: top 'rank' right singular vectors (columns of V)
         // These span the subspace containing the points
-        Eigen::MatrixXd V = svd.matrixV();           // 3x3, orthonormal columns
-        Eigen::MatrixXd basis = V.transpose().block(0, 0, rank, 3); // rank x 3
+        Eigen::MatrixXd V = svd.matrixV();  // 3x3, orthonormal columns
+        Eigen::MatrixXd basis = V.transpose().block(0, 0, rank, 3);  // rank x 3
 
         // Project centered points onto basis: X_sub = centered * basis^T
         // Result: M x rank matrix of coordinates in intrinsic subspace
@@ -702,41 +632,29 @@ open3d::geometry::BoundingSphere ComputeMinimumBSWelzl(
     return open3d::geometry::BoundingSphere(bs.center_, bs.radius_);
 }
 
-BoundingSphere ComputeMinimumBSWelzl(
-        const core::Tensor& points,
-        bool robust) {
-
+BoundingSphere ComputeMinimumBSWelzl(const core::Tensor& points, bool robust) {
     core::AssertTensorShape(points, {std::nullopt, 3});
 
     core::AssertTensorDtypes(points, {core::Float32, core::Float64});
 
     if (points.GetShape(0) < 1) {
-        utility::LogError(
-                "Input point set must have at least 1 point.");
+        utility::LogError("Input point set must have at least 1 point.");
     }
 
     const std::vector<Eigen::Vector3d> eigen_points =
-            core::eigen_converter::
-                    TensorToEigenVector3dVector(
-                            points.To(
-                                    core::Device("CPU:0"),
-                                    core::Float64));
+            core::eigen_converter::TensorToEigenVector3dVector(
+                    points.To(core::Device("CPU:0"), core::Float64));
 
     open3d::geometry::BoundingSphere sphere =
-            ComputeMinimumBSWelzl(
-                    eigen_points,
-                    robust);
+            ComputeMinimumBSWelzl(eigen_points, robust);
 
-    return open3d::t::geometry::BoundingSphere::
-            FromLegacy(
-                    sphere,
-                    points.GetDtype(),
-                    points.GetDevice());
+    return open3d::t::geometry::BoundingSphere::FromLegacy(
+            sphere, points.GetDtype(), points.GetDevice());
 }
 
-
-// // Approximate bounding sphere, based on "An Efficient Bounding Sphere" by Jack Ritter, from "Graphics Gems"
-// Sphere nv::approximateSphere_Ritter(const Vector3 * pointArray, const uint pointCount) {
+// // Approximate bounding sphere, based on "An Efficient Bounding Sphere" by
+// Jack Ritter, from "Graphics Gems" Sphere nv::approximateSphere_Ritter(const
+// Vector3 * pointArray, const uint pointCount) {
 //     nvDebugCheck(pointArray != NULL);
 //     nvDebugCheck(pointCount > 0);
 
@@ -763,7 +681,7 @@ BoundingSphere ComputeMinimumBSWelzl(
 //     float zspan = lengthSquared(zmax - zmin);
 
 //     // Set points dia1 & dia2 to the maximally separated pair.
-//     Vector3 dia1 = xmin; 
+//     Vector3 dia1 = xmin;
 //     Vector3 dia2 = xmax;
 //     float maxspan = xspan;
 //     if (yspan > maxspan) {
@@ -786,7 +704,6 @@ BoundingSphere ComputeMinimumBSWelzl(
 //     float rad_sq = lengthSquared(dia2 - sphere.center);
 //     sphere.radius = sqrtf(rad_sq);
 
-
 //     // SECOND PASS: increment current sphere
 //     for (uint i = 0; i < pointCount; i++) {
 //         const Vector3 & p = pointArray[i];
@@ -794,18 +711,20 @@ BoundingSphere ComputeMinimumBSWelzl(
 //         float old_to_p_sq = lengthSquared(p - sphere.center);
 
 //         if (old_to_p_sq > rad_sq) {    // do r**2 test first
-            
+
 //             // this point is outside of current sphere
 //             float old_to_p = sqrtf(old_to_p_sq);
 
 //             // calc radius of new sphere
 //             sphere.radius = (sphere.radius + old_to_p) / 2.0f;
-//             rad_sq = sphere.radius * sphere.radius;     // for next r**2 compare
-            
+//             rad_sq = sphere.radius * sphere.radius;     // for next r**2
+//             compare
+
 //             float old_to_new = old_to_p - sphere.radius;
 
 //             // calc center of new sphere
-//             sphere.center = (sphere.radius * sphere.center + old_to_new * p) / old_to_p;
+//             sphere.center = (sphere.radius * sphere.center + old_to_new * p)
+//             / old_to_p;
 //         }
 //     }
 
@@ -814,122 +733,103 @@ BoundingSphere ComputeMinimumBSWelzl(
 //     return sphere;
 // }
 
-EigenSphere RitterBSApproximation(
-        const std::vector<Eigen::Vector3d>& points,
-        size_t n) {
+EigenSphere RitterBSApproximation(const std::vector<Eigen::Vector3d>& points,
+                                  size_t n) {
+    Eigen::Vector3d xmin, xmax, ymin, ymax, zmin, zmax;
+    xmin = xmax = ymin = ymax = zmin = zmax = points[0];
 
-            Eigen::Vector3d xmin, xmax, ymin, ymax, zmin, zmax;
-            xmin = xmax = ymin = ymax = zmin = zmax = points[0];
+    // FIRST PASS: find 6 minima/maxima points
+    for (size_t i = 0; i < n; i++) {
+        const Eigen::Vector3d& p = points[i];
+        if (p.x() < xmin.x()) xmin = p;
+        if (p.x() > xmax.x()) xmax = p;
+        if (p.y() < ymin.y()) ymin = p;
+        if (p.y() > ymax.y()) ymax = p;
+        if (p.z() < zmin.z()) zmin = p;
+        if (p.z() > zmax.z()) zmax = p;
+    }
 
-            // FIRST PASS: find 6 minima/maxima points
-            for (size_t i = 0; i < n; i++) {
-                const Eigen::Vector3d & p = points[i];
-                if (p.x() < xmin.x()) xmin = p;
-                if (p.x() > xmax.x()) xmax = p;
-                if (p.y() < ymin.y()) ymin = p;
-                if (p.y() > ymax.y()) ymax = p;
-                if (p.z() < zmin.z()) zmin = p;
-                if (p.z() > zmax.z()) zmax = p;
-            }
+    double x_span_sq = (xmax - xmin).squaredNorm();
+    double y_span_sq = (ymax - ymin).squaredNorm();
+    double z_span_sq = (zmax - zmin).squaredNorm();
 
-            double x_span_sq = (xmax - xmin).squaredNorm();
-            double y_span_sq = (ymax - ymin).squaredNorm();
-            double z_span_sq = (zmax - zmin).squaredNorm();
+    // Set points extreme_point1 & extreme_point2 to
+    // the maximally separated pair.
+    Eigen::Vector3d extreme_point1 = xmin;
+    Eigen::Vector3d extreme_point2 = xmax;
+    double max_span_sq = x_span_sq;
+    if (y_span_sq > max_span_sq) {
+        max_span_sq = y_span_sq;
+        extreme_point1 = ymin;
+        extreme_point2 = ymax;
+    }
+    if (z_span_sq > max_span_sq) {
+        extreme_point1 = zmin;
+        extreme_point2 = zmax;
+    }
 
-            // Set points extreme_point1 & extreme_point2 to 
-            // the maximally separated pair.
-            Eigen::Vector3d extreme_point1 = xmin;
-            Eigen::Vector3d extreme_point2 = xmax;
-            double max_span_sq = x_span_sq;
-            if (y_span_sq > max_span_sq) {
-                max_span_sq = y_span_sq;
-                extreme_point1 = ymin;
-                extreme_point2 = ymax;
-            }
-            if (z_span_sq > max_span_sq) {
-                extreme_point1 = zmin;
-                extreme_point2 = zmax;
-            }
+    // Initial sphere from extrema pair
+    Eigen::Vector3d center = 0.5 * (extreme_point1 + extreme_point2);
+    double radius = (extreme_point2 - extreme_point1).norm() / 2.0;
 
-            // Initial sphere from extrema pair
-            Eigen::Vector3d center = 0.5 * (extreme_point1 + extreme_point2);
-            double radius = (extreme_point2 - extreme_point1).norm() / 2.0;
+    EigenSphere sphere(center, radius);
 
-            EigenSphere sphere(center, radius);
+    // SECOND PASS: increment current sphere
+    for (size_t i = 0; i < n; i++) {
+        const Eigen::Vector3d& p = points[i];
 
-            // SECOND PASS: increment current sphere
-            for (size_t i = 0; i < n; i++) {
-                const Eigen::Vector3d & p = points[i];
-                
-                if (!sphere.IsInside(p)) {
-                    
-                    double center_to_point = (p - center).norm();
+        if (!sphere.IsInside(p)) {
+            double center_to_point = (p - center).norm();
 
-                    // update radius
-                    radius = 0.5 * (radius + center_to_point);
+            // update radius
+            radius = 0.5 * (radius + center_to_point);
 
-                    double center_shift = center_to_point - radius;
-                    
-                    // update center
-                    center = (radius * center + center_shift * p) / 
-                                center_to_point;
-                    
-                    // update sphere for next iteration
-                    sphere = EigenSphere(center, radius);
-                }
+            double center_shift = center_to_point - radius;
 
-            }
+            // update center
+            center = (radius * center + center_shift * p) / center_to_point;
 
-            return sphere;
+            // update sphere for next iteration
+            sphere = EigenSphere(center, radius);
+        }
+    }
 
+    return sphere;
 }
 
 open3d::geometry::BoundingSphere ComputeApproximateBSRitter(
         const std::vector<Eigen::Vector3d>& points) {
-
     if (points.empty()) {
-        utility::LogError(
-                "Input point set is empty.");
+        utility::LogError("Input point set is empty.");
     }
 
     if (static_cast<int>(points.size()) < 2) {
-        utility::LogError(
-                "Input point set has less than 2 points.");
+        utility::LogError("Input point set has less than 2 points.");
     }
-    
+
     EigenSphere bs = RitterBSApproximation(points, points.size());
 
     return open3d::geometry::BoundingSphere(bs.center_, bs.radius_);
 }
 
-BoundingSphere ComputeApproximateBSRitter(
-        const core::Tensor& points) {
-
+BoundingSphere ComputeApproximateBSRitter(const core::Tensor& points) {
     core::AssertTensorShape(points, {std::nullopt, 3});
 
     core::AssertTensorDtypes(points, {core::Float32, core::Float64});
 
     if (points.GetShape(0) < 1) {
-        utility::LogError(
-                "Input point set must have at least 1 point.");
+        utility::LogError("Input point set must have at least 1 point.");
     }
 
     const std::vector<Eigen::Vector3d> eigen_points =
-            core::eigen_converter::
-                    TensorToEigenVector3dVector(
-                            points.To(
-                                    core::Device("CPU:0"),
-                                    core::Float64));
+            core::eigen_converter::TensorToEigenVector3dVector(
+                    points.To(core::Device("CPU:0"), core::Float64));
 
     open3d::geometry::BoundingSphere sphere =
-            ComputeApproximateBSRitter(
-                    eigen_points);
+            ComputeApproximateBSRitter(eigen_points);
 
-    return open3d::t::geometry::BoundingSphere::
-            FromLegacy(
-                    sphere,
-                    points.GetDtype(),
-                    points.GetDevice());
+    return open3d::t::geometry::BoundingSphere::FromLegacy(
+            sphere, points.GetDtype(), points.GetDevice());
 }
 
 }  // namespace bounding_sphere

--- a/cpp/open3d/t/geometry/kernel/MinimumBS.cpp
+++ b/cpp/open3d/t/geometry/kernel/MinimumBS.cpp
@@ -1,0 +1,325 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// Copyright (c) 2018-2024 www.open3d.org
+// SPDX-License-Identifier: MIT
+// ----------------------------------------------------------------------------
+
+#include "open3d/t/geometry/kernel/MinimumBS.h"
+
+#include <algorithm>
+#include <cmath>
+#include <random>
+
+#include "open3d/core/EigenConverter.h"
+#include "open3d/core/TensorCheck.h"
+#include "open3d/geometry/PointCloud.h"
+#include "open3d/geometry/TriangleMesh.h"
+#include "open3d/t/geometry/BoundingVolume.h"
+#include "open3d/utility/Logging.h"
+
+namespace open3d {
+namespace t {
+namespace geometry {
+namespace kernel {
+namespace bounding_sphere {
+
+namespace {
+
+// Helper struct using Eigen datatypes on the stack for sphere computation
+struct EigenSphere {
+    EigenSphere()
+        : center_(Eigen::Vector3d::Zero()), radius_(0.0), boundary_() {}
+
+    EigenSphere(const Eigen::Vector3d& c, double r)
+        : center_(c), radius_(r), boundary_() {}
+
+    EigenSphere(const Eigen::Vector3d& c, double r,
+                const std::vector<Eigen::Vector3d>& b)
+        : center_(c), radius_(r), boundary_(b) {}
+
+    bool IsInside(const Eigen::Vector3d& point, double eps = 1e-9) const {
+        double dist = (point - center_).norm();
+        return dist <= radius_ + eps;
+    }
+
+    double Volume() const {
+        return 4.0 * M_PI * radius_ * radius_ * radius_ / 3.0;
+    }
+
+    Eigen::Vector3d center_;
+    double radius_;
+    std::vector<Eigen::Vector3d> boundary_;
+};
+
+// Compute circumsphere of 2 points
+EigenSphere ComputeCircumsphere2(const Eigen::Vector3d& p1,
+                                  const Eigen::Vector3d& p2) {
+    Eigen::Vector3d center = (p1 + p2) / 2.0;
+    double radius = (p2 - p1).norm() / 2.0;
+    return EigenSphere(center, radius, std::vector<Eigen::Vector3d>{p1, p2});
+}
+
+// Compute circumsphere of 3 points
+EigenSphere ComputeCircumsphere3(const Eigen::Vector3d& p1,
+                                  const Eigen::Vector3d& p2,
+                                  const Eigen::Vector3d& p3) {
+    // Vectors from p1 to p2 and p1 to p3
+    Eigen::Vector3d v1 = p2 - p1;
+    Eigen::Vector3d v2 = p3 - p1;
+
+    // Compute the circumcenter
+    // Using the formula for circumcenter of a triangle
+    double a = v1.squaredNorm();
+    double b = v2.squaredNorm();
+    double c = v1.dot(v2);
+
+    double denom = 2.0 * (a * b - c * c);
+
+    // Degenerate case: collinear points
+    if (std::abs(denom) < 1e-12) {
+        // Fall back to computing minimum sphere from 2 points
+        Eigen::Vector3d p_far;
+        double max_dist = 0.0;
+        double d12 = (p2 - p1).norm();
+        double d13 = (p3 - p1).norm();
+        double d23 = (p3 - p2).norm();
+
+        if (d12 >= d13 && d12 >= d23) {
+            return ComputeCircumsphere2(p1, p2);
+        } else if (d13 >= d12 && d13 >= d23) {
+            return ComputeCircumsphere2(p1, p3);
+        } else {
+            return ComputeCircumsphere2(p2, p3);
+        }
+    }
+
+    double s = (b - c) / denom;
+    double t = (a - c) / denom;
+
+    Eigen::Vector3d center = p1 + s * v1 + t * v2;
+    double radius = (center - p1).norm();
+
+    return EigenSphere(center, radius, std::vector<Eigen::Vector3d>{p1, p2, p3});
+}
+
+// Compute circumsphere of 4 points (minimal sphere through 4 points)
+EigenSphere ComputeCircumsphere4(const Eigen::Vector3d& p1,
+                                  const Eigen::Vector3d& p2,
+                                  const Eigen::Vector3d& p3,
+                                  const Eigen::Vector3d& p4) {
+    // Solve the linear system to find the circumcenter
+    // |p1.x p1.y p1.z 1| |x|   |p1.x^2 + p1.y^2 + p1.z^2|
+    // |p2.x p2.y p2.z 1| |y| = |p2.x^2 + p2.y^2 + p2.z^2|
+    // |p3.x p3.y p3.z 1| |z|   |p3.x^2 + p3.y^2 + p3.z^2|
+    // |p4.x p4.y p4.z 1| |r|   |p4.x^2 + p4.y^2 + p4.z^2|
+
+    Eigen::Matrix4d A;
+    Eigen::Vector4d b;
+
+    A.row(0) << p1.x(), p1.y(), p1.z(), 1.0;
+    A.row(1) << p2.x(), p2.y(), p2.z(), 1.0;
+    A.row(2) << p3.x(), p3.y(), p3.z(), 1.0;
+    A.row(3) << p4.x(), p4.y(), p4.z(), 1.0;
+
+    b(0) = p1.squaredNorm();
+    b(1) = p2.squaredNorm();
+    b(2) = p3.squaredNorm();
+    b(3) = p4.squaredNorm();
+
+    // Solve Ax = b
+    Eigen::Vector4d x = A.colPivHouseholderQr().solve(b);
+
+    Eigen::Vector3d center(x(0) / 2.0, x(1) / 2.0, x(2) / 2.0);
+    double radius_sq = center.squaredNorm() - x(3) / 2.0;
+    double radius = std::max(0.0, std::sqrt(radius_sq));
+    return EigenSphere(center, radius,
+                       std::vector<Eigen::Vector3d>{p1, p2, p3, p4});
+}
+
+// Recursive implementation of Welzl's algorithm
+EigenSphere WelzlRecursive(
+        std::vector<Eigen::Vector3d>& points,
+        std::vector<Eigen::Vector3d> boundary,
+        size_t n) {
+    // Base cases
+    if (n == 0 || boundary.size() == 4) {
+        if (boundary.empty()) {
+            return EigenSphere(Eigen::Vector3d::Zero(), 0.0, boundary);
+        } else if (boundary.size() == 1) {
+            return EigenSphere(boundary[0], 0.0, boundary);
+        } else if (boundary.size() == 2) {
+            return ComputeCircumsphere2(boundary[0], boundary[1]);
+        } else if (boundary.size() == 3) {
+            return ComputeCircumsphere3(boundary[0], boundary[1], boundary[2]);
+        } else {  // boundary.size() == 4
+            return ComputeCircumsphere4(boundary[0], boundary[1], boundary[2],
+                                       boundary[3]);
+        }
+    }
+
+    // Pick a random point
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+    std::uniform_int_distribution<> dis(0, n - 1);
+    size_t idx = dis(gen);
+
+    Eigen::Vector3d p = points[idx];
+
+    // Swap the selected point to the end and reduce n
+    std::swap(points[idx], points[n - 1]);
+
+    // Recursively compute the minimum sphere for n-1 points
+    EigenSphere sphere = WelzlRecursive(points, boundary, n - 1);
+
+    // If p is inside the sphere, we're done
+    if (sphere.IsInside(p)) {
+        // Swap back
+        std::swap(points[idx], points[n - 1]);
+        return sphere;
+    }
+
+    // Otherwise, p must be on the boundary
+    boundary.push_back(p);
+    sphere = WelzlRecursive(points, boundary, n - 1);
+
+    // Swap back
+    std::swap(points[idx], points[n - 1]);
+
+    return sphere;
+}
+
+// Iterative (non-recursive) implementation of Welzl's algorithm.
+// Uses a randomized shuffle and nested loops to enforce the boundary
+// (points on the sphere) up to size 4.
+EigenSphere WelzlIterative(std::vector<Eigen::Vector3d>& points, size_t n) {
+    if (n == 0) return EigenSphere(Eigen::Vector3d::Zero(), 0.0);
+
+    // Random shuffle the first n points for randomized algorithm
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+    std::shuffle(points.begin(), points.begin() + static_cast<std::ptrdiff_t>(n), gen);
+
+    EigenSphere sphere(Eigen::Vector3d::Zero(), -1.0);
+
+    auto make2 = [](const Eigen::Vector3d& a, const Eigen::Vector3d& b) {
+        return ComputeCircumsphere2(a, b);
+    };
+    auto make3 = [](const Eigen::Vector3d& a, const Eigen::Vector3d& b, const Eigen::Vector3d& c) {
+        return ComputeCircumsphere3(a, b, c);
+    };
+    auto make4 = [](const Eigen::Vector3d& a, const Eigen::Vector3d& b, const Eigen::Vector3d& c, const Eigen::Vector3d& d) {
+        return ComputeCircumsphere4(a, b, c, d);
+    };
+
+    for (size_t i = 0; i < n; ++i) {
+        const Eigen::Vector3d& p_i = points[i];
+
+        if (sphere.radius_ >= 0 && sphere.IsInside(p_i)) continue;
+
+        // Sphere must include p_i. Start with trivial sphere at p_i and record boundary.
+        sphere = EigenSphere(p_i, 0.0, std::vector<Eigen::Vector3d>{p_i});
+
+        for (size_t j = 0; j < i; ++j) {
+            const Eigen::Vector3d& p_j = points[j];
+            if (sphere.IsInside(p_j)) continue;
+
+            // Sphere must include p_j and p_i
+            sphere = make2(p_j, p_i);
+
+            for (size_t k = 0; k < j; ++k) {
+                const Eigen::Vector3d& p_k = points[k];
+                if (sphere.IsInside(p_k)) continue;
+
+                // Sphere must include p_k, p_j, p_i
+                sphere = make3(p_k, p_j, p_i);
+
+                for (size_t l = 0; l < k; ++l) {
+                    const Eigen::Vector3d& p_l = points[l];
+                    if (sphere.IsInside(p_l)) continue;
+
+                    // Sphere must include p_l, p_k, p_j, p_i
+                    sphere = make4(p_l, p_k, p_j, p_i);
+                }
+            }
+        }
+    }
+
+    // If we never set a sphere (shouldn't happen for n>0), fallback
+    if (sphere.radius_ < 0) return EigenSphere(points[0], 0.0, std::vector<Eigen::Vector3d>{points[0]});
+
+    return sphere;
+}
+
+}  // namespace
+
+open3d::geometry::BoundingSphere ComputeMinimumBSWelzl(
+        const std::vector<Eigen::Vector3d>& points, bool robust) {
+    if (points.empty()) {
+        utility::LogError("Input point set is empty.");
+    }
+    if (static_cast<int>(points.size()) < 2) {
+        utility::LogError("Input point set has less than 2 points.");
+    }
+
+    // ------------------------------------------------------------
+    // 0) Compute the convex hull of the input point cloud using legacy API
+    // (Eigen types, CPU). This reduces the input size for Welzl's algorithm.
+    // ------------------------------------------------------------
+    open3d::geometry::PointCloud pcd;
+    pcd.points_ = points;
+    auto [hull_mesh, hull_indices] = pcd.ComputeConvexHull(/*robust=*/robust);
+    if (hull_mesh->vertices_.empty()) {
+        utility::LogWarning("Failed to compute convex hull.");
+        return open3d::geometry::BoundingSphere();
+    }
+
+    // Get convex hull vertices
+    const auto& hull_v = hull_mesh->vertices_;
+    int num_vertices = static_cast<int>(hull_v.size());
+
+    // Handle degenerate planar cases up front.
+    if (num_vertices < 4) {
+        utility::LogWarning("Convex hull is degenerate.");
+        return open3d::geometry::BoundingSphere();
+    }
+
+    // Make a copy for processing (Welzl modifies the array)
+    std::vector<Eigen::Vector3d> pts = hull_v;
+    std::vector<Eigen::Vector3d> boundary;
+
+    // Run Welzl's algorithm on convex hull vertices
+    // EigenSphere es = WelzlRecursive(pts, boundary, pts.size());
+    EigenSphere es = WelzlIterative(pts, pts.size());
+
+    open3d::geometry::BoundingSphere sphere(es.center_, es.radius_);
+    return sphere;
+}
+
+BoundingSphere ComputeMinimumBSWelzl(const core::Tensor& points, bool robust) {
+    core::AssertTensorShape(points, {std::nullopt, 3});
+    core::AssertTensorDtypes(points, {core::Float32, core::Float64});
+    if (points.GetShape(0) < 1) {
+        utility::LogError("Input point set must have at least 1 point.");
+    }
+
+    // Convert tensor → Eigen (Float64, CPU)
+    const std::vector<Eigen::Vector3d> eigen_points =
+            core::eigen_converter::TensorToEigenVector3dVector(
+                    points.To(core::Device("CPU:0"), core::Float64));
+
+    // Run Eigen-native core (returns result in Float64, CPU)
+    open3d::geometry::BoundingSphere legacy_mbs = ComputeMinimumBSWelzl(
+        eigen_points, robust);
+
+    // Convert result back to the caller's dtype and device
+    return open3d::t::geometry::BoundingSphere::FromLegacy(legacy_mbs, 
+        points.GetDtype(), 
+        points.GetDevice());
+}
+
+}  // namespace bounding_sphere
+}  // namespace kernel
+}  // namespace geometry
+}  // namespace t
+}  // namespace open3d

--- a/cpp/open3d/t/geometry/kernel/MinimumBS.cpp
+++ b/cpp/open3d/t/geometry/kernel/MinimumBS.cpp
@@ -29,15 +29,109 @@ namespace bounding_sphere {
 // ============================================================================
 // MINIMUM BOUNDING SPHERE COMPUTATION
 // ============================================================================
-// Algorithm: Welzl's linear-time randomized algorithm for the smallest
-// enclosing sphere. Handles full-rank (3D) and lower-dimensional (coplanar,
-// collinear) point sets through projection and lifting.
 //
-// Key features:
-// - O(n) expected time complexity with linear space usage
-// - Robust handling of degenerate (coplanar/collinear) point sets
-// - Analytic circumsphere formulas for small boundary sets (2-4 points)
-// - Single global shuffle for deterministic recursion
+// Implementation of Welzl's randomized linear-time algorithm for the smallest
+// enclosing sphere in 3D.
+//
+// The implementation explicitly separates:
+//
+//   • Full-rank 3D geometry (true tetrahedral configurations)
+//   • Degenerate lower-dimensional geometry (coplanar / collinear sets)
+//
+// in order to achieve both numerical robustness and efficient geometric solves.
+//
+// Key properties:
+// - Expected O(n) runtime with linear space usage
+// - Robust handling of coplanar and collinear point clouds
+// - Convex hull reduction before Welzl recursion
+// - Single global shuffle for deterministic recursion order
+//
+// ============================================================================
+// ARCHITECTURE
+// ============================================================================
+//
+// The solver uses a deliberate dual-path design:
+//
+// -----------------------------------------------------------------------------
+// PATH 1: Full-Rank 3D Solver (rank == 3)
+// -----------------------------------------------------------------------------
+//
+// If the convex hull spans all 3 spatial dimensions, the algorithm uses
+// specialized analytic circumsphere routines operating directly in R^3:
+//
+//     WelzlRecursive()
+//         -> SphereFromBoundary()
+//             -> ComputeCircumsphere2()
+//             -> ComputeCircumsphere3()
+//             -> ComputeCircumsphere4()
+//
+// These routines use explicit geometric constructions:
+//
+// - 2 points -> midpoint sphere
+// - 3 points -> triangle circumcircle in 3D
+// - 4 points -> tetrahedral circumsphere
+//
+// Advantages:
+// - Fast fixed-size computations
+// - Geometry-aware analytic formulas
+// - Strong numerical behavior for true tetrahedral geometry
+// - Clear geometric interpretation of boundary spheres
+//
+// This path is intentionally optimized for non-degenerate 3D point sets.
+//
+// -----------------------------------------------------------------------------
+// PATH 2: Intrinsic-Dimension Solver (rank < 3)
+// -----------------------------------------------------------------------------
+//
+// Degenerate point clouds are not solved using tetrahedral geometry.
+//
+// Instead:
+//
+//   1. Compute intrinsic rank using SVD
+//   2. Construct an orthonormal basis for the intrinsic subspace
+//   3. Project points into intrinsic coordinates
+//   4. Run generic N-D Welzl recursion:
+//
+//          WelzlNDRecursive()
+//              -> FitCircumsphereND()
+//
+//   5. Lift the center back into R^3
+//
+// This projection-based formulation avoids unstable or ill-defined 3D
+// circumsphere computations for degenerate configurations.
+//
+// Examples:
+//
+// - Collinear 3D points  -> solved as a 1D interval problem
+// - Coplanar 3D points   -> solved as a 2D circumcircle problem
+//
+// -----------------------------------------------------------------------------
+// DESIGN RATIONALE
+// -----------------------------------------------------------------------------
+//
+// The implementation intentionally avoids forcing all configurations through a
+// single generic 3D circumsphere solver.
+//
+// Instead, it combines:
+//
+//   • Specialized analytic 3D geometry for full-rank tetrahedral problems
+//   • Generic intrinsic-dimension solvers for degenerate geometry
+//
+// This hybrid architecture provides:
+//
+// - Stable behavior for nearly degenerate configurations
+// - Efficient exact solves for small 3D boundary sets
+// - Cleaner geometric reasoning
+// - Improved numerical robustness
+//
+// The result is a minimum bounding sphere implementation capable of handling:
+//
+// - General 3D point sets
+// - Coplanar convex hulls
+// - Collinear convex hulls
+// - Nearly degenerate inputs
+//
+// while preserving the expected linear-time behavior of Welzl's algorithm.
 // ============================================================================
 
 namespace {
@@ -304,21 +398,18 @@ EigenSphere ComputeCircumsphere4(
     // Proper tetrahedral circumsphere
     // ------------------------------------------------------------------------
 
-    Eigen::Matrix3d A;
-    A.row(0) = 2.0 * (p2 - p1);
-    A.row(1) = 2.0 * (p3 - p1);
-    A.row(2) = 2.0 * (p4 - p1);
+    // Circumsphere linear system:
+    //     A c = b
+    // where A = 2*(p_i - p_1)
+    Eigen::Matrix3d A = 2.0 * M;
 
     Eigen::Vector3d b;
     b(0) = p2.squaredNorm() - p1.squaredNorm();
     b(1) = p3.squaredNorm() - p1.squaredNorm();
     b(2) = p4.squaredNorm() - p1.squaredNorm();
 
-    Eigen::FullPivLU<Eigen::Matrix3d> lu(A);
-    if (lu.rank() < 3) {
-        return ComputeBestLowerDimensionalSphere(pts);
-    }
-
+    // Find the unique point in 3D that is equidistant from the 
+    // four tetrahedron vertices -> center of the circumsphere.
     Eigen::Vector3d center = A.jacobiSvd(
         Eigen::ComputeFullU | Eigen::ComputeFullV).solve(b);
     double radius = (center - p1).norm();
@@ -380,7 +471,6 @@ EigenSphere SphereFromBoundary(
 // Recursive Welzl
 // IMPORTANT:
 // - shuffle once globally
-// - no per-recursion randomization
 // ----------------------------------------------------------------------------
 
 EigenSphere WelzlRecursive(
@@ -412,99 +502,16 @@ EigenSphere WelzlRecursive(
             n - 1);
 }
 
-// ----------------------------------------------------------------------------
-// Iterative Welzl
-// ----------------------------------------------------------------------------
-
-EigenSphere WelzlIterative(
-        std::vector<Eigen::Vector3d>& points,
-        size_t n) {
-
-    if (n == 0) {
-        return EigenSphere(
-                Eigen::Vector3d::Zero(),
-                0.0);
-    }
-
-    static std::random_device rd;
-    static std::mt19937 gen(rd());
-
-    std::shuffle(
-            points.begin(),
-            points.begin() +
-                static_cast<std::ptrdiff_t>(n),
-            gen);
-
-    EigenSphere sphere(
-            Eigen::Vector3d::Zero(),
-            -1.0);
-
-    for (size_t i = 0; i < n; ++i) {
-
-        const Eigen::Vector3d& pi = points[i];
-
-        if (sphere.radius_ >= 0 &&
-            sphere.IsInside(pi)) {
-            continue;
-        }
-
-        sphere = EigenSphere(
-                pi,
-                0.0,
-                {pi});
-
-        for (size_t j = 0; j < i; ++j) {
-
-            const Eigen::Vector3d& pj = points[j];
-
-            if (sphere.IsInside(pj)) {
-                continue;
-            }
-
-            sphere = ComputeCircumsphere2(pi, pj);
-
-            for (size_t k = 0; k < j; ++k) {
-
-                const Eigen::Vector3d& pk = points[k];
-
-                if (sphere.IsInside(pk)) {
-                    continue;
-                }
-
-                sphere =
-                        ComputeCircumsphere3(
-                                pi,
-                                pj,
-                                pk);
-
-                for (size_t l = 0; l < k; ++l) {
-
-                    const Eigen::Vector3d& pl = points[l];
-
-                    if (sphere.IsInside(pl)) {
-                        continue;
-                    }
-
-                    sphere =
-                            ComputeCircumsphere4(
-                                    pi,
-                                    pj,
-                                    pk,
-                                    pl);
-                }
-            }
-        }
-    }
-
-    return sphere;
-}
 
 // ----------------------------------------------------------------------------
 // Generic N-D Welzl (small helper for projecting degenerate 3D sets)
 // Supports D = 1 or 2 (used when points lie in a lower-dimensional subspace).
 // ----------------------------------------------------------------------------
 
-// Fit circumsphere to <= D+1 points in R^D (D small: 1 or 2).
+// Generic circumsphere fit for <= D+1 points in R^D.
+// Used by the intrinsic-dimension Welzl solver.
+// Typically exercised for D=1 or D=2 degenerate 3D point sets,
+// but mathematically valid for arbitrary small D.
 static std::pair<Eigen::VectorXd, double> FitCircumsphereND(
         const Eigen::MatrixXd &points) {
     const int M = static_cast<int>(points.rows());
@@ -621,7 +628,6 @@ open3d::geometry::BoundingSphere ComputeMinimumBSWelzl(
     // ========================================================================
     // DIMENSIONALITY DETECTION AND DUAL-PATH ROUTING
     // ========================================================================
-    // This section mirrors the Python logic in intrinsic_dimension():
     //   1. Center points at first point (affine origin)
     //   2. Compute SVD to find singular values
     //   3. Count non-zero singular values to determine rank
@@ -645,7 +651,6 @@ open3d::geometry::BoundingSphere ComputeMinimumBSWelzl(
     Eigen::MatrixXd centered = Pmat.rowwise() - offset;
 
     // --- Step 2: Compute intrinsic rank using a shared helper ---
-    // Matches Python's matrix_rank(centered, tol=1e-9).
     Eigen::JacobiSVD<Eigen::MatrixXd> svd(
             centered, Eigen::ComputeThinU | Eigen::ComputeThinV);
     const int rank = ComputeIntrinsicRank(svd.singularValues());
@@ -692,9 +697,9 @@ open3d::geometry::BoundingSphere ComputeMinimumBSWelzl(
     // Run standard 3D Welzl directly
     std::shuffle(pts.begin(), pts.end(), gen);
 
-    EigenSphere es = WelzlRecursive(pts, {}, pts.size());
+    EigenSphere bs = WelzlRecursive(pts, {}, pts.size());
 
-    return open3d::geometry::BoundingSphere(es.center_, es.radius_);
+    return open3d::geometry::BoundingSphere(bs.center_, bs.radius_);
 }
 
 BoundingSphere ComputeMinimumBSWelzl(

--- a/cpp/open3d/t/geometry/kernel/MinimumBS.cpp
+++ b/cpp/open3d/t/geometry/kernel/MinimumBS.cpp
@@ -289,8 +289,8 @@ open3d::geometry::BoundingSphere ComputeMinimumBSWelzl(
     std::vector<Eigen::Vector3d> boundary;
 
     // Run Welzl's algorithm on convex hull vertices
-    // EigenSphere es = WelzlRecursive(pts, boundary, pts.size());
-    EigenSphere es = WelzlIterative(pts, pts.size());
+    EigenSphere es = WelzlRecursive(pts, boundary, pts.size());
+    // EigenSphere es = WelzlIterative(pts, pts.size());
 
     open3d::geometry::BoundingSphere sphere(es.center_, es.radius_);
     return sphere;

--- a/cpp/open3d/t/geometry/kernel/MinimumBS.cpp
+++ b/cpp/open3d/t/geometry/kernel/MinimumBS.cpp
@@ -734,6 +734,204 @@ BoundingSphere ComputeMinimumBSWelzl(
                     points.GetDevice());
 }
 
+
+// // Approximate bounding sphere, based on "An Efficient Bounding Sphere" by Jack Ritter, from "Graphics Gems"
+// Sphere nv::approximateSphere_Ritter(const Vector3 * pointArray, const uint pointCount) {
+//     nvDebugCheck(pointArray != NULL);
+//     nvDebugCheck(pointCount > 0);
+
+//     Vector3 xmin, xmax, ymin, ymax, zmin, zmax;
+
+//     xmin = xmax = ymin = ymax = zmin = zmax = pointArray[0];
+
+//     // FIRST PASS: find 6 minima/maxima points
+//     xmin.x = ymin.y = zmin.z = FLT_MAX;
+//     xmax.x = ymax.y = zmax.z = -FLT_MAX;
+
+//     for (uint i = 0; i < pointCount; i++) {
+//         const Vector3 & p = pointArray[i];
+//         if (p.x < xmin.x) xmin = p;
+//         if (p.x > xmax.x) xmax = p;
+//         if (p.y < ymin.y) ymin = p;
+//         if (p.y > ymax.y) ymax = p;
+//         if (p.z < zmin.z) zmin = p;
+//         if (p.z > zmax.z) zmax = p;
+//     }
+
+//     float xspan = lengthSquared(xmax - xmin);
+//     float yspan = lengthSquared(ymax - ymin);
+//     float zspan = lengthSquared(zmax - zmin);
+
+//     // Set points dia1 & dia2 to the maximally separated pair.
+//     Vector3 dia1 = xmin; 
+//     Vector3 dia2 = xmax;
+//     float maxspan = xspan;
+//     if (yspan > maxspan) {
+//         maxspan = yspan;
+//         dia1 = ymin;
+//         dia2 = ymax;
+//     }
+//     if (zspan > maxspan) {
+//         dia1 = zmin;
+//         dia2 = zmax;
+//     }
+
+//     // |dia1-dia2| is a diameter of initial sphere
+
+//     // calc initial center
+//     Sphere sphere;
+//     sphere.center = (dia1 + dia2) / 2.0f;
+
+//     // calculate initial radius**2 and radius
+//     float rad_sq = lengthSquared(dia2 - sphere.center);
+//     sphere.radius = sqrtf(rad_sq);
+
+
+//     // SECOND PASS: increment current sphere
+//     for (uint i = 0; i < pointCount; i++) {
+//         const Vector3 & p = pointArray[i];
+
+//         float old_to_p_sq = lengthSquared(p - sphere.center);
+
+//         if (old_to_p_sq > rad_sq) {    // do r**2 test first
+            
+//             // this point is outside of current sphere
+//             float old_to_p = sqrtf(old_to_p_sq);
+
+//             // calc radius of new sphere
+//             sphere.radius = (sphere.radius + old_to_p) / 2.0f;
+//             rad_sq = sphere.radius * sphere.radius;     // for next r**2 compare
+            
+//             float old_to_new = old_to_p - sphere.radius;
+
+//             // calc center of new sphere
+//             sphere.center = (sphere.radius * sphere.center + old_to_new * p) / old_to_p;
+//         }
+//     }
+
+//     nvDebugCheck(allInside(sphere, pointArray, pointCount));
+
+//     return sphere;
+// }
+
+EigenSphere RitterBSApproximation(
+        const std::vector<Eigen::Vector3d>& points,
+        size_t n) {
+
+            Eigen::Vector3d xmin, xmax, ymin, ymax, zmin, zmax;
+            xmin = xmax = ymin = ymax = zmin = zmax = points[0];
+
+            // FIRST PASS: find 6 minima/maxima points
+            for (size_t i = 0; i < n; i++) {
+                const Eigen::Vector3d & p = points[i];
+                if (p.x() < xmin.x()) xmin = p;
+                if (p.x() > xmax.x()) xmax = p;
+                if (p.y() < ymin.y()) ymin = p;
+                if (p.y() > ymax.y()) ymax = p;
+                if (p.z() < zmin.z()) zmin = p;
+                if (p.z() > zmax.z()) zmax = p;
+            }
+
+            double x_span_sq = (xmax - xmin).squaredNorm();
+            double y_span_sq = (ymax - ymin).squaredNorm();
+            double z_span_sq = (zmax - zmin).squaredNorm();
+
+            // Set points extreme_point1 & extreme_point2 to 
+            // the maximally separated pair.
+            Eigen::Vector3d extreme_point1 = xmin;
+            Eigen::Vector3d extreme_point2 = xmax;
+            double max_span_sq = x_span_sq;
+            if (y_span_sq > max_span_sq) {
+                max_span_sq = y_span_sq;
+                extreme_point1 = ymin;
+                extreme_point2 = ymax;
+            }
+            if (z_span_sq > max_span_sq) {
+                extreme_point1 = zmin;
+                extreme_point2 = zmax;
+            }
+
+            // Initial sphere from extrema pair
+            Eigen::Vector3d center = 0.5 * (extreme_point1 + extreme_point2);
+            double radius = (extreme_point2 - extreme_point1).norm() / 2.0;
+
+            EigenSphere sphere(center, radius);
+
+            // SECOND PASS: increment current sphere
+            for (size_t i = 0; i < n; i++) {
+                const Eigen::Vector3d & p = points[i];
+                
+                if (!sphere.IsInside(p)) {
+                    
+                    double center_to_point = (p - center).norm();
+
+                    // update radius
+                    radius = 0.5 * (radius + center_to_point);
+
+                    double center_shift = center_to_point - radius;
+                    
+                    // update center
+                    center = (radius * center + center_shift * p) / 
+                                center_to_point;
+                    
+                    // update sphere for next iteration
+                    sphere = EigenSphere(center, radius);
+                }
+
+            }
+
+            return sphere;
+
+}
+
+open3d::geometry::BoundingSphere ComputeApproximateBSRitter(
+        const std::vector<Eigen::Vector3d>& points) {
+
+    if (points.empty()) {
+        utility::LogError(
+                "Input point set is empty.");
+    }
+
+    if (static_cast<int>(points.size()) < 2) {
+        utility::LogError(
+                "Input point set has less than 2 points.");
+    }
+    
+    EigenSphere bs = RitterBSApproximation(points, points.size());
+
+    return open3d::geometry::BoundingSphere(bs.center_, bs.radius_);
+}
+
+BoundingSphere ComputeApproximateBSRitter(
+        const core::Tensor& points) {
+
+    core::AssertTensorShape(points, {std::nullopt, 3});
+
+    core::AssertTensorDtypes(points, {core::Float32, core::Float64});
+
+    if (points.GetShape(0) < 1) {
+        utility::LogError(
+                "Input point set must have at least 1 point.");
+    }
+
+    const std::vector<Eigen::Vector3d> eigen_points =
+            core::eigen_converter::
+                    TensorToEigenVector3dVector(
+                            points.To(
+                                    core::Device("CPU:0"),
+                                    core::Float64));
+
+    open3d::geometry::BoundingSphere sphere =
+            ComputeApproximateBSRitter(
+                    eigen_points);
+
+    return open3d::t::geometry::BoundingSphere::
+            FromLegacy(
+                    sphere,
+                    points.GetDtype(),
+                    points.GetDevice());
+}
+
 }  // namespace bounding_sphere
 }  // namespace kernel
 }  // namespace geometry

--- a/cpp/open3d/t/geometry/kernel/MinimumBS.h
+++ b/cpp/open3d/t/geometry/kernel/MinimumBS.h
@@ -1,0 +1,55 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// Copyright (c) 2018-2024 www.open3d.org
+// SPDX-License-Identifier: MIT
+// ----------------------------------------------------------------------------
+#pragma once
+
+#include <Eigen/Core>
+#include <vector>
+
+#include "open3d/core/Tensor.h"
+#include "open3d/geometry/BoundingVolume.h"
+
+namespace open3d {
+namespace t {
+namespace geometry {
+
+// Forward declaration
+class BoundingSphere;
+
+namespace kernel {
+namespace bounding_sphere {
+
+/// Creates the minimum enclosing sphere of a set of 3D points using Welzl's
+/// algorithm. This algorithm computes the smallest sphere that encloses all
+/// points in the input set. The algorithm is randomized with expected linear
+/// time complexity.
+///
+/// The algorithm works by:
+/// 1. Randomizing the input point order
+/// 2. Recursively computing the minimum sphere
+/// 3. Checking if each point lies inside the current sphere
+/// 4. If not, adding it to the boundary set and recomputing
+///
+/// All computation is in Eigen (Float64) on the CPU.
+///
+/// \param points  A set of 3D points. Each element is a 3D point.
+///                Must contain at least 1 point.
+/// \param robust  Whether to use robust computation for the convex hull.
+/// \return Legacy BoundingSphere with center and radius (Eigen types, Float64).
+open3d::geometry::BoundingSphere ComputeMinimumBSWelzl(
+        const std::vector<Eigen::Vector3d> &points, bool robust);
+
+/// Tensor wrapper: accepts an (N, 3) tensor of any supported float dtype on
+/// any device. Converts to Eigen on the CPU, calls the Eigen core above,
+/// and converts the result back to a tensor BoundingSphere with the *same*
+/// dtype and device as the input points.
+BoundingSphere ComputeMinimumBSWelzl(const core::Tensor &points, bool robust);
+
+}  // namespace bounding_sphere
+}  // namespace kernel
+}  // namespace geometry
+}  // namespace t
+}  // namespace open3d

--- a/cpp/open3d/t/geometry/kernel/MinimumBS.h
+++ b/cpp/open3d/t/geometry/kernel/MinimumBS.h
@@ -48,6 +48,23 @@ open3d::geometry::BoundingSphere ComputeMinimumBSWelzl(
 /// dtype and device as the input points.
 BoundingSphere ComputeMinimumBSWelzl(const core::Tensor &points, bool robust);
 
+/// Creates an approximate minimum bounding sphere using Ritter's algorithm.
+/// This is a fast, non-iterative algorithm that provides a bounding sphere
+/// that encloses all input points.
+///
+/// \param points  A set of 3D points. Each element is a 3D point.
+///                Must contain at least 1 point.
+/// \return Legacy BoundingSphere with center and radius (Eigen types, Float64).
+open3d::geometry::BoundingSphere ComputeApproximateBSRitter(
+        const std::vector<Eigen::Vector3d> &points);
+
+/// Tensor wrapper: accepts an (N, 3) tensor of any supported float dtype on
+/// any device. Converts to Eigen on the CPU, calls the Eigen core above,
+/// and converts the result back to a tensor BoundingSphere with the *same*
+/// dtype and device as the input points.
+BoundingSphere ComputeApproximateBSRitter(
+        const core::Tensor &points);
+
 }  // namespace bounding_sphere
 }  // namespace kernel
 }  // namespace geometry

--- a/cpp/open3d/t/geometry/kernel/MinimumBS.h
+++ b/cpp/open3d/t/geometry/kernel/MinimumBS.h
@@ -62,8 +62,7 @@ open3d::geometry::BoundingSphere ComputeApproximateBSRitter(
 /// any device. Converts to Eigen on the CPU, calls the Eigen core above,
 /// and converts the result back to a tensor BoundingSphere with the *same*
 /// dtype and device as the input points.
-BoundingSphere ComputeApproximateBSRitter(
-        const core::Tensor &points);
+BoundingSphere ComputeApproximateBSRitter(const core::Tensor &points);
 
 }  // namespace bounding_sphere
 }  // namespace kernel

--- a/cpp/open3d/visualization/visualizer/VisualizerWithVertexSelection.cpp
+++ b/cpp/open3d/visualization/visualizer/VisualizerWithVertexSelection.cpp
@@ -116,6 +116,7 @@ bool VisualizerWithVertexSelection::AddGeometry(
         case geometry::Geometry::GeometryType::OrientedBoundingBox:
         case geometry::Geometry::GeometryType::AxisAlignedBoundingBox:
         case geometry::Geometry::GeometryType::OrientedBoundingEllipsoid:
+        case geometry::Geometry::GeometryType::BoundingSphere:
         case geometry::Geometry::GeometryType::Unspecified:
             return false;
     }
@@ -216,6 +217,7 @@ bool VisualizerWithVertexSelection::UpdateGeometry(
         case geometry::Geometry::GeometryType::OrientedBoundingBox:
         case geometry::Geometry::GeometryType::AxisAlignedBoundingBox:
         case geometry::Geometry::GeometryType::OrientedBoundingEllipsoid:
+        case geometry::Geometry::GeometryType::BoundingSphere:
         case geometry::Geometry::GeometryType::Unspecified:
             break;
     }
@@ -789,6 +791,7 @@ VisualizerWithVertexSelection::GetGeometryPoints(
         case geometry::Geometry::GeometryType::OrientedBoundingBox:
         case geometry::Geometry::GeometryType::AxisAlignedBoundingBox:
         case geometry::Geometry::GeometryType::OrientedBoundingEllipsoid:
+        case geometry::Geometry::GeometryType::BoundingSphere:
         case geometry::Geometry::GeometryType::Unspecified:
             points = nullptr;
             break;

--- a/cpp/pybind/geometry/boundingvolume.cpp
+++ b/cpp/pybind/geometry/boundingvolume.cpp
@@ -172,7 +172,6 @@ Example::
 
      import open3d as o3d
 
-     # Compute oriented bounding ellipsoid from a mesh
      mesh_path = o3d.data.MonkeyModel().path
      mesh = o3d.io.read_triangle_mesh(mesh_path)
      mesh.compute_triangle_normals()

--- a/cpp/pybind/geometry/boundingvolume.cpp
+++ b/cpp/pybind/geometry/boundingvolume.cpp
@@ -147,20 +147,26 @@ Example::
                   })
 
             .def_static("create_from_points",
-                         &BoundingSphere::CreateFromPoints, "points"_a,
+                         &BoundingSphere::CreateFromPoints,
+                         "points"_a,
+                         py::kw_only(),
+                         "exact"_a = true,
                          "robust"_a = false,
                          R"doc(
 Creates the bounding sphere that encloses the set of points.
 
-Uses Welzl's algorithm to compute the minimum enclosing sphere.
-
 Args:
      points (open3d.utility.Vector3dVector): Input points.
-     robust (bool): If set to true uses a more robust method which works in
-          degenerate cases but introduces noise to the points coordinates.
+         exact (bool): If true, computes the exact minimum bounding sphere using 
+         Welzl’s algorithm (expected O(n)).  
+         If false, uses Ritter’s algorithm for a faster approximation 
+         (up to ~5% larger than optimal).
+     robust (bool): Only used when `exact=True`.  
+         If set to true uses a more robust method which works in
+         degenerate cases but introduces noise to the points coordinates.
 
 Returns:
-     open3d.geometry.BoundingSphere: The minimum bounding sphere.
+     open3d.geometry.BoundingSphere: The bounding sphere.
 
 Example::
 

--- a/cpp/pybind/geometry/boundingvolume.cpp
+++ b/cpp/pybind/geometry/boundingvolume.cpp
@@ -133,10 +133,10 @@ Example::
      py::detail::bind_default_constructor<BoundingSphere>(bounding_sphere);
      py::detail::bind_copy_functions<BoundingSphere>(bounding_sphere);
      bounding_sphere
-             .def(py::init<const Eigen::Vector3d &, double>(),
+            .def(py::init<const Eigen::Vector3d &, double>(),
                   "Create BoundingSphere from center and radius", "center"_a,
                   "radius"_a)
-             .def("__repr__",
+            .def("__repr__",
                   [](const BoundingSphere &sphere) {
                       std::stringstream s;
                       auto c = sphere.center_;
@@ -146,60 +146,60 @@ Example::
                       return s.str();
                   })
 
-                 .def_static("create_from_points",
-                             &BoundingSphere::CreateFromPoints, "points"_a,
-                             "robust"_a = false,
-                             R"doc(
-     Creates the bounding sphere that encloses the set of points.
+            .def_static("create_from_points",
+                         &BoundingSphere::CreateFromPoints, "points"_a,
+                         "robust"_a = false,
+                         R"doc(
+Creates the bounding sphere that encloses the set of points.
 
-     Uses Welzl's algorithm to compute the minimum enclosing sphere.
+Uses Welzl's algorithm to compute the minimum enclosing sphere.
 
-     Args:
-          points (open3d.utility.Vector3dVector): Input points.
-          robust (bool): If set to true uses a more robust method which works in
-               degenerate cases but introduces noise to the points coordinates.
+Args:
+     points (open3d.utility.Vector3dVector): Input points.
+     robust (bool): If set to true uses a more robust method which works in
+          degenerate cases but introduces noise to the points coordinates.
 
-     Returns:
-          open3d.geometry.BoundingSphere: The minimum bounding sphere.
+Returns:
+     open3d.geometry.BoundingSphere: The minimum bounding sphere.
 
-     Example::
+Example::
 
-         import open3d as o3d
+     import open3d as o3d
 
-         # Compute oriented bounding ellipsoid from a mesh
-         mesh_path = o3d.data.MonkeyModel().path
-         mesh = o3d.io.read_triangle_mesh(mesh_path)
-         mesh.compute_triangle_normals()
-         sphere = mesh.get_bounding_sphere()
-         print(f"Volume: {sphere.volume()}")
-         sphere.color = (0, 0.44, 0.77)
+     # Compute oriented bounding ellipsoid from a mesh
+     mesh_path = o3d.data.MonkeyModel().path
+     mesh = o3d.io.read_triangle_mesh(mesh_path)
+     mesh.compute_triangle_normals()
+     sphere = mesh.get_bounding_sphere()
+     print(f"Volume: {sphere.volume()}")
+     sphere.color = (0, 0.44, 0.77)
     
-    # Option 1: wireframe visualization via LineSet
-    sphere_lines = o3d.geometry.LineSet.create_from_bounding_sphere(sphere)
-    o3d.visualization.draw([mesh, sphere_lines])
+     # Option 1: wireframe visualization via LineSet
+     sphere_lines = o3d.geometry.LineSet.create_from_bounding_sphere(sphere)
+     o3d.visualization.draw([mesh, sphere_lines])
     
-    # Option 2: solid sphere mesh
-    sphere_mesh = o3d.geometry.TriangleMesh.create_from_bounding_sphere(sphere)
-    o3d.visualization.draw([mesh, sphere_mesh])
-     )doc")
-                 .def("volume", &BoundingSphere::Volume,
-                      "Returns the volume of the bounding sphere.")
-                 .def("get_sphere_points", &BoundingSphere::GetSpherePoints,
-                      "Returns six critical points on the surface of the sphere.")
-                 .def("get_point_indices_within_bounding_sphere",
-                      &BoundingSphere::GetPointIndicesWithinBoundingSphere,
-                      "Return indices to points that are within the bounding sphere.",
-                      "points"_a)
-                 .def_readwrite("center", &BoundingSphere::center_,
-                                "``float64`` array of shape ``(3, )``")
-                 .def_readwrite("radius", &BoundingSphere::radius_,
-                                "float64: radius of the bounding sphere")
-                 .def_readwrite("color", &BoundingSphere::color_,
-                                "``float64`` array of shape ``(3, )``");
-         docstring::ClassMethodDocInject(m, "BoundingSphere", "volume");
-         docstring::ClassMethodDocInject(m, "BoundingSphere",
-                                         "get_point_indices_within_bounding_sphere",
-                                         {{"points", "A list of points."}});
+     # Option 2: solid sphere mesh
+     sphere_mesh = o3d.geometry.TriangleMesh.create_from_bounding_sphere(sphere)
+     o3d.visualization.draw([mesh, sphere_mesh])
+)doc")
+               .def("volume", &BoundingSphere::Volume,
+                    "Returns the volume of the bounding sphere.")
+               .def("get_sphere_points", &BoundingSphere::GetSpherePoints,
+                    "Returns six critical points on the surface of the sphere.")
+               .def("get_point_indices_within_bounding_sphere",
+                    &BoundingSphere::GetPointIndicesWithinBoundingSphere,
+                    "Return indices to points that are within the bounding sphere.",
+                    "points"_a)
+               .def_readwrite("center", &BoundingSphere::center_,
+                              "``float64`` array of shape ``(3, )``")
+               .def_readwrite("radius", &BoundingSphere::radius_,
+                              "float64: radius of the bounding sphere")
+               .def_readwrite("color", &BoundingSphere::color_,
+                              "``float64`` array of shape ``(3, )``");
+     docstring::ClassMethodDocInject(m, "BoundingSphere", "volume");
+     docstring::ClassMethodDocInject(m, "BoundingSphere",
+                                        "get_point_indices_within_bounding_sphere",
+                                        {{"points", "A list of points."}});
 
     
     auto oriented_bounding_box = static_cast<

--- a/cpp/pybind/geometry/boundingvolume.cpp
+++ b/cpp/pybind/geometry/boundingvolume.cpp
@@ -37,6 +37,14 @@ void pybind_boundingvolume_declarations(py::module &m) {
                     m, "OrientedBoundingEllipsoid",
                     "Class that defines an oriented ellipsoid that can "
                     "be computed from 3D geometries.");
+     
+    py::class_<BoundingSphere, 
+               PyGeometry3D<BoundingSphere>,
+               std::shared_ptr<BoundingSphere>, Geometry3D>
+            bounding_sphere(
+                    m, "BoundingSphere",
+                    "Class that defines a bounding sphere that can "
+                    "be computed from 3D geometries.");
 }
 void pybind_boundingvolume_definitions(py::module &m) {
     auto oriented_bounding_ellipsoid = static_cast<py::class_<
@@ -118,6 +126,82 @@ Example::
                            "``float64`` array of shape ``(3, )``");
     docstring::ClassMethodDocInject(m, "OrientedBoundingEllipsoid", "volume");
 
+    auto bounding_sphere = static_cast<
+            py::class_<BoundingSphere, PyGeometry3D<BoundingSphere>,
+                       std::shared_ptr<BoundingSphere>, Geometry3D>>(
+            m.attr("BoundingSphere"));
+     py::detail::bind_default_constructor<BoundingSphere>(bounding_sphere);
+     py::detail::bind_copy_functions<BoundingSphere>(bounding_sphere);
+     bounding_sphere
+             .def(py::init<const Eigen::Vector3d &, double>(),
+                  "Create BoundingSphere from center and radius", "center"_a,
+                  "radius"_a)
+             .def("__repr__",
+                  [](const BoundingSphere &sphere) {
+                      std::stringstream s;
+                      auto c = sphere.center_;
+                      auto r = sphere.radius_;
+                      s << "BoundingSphere: center: (" << c.x() << ", "
+                        << c.y() << ", " << c.z() << "), radius: " << r;
+                      return s.str();
+                  })
+
+                 .def_static("create_from_points",
+                             &BoundingSphere::CreateFromPoints, "points"_a,
+                             "robust"_a = false,
+                             R"doc(
+     Creates the bounding sphere that encloses the set of points.
+
+     Uses Welzl's algorithm to compute the minimum enclosing sphere.
+
+     Args:
+          points (open3d.utility.Vector3dVector): Input points.
+          robust (bool): If set to true uses a more robust method which works in
+               degenerate cases but introduces noise to the points coordinates.
+
+     Returns:
+          open3d.geometry.BoundingSphere: The minimum bounding sphere.
+
+     Example::
+
+         import open3d as o3d
+
+         # Compute oriented bounding ellipsoid from a mesh
+         mesh_path = o3d.data.MonkeyModel().path
+         mesh = o3d.io.read_triangle_mesh(mesh_path)
+         mesh.compute_triangle_normals()
+         sphere = mesh.get_bounding_sphere()
+         print(f"Volume: {sphere.volume()}")
+         sphere.color = (0, 0.44, 0.77)
+    
+    # Option 1: wireframe visualization via LineSet
+    sphere_lines = o3d.geometry.LineSet.create_from_bounding_sphere(sphere)
+    o3d.visualization.draw([mesh, sphere_lines])
+    
+    # Option 2: solid sphere mesh
+    sphere_mesh = o3d.geometry.TriangleMesh.create_from_bounding_sphere(sphere)
+    o3d.visualization.draw([mesh, sphere_mesh])
+     )doc")
+                 .def("volume", &BoundingSphere::Volume,
+                      "Returns the volume of the bounding sphere.")
+                 .def("get_sphere_points", &BoundingSphere::GetSpherePoints,
+                      "Returns six critical points on the surface of the sphere.")
+                 .def("get_point_indices_within_bounding_sphere",
+                      &BoundingSphere::GetPointIndicesWithinBoundingSphere,
+                      "Return indices to points that are within the bounding sphere.",
+                      "points"_a)
+                 .def_readwrite("center", &BoundingSphere::center_,
+                                "``float64`` array of shape ``(3, )``")
+                 .def_readwrite("radius", &BoundingSphere::radius_,
+                                "float64: radius of the bounding sphere")
+                 .def_readwrite("color", &BoundingSphere::color_,
+                                "``float64`` array of shape ``(3, )``");
+         docstring::ClassMethodDocInject(m, "BoundingSphere", "volume");
+         docstring::ClassMethodDocInject(m, "BoundingSphere",
+                                         "get_point_indices_within_bounding_sphere",
+                                         {{"points", "A list of points."}});
+
+    
     auto oriented_bounding_box = static_cast<
             py::class_<OrientedBoundingBox, PyGeometry3D<OrientedBoundingBox>,
                        std::shared_ptr<OrientedBoundingBox>, Geometry3D>>(

--- a/cpp/pybind/geometry/boundingvolume.cpp
+++ b/cpp/pybind/geometry/boundingvolume.cpp
@@ -37,14 +37,12 @@ void pybind_boundingvolume_declarations(py::module &m) {
                     m, "OrientedBoundingEllipsoid",
                     "Class that defines an oriented ellipsoid that can "
                     "be computed from 3D geometries.");
-     
-    py::class_<BoundingSphere, 
-               PyGeometry3D<BoundingSphere>,
+
+    py::class_<BoundingSphere, PyGeometry3D<BoundingSphere>,
                std::shared_ptr<BoundingSphere>, Geometry3D>
-            bounding_sphere(
-                    m, "BoundingSphere",
-                    "Class that defines a bounding sphere that can "
-                    "be computed from 3D geometries.");
+            bounding_sphere(m, "BoundingSphere",
+                            "Class that defines a bounding sphere that can "
+                            "be computed from 3D geometries.");
 }
 void pybind_boundingvolume_definitions(py::module &m) {
     auto oriented_bounding_ellipsoid = static_cast<py::class_<
@@ -130,29 +128,26 @@ Example::
             py::class_<BoundingSphere, PyGeometry3D<BoundingSphere>,
                        std::shared_ptr<BoundingSphere>, Geometry3D>>(
             m.attr("BoundingSphere"));
-     py::detail::bind_default_constructor<BoundingSphere>(bounding_sphere);
-     py::detail::bind_copy_functions<BoundingSphere>(bounding_sphere);
-     bounding_sphere
+    py::detail::bind_default_constructor<BoundingSphere>(bounding_sphere);
+    py::detail::bind_copy_functions<BoundingSphere>(bounding_sphere);
+    bounding_sphere
             .def(py::init<const Eigen::Vector3d &, double>(),
-                  "Create BoundingSphere from center and radius", "center"_a,
-                  "radius"_a)
+                 "Create BoundingSphere from center and radius", "center"_a,
+                 "radius"_a)
             .def("__repr__",
-                  [](const BoundingSphere &sphere) {
-                      std::stringstream s;
-                      auto c = sphere.center_;
-                      auto r = sphere.radius_;
-                      s << "BoundingSphere: center: (" << c.x() << ", "
-                        << c.y() << ", " << c.z() << "), radius: " << r;
-                      return s.str();
-                  })
+                 [](const BoundingSphere &sphere) {
+                     std::stringstream s;
+                     auto c = sphere.center_;
+                     auto r = sphere.radius_;
+                     s << "BoundingSphere: center: (" << c.x() << ", " << c.y()
+                       << ", " << c.z() << "), radius: " << r;
+                     return s.str();
+                 })
 
-            .def_static("create_from_points",
-                         &BoundingSphere::CreateFromPoints,
-                         "points"_a,
-                         py::kw_only(),
-                         "exact"_a = true,
-                         "robust"_a = false,
-                         R"doc(
+            .def_static("create_from_points", &BoundingSphere::CreateFromPoints,
+                        "points"_a, py::kw_only(), "exact"_a = true,
+                        "robust"_a = false,
+                        R"doc(
 Creates the bounding sphere that encloses the set of points.
 
 Args:
@@ -187,26 +182,26 @@ Example::
      sphere_mesh = o3d.geometry.TriangleMesh.create_from_bounding_sphere(sphere)
      o3d.visualization.draw([mesh, sphere_mesh])
 )doc")
-               .def("volume", &BoundingSphere::Volume,
-                    "Returns the volume of the bounding sphere.")
-               .def("get_sphere_points", &BoundingSphere::GetSpherePoints,
-                    "Returns six critical points on the surface of the sphere.")
-               .def("get_point_indices_within_bounding_sphere",
-                    &BoundingSphere::GetPointIndicesWithinBoundingSphere,
-                    "Return indices to points that are within the bounding sphere.",
-                    "points"_a)
-               .def_readwrite("center", &BoundingSphere::center_,
-                              "``float64`` array of shape ``(3, )``")
-               .def_readwrite("radius", &BoundingSphere::radius_,
-                              "float64: radius of the bounding sphere")
-               .def_readwrite("color", &BoundingSphere::color_,
-                              "``float64`` array of shape ``(3, )``");
-     docstring::ClassMethodDocInject(m, "BoundingSphere", "volume");
-     docstring::ClassMethodDocInject(m, "BoundingSphere",
-                                        "get_point_indices_within_bounding_sphere",
-                                        {{"points", "A list of points."}});
+            .def("volume", &BoundingSphere::Volume,
+                 "Returns the volume of the bounding sphere.")
+            .def("get_sphere_points", &BoundingSphere::GetSpherePoints,
+                 "Returns six critical points on the surface of the sphere.")
+            .def("get_point_indices_within_bounding_sphere",
+                 &BoundingSphere::GetPointIndicesWithinBoundingSphere,
+                 "Return indices to points that are within the bounding "
+                 "sphere.",
+                 "points"_a)
+            .def_readwrite("center", &BoundingSphere::center_,
+                           "``float64`` array of shape ``(3, )``")
+            .def_readwrite("radius", &BoundingSphere::radius_,
+                           "float64: radius of the bounding sphere")
+            .def_readwrite("color", &BoundingSphere::color_,
+                           "``float64`` array of shape ``(3, )``");
+    docstring::ClassMethodDocInject(m, "BoundingSphere", "volume");
+    docstring::ClassMethodDocInject(m, "BoundingSphere",
+                                    "get_point_indices_within_bounding_sphere",
+                                    {{"points", "A list of points."}});
 
-    
     auto oriented_bounding_box = static_cast<
             py::class_<OrientedBoundingBox, PyGeometry3D<OrientedBoundingBox>,
                        std::shared_ptr<OrientedBoundingBox>, Geometry3D>>(

--- a/cpp/pybind/geometry/lineset.cpp
+++ b/cpp/pybind/geometry/lineset.cpp
@@ -139,7 +139,7 @@ void pybind_lineset_definitions(py::module &m) {
             m, "LineSet", "create_from_oriented_bounding_ellipsoid",
             {{"ellipsoid", "The input bounding ellipsoid."}});
     docstring::ClassMethodDocInject(m, "LineSet", "create_from_bounding_sphere",
-                                   {{"sphere", "The input bounding sphere."}});
+                                    {{"sphere", "The input bounding sphere."}});
     docstring::ClassMethodDocInject(m, "LineSet", "create_from_triangle_mesh",
                                     {{"mesh", "The input triangle mesh."}});
     docstring::ClassMethodDocInject(m, "LineSet", "create_from_tetra_mesh",

--- a/cpp/pybind/geometry/lineset.cpp
+++ b/cpp/pybind/geometry/lineset.cpp
@@ -68,6 +68,11 @@ void pybind_lineset_definitions(py::module &m) {
                         "Factory function to create a LineSet from an "
                         "OrientedBoundingEllipsoid.",
                         "ellipsoid"_a)
+            .def_static("create_from_bounding_sphere",
+                        &LineSet::CreateFromBoundingSphere,
+                        "Factory function to create a LineSet from a "
+                        "BoundingSphere.",
+                        "sphere"_a)
             .def_static("create_from_axis_aligned_bounding_box",
                         &LineSet::CreateFromAxisAlignedBoundingBox,
                         "Factory function to create a LineSet from an "
@@ -133,6 +138,8 @@ void pybind_lineset_definitions(py::module &m) {
     docstring::ClassMethodDocInject(
             m, "LineSet", "create_from_oriented_bounding_ellipsoid",
             {{"ellipsoid", "The input bounding ellipsoid."}});
+    docstring::ClassMethodDocInject(m, "LineSet", "create_from_bounding_sphere",
+                                   {{"sphere", "The input bounding sphere."}});
     docstring::ClassMethodDocInject(m, "LineSet", "create_from_triangle_mesh",
                                     {{"mesh", "The input triangle mesh."}});
     docstring::ClassMethodDocInject(m, "LineSet", "create_from_tetra_mesh",

--- a/cpp/pybind/geometry/meshbase.cpp
+++ b/cpp/pybind/geometry/meshbase.cpp
@@ -98,6 +98,19 @@ Args:
 
 Returns:
     open3d.geometry.OrientedBoundingEllipsoid)")
+
+            .def("get_bounding_sphere",
+                 &MeshBase::GetBoundingSphere, "robust"_a = false,
+                 R"(Compute the minimum volume bounding sphere that
+encloses the mesh vertices using welzl's algorithm.
+
+Args:
+    robust (bool): If set to true uses a more robust method which works in
+        degenerate cases but introduces noise to the points coordinates.
+
+Returns:
+    open3d.geometry.BoundingSphere)")
+
             .def_readwrite("vertices", &MeshBase::vertices_,
                            "``float64`` array of shape ``(num_vertices, 3)``, "
                            "use ``numpy.asarray()`` to access data: Vertex "

--- a/cpp/pybind/geometry/meshbase.cpp
+++ b/cpp/pybind/geometry/meshbase.cpp
@@ -99,11 +99,8 @@ Args:
 Returns:
     open3d.geometry.OrientedBoundingEllipsoid)")
 
-            .def("get_bounding_sphere",
-                 &MeshBase::GetBoundingSphere, 
-                 py::kw_only(),
-                 "exact"_a = true,
-                 "robust"_a = false,
+            .def("get_bounding_sphere", &MeshBase::GetBoundingSphere,
+                 py::kw_only(), "exact"_a = true, "robust"_a = false,
                  R"(Compute the minimum volume bounding sphere that
 encloses the mesh vertices using Welzl's algorithm.
 

--- a/cpp/pybind/geometry/meshbase.cpp
+++ b/cpp/pybind/geometry/meshbase.cpp
@@ -100,12 +100,20 @@ Returns:
     open3d.geometry.OrientedBoundingEllipsoid)")
 
             .def("get_bounding_sphere",
-                 &MeshBase::GetBoundingSphere, "robust"_a = false,
+                 &MeshBase::GetBoundingSphere, 
+                 py::kw_only(),
+                 "exact"_a = true,
+                 "robust"_a = false,
                  R"(Compute the minimum volume bounding sphere that
 encloses the mesh vertices using Welzl's algorithm.
 
 Args:
-    robust (bool): If set to true uses a more robust method which works in
+    exact (bool): If true, computes the exact minimum bounding sphere using 
+        Welzl’s algorithm (expected O(n)).  
+        If false, uses Ritter’s algorithm for a faster approximation 
+        (up to ~5% larger than optimal).
+    robust (bool): Only used when `exact=True`.  
+        If set to true uses a more robust method which works in
         degenerate cases but introduces noise to the points coordinates.
 
 Returns:

--- a/cpp/pybind/geometry/meshbase.cpp
+++ b/cpp/pybind/geometry/meshbase.cpp
@@ -102,7 +102,7 @@ Returns:
             .def("get_bounding_sphere",
                  &MeshBase::GetBoundingSphere, "robust"_a = false,
                  R"(Compute the minimum volume bounding sphere that
-encloses the mesh vertices using welzl's algorithm.
+encloses the mesh vertices using Welzl's algorithm.
 
 Args:
     robust (bool): If set to true uses a more robust method which works in

--- a/cpp/pybind/geometry/pointcloud.cpp
+++ b/cpp/pybind/geometry/pointcloud.cpp
@@ -122,7 +122,7 @@ Returns:
             .def("get_bounding_sphere",
                  &PointCloud::GetBoundingSphere, "robust"_a = false,
                  R"(Compute the minimum volume bounding sphere that
-encloses the point cloud using welzl's algorithm.
+encloses the point cloud using Welzl's algorithm.
 
 Args:
     robust (bool): If set to true uses a more robust method which works in

--- a/cpp/pybind/geometry/pointcloud.cpp
+++ b/cpp/pybind/geometry/pointcloud.cpp
@@ -120,12 +120,20 @@ Args:
 Returns:
     open3d.geometry.OrientedBoundingEllipsoid)")
             .def("get_bounding_sphere",
-                 &PointCloud::GetBoundingSphere, "robust"_a = false,
+                 &PointCloud::GetBoundingSphere,
+                 py::kw_only(),
+                 "exact"_a = true,
+                 "robust"_a = false,
                  R"(Compute the minimum volume bounding sphere that
 encloses the point cloud using Welzl's algorithm.
 
 Args:
-    robust (bool): If set to true uses a more robust method which works in
+    exact (bool): If true, computes the exact minimum bounding sphere using 
+        Welzl’s algorithm (expected O(n)).  
+        If false, uses Ritter’s algorithm for a faster approximation 
+        (up to ~5% larger than optimal).
+    robust (bool): Only used when `exact=True`.  
+        If set to true uses a more robust method which works in
         degenerate cases but introduces noise to the points coordinates.
 
 Returns:

--- a/cpp/pybind/geometry/pointcloud.cpp
+++ b/cpp/pybind/geometry/pointcloud.cpp
@@ -119,6 +119,17 @@ Args:
 
 Returns:
     open3d.geometry.OrientedBoundingEllipsoid)")
+            .def("get_bounding_sphere",
+                 &PointCloud::GetBoundingSphere, "robust"_a = false,
+                 R"(Compute the minimum volume bounding sphere that
+encloses the point cloud using welzl's algorithm.
+
+Args:
+    robust (bool): If set to true uses a more robust method which works in
+        degenerate cases but introduces noise to the points coordinates.
+
+Returns:
+    open3d.geometry.BoundingSphere)")
             .def("remove_non_finite_points", &PointCloud::RemoveNonFinitePoints,
                  "Removes all points from the point cloud that have a nan "
                  "entry, or infinite entries. It also removes the "

--- a/cpp/pybind/geometry/pointcloud.cpp
+++ b/cpp/pybind/geometry/pointcloud.cpp
@@ -119,11 +119,8 @@ Args:
 
 Returns:
     open3d.geometry.OrientedBoundingEllipsoid)")
-            .def("get_bounding_sphere",
-                 &PointCloud::GetBoundingSphere,
-                 py::kw_only(),
-                 "exact"_a = true,
-                 "robust"_a = false,
+            .def("get_bounding_sphere", &PointCloud::GetBoundingSphere,
+                 py::kw_only(), "exact"_a = true, "robust"_a = false,
                  R"(Compute the minimum volume bounding sphere that
 encloses the point cloud using Welzl's algorithm.
 

--- a/cpp/pybind/geometry/trianglemesh.cpp
+++ b/cpp/pybind/geometry/trianglemesh.cpp
@@ -366,8 +366,8 @@ void pybind_trianglemesh_definitions(py::module &m) {
             .def_static("create_from_bounding_sphere",
                         &TriangleMesh::CreateFromBoundingSphere,
                         "Factory function to create a solid bounding sphere.",
-                        "bsphere"_a, "scale"_a = Eigen::Vector3d::Ones(),
-                        "resolution"_a = 20, "create_uv_map"_a = false)
+                        "sphere"_a, "resolution"_a = 20,
+                        "create_uv_map"_a = false)
             .def_static("create_box", &TriangleMesh::CreateBox,
                         "Factory function to create a box. The left bottom "
                         "corner on the "

--- a/cpp/pybind/geometry/trianglemesh.cpp
+++ b/cpp/pybind/geometry/trianglemesh.cpp
@@ -363,6 +363,11 @@ void pybind_trianglemesh_definitions(py::module &m) {
                         "ellipsoid.",
                         "obel"_a, "scale"_a = Eigen::Vector3d::Ones(),
                         "resolution"_a = 20, "create_uv_map"_a = false)
+            .def_static("create_from_bounding_sphere",
+                        &TriangleMesh::CreateFromBoundingSphere,
+                        "Factory function to create a solid bounding sphere.",
+                        "bsphere"_a, "scale"_a = Eigen::Vector3d::Ones(),
+                        "resolution"_a = 20, "create_uv_map"_a = false)
             .def_static("create_box", &TriangleMesh::CreateBox,
                         "Factory function to create a box. The left bottom "
                         "corner on the "

--- a/cpp/pybind/t/geometry/boundingvolume.cpp
+++ b/cpp/pybind/t/geometry/boundingvolume.cpp
@@ -695,7 +695,9 @@ must be on the same device and have the same data type.)");
 
 Args:
     points (open3d.core.Tensor): A list of points with data type of float32 or
-        float64 (N x 3 tensor, where N must be at least 1).
+        float64 (N x 3 tensor, where N must be larger than 3).
+    robust (bool): If set to true uses a more robust method which works in
+        degenerate cases but introduces noise to the points coordinates.
 
 Returns:
     BoundingSphere with same data type and device as input points.
@@ -759,7 +761,9 @@ Example::
             m, "BoundingSphere", "create_from_points",
             {{"points",
               "A list of points with data type of float32 or float64 (N x 3 "
-              "tensor, where N must be at least 1)."}});
+              "tensor, where N must be larger than 3)."},
+             {"robust", "If set to true uses a more robust method which works in "
+                        "degenerate cases but introduces noise to the points coordinates."}});
 }
 
 }  // namespace geometry

--- a/cpp/pybind/t/geometry/boundingvolume.cpp
+++ b/cpp/pybind/t/geometry/boundingvolume.cpp
@@ -51,9 +51,8 @@ arbitrary frame of reference with the properties:
   a data type ``open3d.core.float32`` (default) or ``open3d.core.float64``.
   Values can only be in the range [0.0, 1.0].)");
 
-     py::class_<BoundingSphere, PyGeometry<BoundingSphere>, 
-     std::shared_ptr<BoundingSphere>,
-                Geometry>
+    py::class_<BoundingSphere, PyGeometry<BoundingSphere>,
+               std::shared_ptr<BoundingSphere>, Geometry>
             bs(m, "BoundingSphere",
                R"(A bounding sphere defined by a center point and a radius 
                with the properties:
@@ -605,18 +604,17 @@ Example::
         o3d.visualization.draw([pcd, ellipsoid_mesh])
 )",
             "points"_a, "robust"_a = false);
-    
+
     // BoundingSphere
-    auto bs = static_cast<py::class_<
-            BoundingSphere, PyGeometry<BoundingSphere>,
-            std::shared_ptr<BoundingSphere>, Geometry>>(
-            m.attr("BoundingSphere"));
-    bs.def(py::init<const core::Device&>(),
-                        "device"_a = core::Device("CPU:0"),
-                        "Construct an empty BoundingSphere on the provided device.");
-    bs.def(py::init<const core::Tensor&, const core::Tensor&>(),
-                        "center"_a, "radius"_a,
-                        R"(Construct a BoundingSphere from center and radius.
+    auto bs =
+            static_cast<py::class_<BoundingSphere, PyGeometry<BoundingSphere>,
+                                   std::shared_ptr<BoundingSphere>, Geometry>>(
+                    m.attr("BoundingSphere"));
+    bs.def(py::init<const core::Device&>(), "device"_a = core::Device("CPU:0"),
+           "Construct an empty BoundingSphere on the provided device.");
+    bs.def(py::init<const core::Tensor&, const core::Tensor&>(), "center"_a,
+           "radius"_a,
+           R"(Construct a BoundingSphere from center and radius.
 The BoundingSphere will be created on the device of the given tensors, which
 must be on the same device and have the same data type.)");
     docstring::ClassMethodDocInject(
@@ -631,12 +629,12 @@ must be on the same device and have the same data type.)");
     bs.def("__repr__", &BoundingSphere::ToString);
 
     bs.def("to", &BoundingSphere::To,
-                        "Transfer the bounding sphere to a specified device and "
-                        "data type.",
-                        "device"_a, "dtype"_a, "copy"_a = false);
+           "Transfer the bounding sphere to a specified device and "
+           "data type.",
+           "device"_a, "dtype"_a, "copy"_a = false);
     bs.def("clone", &BoundingSphere::Clone,
-                        "Returns a copy of the bounding sphere on the same "
-                        "device.");
+           "Returns a copy of the bounding sphere on the same "
+           "device.");
     bs.def(
             "cpu",
             [](const BoundingSphere& bs) {
@@ -652,62 +650,55 @@ must be on the same device and have the same data type.)");
             "device_id"_a = 0);
 
     bs.def("set_center", &BoundingSphere::SetCenter, "center"_a,
-                        "Set the center of the bounding sphere.");
+           "Set the center of the bounding sphere.");
     bs.def("set_radius", &BoundingSphere::SetRadius, "radius"_a,
-                        "Set the radius of the bounding sphere.");
+           "Set the radius of the bounding sphere.");
     bs.def("set_color", &BoundingSphere::SetColor, "color"_a,
-                        "Set the color of the bounding sphere.");
+           "Set the color of the bounding sphere.");
 
-    bs.def_property_readonly("center",
-                                          &BoundingSphere::GetCenter,
-                                          "Center of the bounding sphere.");
+    bs.def_property_readonly("center", &BoundingSphere::GetCenter,
+                             "Center of the bounding sphere.");
     bs.def_property_readonly("radius", &BoundingSphere::GetRadius,
-                                          "Radius of the bounding sphere.");
+                             "Radius of the bounding sphere.");
     bs.def_property_readonly("color", &BoundingSphere::GetColor,
-                                          "Color of the bounding sphere.");
+                             "Color of the bounding sphere.");
 
     bs.def("translate", &BoundingSphere::Translate,
-                        "Translate the bounding sphere.", "translation"_a,
-                        "relative"_a = true);
-    bs.def("rotate", &BoundingSphere::Rotate,
-                        "Rotate the bounding sphere.", "rotation"_a,
-                        "center"_a = std::nullopt);
-    bs.def("scale", &BoundingSphere::Scale,
-                        "Scale the bounding sphere.", "scale"_a,
-                        "center"_a = std::nullopt);
+           "Translate the bounding sphere.", "translation"_a,
+           "relative"_a = true);
+    bs.def("rotate", &BoundingSphere::Rotate, "Rotate the bounding sphere.",
+           "rotation"_a, "center"_a = std::nullopt);
+    bs.def("scale", &BoundingSphere::Scale, "Scale the bounding sphere.",
+           "scale"_a, "center"_a = std::nullopt);
 
     bs.def("volume", &BoundingSphere::Volume,
-                        "Returns the volume of the bounding sphere.");
+           "Returns the volume of the bounding sphere.");
     bs.def("get_sphere_points", &BoundingSphere::GetSpherePoints,
-                        "Returns the six critical points of the bounding sphere. "
-                        "Return tensor has shape {6, 3}.");
+           "Returns the six critical points of the bounding sphere. "
+           "Return tensor has shape {6, 3}.");
     bs.def("get_point_indices_within_bounding_sphere",
-                        &BoundingSphere::GetPointIndicesWithinBoundingSphere,
-                        "Indices to points that are within the bounding sphere.",
-                        "points"_a);
+           &BoundingSphere::GetPointIndicesWithinBoundingSphere,
+           "Indices to points that are within the bounding sphere.",
+           "points"_a);
     bs.def("get_axis_aligned_bounding_box",
-                        &BoundingSphere::GetAxisAlignedBoundingBox,
-                        "Returns the axis-aligned bounding box that contains this "
-                        "sphere.");
-    bs.def("get_oriented_bounding_box",
-                        &BoundingSphere::GetOrientedBoundingBox,
-                        "Returns an oriented bounding box around the sphere.",
-                        "robust"_a = false);
+           &BoundingSphere::GetAxisAlignedBoundingBox,
+           "Returns the axis-aligned bounding box that contains this "
+           "sphere.");
+    bs.def("get_oriented_bounding_box", &BoundingSphere::GetOrientedBoundingBox,
+           "Returns an oriented bounding box around the sphere.",
+           "robust"_a = false);
     bs.def("get_minimal_oriented_bounding_box",
-                        &BoundingSphere::GetMinimalOrientedBoundingBox,
-                        "Returns the minimal oriented bounding box around the "
-                        "sphere.",
-                        "robust"_a = false);
+           &BoundingSphere::GetMinimalOrientedBoundingBox,
+           "Returns the minimal oriented bounding box around the "
+           "sphere.",
+           "robust"_a = false);
     bs.def("to_legacy", &BoundingSphere::ToLegacy,
-                        "Convert to a legacy Open3D bounding sphere.");
-    bs.def_static(
-            "from_legacy", &BoundingSphere::FromLegacy, "sphere"_a,
-            "dtype"_a = core::Float32,
-            "device"_a = core::Device("CPU:0"),
-            "Convert from a legacy Open3D bounding sphere.");
-    bs.def_static(
-            "create_from_points", &BoundingSphere::CreateFromPoints,
-            R"(Creates a bounding sphere from a set of points.
+           "Convert to a legacy Open3D bounding sphere.");
+    bs.def_static("from_legacy", &BoundingSphere::FromLegacy, "sphere"_a,
+                  "dtype"_a = core::Float32, "device"_a = core::Device("CPU:0"),
+                  "Convert from a legacy Open3D bounding sphere.");
+    bs.def_static("create_from_points", &BoundingSphere::CreateFromPoints,
+                  R"(Creates a bounding sphere from a set of points.
 
 Args:
     points (open3d.core.Tensor): A list of points with data type of float32 or
@@ -738,10 +729,8 @@ Example::
         print(f"Center: {sphere.center}")
         print(f"Radius: {sphere.radius}")
 )",
-            "points"_a,
-            py::kw_only(),
-            "exact"_a = true, 
-            "robust"_a = false);
+                  "points"_a, py::kw_only(), "exact"_a = true,
+                  "robust"_a = false);
 
     docstring::ClassMethodDocInject(
             m, "BoundingSphere", "set_center",
@@ -785,12 +774,15 @@ Example::
             {{"points",
               "A list of points with data type of float32 or float64 (N x 3 "
               "tensor, where N must be larger than 3)."},
-             {"exact", "If true, computes the exact minimum bounding sphere "
-              "using Welzl’s algorithm (expected O(n))."  
+             {"exact",
+              "If true, computes the exact minimum bounding sphere "
+              "using Welzl’s algorithm (expected O(n))."
               "If false, uses Ritter’s algorithm for a faster approximation "
               "(~5% larger than optimal)."},
-             {"robust", "If set to true uses a more robust method which works in "
-                        "degenerate cases but introduces noise to the points coordinates."}});
+             {"robust",
+              "If set to true uses a more robust method which works in "
+              "degenerate cases but introduces noise to the points "
+              "coordinates."}});
 }
 
 }  // namespace geometry

--- a/cpp/pybind/t/geometry/boundingvolume.cpp
+++ b/cpp/pybind/t/geometry/boundingvolume.cpp
@@ -700,14 +700,14 @@ must be on the same device and have the same data type.)");
             "Create a BoundingSphere from a legacy Open3D bounding sphere.");
     bs.def_static(
             "create_from_points", &BoundingSphere::CreateFromPoints,
-            R"(Creates a bounding sphere from a set of points using Welzl's algorithm.
+            R"(Creates a bounding sphere from a set of points.
 
 Args:
     points (open3d.core.Tensor): A list of points with data type of float32 or
         float64 (N x 3 tensor, where N must be larger than 3).
+    method (MethodBoundingSphereCreate): The method to use for creating the bounding sphere.
     robust (bool): If set to true uses a more robust method which works in
         degenerate cases but introduces noise to the points coordinates.
-
 Returns:
     BoundingSphere with same data type and device as input points.
 
@@ -727,7 +727,9 @@ Example::
         print(f"Center: {sphere.center}")
         print(f"Radius: {sphere.radius}")
 )",
-            "points"_a, "robust"_a = false);
+            "points"_a,
+            "method"_a = MethodBoundingSphereCreate::EXACT, 
+            "robust"_a = false);
 
     docstring::ClassMethodDocInject(
             m, "BoundingSphere", "set_center",
@@ -771,6 +773,7 @@ Example::
             {{"points",
               "A list of points with data type of float32 or float64 (N x 3 "
               "tensor, where N must be larger than 3)."},
+             {"method", "The method to use for creating the bounding sphere."},
              {"robust", "If set to true uses a more robust method which works in "
                         "degenerate cases but introduces noise to the points coordinates."}});
 }

--- a/cpp/pybind/t/geometry/boundingvolume.cpp
+++ b/cpp/pybind/t/geometry/boundingvolume.cpp
@@ -589,6 +589,177 @@ Example::
         o3d.visualization.draw([pcd, ellipsoid_mesh])
 )",
             "points"_a, "robust"_a = false);
+    
+    // BoundingSphere
+    auto bs = static_cast<py::class_<
+            BoundingSphere, PyGeometry<BoundingSphere>,
+            std::shared_ptr<BoundingSphere>, Geometry>>(
+            m.attr("BoundingSphere"));
+    bs.def(py::init<const core::Device&>(),
+                        "device"_a = core::Device("CPU:0"),
+                        "Construct an empty BoundingSphere on the provided device.");
+    bs.def(py::init<const core::Tensor&, const core::Tensor&>(),
+                        "center"_a, "radius"_a,
+                        R"(Construct a BoundingSphere from center and radius.
+The BoundingSphere will be created on the device of the given tensors, which
+must be on the same device and have the same data type.)");
+    docstring::ClassMethodDocInject(
+            m, "BoundingSphere", "__init__",
+            {{"center",
+              "Center of the bounding sphere. Tensor of shape {3,}, and type "
+              "float32 or float64."},
+             {"radius",
+              "Radius of the bounding sphere. Tensor of shape {1,}, and type "
+              "float32 or float64."}});
+    py::detail::bind_copy_functions<BoundingSphere>(bs);
+    bs.def("__repr__", &BoundingSphere::ToString);
+
+    bs.def("to", &BoundingSphere::To,
+                        "Transfer the bounding sphere to a specified device and "
+                        "data type.",
+                        "device"_a, "dtype"_a, "copy"_a = false);
+    bs.def("clone", &BoundingSphere::Clone,
+                        "Returns a copy of the bounding sphere on the same "
+                        "device.");
+    bs.def(
+            "cpu",
+            [](const BoundingSphere& bs) {
+                return bs.To(core::Device("CPU:0"), bs.GetDtype());
+            },
+            "Transfer the bounding sphere to CPU. No-op if already on CPU.");
+    bs.def(
+            "cuda",
+            [](const BoundingSphere& bs, int device_id) {
+                return bs.To(core::Device("CUDA", device_id), bs.GetDtype());
+            },
+            "Transfer the bounding sphere to a CUDA device.",
+            "device_id"_a = 0);
+
+    bs.def("set_center", &BoundingSphere::SetCenter, "center"_a,
+                        "Set the center of the bounding sphere.");
+    bs.def("set_radius", &BoundingSphere::SetRadius, "radius"_a,
+                        "Set the radius of the bounding sphere.");
+    bs.def("set_color", &BoundingSphere::SetColor, "color"_a,
+                        "Set the color of the bounding sphere.");
+
+    bs.def_property_readonly("center",
+                                          &BoundingSphere::GetCenter,
+                                          "Center of the bounding sphere.");
+    bs.def_property_readonly("radius", &BoundingSphere::GetRadius,
+                                          "Radius of the bounding sphere.");
+    bs.def_property_readonly("color", &BoundingSphere::GetColor,
+                                          "Color of the bounding sphere.");
+
+    bs.def("translate", &BoundingSphere::Translate,
+                        "Translate the bounding sphere.", "translation"_a,
+                        "relative"_a = true);
+    bs.def("rotate", &BoundingSphere::Rotate,
+                        "Rotate the bounding sphere.", "rotation"_a,
+                        "center"_a = std::nullopt);
+    bs.def("scale", &BoundingSphere::Scale,
+                        "Scale the bounding sphere.", "scale"_a,
+                        "center"_a = std::nullopt);
+
+    bs.def("volume", &BoundingSphere::Volume,
+                        "Returns the volume of the bounding sphere.");
+    bs.def("get_sphere_points", &BoundingSphere::GetSpherePoints,
+                        "Returns the six critical points of the bounding sphere. "
+                        "Return tensor has shape {6, 3}.");
+    bs.def("get_point_indices_within_bounding_sphere",
+                        &BoundingSphere::GetPointIndicesWithinBoundingSphere,
+                        "Indices to points that are within the bounding sphere.",
+                        "points"_a);
+    bs.def("get_axis_aligned_bounding_box",
+                        &BoundingSphere::GetAxisAlignedBoundingBox,
+                        "Returns the axis-aligned bounding box that contains this "
+                        "sphere.");
+    bs.def("get_oriented_bounding_box",
+                        &BoundingSphere::GetOrientedBoundingBox,
+                        "Returns an oriented bounding box around the sphere.",
+                        "robust"_a = false);
+    bs.def("get_minimal_oriented_bounding_box",
+                        &BoundingSphere::GetMinimalOrientedBoundingBox,
+                        "Returns the minimal oriented bounding box around the "
+                        "sphere.",
+                        "robust"_a = false);
+    bs.def("to_legacy", &BoundingSphere::ToLegacy,
+                        "Convert to a legacy Open3D bounding sphere.");
+    bs.def_static(
+            "from_legacy", &BoundingSphere::FromLegacy, "sphere"_a,
+            "dtype"_a = core::Float32,
+            "device"_a = core::Device("CPU:0"),
+            "Create a BoundingSphere from a legacy Open3D bounding sphere.");
+    bs.def_static(
+            "create_from_points", &BoundingSphere::CreateFromPoints,
+            R"(Creates a bounding sphere from a set of points using Welzl's algorithm.
+
+Args:
+    points (open3d.core.Tensor): A list of points with data type of float32 or
+        float64 (N x 3 tensor, where N must be at least 1).
+
+Returns:
+    BoundingSphere with same data type and device as input points.
+
+Example::
+
+        import open3d as o3d
+        import open3d.t.geometry as o3g
+        import numpy as np
+
+        pcd = o3g.PointCloud()
+        pcd.point["positions"] = o3d.core.Tensor(
+                np.random.randn(100, 3).astype(np.float32))
+        sphere = o3g.BoundingSphere.create_from_points(
+                pcd.point["positions"])
+        sphere.set_color((0.0, 0.44, 0.77))
+        print(f"Volume: {sphere.volume()}")
+        print(f"Center: {sphere.center}")
+        print(f"Radius: {sphere.radius}")
+)",
+            "points"_a);
+
+    docstring::ClassMethodDocInject(
+            m, "BoundingSphere", "set_center",
+            {{"center",
+              "Tensor with {3,} shape, and type float32 or float64."}});
+    docstring::ClassMethodDocInject(
+            m, "BoundingSphere", "set_radius",
+            {{"radius",
+              "Tensor with {1,} shape, and type float32 or float64."}});
+    docstring::ClassMethodDocInject(
+            m, "BoundingSphere", "set_color",
+            {{"color",
+              "Tensor with {3,} shape, and type float32 or float64, with "
+              "values in range [0.0, 1.0]."}});
+    docstring::ClassMethodDocInject(
+            m, "BoundingSphere", "translate",
+            {{"translation",
+              "Translation tensor of shape {3,}, type float32 or float64, "
+              "device same as the sphere."},
+             {"relative", "Whether to perform relative translation."}});
+    docstring::ClassMethodDocInject(
+            m, "BoundingSphere", "rotate",
+            {{"rotation",
+              "Rotation matrix of shape {3, 3}, type float32 or float64, "
+              "device same as the sphere."},
+             {"center",
+              "Center of the rotation, default is null, which means use center "
+              "of the sphere as rotation center."}});
+    docstring::ClassMethodDocInject(
+            m, "BoundingSphere", "scale",
+            {{"scale", "The scale parameter."},
+             {"center",
+              "Center used for the scaling operation. Tensor with {3,} shape, "
+              "and type float32 or float64"}});
+    docstring::ClassMethodDocInject(
+            m, "BoundingSphere", "get_point_indices_within_bounding_sphere",
+            {{"points",
+              "Tensor with {N, 3} shape, and type float32 or float64."}});
+    docstring::ClassMethodDocInject(
+            m, "BoundingSphere", "create_from_points",
+            {{"points",
+              "A list of points with data type of float32 or float64 (N x 3 "
+              "tensor, where N must be at least 1)."}});
 }
 
 }  // namespace geometry

--- a/cpp/pybind/t/geometry/boundingvolume.cpp
+++ b/cpp/pybind/t/geometry/boundingvolume.cpp
@@ -51,14 +51,21 @@ arbitrary frame of reference with the properties:
   a data type ``open3d.core.float32`` (default) or ``open3d.core.float64``.
   Values can only be in the range [0.0, 1.0].)");
 
-     py::class_<BoundingSphere, PyGeometry<BoundingSphere>, std::shared_ptr<BoundingSphere>,
+     py::class_<BoundingSphere, PyGeometry<BoundingSphere>, 
+     std::shared_ptr<BoundingSphere>,
                 Geometry>
             bs(m, "BoundingSphere",
-               R"(A bounding sphere defined by a center point and a radius with the properties:
+               R"(A bounding sphere defined by a center point and a radius 
+               with the properties:
 
-- ``center``: Center point of the bounding sphere. Tensor with shape (3,) and a data type ``open3d.core.float32`` (default) or ``open3d.core.float64``. The device of the tensor determines the device of the sphere.
-- ``radius``: Radius of the bounding sphere. Scalar tensor with a data type ``open3d.core.float32`` (default) or ``open3d.core.float64``. The device of the tensor determines the device of the sphere.
-- ``color``: Color of the bounding sphere is a tensor with shape (3,) and a data type ``open3d.core.float32`` (default) or ``open3d.core.float64``. Values can only be in the range [0.0, 1.0].)");
+- (``center``, ``radius``): The bounding sphere is defined by a center point 
+  (shape (3,)) and a radius (shape (1,)). Both tensors must have the same data 
+  type and device. The data type can only be ``open3d.core.float32`` (default) 
+  or ``open3d.core.float64``. The device of the tensor determines the device of
+  the sphere.
+- ``color``: Color of the bounding sphere is a tensor with shape (3,) and 
+   a data type ``open3d.core.float32`` (default) or ``open3d.core.float64``.
+   Values can only be in the range [0.0, 1.0].)");
 }
 void pybind_boundingvolume_definitions(py::module& m) {
     auto aabb = static_cast<py::class_<AxisAlignedBoundingBox,
@@ -348,7 +355,7 @@ Args:
     points (open3d.core.Tensor): A list of points with data type of float32 or 
         float64 (N x 3 tensor, where N must be larger than 3).
     robust (bool): If set to true uses a more robust method which works in 
-        degenerate cases but introduces noise to the points coordinates.
+         degenerate cases but introduces noise to the points coordinates.    
     method (open3d.t.geometry.OrientedBoundingBox.Method): This is one of 
         ``PCA``, ``MINIMAL_APPROX``, ``MINIMAL_JYLANKI``. 
 
@@ -697,7 +704,7 @@ must be on the same device and have the same data type.)");
             "from_legacy", &BoundingSphere::FromLegacy, "sphere"_a,
             "dtype"_a = core::Float32,
             "device"_a = core::Device("CPU:0"),
-            "Create a BoundingSphere from a legacy Open3D bounding sphere.");
+            "Convert from a legacy Open3D bounding sphere.");
     bs.def_static(
             "create_from_points", &BoundingSphere::CreateFromPoints,
             R"(Creates a bounding sphere from a set of points.
@@ -705,8 +712,12 @@ must be on the same device and have the same data type.)");
 Args:
     points (open3d.core.Tensor): A list of points with data type of float32 or
         float64 (N x 3 tensor, where N must be larger than 3).
-    method (MethodBoundingSphereCreate): The method to use for creating the bounding sphere.
-    robust (bool): If set to true uses a more robust method which works in
+    exact (bool): If true, computes the exact minimum bounding sphere using 
+    Welzl’s algorithm (expected O(n)).  
+    If false, uses Ritter’s algorithm for a faster approximation 
+    (~5% larger than optimal).
+    robust (bool): Only used when `exact=True`. 
+        If set to true uses a more robust method which works in
         degenerate cases but introduces noise to the points coordinates.
 Returns:
     BoundingSphere with same data type and device as input points.
@@ -728,7 +739,8 @@ Example::
         print(f"Radius: {sphere.radius}")
 )",
             "points"_a,
-            "method"_a = MethodBoundingSphereCreate::EXACT, 
+            py::kw_only(),
+            "exact"_a = true, 
             "robust"_a = false);
 
     docstring::ClassMethodDocInject(
@@ -773,7 +785,10 @@ Example::
             {{"points",
               "A list of points with data type of float32 or float64 (N x 3 "
               "tensor, where N must be larger than 3)."},
-             {"method", "The method to use for creating the bounding sphere."},
+             {"exact", "If true, computes the exact minimum bounding sphere "
+              "using Welzl’s algorithm (expected O(n))."  
+              "If false, uses Ritter’s algorithm for a faster approximation "
+              "(~5% larger than optimal)."},
              {"robust", "If set to true uses a more robust method which works in "
                         "degenerate cases but introduces noise to the points coordinates."}});
 }

--- a/cpp/pybind/t/geometry/boundingvolume.cpp
+++ b/cpp/pybind/t/geometry/boundingvolume.cpp
@@ -50,6 +50,15 @@ arbitrary frame of reference with the properties:
 - ``color``: Color of the bounding ellipsoid is a tensor with shape (3,) and
   a data type ``open3d.core.float32`` (default) or ``open3d.core.float64``.
   Values can only be in the range [0.0, 1.0].)");
+
+     py::class_<BoundingSphere, PyGeometry<BoundingSphere>, std::shared_ptr<BoundingSphere>,
+                Geometry>
+            bs(m, "BoundingSphere",
+               R"(A bounding sphere defined by a center point and a radius with the properties:
+
+- ``center``: Center point of the bounding sphere. Tensor with shape (3,) and a data type ``open3d.core.float32`` (default) or ``open3d.core.float64``. The device of the tensor determines the device of the sphere.
+- ``radius``: Radius of the bounding sphere. Scalar tensor with a data type ``open3d.core.float32`` (default) or ``open3d.core.float64``. The device of the tensor determines the device of the sphere.
+- ``color``: Color of the bounding sphere is a tensor with shape (3,) and a data type ``open3d.core.float32`` (default) or ``open3d.core.float64``. Values can only be in the range [0.0, 1.0].)");
 }
 void pybind_boundingvolume_definitions(py::module& m) {
     auto aabb = static_cast<py::class_<AxisAlignedBoundingBox,

--- a/cpp/pybind/t/geometry/boundingvolume.cpp
+++ b/cpp/pybind/t/geometry/boundingvolume.cpp
@@ -718,7 +718,7 @@ Example::
         print(f"Center: {sphere.center}")
         print(f"Radius: {sphere.radius}")
 )",
-            "points"_a);
+            "points"_a, "robust"_a = false);
 
     docstring::ClassMethodDocInject(
             m, "BoundingSphere", "set_center",

--- a/cpp/pybind/t/geometry/geometry.cpp
+++ b/cpp/pybind/t/geometry/geometry.cpp
@@ -72,15 +72,6 @@ void pybind_geometry_declarations(py::module& m) {
             .export_values()
             .finalize();
 
-    py::native_enum<MethodBoundingSphereCreate>(
-            m_geometry, "MethodBoundingSphereCreate", "enum.Enum",
-            "Methods for creating bounding spheres.")
-            .value("EXACT", MethodBoundingSphereCreate::EXACT,
-                   "Exact method for creating bounding spheres.")
-            .value("APPROX", MethodBoundingSphereCreate::APPROX,
-                   "Approximate method for creating bounding spheres.")
-            .finalize();       
-
     pybind_geometry_class_declarations(m_geometry);
     pybind_drawable_geometry_class_declarations(m_geometry);
     pybind_tensormap_declarations(m_geometry);

--- a/cpp/pybind/t/geometry/geometry.cpp
+++ b/cpp/pybind/t/geometry/geometry.cpp
@@ -72,6 +72,15 @@ void pybind_geometry_declarations(py::module& m) {
             .export_values()
             .finalize();
 
+    py::native_enum<MethodBoundingSphereCreate>(
+            m_geometry, "MethodBoundingSphereCreate", "enum.Enum",
+            "Methods for creating bounding spheres.")
+            .value("EXACT", MethodBoundingSphereCreate::EXACT,
+                   "Exact method for creating bounding spheres.")
+            .value("APPROX", MethodBoundingSphereCreate::APPROX,
+                   "Approximate method for creating bounding spheres.")
+            .finalize();       
+
     pybind_geometry_class_declarations(m_geometry);
     pybind_drawable_geometry_class_declarations(m_geometry);
     pybind_tensormap_declarations(m_geometry);

--- a/cpp/pybind/t/geometry/lineset.cpp
+++ b/cpp/pybind/t/geometry/lineset.cpp
@@ -268,8 +268,7 @@ Args:
 Returns:
     open3d.t.geometry.LineSet: Wireframe line set of the ellipsoid.)");
     line_set.def_static(
-            "create_from_bounding_sphere",
-            &LineSet::CreateFromBoundingSphere,
+            "create_from_bounding_sphere", &LineSet::CreateFromBoundingSphere,
             "sphere"_a, "resolution"_a = 20, "float_dtype"_a = core::Float32,
             "int_dtype"_a = core::Int64, "device"_a = core::Device("CPU:0"),
             R"(Create a wireframe LineSet representing the surface of a BoundingSphere.

--- a/cpp/pybind/t/geometry/lineset.cpp
+++ b/cpp/pybind/t/geometry/lineset.cpp
@@ -269,13 +269,13 @@ Returns:
     open3d.t.geometry.LineSet: Wireframe line set of the ellipsoid.)");
     line_set.def_static(
             "create_from_bounding_sphere",
-            &LineSet::CreateFromBoundingSphere, "bsphere"_a,
-            "resolution"_a = 20, "float_dtype"_a = core::Float32,
+            &LineSet::CreateFromBoundingSphere,
+            "sphere"_a, "resolution"_a = 20, "float_dtype"_a = core::Float32,
             "int_dtype"_a = core::Int64, "device"_a = core::Device("CPU:0"),
             R"(Create a wireframe LineSet representing the surface of a BoundingSphere.
 
 Args:
-    bsphere (open3d.t.geometry.BoundingSphere): The bounding sphere.
+    sphere (open3d.t.geometry.BoundingSphere): The bounding sphere.
     resolution (int): Resolution of the generated sphere wireframe.
     float_dtype (open3d.core.Dtype): Float32 or Float64, for point attributes.
     int_dtype (open3d.core.Dtype): Int32 or Int64, for line indices.

--- a/cpp/pybind/t/geometry/lineset.cpp
+++ b/cpp/pybind/t/geometry/lineset.cpp
@@ -267,6 +267,22 @@ Args:
 
 Returns:
     open3d.t.geometry.LineSet: Wireframe line set of the ellipsoid.)");
+    line_set.def_static(
+            "create_from_bounding_sphere",
+            &LineSet::CreateFromBoundingSphere, "bsphere"_a,
+            "resolution"_a = 20, "float_dtype"_a = core::Float32,
+            "int_dtype"_a = core::Int64, "device"_a = core::Device("CPU:0"),
+            R"(Create a wireframe LineSet representing the surface of a BoundingSphere.
+
+Args:
+    bsphere (open3d.t.geometry.BoundingSphere): The bounding sphere.
+    resolution (int): Resolution of the generated sphere wireframe.
+    float_dtype (open3d.core.Dtype): Float32 or Float64, for point attributes.
+    int_dtype (open3d.core.Dtype): Int32 or Int64, for line indices.
+    device (open3d.core.Device): The device for the returned line set.
+
+Returns:
+    open3d.t.geometry.LineSet: Wireframe line set of the sphere.)");
     line_set.def("extrude_rotation", &LineSet::ExtrudeRotation, "angle"_a,
                  "axis"_a, "resolution"_a = 16, "translation"_a = 0.0,
                  "capping"_a = true,

--- a/cpp/pybind/t/geometry/pointcloud.cpp
+++ b/cpp/pybind/t/geometry/pointcloud.cpp
@@ -624,7 +624,8 @@ Example:
                    &PointCloud::GetBoundingSphere,
                    "Create a bounding sphere from attribute "
                    "'positions'.",
-                   "method"_a = MethodBoundingSphereCreate::EXACT,
+                   py::kw_only(),
+                   "exact"_a = true,
                    "robust"_a = false);
     pointcloud.def("crop",
                    (PointCloud(PointCloud::*)(const AxisAlignedBoundingBox&,

--- a/cpp/pybind/t/geometry/pointcloud.cpp
+++ b/cpp/pybind/t/geometry/pointcloud.cpp
@@ -624,6 +624,7 @@ Example:
                    &PointCloud::GetBoundingSphere,
                    "Create a bounding sphere from attribute "
                    "'positions'.",
+                   "method"_a = MethodBoundingSphereCreate::EXACT,
                    "robust"_a = false);
     pointcloud.def("crop",
                    (PointCloud(PointCloud::*)(const AxisAlignedBoundingBox&,

--- a/cpp/pybind/t/geometry/pointcloud.cpp
+++ b/cpp/pybind/t/geometry/pointcloud.cpp
@@ -620,6 +620,11 @@ Example:
                    "Create an oriented bounding ellipsoid from attribute "
                    "'positions'.",
                    "robust"_a = false);
+    pointcloud.def("get_bounding_sphere",
+                   &PointCloud::GetBoundingSphere,
+                   "Create a bounding sphere from attribute "
+                   "'positions'.",
+                   "robust"_a = false);
     pointcloud.def("crop",
                    (PointCloud(PointCloud::*)(const AxisAlignedBoundingBox&,
                                               bool) const) &

--- a/cpp/pybind/t/geometry/pointcloud.cpp
+++ b/cpp/pybind/t/geometry/pointcloud.cpp
@@ -261,9 +261,10 @@ Example:
                    "non-negative number less than number of points in the "
                    "input pointcloud.",
                    "start_index"_a = 0);
-    pointcloud.def("remove_radius_outliers", &PointCloud::RemoveRadiusOutliers,
-                   "nb_points"_a, "search_radius"_a,
-                   R"(Remove points that have less than nb_points neighbors in a
+    pointcloud.def(
+            "remove_radius_outliers", &PointCloud::RemoveRadiusOutliers,
+            "nb_points"_a, "search_radius"_a,
+            R"(Remove points that have less than nb_points neighbors in a
 sphere of a given search radius.
 
 Args:
@@ -620,13 +621,10 @@ Example:
                    "Create an oriented bounding ellipsoid from attribute "
                    "'positions'.",
                    "robust"_a = false);
-    pointcloud.def("get_bounding_sphere",
-                   &PointCloud::GetBoundingSphere,
+    pointcloud.def("get_bounding_sphere", &PointCloud::GetBoundingSphere,
                    "Create a bounding sphere from attribute "
                    "'positions'.",
-                   py::kw_only(),
-                   "exact"_a = true,
-                   "robust"_a = false);
+                   py::kw_only(), "exact"_a = true, "robust"_a = false);
     pointcloud.def("crop",
                    (PointCloud(PointCloud::*)(const AxisAlignedBoundingBox&,
                                               bool) const) &

--- a/cpp/pybind/t/geometry/trianglemesh.cpp
+++ b/cpp/pybind/t/geometry/trianglemesh.cpp
@@ -583,6 +583,25 @@ Returns:
     open3d.t.geometry.TriangleMesh: Solid surface mesh of the ellipsoid.)");
 
     triangle_mesh.def_static(
+            "create_from_bounding_sphere",
+            &TriangleMesh::CreateFromBoundingSphere, "sphere"_a,
+            "scale"_a = 1.0,
+            "resolution"_a = 20, "float_dtype"_a = core::Float32,
+            "int_dtype"_a = core::Int64, "device"_a = core::Device("CPU:0"),
+            R"(Create a solid TriangleMesh representing the surface of a BoundingSphere.
+
+Args:
+    sphere (open3d.t.geometry.BoundingSphere): The bounding sphere.
+    scale (float): Scale factor applied to the radius.
+    resolution (int): Resolution of the generated sphere surface mesh.
+    float_dtype (open3d.core.Dtype): Float32 or Float64, for vertex attributes.
+    int_dtype (open3d.core.Dtype): Int32 or Int64, for triangle indices.
+    device (open3d.core.Device): The device for the returned mesh.
+
+Returns:
+    open3d.t.geometry.TriangleMesh: Solid surface mesh of the sphere.)");
+
+    triangle_mesh.def_static(
             "create_isosurfaces",
             // Accept anything for contour_values that pybind can convert to
             // std::list. This also avoids o3d.utility.DoubleVector.
@@ -776,6 +795,11 @@ Example:
     triangle_mesh.def("get_oriented_bounding_ellipsoid",
                       &TriangleMesh::GetOrientedBoundingEllipsoid,
                       "Create an oriented bounding ellipsoid from vertex "
+                      "attribute 'positions'.",
+                      "robust"_a = false);
+    triangle_mesh.def("get_bounding_sphere",
+                      &TriangleMesh::GetBoundingSphere,
+                      "Create a bounding sphere from vertex "
                       "attribute 'positions'.",
                       "robust"_a = false);
 

--- a/cpp/pybind/t/geometry/trianglemesh.cpp
+++ b/cpp/pybind/t/geometry/trianglemesh.cpp
@@ -799,7 +799,8 @@ Example:
                       &TriangleMesh::GetBoundingSphere,
                       "Create a bounding sphere from vertex "
                       "attribute 'positions'.",
-                      "method"_a = MethodBoundingSphereCreate::EXACT,
+                      py::kw_only(),
+                      "exact"_a = true,
                       "robust"_a = false);
 
     triangle_mesh.def("fill_holes", &TriangleMesh::FillHoles,

--- a/cpp/pybind/t/geometry/trianglemesh.cpp
+++ b/cpp/pybind/t/geometry/trianglemesh.cpp
@@ -795,13 +795,10 @@ Example:
                       "Create an oriented bounding ellipsoid from vertex "
                       "attribute 'positions'.",
                       "robust"_a = false);
-    triangle_mesh.def("get_bounding_sphere",
-                      &TriangleMesh::GetBoundingSphere,
+    triangle_mesh.def("get_bounding_sphere", &TriangleMesh::GetBoundingSphere,
                       "Create a bounding sphere from vertex "
                       "attribute 'positions'.",
-                      py::kw_only(),
-                      "exact"_a = true,
-                      "robust"_a = false);
+                      py::kw_only(), "exact"_a = true, "robust"_a = false);
 
     triangle_mesh.def("fill_holes", &TriangleMesh::FillHoles,
                       "hole_size"_a = 1e6,

--- a/cpp/pybind/t/geometry/trianglemesh.cpp
+++ b/cpp/pybind/t/geometry/trianglemesh.cpp
@@ -799,6 +799,7 @@ Example:
                       &TriangleMesh::GetBoundingSphere,
                       "Create a bounding sphere from vertex "
                       "attribute 'positions'.",
+                      "method"_a = MethodBoundingSphereCreate::EXACT,
                       "robust"_a = false);
 
     triangle_mesh.def("fill_holes", &TriangleMesh::FillHoles,

--- a/cpp/pybind/t/geometry/trianglemesh.cpp
+++ b/cpp/pybind/t/geometry/trianglemesh.cpp
@@ -585,14 +585,12 @@ Returns:
     triangle_mesh.def_static(
             "create_from_bounding_sphere",
             &TriangleMesh::CreateFromBoundingSphere, "sphere"_a,
-            "scale"_a = 1.0,
             "resolution"_a = 20, "float_dtype"_a = core::Float32,
             "int_dtype"_a = core::Int64, "device"_a = core::Device("CPU:0"),
             R"(Create a solid TriangleMesh representing the surface of a BoundingSphere.
 
 Args:
     sphere (open3d.t.geometry.BoundingSphere): The bounding sphere.
-    scale (float): Scale factor applied to the radius.
     resolution (int): Resolution of the generated sphere surface mesh.
     float_dtype (open3d.core.Dtype): Float32 or Float64, for vertex attributes.
     int_dtype (open3d.core.Dtype): Int32 or Int64, for triangle indices.

--- a/cpp/tests/t/geometry/BoundingSphere.cpp
+++ b/cpp/tests/t/geometry/BoundingSphere.cpp
@@ -1,0 +1,79 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// Copyright (c) 2018-2024 www.open3d.org
+// SPDX-License-Identifier: MIT
+// ----------------------------------------------------------------------------
+
+#include <gmock/gmock.h>
+
+#include "core/CoreTest.h"
+#include "open3d/core/Tensor.h"
+#include "open3d/t/geometry/BoundingVolume.h"
+#include "open3d/t/geometry/PointCloud.h"
+#include "open3d/t/geometry/TriangleMesh.h"
+#include "tests/Tests.h"
+
+namespace open3d {
+namespace tests {
+
+class BoundingSpherePermuteDevices : public PermuteDevicesWithSYCL {
+};
+INSTANTIATE_TEST_SUITE_P(
+        BoundingSphere,
+        BoundingSpherePermuteDevices,
+        testing::ValuesIn(PermuteDevicesWithSYCL::TestCases()));
+
+// Mirror of test_pointcloud_get_oriented_bounding_ellipsoid in
+// python/test/t/geometry/test_bounding_volume_ellipsoid.py
+TEST_P(BoundingSpherePermuteDevices,
+       PointCloudGetBoundingSphere) {
+    core::Device device = GetParam();
+
+    // Six points spread along three axes.
+    t::geometry::PointCloud pcd(core::Tensor::Init<float>({{1.0f, 0.0f, 0.0f},
+                                                           {-1.0f, 0.0f, 0.0f},
+                                                           {0.0f, 2.0f, 0.0f},
+                                                           {0.0f, -2.0f, 0.0f},
+                                                           {0.0f, 0.0f, 3.0f},
+                                                           {0.0f, 0.0f, -3.0f}},
+                                                          device));
+
+    t::geometry::BoundingSphere ebs =
+            pcd.GetBoundingSphere();
+    // Volume of sphere with diameter of 6.0 
+    // (the largest distance between points).
+    EXPECT_NEAR(ebs.Volume(), 113.09733552923255, 1e-5);
+    // Center should be near the origin for this symmetric point set.
+    EXPECT_TRUE(ebs.GetCenter().AllClose(
+            core::Tensor::Zeros({3}, core::Float32, device),
+            /*rtol=*/0.0, /*atol=*/1e-3));
+}
+
+// Mirror of test_trianglemesh_get_oriented_bounding_ellipsoid in
+// python/test/t/geometry/test_bounding_volume_ellipsoid.py
+TEST_P(BoundingSpherePermuteDevices,
+       TriangleMeshGetBoundingSphere) {
+    core::Device device = GetParam();
+
+    t::geometry::TriangleMesh mesh = t::geometry::TriangleMesh::CreateSphere(
+            /*radius=*/1.0, /*resolution=*/20,
+            /*float_dtype=*/core::Float32, /*int_dtype=*/core::Int64, device);
+
+    t::geometry::BoundingSphere ebs =
+            mesh.GetBoundingSphere();
+
+    EXPECT_NEAR(ebs.Volume(), 4.18879, 1e-5);
+    // Sphere centered at origin — ellipsoid center should be near origin.
+    EXPECT_TRUE(ebs.GetCenter().AllClose(
+            core::Tensor::Zeros({3}, core::Float32, device),
+            /*rtol=*/0.0, /*atol=*/1e-3));
+    // Radius must be positive.
+    EXPECT_TRUE(
+    ebs.GetRadius()
+          .To(core::Device("CPU:0"))
+          .Item<double>() > 0.0);
+}
+
+}  // namespace tests
+}  // namespace open3d

--- a/cpp/tests/t/geometry/BoundingSphere.cpp
+++ b/cpp/tests/t/geometry/BoundingSphere.cpp
@@ -75,5 +75,26 @@ TEST_P(BoundingSpherePermuteDevices,
           .Item<double>() > 0.0);
 }
 
+TEST_P(BoundingSpherePermuteDevices,
+       PointCloudGetBoundingSphereCoplanar) {
+    core::Device device = GetParam();
+
+    t::geometry::PointCloud pcd(core::Tensor::Init<float>({
+            {1.0f, 0.0f, 0.0f},
+            {-1.0f, 0.0f, 0.0f},
+            {0.0f, 1.0f, 0.0f},
+            {0.0f, -1.0f, 0.0f}},
+            device));
+
+    t::geometry::BoundingSphere ebs = pcd.GetBoundingSphere();
+
+    EXPECT_TRUE(ebs.GetCenter().AllClose(
+            core::Tensor::Zeros({3}, core::Float32, device),
+            /*rtol=*/0.0, /*atol=*/1e-5));
+    EXPECT_NEAR(
+            ebs.GetRadius().To(core::Device("CPU:0")).Item<double>(),
+            1.0, 1e-5);
+}
+
 }  // namespace tests
 }  // namespace open3d

--- a/cpp/tests/t/geometry/BoundingSphere.cpp
+++ b/cpp/tests/t/geometry/BoundingSphere.cpp
@@ -17,8 +17,7 @@
 namespace open3d {
 namespace tests {
 
-class BoundingSpherePermuteDevices : public PermuteDevicesWithSYCL {
-};
+class BoundingSpherePermuteDevices : public PermuteDevicesWithSYCL {};
 INSTANTIATE_TEST_SUITE_P(
         BoundingSphere,
         BoundingSpherePermuteDevices,
@@ -26,8 +25,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 // Mirror of test_pointcloud_get_oriented_bounding_ellipsoid in
 // python/test/t/geometry/test_bounding_volume_ellipsoid.py
-TEST_P(BoundingSpherePermuteDevices,
-       PointCloudGetBoundingSphere) {
+TEST_P(BoundingSpherePermuteDevices, PointCloudGetBoundingSphere) {
     core::Device device = GetParam();
 
     // Six points spread along three axes.
@@ -39,9 +37,8 @@ TEST_P(BoundingSpherePermuteDevices,
                                                            {0.0f, 0.0f, -3.0f}},
                                                           device));
 
-    t::geometry::BoundingSphere ebs =
-            pcd.GetBoundingSphere();
-    // Volume of sphere with diameter of 6.0 
+    t::geometry::BoundingSphere ebs = pcd.GetBoundingSphere();
+    // Volume of sphere with diameter of 6.0
     // (the largest distance between points).
     EXPECT_NEAR(ebs.Volume(), 113.09733552923255, 1e-5);
     // Center should be near the origin for this symmetric point set.
@@ -52,16 +49,14 @@ TEST_P(BoundingSpherePermuteDevices,
 
 // Mirror of test_trianglemesh_get_oriented_bounding_ellipsoid in
 // python/test/t/geometry/test_bounding_volume_ellipsoid.py
-TEST_P(BoundingSpherePermuteDevices,
-       TriangleMeshGetBoundingSphere) {
+TEST_P(BoundingSpherePermuteDevices, TriangleMeshGetBoundingSphere) {
     core::Device device = GetParam();
 
     t::geometry::TriangleMesh mesh = t::geometry::TriangleMesh::CreateSphere(
             /*radius=*/1.0, /*resolution=*/20,
             /*float_dtype=*/core::Float32, /*int_dtype=*/core::Int64, device);
 
-    t::geometry::BoundingSphere ebs =
-            mesh.GetBoundingSphere();
+    t::geometry::BoundingSphere ebs = mesh.GetBoundingSphere();
 
     EXPECT_NEAR(ebs.Volume(), 4.18879, 1e-5);
     // Sphere centered at origin — ellipsoid center should be near origin.
@@ -69,31 +64,25 @@ TEST_P(BoundingSpherePermuteDevices,
             core::Tensor::Zeros({3}, core::Float32, device),
             /*rtol=*/0.0, /*atol=*/1e-3));
     // Radius must be positive.
-    EXPECT_TRUE(
-    ebs.GetRadius()
-          .To(core::Device("CPU:0"))
-          .Item<double>() > 0.0);
+    EXPECT_TRUE(ebs.GetRadius().To(core::Device("CPU:0")).Item<double>() > 0.0);
 }
 
-TEST_P(BoundingSpherePermuteDevices,
-       PointCloudGetBoundingSphereCoplanar) {
+TEST_P(BoundingSpherePermuteDevices, PointCloudGetBoundingSphereCoplanar) {
     core::Device device = GetParam();
 
-    t::geometry::PointCloud pcd(core::Tensor::Init<float>({
-            {1.0f, 0.0f, 0.0f},
-            {-1.0f, 0.0f, 0.0f},
-            {0.0f, 1.0f, 0.0f},
-            {0.0f, -1.0f, 0.0f}},
-            device));
+    t::geometry::PointCloud pcd(core::Tensor::Init<float>({{1.0f, 0.0f, 0.0f},
+                                                           {-1.0f, 0.0f, 0.0f},
+                                                           {0.0f, 1.0f, 0.0f},
+                                                           {0.0f, -1.0f, 0.0f}},
+                                                          device));
 
     t::geometry::BoundingSphere ebs = pcd.GetBoundingSphere();
 
     EXPECT_TRUE(ebs.GetCenter().AllClose(
             core::Tensor::Zeros({3}, core::Float32, device),
             /*rtol=*/0.0, /*atol=*/1e-5));
-    EXPECT_NEAR(
-            ebs.GetRadius().To(core::Device("CPU:0")).Item<double>(),
-            1.0, 1e-5);
+    EXPECT_NEAR(ebs.GetRadius().To(core::Device("CPU:0")).Item<double>(), 1.0,
+                1e-5);
 }
 
 }  // namespace tests

--- a/cpp/tests/t/geometry/CMakeLists.txt
+++ b/cpp/tests/t/geometry/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(tests PRIVATE
     AxisAlignedBoundingBox.cpp
     OrientedBoundingBox.cpp
     OrientedBoundingEllipsoid.cpp
+    BoundingSphere.cpp
     VoxelBlockGrid.cpp
     VtkUtils.cpp
 )


### PR DESCRIPTION
# Add Minimum Bounding Sphere support to Open3D

## Type

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [x] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

This change introduces support for computing Minimum Bounding Spheres. While Open3D currently supports axis-aligned and oriented bounding volumes, it lacks a native spherical bounding representation.

Recently, support for an **Oriented Bounding Ellipsoid** was introduced in Open3D ([PR #7377](https://github.com/isl-org/Open3D/pull/7377)), extending the available set of bounding primitives beyond boxes.

Bounding spheres complement these existing and emerging primitives by providing a simple, robust, and computationally efficient bounding volume.

Bounding spheres are useful in many applications, including:
- Fast spatial queries and collision detection
- Geometry simplification and approximation
- Robust bounding representations for noisy or irregular data

This feature adds both approximate and exact methods for computing bounding spheres, giving users flexibility depending on performance and accuracy requirements.

## Checklist:

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style** to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [x] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is updated accordingly.
    -   [x] I have added or updated C++ and / or Python **unit tests** OR included **test results** here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

This PR adds a complete implementation of Minimum Bounding Sphere (BS) support across both legacy and tensor geometry APIs in Open3D.

### Key Features:
- Implementation of **exact bounding sphere computation** using Welzl’s algorithm
- Support for fast and **approximate bounding sphere computation** using Ritter's method
- Integration into both legacy API and Tensor:
  - `PointCloud`
  - `TriangleMesh`
  - `LineSet`
- Both legacy and tensor implementations follow consistent APIs and produce comparable results across geometry types. 
- Exposure through both:
  - C++ API
  - Python bindings (pybind)

### API Changes:
- Added `BoundingSphere` class:
- `CreateFromPoints` methods expose a flag to select between exact (Welzl) and approximate (Ritter) algorithms

### Implementation Details:
- Added kernel implementation in:
  - `cpp/open3d/t/geometry/kernel/MinimumBS.*`
- Robustness for edge cases (e.g., coplanar points, degenerate inputs)

### Testing:
- Added unit tests for:
  - General point sets
  - Degenerate configurations (coplanar / minimal cases)
- Verified correctness and robustness across different geometries

### Exact Bounding Sphere
<img width="1024" height="744" alt="example_exact_Bounding_sphere_Monkey" src="https://github.com/user-attachments/assets/6066fcbf-79ed-41c1-8aab-d42f63345154" />

### Approximate Bounding Sphere
<img width="1024" height="744" alt="example_approx_Bounding_sphere_Armadillo" src="https://github.com/user-attachments/assets/a559deda-1fc5-44a9-8b79-f50ece1fbf4e" />

### Exact and Approximate Bounding Sphere
<img width="1024" height="744" alt="example_approx_and_exact_Bounding_sphere_Bunny" src="https://github.com/user-attachments/assets/70993cfd-da6a-4bda-95c7-8c781db6fc63" />

### Notes:
- The implementation is non-breaking and consistent with existing Open3D design patterns
- CI workflow files were preserved to ensure compatibility with upstream testing

### Example usage
```python
import open3d as o3d

mesh_path = o3d.data.MonkeyModel().path
mesh = o3d.io.read_triangle_mesh(mesh_path)
mesh.compute_triangle_normals()
# sphere = mesh.get_bounding_sphere(exact=False)
sphere = mesh.get_bounding_sphere()
print(f"Volume: {sphere.volume()}")
sphere.color = (0, 0.44, 0.77)

sphere_lines = o3d.geometry.LineSet.create_from_bounding_sphere(sphere)
o3d.visualization.draw([mesh, sphere_lines])

```
---