### PR TITLE
add backface culling to Open3DScene and expose the interface to Python

### DIFF
--- a/cpp/open3d/visualization/rendering/MaterialRecord.h
+++ b/cpp/open3d/visualization/rendering/MaterialRecord.h
@@ -25,6 +25,12 @@ struct MaterialRecord {
     // Rendering attributes
     bool has_alpha = false;
 
+    // If true, cull back faces (single-sided); if false (default), draw both
+    // faces. Inverse of the legacy Visualizer's mesh_show_back_face. Honored
+    // only by the surface shaders defaultLit, defaultLitTransparency,
+    // defaultUnlit, normals, unlitGradient, unlitSolidColor.
+    bool backface_culling = false;
+
     // PBR Material properties and maps
     Eigen::Vector4f base_color = Eigen::Vector4f(1.f, 1.f, 1.f, 1.f);
     float base_metallic = 0.f;

--- a/cpp/open3d/visualization/rendering/Open3DScene.cpp
+++ b/cpp/open3d/visualization/rendering/Open3DScene.cpp
@@ -363,6 +363,18 @@ void Open3DScene::ModifyGeometryMaterial(const std::string& name,
     }
 }
 
+void Open3DScene::SetGeometryBackfaceCulling(const std::string& name,
+                                             bool enable) {
+    auto scene = renderer_.GetScene(scene_);
+    auto g = geometries_.find(name);
+    if (g != geometries_.end()) {
+        scene->SetGeometryBackfaceCulling(name, enable);
+        if (!g->second.fast_name.empty()) {
+            scene->SetGeometryBackfaceCulling(g->second.fast_name, enable);
+        }
+    }
+}
+
 void Open3DScene::ShowGeometry(const std::string& name, bool show) {
     auto it = geometries_.find(name);
     if (it != geometries_.end()) {

--- a/cpp/open3d/visualization/rendering/Open3DScene.h
+++ b/cpp/open3d/visualization/rendering/Open3DScene.h
@@ -96,6 +96,8 @@ public:
 
     void ModifyGeometryMaterial(const std::string& name,
                                 const MaterialRecord& mat);
+    /// Enables or disables back-face culling for the named geometry.
+    void SetGeometryBackfaceCulling(const std::string& name, bool enable);
     void AddModel(const std::string& name, const TriangleMeshModel& model);
 
     /// Updates all geometries to use this material

--- a/cpp/open3d/visualization/rendering/Scene.h
+++ b/cpp/open3d/visualization/rendering/Scene.h
@@ -103,6 +103,9 @@ public:
                                  bool receive_shadows) = 0;
     virtual void SetGeometryCulling(const std::string& object_name,
                                     bool enable) = 0;
+    /// Enables/disables back-face culling for the named geometry.
+    virtual void SetGeometryBackfaceCulling(const std::string& object_name,
+                                            bool enable) = 0;
     virtual void SetGeometryPriority(const std::string& object_name,
                                      uint8_t priority) = 0;
     virtual void QueryGeometry(std::vector<std::string>& geometry) = 0;

--- a/cpp/open3d/visualization/rendering/filament/FilamentScene.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentScene.cpp
@@ -1338,8 +1338,8 @@ void FilamentScene::UpdateBackfaceCulling(GeometryMaterialInstance& geom_mi) {
     // surface/mesh shaders where it is meaningful (ignore points, lines, depth,
     // background, etc.).
     static const std::unordered_set<std::string> kCullableShaders = {
-            "defaultLit",   "defaultLitTransparency", "defaultUnlit",
-            "normals",      "unlitGradient",          "unlitSolidColor"};
+            "defaultLit", "defaultLitTransparency", "defaultUnlit",
+            "normals",    "unlitGradient",          "unlitSolidColor"};
     if (kCullableShaders.count(geom_mi.properties.shader) == 0) {
         return;
     }
@@ -1350,9 +1350,10 @@ void FilamentScene::UpdateBackfaceCulling(GeometryMaterialInstance& geom_mi) {
         //                              lighting stays correct because these
         //                              materials keep back-face normal flipping
         //                              on by default.
-        mi->setCullingMode(geom_mi.properties.backface_culling
-                                   ? filament::MaterialInstance::CullingMode::BACK
-                                   : filament::MaterialInstance::CullingMode::NONE);
+        mi->setCullingMode(
+                geom_mi.properties.backface_culling
+                        ? filament::MaterialInstance::CullingMode::BACK
+                        : filament::MaterialInstance::CullingMode::NONE);
     }
 }
 

--- a/cpp/open3d/visualization/rendering/filament/FilamentScene.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentScene.cpp
@@ -1300,6 +1300,21 @@ void FilamentScene::SetGeometryCulling(const std::string& object_name,
     }
 }
 
