### PR TITLE
Fix SYCL devel wheel upload glob

### DIFF
--- a/.github/workflows/ubuntu-sycl.yml
+++ b/.github/workflows/ubuntu-sycl.yml
@@ -164,6 +164,5 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload main-devel open3d-*.whl --clobber
-          gh release view main-devel
+          .github/workflows/update_release.sh open3d*.whl
 


### PR DESCRIPTION
## Summary
- Main SYCL wheel jobs built successfully but failed on `gh release upload main-devel open3d-*.whl` because SYCL wheels are named `open3d_xpu-*.whl`.
- Use `.github/workflows/update_release.sh open3d*.whl` (same pattern as the build-lib job).

## Test plan
- [ ] Ubuntu SYCL workflow on main uploads wheels to `main-devel` release

Made with [Cursor](https://cursor.com)