### PR TITLE
Fix ICP fitness denominator documentation

### DIFF
--- a/cpp/open3d/pipelines/registration/Registration.h
+++ b/cpp/open3d/pipelines/registration/Registration.h
@@ -122,7 +122,7 @@ public:
     /// RMSE of all inlier correspondences. Lower is better.
     double inlier_rmse_;
     /// For ICP: the overlapping area (# of inlier correspondences / # of points
-    /// in target). Higher is better.
+    /// in source). Higher is better.
     /// For RANSAC: inlier ratio (# of inlier correspondences / # of
     /// all correspondences)
     double fitness_;

--- a/cpp/open3d/t/pipelines/registration/Registration.h
+++ b/cpp/open3d/t/pipelines/registration/Registration.h
@@ -89,7 +89,7 @@ public:
     /// RMSE of all inlier correspondences. Lower is better.
     double inlier_rmse_;
     /// For ICP: the overlapping area (# of inlier correspondences / # of points
-    /// in target). Higher is better.
+    /// in source). Higher is better.
     double fitness_;
     /// Specifies whether the algorithm converged or not.
     bool converged_{false};


### PR DESCRIPTION
## Type

- [x] Bug fix (non-breaking change which fixes an issue): Fixes #7503
- [ ] New feature (non-breaking change which adds functionality). Resolves 
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected). Resolves 

## Motivation and Context

The legacy and tensor `RegistrationResult` headers describe ICP fitness as
the number of inlier correspondences divided by the number of target points.

Both implementations divide by the number of source points, and the Python
binding documentation and ICP tutorial already describe the source-point
denominator correctly.

Plan summary:
1. Confirm the denominator in both implementations.
2. Audit the legacy API, tensor API, Python bindings, and user documentation.
3. Update only the two incorrect C++ header comments.
4. Run style and consistency checks.

## Checklist

- [x] I have run `python util/check_style.py --apply` to apply Open3D code style.
- [ ] This PR changes Open3D behavior or adds new functionality.
- [x] I will follow up and update the code if CI fails.
- [x] For fork PRs, I have selected Allow edits from maintainers.

## Description

- Correct the legacy `RegistrationResult::fitness_` documentation.
- Correct the tensor `RegistrationResult::fitness_` documentation.
- Keep the existing RANSAC definition unchanged.

Validation:
- `python util/check_style.py --apply --changed-only`
- `python util/check_style.py --changed-only`
- `git diff --check`
- Exact-text consistency search across registration headers, implementations,
  Python bindings, and docs

All style and consistency checks passed. A full Doxygen build was not run
because CMake and Doxygen are unavailable in the current environment. This is
a documentation-only change with no runtime behavior change.