+void FilamentScene::SetGeometryBackfaceCulling(const std::string& object_name,
+                                               bool enable) {
+    bool changed = false;
+    auto geoms = GetGeometry(object_name);
+    for (auto* g : geoms) {
+        g->mat.properties.backface_culling = enable;
+        if (g->filament_entity.isNull()) continue;
+        UpdateBackfaceCulling(g->mat);
+        changed = true;
+    }
+    if (changed) {
+        MarkGeometryChanged();
+    }
+}
+
 void FilamentScene::SetGeometryPriority(const std::string& object_name,
                                         uint8_t priority) {
     bool changed = false;
@@ -1315,6 +1330,29 @@ void FilamentScene::SetGeometryPriority(const std::string& object_name,
     }
     if (changed) {
         MarkGeometryChanged();
+    }
+}
+
+void FilamentScene::UpdateBackfaceCulling(GeometryMaterialInstance& geom_mi) {
+    // Back-face culling maps to the rasterizer culling mode. Restrict it to the
+    // surface/mesh shaders where it is meaningful (ignore points, lines, depth,
+    // background, etc.).
+    static const std::unordered_set<std::string> kCullableShaders = {
+            "defaultLit",   "defaultLitTransparency", "defaultUnlit",
+            "normals",      "unlitGradient",          "unlitSolidColor"};
+    if (kCullableShaders.count(geom_mi.properties.shader) == 0) {
+        return;
+    }
+    auto w_mi = resource_mgr_.GetMaterialInstance(geom_mi.mat_instance);
+    if (auto mi = w_mi.lock()) {
+        // backface_culling == true  -> BACK: cull back faces.
+        // backface_culling == false -> NONE: draw both faces. Back-face
+        //                              lighting stays correct because these
+        //                              materials keep back-face normal flipping
+        //                              on by default.
+        mi->setCullingMode(geom_mi.properties.backface_culling
+                                   ? filament::MaterialInstance::CullingMode::BACK
+                                   : filament::MaterialInstance::CullingMode::NONE);
     }
 }
 
@@ -1640,6 +1678,8 @@ void FilamentScene::UpdateMaterialProperties(RenderableGeometry& geom) {
     } else {
         utility::LogWarning("'{}' is not a valid shader", props.shader);
     }
+
+    UpdateBackfaceCulling(geom.mat);
 }
 
 void FilamentScene::OverrideMaterialInternal(RenderableGeometry* geom,
@@ -1697,6 +1737,7 @@ void FilamentScene::OverrideMaterialInternal(RenderableGeometry* geom,
         } else {
             UpdateDepthShader(geom->mat);
         }
+        UpdateBackfaceCulling(geom->mat);
     } else {
         UpdateMaterialProperties(*geom);
     }

--- a/cpp/open3d/visualization/rendering/filament/FilamentScene.h
+++ b/cpp/open3d/visualization/rendering/filament/FilamentScene.h
@@ -125,6 +125,8 @@ public:
                          bool receive_shadows) override;
     void SetGeometryCulling(const std::string& object_name,
                             bool enable) override;
+    void SetGeometryBackfaceCulling(const std::string& object_name,
+                                    bool enable) override;
     void SetGeometryPriority(const std::string& object_name,
                              uint8_t priority) override;
     void OverrideMaterial(const std::string& object_name,
@@ -339,6 +341,10 @@ private:
                                   const MaterialRecord& material,
                                   bool shader_only = false);
     void UpdateMaterialProperties(RenderableGeometry& geom);
+    // Applies the back-face-culling state to material instances whose shader
+    // was compiled with the double-sided capability. No-op for other shaders
+    // (points, lines, transparency/SSR, background, etc.).
+    void UpdateBackfaceCulling(GeometryMaterialInstance& geom_mi);
     void UpdateDefaultLit(GeometryMaterialInstance& geom_mi);
     void UpdateDefaultLitSSR(GeometryMaterialInstance& geom_mi);
     void UpdateDefaultUnlit(GeometryMaterialInstance& geom_mi);

--- a/cpp/pybind/visualization/rendering/rendering.cpp
+++ b/cpp/pybind/visualization/rendering/rendering.cpp
@@ -409,6 +409,12 @@ void pybind_rendering_definitions(py::module &m) {
             m_rendering.attr("MaterialRecord"));
     mat.def(py::init<>())
             .def_readwrite("has_alpha", &MaterialRecord::has_alpha)
+            .def_readwrite("backface_culling",
+                           &MaterialRecord::backface_culling,
+                           "If True, back faces are culled (single-sided "
+                           "rendering). If False (default), both faces are "
+                           "drawn. Inverse of the legacy Visualizer's "
+                           "RenderOption.mesh_show_back_face.")
             .def_readwrite("base_color", &MaterialRecord::base_color)
             .def_readwrite("base_metallic", &MaterialRecord::base_metallic)
             .def_readwrite("base_roughness", &MaterialRecord::base_roughness)
@@ -753,6 +759,12 @@ void pybind_rendering_definitions(py::module &m) {
             .def("modify_geometry_material",
                  &Open3DScene::ModifyGeometryMaterial, "name"_a, "material"_a,
                  "Modifies the material of the specified geometry")
+            .def("set_geometry_backface_culling",
+                 &Open3DScene::SetGeometryBackfaceCulling, "name"_a, "enable"_a,
+                 "Enables or disables back-face culling for the geometry with "
+                 "the given name. Pass enable=True to cull back faces "
+                 "(single-sided rendering), matching the legacy Visualizer's "
+                 "RenderOption.mesh_show_back_face=False.")
             .def("show_geometry", &Open3DScene::ShowGeometry, "name"_a,
                  "show"_a, "Shows or hides the geometry with the given name")
             .def("update_material", &Open3DScene::UpdateMaterial, "material"_a,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

`open3d.visualization.Visualizer` can enable backface culling via the `RenderOption`. This feature is missing for Open3DScene. This pull request is to add the backface culling feature to Open3DScene and provide the corresponding Python binding. Then, with Python, we can write

```python
import sys
import numpy as np
import open3d as o3d
import open3d.visualization.gui as gui
import open3d.visualization.rendering as rendering

DEFAULT_PLY = "<TEST_MESH_PLY_HERE>"
ply = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_PLY

# Start with back-face culling enabled so the ceiling is removed on open.
CULL_ON_START = True

mesh = o3d.io.read_triangle_mesh(ply)
if not mesh.has_vertex_normals():
    mesh.compute_vertex_normals()

gui.Application.instance.initialize()
win = gui.Application.instance.create_window("Back-face Culling Demo", 1280, 900)

widget = gui.SceneWidget()
widget.scene = rendering.Open3DScene(win.renderer)
win.add_child(widget)

mat = rendering.MaterialRecord()
mat.shader = "defaultLit"
mat.backface_culling = CULL_ON_START
widget.scene.add_geometry("mesh", mesh, mat)

bounds = widget.scene.bounding_box
widget.setup_camera(60.0, bounds, bounds.get_center())
# Elevated, looking-down viewpoint so that back-face culling visibly removes the
# ceiling and reveals the room interior.
c = bounds.get_center()
e = bounds.get_extent()
eye = c + np.array([e[0] * 0.2, -e[1] * 0.6, e[2] * 2.5])
widget.look_at(c, eye, np.array([0.0, 0.0, 1.0]))
widget.scene.show_axes(True)

# --- Controls panel ---
em = win.theme.font_size
panel = gui.Vert(0, gui.Margins(em, em, em, em))
cb = gui.Checkbox("Back-face culling")
cb.checked = CULL_ON_START


def on_cull(is_checked):
    # NOTE: the binding to enable backface culling
    widget.scene.set_geometry_backface_culling("mesh", is_checked)


cb.set_on_checked(on_cull)
panel.add_child(cb)
win.add_child(panel)


def on_layout(ctx):
    r = win.content_rect
    widget.frame = r
    pref = panel.calc_preferred_size(ctx, gui.Widget.Constraints())
    panel.frame = gui.Rect(r.get_right() - pref.width, r.y, pref.width, pref.height)


win.set_on_layout(on_layout)
gui.Application.instance.run()
```

## Type

<!--- Select with 'x' and link to a related issue. What types of changes does your code introduce? -->

-   [ ] Bug fix (non-breaking change which fixes an issue): Fixes #
-   [x] New feature (non-breaking change which adds functionality). Resolves #
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) Resolves #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply.  If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->

-   [x] I have run `python util/check_style.py --apply` to apply Open3D **code style**
    to my code.
-   [x] This PR changes Open3D behavior or adds new functionality.
    -   [x] Both C++ (Doxygen) and Python (Sphinx / Google style) **documentation** is
        updated accordingly.
    -   [x] I have added or updated C++ and / or Python **unit tests** OR included **test
        results** (e.g. screenshots or numbers) here.
-   [x] I will follow up and update the code if CI fails.
    <!-- In case I am unavailable later -->
-   [x] For fork PRs, I have selected **Allow edits from maintainers**.

## Description

<!--- Describe your changes, with test results and screenshots as appropriate. Move unrelated changes, if any, to a separate PR. -->

1. add a member `backface_culling` to `open3d::visualization::rendering::MaterialRecord`.
2. add a method `SetGeometryBackfaceCulling` to `open3d::visualization::rendering::Scene`, `open3d::visualization::rendering::Open3DScene` and `open3d::visualization::rendering::FilamentScene`
3. add the corresponding Python binding: `backface_culling` to `mat` for `MaterialRecord` and `set_geometry_backface_culling` to `o3dscene` for `Open3DScene`.

With `backface_culling=True`:
<img width="1024" height="768" alt="image" src="https://github.com/user-attachments/assets/a8a51402-0305-433a-bcc5-6612a868eaef" />

With `backface_culling=False`:
<img width="1024" height="768" alt="image" src="https://github.com/user-attachments/assets/59773ac0-db71-4cfc-b140-a6ff83eda4f0" />
